### PR TITLE
Use 'DoNot' instead of contraction 'Dont' in symbol names

### DIFF
--- a/src/Analyzers/CSharp/Tests/AddInheritdoc/AddInheritdocTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddInheritdoc/AddInheritdocTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddInheritd
         [InlineData("public void {|CS1591:OtherMethod|}() { }")]
         [InlineData("public void {|CS1591:M|}() { }")]
         [InlineData("public new void {|CS1591:M|}() { }")]
-        public async Task DontOfferOnNotOverridenMethod(string methodDefintion)
+        public async Task DoNotOfferOnNotOverridenMethod(string methodDefintion)
         {
             await TestMissingAsync(
             $@"
@@ -120,7 +120,7 @@ public class Derived: BaseClass
         }
 
         [Fact]
-        public async Task DontOfferOnExplicitInterfaceMethod()
+        public async Task DoNotOfferOnExplicitInterfaceMethod()
         {
             await TestMissingAsync(
                 """

--- a/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
@@ -2526,7 +2526,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddParameter
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/29061")]
-        public async Task TestThis_DontOfferToFixTheConstructorWithTheDiagnosticOnIt()
+        public async Task TestThis_DoNotOfferToFixTheConstructorWithTheDiagnosticOnIt()
         {
             // error CS1729: 'C' does not contain a constructor that takes 1 arguments
             var code =

--- a/src/Analyzers/CSharp/Tests/AliasAmbiguousType/AliasAmbiguousTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/AliasAmbiguousType/AliasAmbiguousTypeTests.cs
@@ -130,7 +130,7 @@ namespace Test
         }
 
         [Fact]
-        public async Task TestAmbiguousClassObjectCreationGenericsDontOfferDiagnostic()
+        public async Task TestAmbiguousClassObjectCreationGenericsDoNotOfferDiagnostic()
         {
             var genericAmbiguousClassDefinition = GetAmbiguousDefinition("public class Ambiguous<T> { }");
             await TestMissingAsync(@"

--- a/src/Analyzers/CSharp/Tests/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveInKeyword/RemoveInKeywordCodeFixProviderTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveInKeyword
         }
 
         [Fact]
-        public async Task TestDontRemoveInKeyword()
+        public async Task TestDoNotRemoveInKeyword()
         {
             await TestMissingInRegularAndScriptAsync(
                 """

--- a/src/Analyzers/VisualBasic/Tests/AddParameter/AddParameterTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/AddParameter/AddParameterTests.vb
@@ -1017,7 +1017,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/29061")>
-        Public Async Function TestConstructorInitializer_DontOfferFixForConstructorWithDiagnostic() As Task
+        Public Async Function TestConstructorInitializer_DoNotOfferFixForConstructorWithDiagnostic() As Task
             ' Error BC30057: Too many arguments to 'Public Sub New()'.
             Dim code =
 "

--- a/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.RemoveUnnecessaryC
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545979")>
-        Public Async Function TestDontRemoveCastToErrorType() As Task
+        Public Async Function TestDoNotRemoveCastToErrorType() As Task
             Dim markup =
 <File>
 Module M
@@ -32,7 +32,7 @@ End Module
         End Function
 
         <Fact>
-        Public Async Function TestDontRemoveCastSimpleArgument1() As Task
+        Public Async Function TestDoNotRemoveCastSimpleArgument1() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -49,7 +49,7 @@ End Module
         End Function
 
         <Fact>
-        Public Async Function TestDontRemoveCastSimpleArgument2() As Task
+        Public Async Function TestDoNotRemoveCastSimpleArgument2() As Task
             Dim markup =
 <File>
 Option Strict On    
@@ -249,7 +249,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545134")>
-        Public Async Function TestDontRemoveConversionFromNullableLongToIComparable() As Task
+        Public Async Function TestDoNotRemoveConversionFromNullableLongToIComparable() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -265,7 +265,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545151")>
-        Public Async Function TestDontRemoveArrayLiteralConversion() As Task
+        Public Async Function TestDoNotRemoveArrayLiteralConversion() As Task
             Dim markup =
 <File>
 Module Program
@@ -280,7 +280,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545152")>
-        Public Async Function TestDontRemoveAddressOfCastToDelegate() As Task
+        Public Async Function TestDoNotRemoveAddressOfCastToDelegate() As Task
             Dim markup =
 <File>
 Imports System
@@ -635,7 +635,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545599")>
-        Public Async Function TestDontRemoveNeededCastWithUserDefinedConversionsAndOptionStrictOff() As Task
+        Public Async Function TestDoNotRemoveNeededCastWithUserDefinedConversionsAndOptionStrictOff() As Task
             Dim markup =
 <File>
 Option Strict Off
@@ -657,7 +657,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529535")>
-        Public Async Function TestDontRemoveNeededCastWhenResultIsAmbiguous() As Task
+        Public Async Function TestDoNotRemoveNeededCastWhenResultIsAmbiguous() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -727,7 +727,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545526")>
-        Public Async Function TestDontRemoveCastThatResultsInDifferentStringRepresentations() As Task
+        Public Async Function TestDoNotRemoveCastThatResultsInDifferentStringRepresentations() As Task
             Dim markup =
 <File>
 Option Strict Off
@@ -747,7 +747,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545631")>
-        Public Async Function TestDontRemoveCastThatChangesArrayLiteralTypeAndBreaksOverloadResolution() As Task
+        Public Async Function TestDoNotRemoveCastThatChangesArrayLiteralTypeAndBreaksOverloadResolution() As Task
             Dim markup =
 <File>
 Module Program
@@ -901,7 +901,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545971")>
-        Public Async Function TestDontRemoveNecessaryCastPassedToParamArray1() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastPassedToParamArray1() As Task
             Dim markup =
 <File>
 Module M
@@ -918,7 +918,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545971")>
-        Public Async Function TestDontRemoveNecessaryCastPassedToParamArray2() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastPassedToParamArray2() As Task
             Dim markup =
 <File>
 Module M
@@ -1109,7 +1109,7 @@ End Module
         End Function
 
         <Fact>
-        Public Async Function TestDontRemoveNecessaryCastToArrayLiteral2() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastToArrayLiteral2() As Task
             Dim markup =
 <File>
 Module Program
@@ -1127,7 +1127,7 @@ End Module
         End Function
 
         <Fact>
-        Public Async Function TestDontRemoveNecessaryCastToArrayLiteral() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastToArrayLiteral() As Task
             Dim markup =
 <File>
 Module M
@@ -1243,7 +1243,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545526")>
-        Public Async Function TestDontRemoveCastToDoubleInOptionStrictOff() As Task
+        Public Async Function TestDoNotRemoveCastToDoubleInOptionStrictOff() As Task
             Dim markup =
 <File>
 Option Strict Off
@@ -1263,7 +1263,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545828")>
-        Public Async Function TestDontRemoveCStrInCharToStringToObjectChain() As Task
+        Public Async Function TestDoNotRemoveCStrInCharToStringToObjectChain() As Task
             Dim markup =
 <File>
 Imports System
@@ -1279,7 +1279,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545808")>
-        Public Async Function TestDontRemoveNecessaryCastWithMultipleUserDefinedConversionsAndOptionStrictOff() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastWithMultipleUserDefinedConversionsAndOptionStrictOff() As Task
             Dim markup =
 <File>
 Option Strict Off
@@ -1304,7 +1304,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545998")>
-        Public Async Function TestDontRemoveCastWhichWouldChangeAttributeOverloadResolution() As Task
+        Public Async Function TestDoNotRemoveCastWhichWouldChangeAttributeOverloadResolution() As Task
             Dim markup =
 <File>
 Imports System
@@ -1325,7 +1325,7 @@ End Class
         End Function
 
         <Fact>
-        Public Async Function TestDontMoveTrailingComment() As Task
+        Public Async Function TestDoNotMoveTrailingComment() As Task
             Dim markup =
 <File>
 Module Program
@@ -1352,7 +1352,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryStringPredefinedCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryStringPredefinedCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1366,7 +1366,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryWideningPredefinedCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryWideningPredefinedCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1380,7 +1380,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryNarrowingPredefinedCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryNarrowingPredefinedCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1394,7 +1394,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryStringCTypeCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryStringCTypeCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1408,7 +1408,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryWideningCTypeCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryWideningCTypeCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1422,7 +1422,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryNarrowingCTypeCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryNarrowingCTypeCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1436,7 +1436,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryUserDefinedCTypeCastWithGetType() As Task
+        Public Async Function TestDoNotRemoveNecessaryUserDefinedCTypeCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1569,7 +1569,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryPredefinedCastWithToString() As Task
+        Public Async Function TestDoNotRemoveNecessaryPredefinedCastWithToString() As Task
             Dim markup =
 <File>
 Module Program
@@ -1583,7 +1583,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30617")>
-        Public Async Function TestDontRemoveNecessaryPredefinedCastInWithStatement() As Task
+        Public Async Function TestDoNotRemoveNecessaryPredefinedCastInWithStatement() As Task
             Dim markup =
 <File>
 Module Program
@@ -1600,7 +1600,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30617")>
-        Public Async Function TestDontRemoveNecessaryDirectCastInWithStatement() As Task
+        Public Async Function TestDoNotRemoveNecessaryDirectCastInWithStatement() As Task
             Dim markup =
 <File>
 Module Program
@@ -1617,7 +1617,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30617")>
-        Public Async Function TestDontRemoveNecessaryCTypeCastInWithStatement() As Task
+        Public Async Function TestDoNotRemoveNecessaryCTypeCastInWithStatement() As Task
             Dim markup =
 <File>
 Module Program
@@ -1634,7 +1634,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30617")>
-        Public Async Function TestDontRemoveNecessaryTryCastInWithStatement() As Task
+        Public Async Function TestDoNotRemoveNecessaryTryCastInWithStatement() As Task
             Dim markup =
 <File>
 Module Program
@@ -1792,7 +1792,7 @@ End Class
         End Function
 
         <Fact>
-        Public Async Function TestDontDuplicateTrivia() As Task
+        Public Async Function TestDoNotDuplicateTrivia() As Task
             Dim markup =
 <File>
 Imports System
@@ -1916,7 +1916,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552813")>
-        Public Async Function TestDontRemoveCastWhileNarrowingWithOptionOn() As Task
+        Public Async Function TestDoNotRemoveCastWhileNarrowingWithOptionOn() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -1932,7 +1932,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/577929")>
-        Public Async Function TestDontRemoveCastWhileDefaultingNullables() As Task
+        Public Async Function TestDoNotRemoveCastWhileDefaultingNullables() As Task
             Dim markup =
 <File>
 Module M
@@ -1976,7 +1976,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578016")>
-        Public Async Function TestDontRemoveCStr() As Task
+        Public Async Function TestDoNotRemoveCStr() As Task
             Dim markup =
 <File>Option Strict On
 
@@ -1993,7 +1993,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530105")>
-        Public Async Function TestDontRemoveNumericCast() As Task
+        Public Async Function TestDoNotRemoveNumericCast() As Task
             Dim markup =
 <File>
 Interface I
@@ -2004,7 +2004,7 @@ End Interface
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530104")>
-        Public Async Function TestDontRemoveCTypeFromNumberToEnum() As Task
+        Public Async Function TestDoNotRemoveCTypeFromNumberToEnum() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -2017,7 +2017,7 @@ End Interface
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530077")>
-        Public Async Function TestDontRemoveCastForLambdaToDelegateConversionWithOptionStrictOn() As Task
+        Public Async Function TestDoNotRemoveCastForLambdaToDelegateConversionWithOptionStrictOn() As Task
             Dim markup =
  <File>
 Option Strict On
@@ -2035,7 +2035,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529966")>
-        Public Async Function TestDontRemoveForNarrowingConversionFromObjectWithOptionStrictOnInsideQueryExpression() As Task
+        Public Async Function TestDoNotRemoveForNarrowingConversionFromObjectWithOptionStrictOnInsideQueryExpression() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -2156,7 +2156,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770187")>
         <WpfFact(Skip:="770187")>
-        Public Async Function TestDontRemoveNecessaryCastInSelectCaseExpression() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastInSelectCaseExpression() As Task
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
             Dim markup =
@@ -2201,7 +2201,7 @@ End Namespace]]>
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770187")>
         <WpfFact(Skip:="770187")>
-        Public Async Function TestDontRemoveNecessaryCastInSelectCaseExpression2() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastInSelectCaseExpression2() As Task
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
             Dim markup =
@@ -2246,7 +2246,7 @@ End Namespace]]>
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770187")>
         <WpfFact(Skip:="770187")>
-        Public Async Function TestDontRemoveNecessaryCastInSelectCaseExpression3() As Task
+        Public Async Function TestDoNotRemoveNecessaryCastInSelectCaseExpression3() As Task
             ' Cast removal invokes a different user defined operator, hence the cast is necessary.
 
             Dim markup =
@@ -2292,7 +2292,7 @@ End Namespace]]>
 #Region "Interface Casts"
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545889")>
-        Public Async Function TestDontRemoveCastToInterfaceForUnsealedType() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForUnsealedType() As Task
             Dim markup =
 <File>
 Imports System
@@ -2403,7 +2403,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545890")>
-        Public Async Function TestDontRemoveCastToInterfaceForSealedType4() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForSealedType4() As Task
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because the unspecified optional parameter default values differ.
 
@@ -2431,7 +2431,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545890")>
-        Public Async Function TestDontRemoveCastToInterfaceForSealedType5() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForSealedType5() As Task
             ' Note: The cast below cannot be removed (even though C is sealed)
             ' because default values differ for optional parameters and
             ' hence the method is not considered an implementation.
@@ -2460,7 +2460,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545888")>
-        Public Async Function TestDontRemoveCastToInterfaceForSealedType6() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForSealedType6() As Task
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because the specified named arguments refer to parameters that
             ' appear at different positions in the member signatures.
@@ -2513,7 +2513,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545888")>
-        Public Async Function TestDontRemoveCastToInterfaceForSealedType9() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForSealedType9() As Task
             ' Note: The cast below can't be removed (even though C is sealed)
             ' because it would result in binding to a Dispose method that doesn't
             ' implement IDisposable.Dispose().
@@ -2540,7 +2540,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545887")>
-        Public Async Function TestDontRemoveCastToInterfaceForStruct1() As Task
+        Public Async Function TestDoNotRemoveCastToInterfaceForStruct1() As Task
             ' Note: The cast below can't be removed because the cast boxes 's' and
             ' unboxing would change program behavior.
 
@@ -2888,7 +2888,7 @@ End Module
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2761")>
-        Public Async Function TestDontRemoveCastFromBaseToDerivedWithNarrowingReference() As Task
+        Public Async Function TestDoNotRemoveCastFromBaseToDerivedWithNarrowingReference() As Task
             Dim markup =
 <File>
 Module Module1
@@ -2910,7 +2910,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/3254")>
-        Public Async Function TestDontRemoveCastToTypeParameterWithExceptionConstraint() As Task
+        Public Async Function TestDoNotRemoveCastToTypeParameterWithExceptionConstraint() As Task
             Dim markup =
 <File>
 Imports System
@@ -2927,7 +2927,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/3254")>
-        Public Async Function TestDontRemoveCastToTypeParameterWithExceptionSubTypeConstraint() As Task
+        Public Async Function TestDoNotRemoveCastToTypeParameterWithExceptionSubTypeConstraint() As Task
             Dim markup =
 <File>
 Imports System
@@ -3020,7 +3020,7 @@ End Structure
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/11008#issuecomment-230786838")>
-        Public Async Function DontOfferToRemoveCastWhenAccessingHiddenProperty() As Task
+        Public Async Function DoNotOfferToRemoveCastWhenAccessingHiddenProperty() As Task
             Await TestMissingInRegularAndScriptAsync(
 <Code>
 Imports System.Collections.Generic

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -646,7 +646,7 @@ $$", @"         using
 
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530716")]
         [WpfFact]
-        public void DontAssertOnMultilineToken()
+        public void DoNotAssertOnMultilineToken()
         {
             Test(@"interface I
 {

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLiteralCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLiteralCompletionTests.cs
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AutomaticCompletion
         }
 
         [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/59178")]
-        public void String_DontCompleteVerbatim()
+        public void String_DoNotCompleteVerbatim()
         {
             var code = @"class C
 {

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2246,12 +2246,12 @@ q = from",
 
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")]
         [CombinatorialData]
-        public async Task DontColorThingsOtherThanFromInDeclaration(TestHost testHost)
+        public async Task DoNotColorThingsOtherThanFromInDeclaration(TestHost testHost)
             => await TestInExpressionAsync("fro ", testHost);
 
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")]
         [CombinatorialData]
-        public async Task DontColorThingsOtherThanFromInAssignment(TestHost testHost)
+        public async Task DoNotColorThingsOtherThanFromInAssignment(TestHost testHost)
         {
             await TestInMethodAsync(
 @"var q = 3;
@@ -2264,7 +2264,7 @@ q = fro",
 
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")]
         [CombinatorialData]
-        public async Task DontColorFromWhenBoundInDeclaration(TestHost testHost)
+        public async Task DoNotColorFromWhenBoundInDeclaration(TestHost testHost)
         {
             await TestInMethodAsync(
 @"var from = 3;
@@ -2277,7 +2277,7 @@ var q = from",
 
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")]
         [CombinatorialData]
-        public async Task DontColorFromWhenBoundInAssignment(TestHost testHost)
+        public async Task DoNotColorFromWhenBoundInAssignment(TestHost testHost)
         {
             await TestInMethodAsync(
 @"var q = 3;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -647,7 +647,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
-        public async Task DontOverparenthesize()
+        public async Task DoNotOverparenthesize()
         {
             await TestAsync(
                 """
@@ -752,7 +752,7 @@ parseOptions: Options.Regular, index: CodeActionIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
-        public async Task DontOverparenthesizeGenerics()
+        public async Task DoNotOverparenthesizeGenerics()
         {
             await TestAsync(
                 """

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -877,7 +877,7 @@ new TestParameters(options: Option(CSharpCodeStyleOptions.PreferExpressionBodied
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530709")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632182")]
-        public async Task DontOverparenthesize()
+        public async Task DoNotOverparenthesize()
         {
             await TestAsync(
                 """
@@ -979,7 +979,7 @@ parseOptions: Options.Regular);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632182")]
-        public async Task DontOverparenthesizeGenerics()
+        public async Task DoNotOverparenthesizeGenerics()
         {
             await TestAsync(
                 """
@@ -4365,7 +4365,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40209")]
-        public async Task TestNaming_CamelCase_VerifyLocalFunctionSettingsDontApply()
+        public async Task TestNaming_CamelCase_VerifyLocalFunctionSettingsDoNotApply()
         {
             var input = """
                 <Workspace>
@@ -4416,7 +4416,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40209")]
-        public async Task TestNaming_CamelCase_VerifyLocalFunctionSettingsDontApply_GetName()
+        public async Task TestNaming_CamelCase_VerifyLocalFunctionSettingsDoNotApply_GetName()
         {
             var input = """
                 <Workspace>

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact]
-        public async Task DontBreakOverloadResolution_Case5()
+        public async Task DoNotBreakOverloadResolution_Case5()
         {
             var code = """
                 class C
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact]
-        public async Task DontTouchUnrelatedBlocks()
+        public async Task DoNotTouchUnrelatedBlocks()
         {
             var code = """
                 class C
@@ -2440,7 +2440,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544563")]
-        public async Task DontInlineStackAlloc()
+        public async Task DoNotInlineStackAlloc()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2733,7 +2733,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545103")]
-        public async Task DontInsertCastForTypeThatNoLongerBindsToTheSameType()
+        public async Task DoNotInsertCastForTypeThatNoLongerBindsToTheSameType()
         {
             await TestAsync(
             """
@@ -2799,7 +2799,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545523")]
-        public async Task DontInsertCastForObjectCreationIfUnneeded()
+        public async Task DoNotInsertCastForObjectCreationIfUnneeded()
         {
             await TestInRegularAndScriptAsync(
             """
@@ -2827,7 +2827,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact]
-        public async Task DontInsertCastInForeachIfUnneeded01()
+        public async Task DoNotInsertCastInForeachIfUnneeded01()
         {
             await TestInRegularAndScriptAsync(
             """
@@ -4009,7 +4009,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4583")]
-        public async Task DontParenthesizeInterpolatedStringWithNoInterpolation_CSharp7()
+        public async Task DoNotParenthesizeInterpolatedStringWithNoInterpolation_CSharp7()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -4090,7 +4090,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4583")]
-        public async Task DontParenthesizeInterpolatedStringWithInterpolation_CSharp7()
+        public async Task DoNotParenthesizeInterpolatedStringWithInterpolation_CSharp7()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -4116,7 +4116,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/33108")]
         [WorkItem("https://github.com/dotnet/roslyn/issues/4583")]
-        public async Task DontParenthesizeInterpolatedStringWithInterpolation()
+        public async Task DoNotParenthesizeInterpolatedStringWithInterpolation()
         {
             await TestInRegularAndScriptAsync(
                 """

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -3074,7 +3074,7 @@ options: ImplicitTypingEverywhere());
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/682683")]
-        public async Task DontRemoveParenthesesIfOperatorPrecedenceWouldBeBroken()
+        public async Task DoNotRemoveParenthesesIfOperatorPrecedenceWouldBeBroken()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -8056,7 +8056,7 @@ $@"a b c"
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40381")]
-        public async Task TestIntroduceFromMethod_AllOccurences_DontIncludeStaticLocalFunctionReferences()
+        public async Task TestIntroduceFromMethod_AllOccurences_DoNotIncludeStaticLocalFunctionReferences()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -8105,7 +8105,7 @@ $@"a b c"
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40381")]
-        public async Task TestIntroduceFromMethod_AllOccurences_DontIncludeStaticLocalFunctionReferences2()
+        public async Task TestIntroduceFromMethod_AllOccurences_DoNotIncludeStaticLocalFunctionReferences2()
         {
             await TestInRegularAndScriptAsync(
                 """

--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
@@ -141,7 +141,7 @@ namespace B
         }
 
         [WpfFact]
-        public async Task AddMissingImports_AddImportsAboveSystem_DontPlaceSystemFirstPasteContainsMultipleMissingImports()
+        public async Task AddMissingImports_AddImportsAboveSystem_DoNotPlaceSystemFirstPasteContainsMultipleMissingImports()
         {
             var code = @"
 using System;

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -2638,7 +2638,7 @@ public class Class1
         }
 
         [WpfFact]
-        public void DontComplete_SemicolonBeforeClassDeclaration()
+        public void DoNotComplete_SemicolonBeforeClassDeclaration()
         {
             var code =
 @"$$
@@ -2650,7 +2650,7 @@ class C
         }
 
         [WpfFact]
-        public void DontCompleteStatment_DocComments()
+        public void DoNotCompleteStatment_DocComments()
         {
             var code =
 @"
@@ -2663,7 +2663,7 @@ class C
         }
 
         [WpfFact]
-        public void DontComplete_FormatString()
+        public void DoNotComplete_FormatString()
         {
             var code =
 @"
@@ -2679,7 +2679,7 @@ class C
         }
 
         [WpfFact]
-        public void DontComplete_EmptyStatement()
+        public void DoNotComplete_EmptyStatement()
         {
             var code =
 @"
@@ -2695,7 +2695,7 @@ class C
         }
 
         [WpfFact]
-        public void DontComplete_EmptyStatement2()
+        public void DoNotComplete_EmptyStatement2()
         {
             var code =
 @"
@@ -2933,7 +2933,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Break()
+        public void DoNotComplete_Break()
         {
             var code =
 @"
@@ -2955,7 +2955,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Break2()
+        public void DoNotComplete_Break2()
         {
             var code =
 @"
@@ -2977,7 +2977,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Break3()
+        public void DoNotComplete_Break3()
         {
             var code =
 @"
@@ -2999,7 +2999,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Checked()
+        public void DoNotComplete_Checked()
         {
             var code =
 @"
@@ -3030,7 +3030,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Unchecked()
+        public void DoNotComplete_Unchecked()
         {
             var code =
 @"
@@ -3061,7 +3061,7 @@ public class C
         }
 
         [WpfFact]
-        public void DontComplete_Fixed()
+        public void DoNotComplete_Fixed()
         {
             var code =
 @"
@@ -3090,7 +3090,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Continue()
+        public void DoNotComplete_Continue()
         {
             var code =
 @"
@@ -3113,7 +3113,7 @@ class ContinueTest
         }
 
         [WpfFact]
-        public void DontComplete_Continue2()
+        public void DoNotComplete_Continue2()
         {
             var code =
 @"
@@ -3136,7 +3136,7 @@ class ContinueTest
         }
 
         [WpfFact]
-        public void DontComplete_Continue3()
+        public void DoNotComplete_Continue3()
         {
             var code =
 @"
@@ -3159,7 +3159,7 @@ class ContinueTest
         }
 
         [WpfFact]
-        public void DontComplete_GoTo()
+        public void DoNotComplete_GoTo()
         {
             var code =
 @"
@@ -3183,7 +3183,7 @@ static void Main()
         }
 
         [WpfFact]
-        public void DontComplete_IfStatement()
+        public void DoNotComplete_IfStatement()
         {
             var code =
 @"
@@ -3204,7 +3204,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Labeled()
+        public void DoNotComplete_Labeled()
         {
             var code =
 @"
@@ -3223,7 +3223,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_IfStatement2()
+        public void DoNotComplete_IfStatement2()
         {
             var code =
 @"
@@ -3244,7 +3244,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_ClassNameOfMethodInvocation1()
+        public void DoNotComplete_ClassNameOfMethodInvocation1()
         {
             var code = CreateTestWithMethodCall(@"var test = $$ClassC.MethodM(x,y)");
 
@@ -3252,7 +3252,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_ClassNameOfMethodInvocation2()
+        public void DoNotComplete_ClassNameOfMethodInvocation2()
         {
             var code = CreateTestWithMethodCall(@"var test = C$$lassC.MethodM(x,y)");
 
@@ -3260,7 +3260,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_ClassNameOfMethodInvocation3()
+        public void DoNotComplete_ClassNameOfMethodInvocation3()
         {
             var code = CreateTestWithMethodCall(@"var test = Class$$C.MethodM(x,y)");
 
@@ -3268,7 +3268,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_ClassNameOfMethodInvocation4()
+        public void DoNotComplete_ClassNameOfMethodInvocation4()
         {
             var code = CreateTestWithMethodCall(@"var test = ClassC$$.MethodM(x,y)");
 
@@ -3276,7 +3276,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_MethodNameOfMethodInvocation1()
+        public void DoNotComplete_MethodNameOfMethodInvocation1()
         {
             var code = CreateTestWithMethodCall(@"var test = ClassC.Meth$$odM(x,y)");
 
@@ -3284,7 +3284,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_MethodNameOfMethodInvocation2()
+        public void DoNotComplete_MethodNameOfMethodInvocation2()
         {
             var code = CreateTestWithMethodCall(@"var test = ClassC.$$MethodM(x,y)");
 
@@ -3292,7 +3292,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_MethodNameOfMethodInvocation3()
+        public void DoNotComplete_MethodNameOfMethodInvocation3()
         {
             var code = CreateTestWithMethodCall(@"var test = ClassC.MethodM$$(x,y)");
 
@@ -3300,7 +3300,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_SemicolonBeforeEquals()
+        public void DoNotComplete_SemicolonBeforeEquals()
         {
             var code = CreateTestWithMethodCall(@"var test $$= ClassC.MethodM(x,y)");
 
@@ -3308,7 +3308,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_SemicolonAfterEquals()
+        public void DoNotComplete_SemicolonAfterEquals()
         {
             var code = CreateTestWithMethodCall(@"var test =$$ ClassC.MethodM(x,y)");
 
@@ -3316,7 +3316,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_String()
+        public void DoNotComplete_String()
         {
             var code = CreateTestWithMethodCall(@"var s=""Test $$Test""");
 
@@ -3324,7 +3324,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_String2()
+        public void DoNotComplete_String2()
         {
             var code = CreateTestWithMethodCall(@"var s=""Test Test$$""");
 
@@ -3332,7 +3332,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_String3()
+        public void DoNotComplete_String3()
         {
             var code = CreateTestWithMethodCall(@"var s=""Test Test""$$");
 
@@ -3341,7 +3341,7 @@ class Program
 
         [WorkItem("https://github.com/dotnet/roslyn/issues/34176")]
         [WpfFact]
-        public void DontComplete_VerbatimStringAsMethodArgument_EndOfLine_NotEndOfString()
+        public void DoNotComplete_VerbatimStringAsMethodArgument_EndOfLine_NotEndOfString()
         {
             var code = @"
             var code = Foo(@""$$
@@ -3352,7 +3352,7 @@ class Program
 
         [WorkItem("https://github.com/dotnet/roslyn/issues/34176")]
         [WpfFact]
-        public void DontComplete_VerbatimStringAsMethodArgument_EndOfString_NotEndOfLine()
+        public void DoNotComplete_VerbatimStringAsMethodArgument_EndOfString_NotEndOfLine()
         {
 
             var code = @"
@@ -3363,7 +3363,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_InterpolatedString()
+        public void DoNotComplete_InterpolatedString()
         {
             var code = CreateTestWithMethodCall(@"var s=$""{obj.ToString($$)}""");
 
@@ -3371,7 +3371,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Attribute()
+        public void DoNotComplete_Attribute()
         {
             var code = @"
 using System;
@@ -3393,7 +3393,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Attribute2()
+        public void DoNotComplete_Attribute2()
         {
             var code = @"
 [assembly: System.Reflection.AssemblyVersionAttribute(null$$)]
@@ -3404,7 +3404,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Attribute3()
+        public void DoNotComplete_Attribute3()
         {
             var code = @"
 using System.Runtime.CompilerServices;
@@ -3428,7 +3428,7 @@ class A
         }
 
         [WpfFact]
-        public void DontComplete_Attribute4()
+        public void DoNotComplete_Attribute4()
         {
             var code = @"
 using System;
@@ -3456,7 +3456,7 @@ static class Program
         }
 
         [WpfFact]
-        public void DontComplete_Attribute5()
+        public void DoNotComplete_Attribute5()
         {
             var code = @"
 using System;
@@ -3484,7 +3484,7 @@ static class Program
         }
 
         [WpfFact]
-        public void DontComplete_Attribute6()
+        public void DoNotComplete_Attribute6()
         {
             var code = @"
 using System;
@@ -3506,7 +3506,7 @@ class Program
         }
 
         [WpfFact]
-        public void DontComplete_Using()
+        public void DoNotComplete_Using()
         {
             var code = @"
 using System.Linq$$
@@ -3515,7 +3515,7 @@ using System.Linq$$
         }
 
         [WpfFact]
-        public void DontComplete_Using2()
+        public void DoNotComplete_Using2()
         {
             var code = @"
 using System.Linq$$;
@@ -3524,7 +3524,7 @@ using System.Linq$$;
         }
 
         [WpfFact]
-        public void DontComplete_Using3()
+        public void DoNotComplete_Using3()
         {
             var code = @"
 using System.$$Linq

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -347,7 +347,7 @@ public {record} R(MyClass $$
         [Theory]
         [InlineData("class")]
         [InlineData("struct")]
-        public async Task DontTreatPrimaryConstructorParameterAsProperty(string record)
+        public async Task DoNotTreatPrimaryConstructorParameterAsProperty(string record)
         {
             var markup = $@"
 public class MyClass

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -373,7 +373,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem("https://github.com/dotnet/roslyn/issues/34774")]
-        public async Task DontSuggestEventAfterReadonlyInClass()
+        public async Task DoNotSuggestEventAfterReadonlyInClass()
         {
             var markup =
 @"class C {
@@ -385,7 +385,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         [WorkItem("https://github.com/dotnet/roslyn/issues/34774")]
-        public async Task DontSuggestEventAfterReadonlyInInterface()
+        public async Task DoNotSuggestEventAfterReadonlyInInterface()
         {
             var markup =
 @"interface C {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.cs
@@ -258,7 +258,7 @@ class Class1
         }
 
         [Fact]
-        public async Task DontFilterYet()
+        public async Task DoNotFilterYet()
         {
             var markup = @"
 class Class1

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -363,7 +363,7 @@ class C
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4115")]
-        public async Task DontCommitObjectWithOpenBrace1()
+        public async Task DoNotCommitObjectWithOpenBrace1()
         {
             var markup = @"
 class C
@@ -387,7 +387,7 @@ class C
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4115")]
-        public async Task DontCommitObjectWithOpenBrace2()
+        public async Task DoNotCommitObjectWithOpenBrace2()
         {
             var markup = @"
 class C

--- a/src/EditorFeatures/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToRecord/ConvertToRecordCodeRefactoringTests.cs
@@ -4278,7 +4278,7 @@ namespace N
         }
 
         [Fact]
-        public async Task TestMovePropertiesAndDontRefactorInitializerWithExistingConstructor()
+        public async Task TestMovePropertiesAndDoNotRefactorInitializerWithExistingConstructor()
         {
             var initialMarkup = @"
 namespace N

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1393,7 +1393,7 @@ class C
         }
 
         [WpfFact]
-        public void PressingEnter_DontInsertSlashes1()
+        public void PressingEnter_DoNotInsertSlashes1()
         {
             var code =
 @"/// <summary></summary>
@@ -1415,7 +1415,7 @@ class C
 
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538701")]
         [WpfFact]
-        public void PressingEnter_DontInsertSlashes2()
+        public void PressingEnter_DoNotInsertSlashes2()
         {
             var code =
 @"///<summary></summary>

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var options = new ExtractMethodGenerationOptions()
             {
                 CodeGenerationOptions = CodeGenerationOptions.GetDefault(document.Project.Services),
-                ExtractOptions = new() { DontPutOutOrRefOnStruct = dontPutOutOrRefOnStruct }
+                ExtractOptions = new() { DoNotPutOutOrRefOnStruct = dontPutOutOrRefOnStruct }
             };
 
             var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -8360,7 +8360,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541627")]
-        public async Task DontUseConvertedTypeForImplicitNumericConversion()
+        public async Task DoNotUseConvertedTypeForImplicitNumericConversion()
         {
             var code = """
                 class T
@@ -8471,7 +8471,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539862")]
-        public async Task DontBlindlyPutCapturedVariable1()
+        public async Task DoNotBlindlyPutCapturedVariable1()
         {
             var code = """
                 using System;
@@ -8532,7 +8532,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539862")]
-        public async Task DontBlindlyPutCapturedVariable2()
+        public async Task DoNotBlindlyPutCapturedVariable2()
         {
             var code = """
                 using System;
@@ -8573,7 +8573,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541889")]
-        public async Task DontCrashOnRangeVariableSymbol()
+        public async Task DoNotCrashOnRangeVariableSymbol()
         {
             var code = """
                 class Test
@@ -10975,7 +10975,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact]
-        public async Task TestDontPutOutOrRefForStructOff()
+        public async Task TestDoNotPutOutOrRefForStructOff()
         {
             var code =
                 """
@@ -11010,7 +11010,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
         }
 
         [Fact]
-        public async Task TestDontPutOutOrRefForStructOn()
+        public async Task TestDoNotPutOutOrRefForStructOn()
         {
             var code =
                 """

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/SelectionValidatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/SelectionValidatorTests.cs
@@ -1006,7 +1006,7 @@ class C
         }
 
         [Fact]
-        public async Task SelectValidSubexpressionAndHenceDontExpand()
+        public async Task SelectValidSubexpressionAndHenceDoNotExpand()
         {
             var code = @"class A
 {
@@ -1275,7 +1275,7 @@ class P
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542722")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540787")]
-        public async Task DontCrash()
+        public async Task DoNotCrash()
             => await IterateAllAsync(TestResource.AllInOneCSharpCode);
 
         [Fact, WorkItem(9931, "DevDiv_Projects/Roslyn")]
@@ -1592,7 +1592,7 @@ class B
         }
 
         [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1228916")]
-        public async Task DontCrashPastEndOfLine()
+        public async Task DoNotCrashPastEndOfLine()
         {
             //                    11 1
             //          012345678901 2

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1055,7 +1055,7 @@ class C : Attribute
 
         [WorkItem("https://github.com/dotnet/roslyn/issues/2224")]
         [WpfFact]
-        public void DontSmartFormatBracesOnSmartIndentNone()
+        public void DoNotSmartFormatBracesOnSmartIndentNone()
         {
             var code = @"class Program<T>
 {

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -3029,7 +3029,7 @@ index: 0);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543813")]
-        public async Task DontAddBlankLineBetweenFields()
+        public async Task DoNotAddBlankLineBetweenFields()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -3061,7 +3061,7 @@ index: ReadonlyFieldIndex);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543813")]
-        public async Task DontAddBlankLineBetweenAutoProperties()
+        public async Task DoNotAddBlankLineBetweenAutoProperties()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -10583,7 +10583,7 @@ index: PropertyIndex);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/45367")]
-        public async Task DontOfferPropertyOrFieldInNamespace()
+        public async Task DoNotOfferPropertyOrFieldInNamespace()
         {
             await TestExactActionSetOfferedAsync(
                 """

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -6279,7 +6279,7 @@ class C : I
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/941469")]
-        public async Task TestDontImplementDisposePatternForLocallyDefinedIDisposable()
+        public async Task TestDoNotImplementDisposePatternForLocallyDefinedIDisposable()
         {
             await TestWithAllCodeStyleOptionsOffAsync(
                 """
@@ -6313,7 +6313,7 @@ class C : I
         }
 
         [Fact]
-        public async Task TestDontImplementDisposePatternForStructures1()
+        public async Task TestDoNotImplementDisposePatternForStructures1()
         {
             await TestWithAllCodeStyleOptionsOffAsync(
                 """
@@ -6334,7 +6334,7 @@ class C : I
         }
 
         [Fact]
-        public async Task TestDontImplementDisposePatternForStructures2()
+        public async Task TestDoNotImplementDisposePatternForStructures2()
         {
             await TestWithAllCodeStyleOptionsOffAsync(
                 """

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -1849,7 +1849,7 @@ namespace TestNs2
         }
 
         [Fact]
-        public async Task TestMoveExtensionMethodDontRefactor()
+        public async Task TestMoveExtensionMethodDoNotRefactor()
         {
             var initialMarkup = @"
 namespace TestNs1

--- a/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
@@ -1086,7 +1086,7 @@ $@"{typeKind} Program
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537614")]
         [InlineData("class")]
         [InlineData("record")]
-        public async Task TestDontMoveBanner(string typeKind)
+        public async Task TestDoNotMoveBanner(string typeKind)
         {
             var initial =
 $@"{typeKind} Program
@@ -1121,7 +1121,7 @@ $@"{typeKind} Program
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537614")]
         [InlineData("class")]
         [InlineData("record")]
-        public async Task TestDontMoveBanner2(string typeKind)
+        public async Task TestDoNotMoveBanner2(string typeKind)
         {
             var initial =
 $@"{typeKind} Program

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -2215,7 +2215,7 @@ enum E$$ : {underlyingTypeName}
         [InlineData("")]
         [InlineData(": int")]
         [InlineData(": System.Int32")]
-        public async Task EnumNonDefaultUnderlyingType_DontShowForDefaultType(string defaultType)
+        public async Task EnumNonDefaultUnderlyingType_DoNotShowForDefaultType(string defaultType)
         {
             await TestInClassAsync(@$"
 enum E$$ {defaultType}
@@ -4216,7 +4216,7 @@ class myClass
         }
 
         [Fact]
-        public async Task DontRemoveAttributeSuffixAndProduceInvalidIdentifier1()
+        public async Task DoNotRemoveAttributeSuffixAndProduceInvalidIdentifier1()
         {
             await TestAsync(
 @"using System;
@@ -4229,7 +4229,7 @@ class classAttribute : Attribute
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544026")]
-        public async Task DontRemoveAttributeSuffix2()
+        public async Task DoNotRemoveAttributeSuffix2()
         {
             await TestAsync(
 @"using System;

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_AsTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests_AsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
             => (new CSharpRemoveUnnecessaryCastDiagnosticAnalyzer(), new CSharpRemoveUnnecessaryCastCodeFixProvider());
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545979")]
-        public async Task DontRemoveCastToErrorType()
+        public async Task DoNotRemoveCastToErrorType()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545138")]
-        public async Task DontRemoveTypeParameterCastToObject()
+        public async Task DoNotRemoveTypeParameterCastToObject()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545139")]
-        public async Task DontRemoveCastInIsTest()
+        public async Task DoNotRemoveCastInIsTest()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545142")]
-        public async Task DontRemoveCastNeedForUserDefinedOperator()
+        public async Task DoNotRemoveCastNeedForUserDefinedOperator()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545143")]
-        public async Task DontRemovePointerCast1()
+        public async Task DoNotRemovePointerCast1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545144")]
-        public async Task DontRemoveCastToObjectFromDelegateComparison()
+        public async Task DoNotRemoveCastToObjectFromDelegateComparison()
         {
             // The cast below can't be removed because it would result in the Delegate
             // op_Equality operator overload being used over reference equality.
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545145")]
-        public async Task DontRemoveCastToAnonymousMethodWhenOnLeftOfAsCast()
+        public async Task DoNotRemoveCastToAnonymousMethodWhenOnLeftOfAsCast()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545157")]
-        public async Task DontRemoveIdentityCastWhichAffectsOverloadResolution1()
+        public async Task DoNotRemoveIdentityCastWhichAffectsOverloadResolution1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545158")]
-        public async Task DontRemoveIdentityCastWhichAffectsOverloadResolution2()
+        public async Task DoNotRemoveIdentityCastWhichAffectsOverloadResolution2()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545158")]
-        public async Task DontRemoveIdentityCastWhichAffectsOverloadResolution3()
+        public async Task DoNotRemoveIdentityCastWhichAffectsOverloadResolution3()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545747")]
-        public async Task DontRemoveCastWhichChangesTypeOfInferredLocal()
+        public async Task DoNotRemoveCastWhichChangesTypeOfInferredLocal()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545159")]
-        public async Task DontRemoveNeededCastToIListOfObject()
+        public async Task DoNotRemoveNeededCastToIListOfObject()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545291")]
-        public async Task DontRemoveNeededCastInConditionalExpression()
+        public async Task DoNotRemoveNeededCastInConditionalExpression()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -625,7 +625,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
 
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529787")]
         [WpfFact(Skip = "529787")]
-        public async Task DontRemoveNecessaryCastWhichInCollectionInitializer1()
+        public async Task DoNotRemoveNecessaryCastWhichInCollectionInitializer1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
 
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529787")]
         [WpfFact(Skip = "529787")]
-        public async Task DontRemoveNecessaryCastWhichInCollectionInitializer2()
+        public async Task DoNotRemoveNecessaryCastWhichInCollectionInitializer2()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -709,7 +709,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545608")]
-        public async Task DontRemoveNecessaryCastWithImplicitUserDefinedConversion()
+        public async Task DoNotRemoveNecessaryCastWithImplicitUserDefinedConversion()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545941")]
-        public async Task DontRemoveNecessaryCastWithImplicitConversionInThrow()
+        public async Task DoNotRemoveNecessaryCastWithImplicitConversionInThrow()
         {
             // The cast below can't be removed because the throw statement expects
             // an expression of type Exception -- not an expression convertible to
@@ -756,7 +756,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545981")]
-        public async Task DontRemoveNecessaryCastInThrow()
+        public async Task DoNotRemoveNecessaryCastInThrow()
         {
             // The cast below can't be removed because the throw statement expects
             // an expression of type Exception -- not an expression convertible to
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545945")]
-        public async Task DontRemoveNecessaryDowncast()
+        public async Task DoNotRemoveNecessaryDowncast()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -822,7 +822,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545606")]
-        public async Task DontRemoveNecessaryCastFromNullToTypeParameter()
+        public async Task DoNotRemoveNecessaryCastFromNullToTypeParameter()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -837,7 +837,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545744")]
-        public async Task DontRemoveNecessaryCastInImplicitlyTypedArray()
+        public async Task DoNotRemoveNecessaryCastInImplicitlyTypedArray()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -952,7 +952,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529816")]
-        public async Task DontRemoveNecessaryCastInQueryExpression()
+        public async Task DoNotRemoveNecessaryCastInQueryExpression()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -980,7 +980,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529831")]
-        public async Task DontRemoveNecessaryCastFromTypeParameterToInterface()
+        public async Task DoNotRemoveNecessaryCastFromTypeParameterToInterface()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1121,7 +1121,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545877")]
-        public async Task DontCrashOnIncompleteMethodDeclaration()
+        public async Task DoNotCrashOnIncompleteMethodDeclaration()
         {
             await TestInRegularAndScriptAsync(
                 """
@@ -1213,7 +1213,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529846")]
-        public async Task DontRemoveNecessaryCastFromTypeParameterToObject()
+        public async Task DoNotRemoveNecessaryCastFromTypeParameterToObject()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1230,7 +1230,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545858")]
-        public async Task DontRemoveNecessaryCastFromDelegateTypeToMulticastDelegate()
+        public async Task DoNotRemoveNecessaryCastFromDelegateTypeToMulticastDelegate()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1249,7 +1249,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529842")]
-        public async Task DontRemoveNecessaryCastInTernaryExpression()
+        public async Task DoNotRemoveNecessaryCastInTernaryExpression()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1321,7 +1321,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545957")]
-        public async Task DontRemoveCastInConstructorInitializer3()
+        public async Task DoNotRemoveCastInConstructorInitializer3()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1386,7 +1386,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545962")]
-        public async Task DontRemoveCastWhenExpressionDoesntBind()
+        public async Task DoNotRemoveCastWhenExpressionDoesntBind()
         {
             // Note: The cast below can't be removed because its expression doesn't bind.
 
@@ -1405,7 +1405,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545944")]
-        public async Task DontRemoveNecessaryCastBeforePointerDereference1()
+        public async Task DoNotRemoveNecessaryCastBeforePointerDereference1()
         {
             // Note: The cast below can't be removed because it would result in *null,
             // which is illegal.
@@ -1420,7 +1420,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545978")]
-        public async Task DontRemoveNecessaryCastBeforePointerDereference2()
+        public async Task DoNotRemoveNecessaryCastBeforePointerDereference2()
         {
             // Note: The cast below can't be removed because it would result in dereferencing
             // void*, which is illegal.
@@ -1439,7 +1439,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/26640")]
-        public async Task DontRemoveCastToByteFromIntInConditionalExpression_CSharp8()
+        public async Task DoNotRemoveCastToByteFromIntInConditionalExpression_CSharp8()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1454,7 +1454,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/26640")]
-        public async Task DontRemoveCastToByteFromIntInConditionalExpression_CSharp9()
+        public async Task DoNotRemoveCastToByteFromIntInConditionalExpression_CSharp9()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -1471,7 +1471,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         #region Interface Casts
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545889")]
-        public async Task DontRemoveCastToInterfaceForUnsealedType()
+        public async Task DoNotRemoveCastToInterfaceForUnsealedType()
         {
             // Note: The cast below can't be removed because X is not sealed.
 
@@ -1638,7 +1638,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545890")]
-        public async Task DontRemoveCastToInterfaceForSealedType4()
+        public async Task DoNotRemoveCastToInterfaceForSealedType4()
         {
             // Note: The cast below can't be removed (even though C is sealed)
             // because the unspecified optional parameter default values differ.
@@ -1716,7 +1716,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545888")]
-        public async Task DontRemoveCastToInterfaceForSealedType6()
+        public async Task DoNotRemoveCastToInterfaceForSealedType6()
         {
             // Note: The cast below can't be removed (even though C is sealed)
             // because the specified named arguments refer to parameters that
@@ -1777,7 +1777,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545888")]
-        public async Task DontRemoveCastToInterfaceForSealedType8()
+        public async Task DoNotRemoveCastToInterfaceForSealedType8()
         {
             // Note: The cast below can't be removed (even though C is sealed)
             // because the specified named arguments refer to parameters that
@@ -1811,7 +1811,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545883")]
-        public async Task DontRemoveCastToInterfaceForSealedType9()
+        public async Task DoNotRemoveCastToInterfaceForSealedType9()
         {
             // Note: The cast below can't be removed (even though C is sealed)
             // because it would result in binding to a Dispose method that doesn't
@@ -1839,7 +1839,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545887")]
-        public async Task DontRemoveCastToInterfaceForStruct1()
+        public async Task DoNotRemoveCastToInterfaceForStruct1()
         {
             // Note: The cast below can't be removed because the cast boxes 's' and
             // unboxing would change program behavior.
@@ -2027,7 +2027,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         #region ParamArray Parameter Casts
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545141")]
-        public async Task DontRemoveCastToObjectInParamArrayArg1()
+        public async Task DoNotRemoveCastToObjectInParamArrayArg1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2049,7 +2049,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529911")]
-        public async Task DontRemoveCastToIntArrayInParamArrayArg2()
+        public async Task DoNotRemoveCastToIntArrayInParamArrayArg2()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2071,7 +2071,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529911")]
-        public async Task DontRemoveCastToObjectArrayInParamArrayArg3()
+        public async Task DoNotRemoveCastToObjectArrayInParamArrayArg3()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2270,7 +2270,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         #region ForEach Statements
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545961")]
-        public async Task DontRemoveNecessaryCastInForEach1()
+        public async Task DoNotRemoveNecessaryCastInForEach1()
         {
             // The cast below can't be removed because it would result an error
             // in the foreach statement.
@@ -2293,7 +2293,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545961")]
-        public async Task DontRemoveNecessaryCastInForEach2()
+        public async Task DoNotRemoveNecessaryCastInForEach2()
         {
             // The cast below can't be removed because it would result an error
             // in the foreach statement.
@@ -2316,7 +2316,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545961")]
-        public async Task DontRemoveNecessaryCastInForEach3()
+        public async Task DoNotRemoveNecessaryCastInForEach3()
         {
             // The cast below can't be removed because it would result an error
             // in the foreach statement since C doesn't contain a GetEnumerator()
@@ -2353,7 +2353,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545961")]
-        public async Task DontRemoveNecessaryCastInForEach4()
+        public async Task DoNotRemoveNecessaryCastInForEach4()
         {
             // The cast below can't be removed because it would result in
             // C.GetEnumerator() being called rather than D.GetEnumerator().
@@ -2396,7 +2396,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545961")]
-        public async Task DontRemoveNecessaryCastInForEach5()
+        public async Task DoNotRemoveNecessaryCastInForEach5()
         {
             // The cast below can't be removed because it would change the
             // type of 'x'.
@@ -2425,7 +2425,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         #endregion
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545925")]
-        public async Task DontRemoveCastIfOverriddenMethodHasIncompatibleParameterList()
+        public async Task DoNotRemoveCastIfOverriddenMethodHasIncompatibleParameterList()
         {
             // Note: The cast below can't be removed because the parameter list
             // of Goo and its override have different default values.
@@ -2568,7 +2568,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/624252")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608180")]
-        public async Task DontRemoveCastIfArgumentIsRestricted_TypedReference()
+        public async Task DoNotRemoveCastIfArgumentIsRestricted_TypedReference()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2594,7 +2594,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithOtherDynamicArguments()
+        public async Task DoNotRemoveCastOnArgumentsWithOtherDynamicArguments()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2628,7 +2628,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithOtherDynamicArguments_Bracketed()
+        public async Task DoNotRemoveCastOnArgumentsWithOtherDynamicArguments_Bracketed()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2667,7 +2667,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithDynamicReceiverOpt()
+        public async Task DoNotRemoveCastOnArgumentsWithDynamicReceiverOpt()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2683,7 +2683,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithDynamicReceiverOpt_1()
+        public async Task DoNotRemoveCastOnArgumentsWithDynamicReceiverOpt_1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2699,7 +2699,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithDynamicReceiverOpt_2()
+        public async Task DoNotRemoveCastOnArgumentsWithDynamicReceiverOpt_2()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2715,7 +2715,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithDynamicReceiverOpt_3()
+        public async Task DoNotRemoveCastOnArgumentsWithDynamicReceiverOpt_3()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2731,7 +2731,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627107")]
-        public async Task DontRemoveCastOnArgumentsWithOtherDynamicArguments_1()
+        public async Task DoNotRemoveCastOnArgumentsWithOtherDynamicArguments_1()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2765,7 +2765,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529846")]
-        public async Task DontUnnecessaryCastFromTypeParameterToObject()
+        public async Task DoNotUnnecessaryCastFromTypeParameterToObject()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2813,7 +2813,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/626026")]
-        public async Task DontRemoveCastIfUserDefinedExplicitCast()
+        public async Task DoNotRemoveCastIfUserDefinedExplicitCast()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2841,7 +2841,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770187")]
-        public async Task DontRemoveNecessaryCastInSwitchExpression()
+        public async Task DoNotRemoveNecessaryCastInSwitchExpression()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2873,7 +2873,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2761")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/844482")]
-        public async Task DontRemoveCastFromBaseToDerivedWithExplicitReference()
+        public async Task DoNotRemoveCastFromBaseToDerivedWithExplicitReference()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2898,7 +2898,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/3254")]
-        public async Task DontRemoveCastToTypeParameterWithExceptionConstraint()
+        public async Task DoNotRemoveCastToTypeParameterWithExceptionConstraint()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2918,7 +2918,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/3254")]
-        public async Task DontRemoveCastToTypeParameterWithExceptionSubTypeConstraint()
+        public async Task DoNotRemoveCastToTypeParameterWithExceptionSubTypeConstraint()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2938,7 +2938,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8111")]
-        public async Task DontRemoveCastThatChangesShapeOfAnonymousTypeObject()
+        public async Task DoNotRemoveCastThatChangesShapeOfAnonymousTypeObject()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -2978,7 +2978,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/18978")]
-        public async Task DontRemoveCastOnCallToMethodWithParamsArgs()
+        public async Task DoNotRemoveCastOnCallToMethodWithParamsArgs()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3089,7 +3089,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20630")]
-        public async Task DontRemoveCastOnCallToAttributeWithParamsArgs()
+        public async Task DoNotRemoveCastOnCallToAttributeWithParamsArgs()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3154,7 +3154,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20630")]
-        public async Task DontRemoveCastOnCallToAttributeWithParamsArgsAndProperty()
+        public async Task DoNotRemoveCastOnCallToAttributeWithParamsArgsAndProperty()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3175,7 +3175,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20630")]
-        public async Task DontRemoveCastOnCallToAttributeWithParamsArgsPropertyAndOtherArg()
+        public async Task DoNotRemoveCastOnCallToAttributeWithParamsArgsPropertyAndOtherArg()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3196,7 +3196,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20630")]
-        public async Task DontRemoveCastOnCallToAttributeWithParamsArgsNamedArgsAndProperty()
+        public async Task DoNotRemoveCastOnCallToAttributeWithParamsArgsNamedArgsAndProperty()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3314,7 +3314,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25456#issuecomment-373549735")]
-        public async Task DontIntroduceDefaultLiteralInSwitchCase()
+        public async Task DoNotIntroduceDefaultLiteralInSwitchCase()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3333,7 +3333,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact]
-        public async Task DontIntroduceDefaultLiteralInSwitchCase_CastInsideParentheses()
+        public async Task DoNotIntroduceDefaultLiteralInSwitchCase_CastInsideParentheses()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3352,7 +3352,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact]
-        public async Task DontIntroduceDefaultLiteralInSwitchCase_DefaultInsideParentheses()
+        public async Task DoNotIntroduceDefaultLiteralInSwitchCase_DefaultInsideParentheses()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3371,7 +3371,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/27239")]
-        public async Task DontOfferToRemoveCastWhereNoConversionExists()
+        public async Task DoNotOfferToRemoveCastWhereNoConversionExists()
         {
             await TestMissingInRegularAndScriptAsync(
                 """
@@ -3389,7 +3389,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryCast
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/28412")]
-        public async Task DontOfferToRemoveCastWhenAccessingHiddenProperty()
+        public async Task DoNotOfferToRemoveCastWhenAccessingHiddenProperty()
         {
             await TestMissingInRegularAndScriptAsync("""
                 using System.Collections.Generic;

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedVariable
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedVariable)]
         [WorkItem("https://github.com/dotnet/roslyn/issues/49827")]
-        public async Task DontCrashOnDeclarationInsideIfStatement()
+        public async Task DoNotCrashOnDeclarationInsideIfStatement()
         {
             await TestMissingInRegularAndScriptAsync(
                 """

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
             Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
         {
-            if (options.ExtractOptions.DontPutOutOrRefOnStruct || !result.Reasons.IsSingle())
+            if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
                 return null;
 
             var reason = result.Reasons.FirstOrDefault();
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     document,
                     span,
                     localFunction: false,
-                    options with { ExtractOptions = options.ExtractOptions with { DontPutOutOrRefOnStruct = true } },
+                    options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
                     cancellationToken).ConfigureAwait(false);
 
                 // retry succeeded, return new result

--- a/src/EditorFeatures/Test2/Expansion/NameExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/NameExpansionTests.vb
@@ -151,7 +151,7 @@ namespace NS
         End Function
 
         <Fact>
-        Public Async Function TestCSharp_GenericNameExpansion_DontExpandAnonymousTypes() As Task
+        Public Async Function TestCSharp_GenericNameExpansion_DoNotExpandAnonymousTypes() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -186,7 +186,7 @@ class C
         End Function
 
         <Fact>
-        Public Async Function TestCSharp_LambdaParameter_DontExpandAnonymousTypes1() As Task
+        Public Async Function TestCSharp_LambdaParameter_DoNotExpandAnonymousTypes1() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -223,7 +223,7 @@ class C
         End Function
 
         <Fact>
-        Public Async Function TestCSharp_LambdaParameter_DontExpandAnonymousTypes2() As Task
+        Public Async Function TestCSharp_LambdaParameter_DoNotExpandAnonymousTypes2() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -260,7 +260,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/11979")>
-        Public Async Function TestCSharp_LambdaParameter_DontExpandAnonymousTypes2_variation() As Task
+        Public Async Function TestCSharp_LambdaParameter_DoNotExpandAnonymousTypes2_variation() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -1366,7 +1366,7 @@ class C
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538726")>
         <WpfTheory, CombinatorialData>
-        Public Async Function TestOrdinaryMethodInterfaceMethodsDontCascadeThroughOtherInterfaceMethods1(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceMethodsDoNotCascadeThroughOtherInterfaceMethods1(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1393,7 +1393,7 @@ class C
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538726")>
         <WpfTheory, CombinatorialData>
-        Public Async Function TestOrdinaryMethodInterfaceMethodsDontCascadeThroughOtherInterfaceMethods2(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceMethodsDoNotCascadeThroughOtherInterfaceMethods2(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1420,7 +1420,7 @@ class C
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538726")>
         <WpfTheory, CombinatorialData>
-        Public Async Function TestOrdinaryMethodInterfaceMethodsDontCascadeThroughOtherInterfaceMethods3(kind As TestKind, host As TestHost) As Task
+        Public Async Function TestOrdinaryMethodInterfaceMethodsDoNotCascadeThroughOtherInterfaceMethods3(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -8053,7 +8053,7 @@ namespace NS2
 
         <WorkItem("https://github.com/dotnet/roslyn/issues/39519")>
         <WpfTheory, CombinatorialData>
-        Public Async Function TestSuggestedNamesDontStartWithDigit_DigitsInTheMiddle(showCompletionInArgumentLists As Boolean) As Task
+        Public Async Function TestSuggestedNamesDoNotStartWithDigit_DigitsInTheMiddle(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                   <Document><![CDATA[
 namespace NS
@@ -8082,7 +8082,7 @@ namespace NS
 
         <WorkItem("https://github.com/dotnet/roslyn/issues/39519")>
         <WpfTheory, CombinatorialData>
-        Public Async Function TestSuggestedNamesDontStartWithDigit_DigitsOnTheRight(showCompletionInArgumentLists As Boolean) As Task
+        Public Async Function TestSuggestedNamesDoNotStartWithDigit_DigitsOnTheRight(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                   <Document><![CDATA[
 namespace NS

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
@@ -871,7 +871,7 @@ class C
 
         <WorkItem("https://github.com/dotnet/roslyn/issues/5174")>
         <WpfTheory, CombinatorialData>
-        Public Async Function DontShowSignatureHelpIfOptionIsTurnedOffUnlessExplicitlyInvoked(showCompletionInArgumentLists As Boolean) As Task
+        Public Async Function DoNotShowSignatureHelpIfOptionIsTurnedOffUnlessExplicitlyInvoked(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                               <Document>
 class C

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -1097,7 +1097,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544471")>
         <WpfFact>
-        Public Async Function TestDontCrashOnEmptyParameterList() As Task
+        Public Async Function TestDoNotCrashOnEmptyParameterList() As Task
             Using state = TestStateFactory.CreateVisualBasicTestState(
                               <Document>
 &lt;Obsolete()$$&gt;

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
@@ -273,7 +273,7 @@ End Class
 
         <WorkItem("https://github.com/dotnet/roslyn/issues/5174")>
         <WpfFact>
-        Public Async Function DontShowSignatureHelpIfOptionIsTurnedOffUnlessExplicitlyInvoked() As Task
+        Public Async Function DoNotShowSignatureHelpIfOptionIsTurnedOffUnlessExplicitlyInvoked() As Task
             Using state = TestStateFactory.CreateVisualBasicTestState(
                               <Document>
 Class C

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -5736,7 +5736,7 @@ End Module
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/641231")>
-        Public Sub RenameDontReplaceBaseConstructorToken_CSharp(host As RenameTestHost)
+        Public Sub RenameDoNotReplaceBaseConstructorToken_CSharp(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -5766,7 +5766,7 @@ class Program
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/641231")>
-        Public Sub RenameDontReplaceBaseConstructorToken_VisualBasic(host As RenameTestHost)
+        Public Sub RenameDoNotReplaceBaseConstructorToken_VisualBasic(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -5284,7 +5284,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/5314")>
-        Public Async Function TestCSharp_DontRemove_NecessaryCastToObjectInConditionalExpression() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryCastToObjectInConditionalExpression() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5317,7 +5317,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/6490")>
-        Public Async Function TestCSharp_DontRemove_NecessaryCastOfLambdaToDelegateWithDynamic() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryCastOfLambdaToDelegateWithDynamic() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5356,7 +5356,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/6966")>
-        Public Async Function TestCSharp_DontRemove_NecessaryCastToNullInImplicitlyTypedArray() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryCastToNullInImplicitlyTypedArray() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5395,7 +5395,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7861")>
-        Public Async Function TestCSharp_DontRemove_NecessaryCastOnNullableAssignedToDynamic() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryCastOnNullableAssignedToDynamic() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5438,7 +5438,7 @@ static void Main(string[] args)
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/10311")>
-        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean1() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryUnboxingCastFromObjectToBoolean1() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5473,7 +5473,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/10311")>
-        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean2() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryUnboxingCastFromObjectToBoolean2() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5508,7 +5508,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/10311")>
-        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean1_ExpressionBody() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryUnboxingCastFromObjectToBoolean1_ExpressionBody() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5535,7 +5535,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/10311")>
-        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean2_ExpressionBody() As Task
+        Public Async Function TestCSharp_DoNotRemove_NecessaryUnboxingCastFromObjectToBoolean2_ExpressionBody() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -5688,7 +5688,7 @@ class Program
 #Region "Visual Basic tests"
 
         <Fact>
-        Public Async Function TestVisualBasic_DontRemove_IntToObj_Overloads1() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntToObj_Overloads1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -5726,7 +5726,7 @@ End Class
         End Function
 
         <Fact>
-        Public Async Function TestVisualBasic_DontRemove_IntToLng_Overloads2() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntToLng_Overloads2() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -5955,7 +5955,7 @@ End Class
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530083")>
         <WorkItem("https://github.com/dotnet/roslyn/issues/2761")>
-        Public Async Function TestVisualBasic_DontRemove_InsideThrowStatement2() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_InsideThrowStatement2() As Task
             ' We can't remove cast from base to derived, as we cannot be sure that the cast will succeed at runtime.
             Dim input =
 <Workspace>
@@ -8534,7 +8534,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/995855")>
-        Public Async Function TestVisualBasic_DontRemove_NecessaryCastInTernaryExpression1() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_NecessaryCastInTernaryExpression1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -8567,7 +8567,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/995855")>
-        Public Async Function TestVisualBasic_DontRemove_NecessaryCastInTernaryExpression2() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_NecessaryCastInTernaryExpression2() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -8995,7 +8995,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/5314")>
-        Public Async Function TestVisualBasic_DontRemove_NecessaryCastToObjectInConditionalExpression() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_NecessaryCastToObjectInConditionalExpression() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -9024,7 +9024,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/5685")>
-        Public Async Function TestVisualBasic_DontRemove_NecessaryCastToNullable1() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_NecessaryCastToNullable1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -9171,7 +9171,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2560")>
-        Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn1() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntegerToByte_OptionStrictOn1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -9202,7 +9202,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2560")>
-        Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn2() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntegerToByte_OptionStrictOn2() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -9235,7 +9235,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2560")>
-        Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn3() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntegerToByte_OptionStrictOn3() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -9268,7 +9268,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2560")>
-        Public Async Function TestVisualBasic_DontRemove_IntegerToByte_OptionStrictOn4() As Task
+        Public Async Function TestVisualBasic_DoNotRemove_IntegerToByte_OptionStrictOn4() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/InitializerSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/InitializerSimplificationTests.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
 #Region "VB tests"
 
         <Fact>
-        Public Async Function TestVisualBasic_DontRemovePropertyNameForObjectCreationInitializer() As Task
+        Public Async Function TestVisualBasic_DoNotRemovePropertyNameForObjectCreationInitializer() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/ModuleNameSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ModuleNameSimplificationTests.vb
@@ -165,7 +165,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608198")>
-        Public Async Function TestDontSimplifyModuleNameInFieldInitializerAndConflictOfModuleNameAndField() As Task
+        Public Async Function TestDoNotSimplifyModuleNameInFieldInitializerAndConflictOfModuleNameAndField() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -188,7 +188,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608198")>
-        Public Async Function TestDontSimplifyModuleNameInFieldInitializerAndConflictOfModuleNameAndField_2() As Task
+        Public Async Function TestDoNotSimplifyModuleNameInFieldInitializerAndConflictOfModuleNameAndField_2() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
 
 #Region "VB"
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2211")>
-        Public Async Function TestVisualBasic_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -170,7 +170,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4490")>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsLessThan() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsLessThan() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -201,7 +201,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4490")>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsGreaterThan() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsGreaterThan() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -232,7 +232,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4490")>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsLessThan() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveParenthesesAroundXmlElementWhenPreviousTokenIsLessThan() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -263,7 +263,7 @@ End Class
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4490")>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsGreaterThan() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveParenthesesAroundXmlElementWhenPreviousTokenIsGreaterThan() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -452,7 +452,7 @@ End Class
 #Region "VB Array Literal tests"
 
         <Fact>
-        Public Async Function TestVisualBasic_DontRemoveInJaggedArrayLiteral() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveInJaggedArrayLiteral() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -480,7 +480,7 @@ End Class
         End Function
 
         <Fact>
-        Public Async Function TestVisualBasic_DontRemoveInCollectionInitializer() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveInCollectionInitializer() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -667,7 +667,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633582")>
-        Public Async Function TestVisualBasic_DontSimplifyOnRightSideOfBinaryExpressionIfOperatorsAreNotCommutative() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyOnRightSideOfBinaryExpressionIfOperatorsAreNotCommutative() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -1287,7 +1287,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2211")>
-        Public Async Function TestCSharp_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+        Public Async Function TestCSharp_DoNotRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1555,7 +1555,7 @@ class Program
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633582")>
-        Public Async Function TestCSharp_DontSimplifyOnRightSideOfBinaryExpressionIfOperatorsAreNotCommutative() As Task
+        Public Async Function TestCSharp_DoNotSimplifyOnRightSideOfBinaryExpressionIfOperatorsAreNotCommutative() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1652,7 +1652,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/11958")>
-        Public Async Function TestCSharp_DontSimplifyIfItWouldChangeStringConcatenation() As Task
+        Public Async Function TestCSharp_DoNotSimplifyIfItWouldChangeStringConcatenation() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1683,7 +1683,7 @@ class C
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/11958")>
-        Public Async Function TestCSharp_DontSimplifyIfOperatorOverloadsWouldNoLongerByCalled() As Task
+        Public Async Function TestCSharp_DoNotSimplifyIfOperatorOverloadsWouldNoLongerByCalled() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeInferenceSimplifierTests.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
     Public Class TypeInferenceSimplifierTests
         Inherits AbstractSimplificationTests
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/734369")>
-        Public Async Function TestDontSimplify1() As Task
+        Public Async Function TestDoNotSimplify1() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
         End Function
 
         <Fact>
-        Public Async Function TestDontSimplify_Using() As Task
+        Public Async Function TestDoNotSimplify_Using() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
         End Function
 
         <Fact>
-        Public Async Function TestDontSimplify_For_0() As Task
+        Public Async Function TestDoNotSimplify_For_0() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -201,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
         End Function
 
         <Fact>
-        Public Async Function TestDontSimplify_For_1() As Task
+        Public Async Function TestDoNotSimplify_For_1() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
@@ -1652,7 +1652,7 @@ class Program
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/649385")>
-        Public Async Function TestCSharpSimplifyToVarDontSimplify() As Task
+        Public Async Function TestCSharpSimplifyToVarDoNotSimplify() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -1945,7 +1945,7 @@ class Program
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838109")>
-        Public Async Function TestDontSimplifyToGenericNameCSharp() As Task
+        Public Async Function TestDoNotSimplifyToGenericNameCSharp() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -2063,7 +2063,7 @@ class E
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838109")>
-        Public Async Function TestDontSimplifyAllNodes_SimplifyNestedType() As Task
+        Public Async Function TestDoNotSimplifyAllNodes_SimplifyNestedType() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -2254,7 +2254,7 @@ namespace A
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/966633")>
-        Public Async Function TestCSharp_DontSimplifyNullableQualifiedName() As Task
+        Public Async Function TestCSharp_DoNotSimplifyNullableQualifiedName() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -2284,7 +2284,7 @@ class C
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/965240")>
-        Public Async Function TestCSharp_DontSimplifyOpenGenericNullable() As Task
+        Public Async Function TestCSharp_DoNotSimplifyOpenGenericNullable() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -2390,7 +2390,7 @@ namespace N
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2232")>
-        Public Async Function TestCSharp_DontSimplifyToPredefinedTypeNameInQualifiedName() As Task
+        Public Async Function TestCSharp_DoNotSimplifyToPredefinedTypeNameInQualifiedName() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -2430,7 +2430,7 @@ namespace N
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4859")>
-        Public Async Function TestCSharp_DontSimplifyNullableInNameOfExpression() As Task
+        Public Async Function TestCSharp_DoNotSimplifyNullableInNameOfExpression() As Task
             Dim input =
         <Workspace>
             <Project Language="C#" CommonReferences="true">
@@ -4721,7 +4721,7 @@ End Class]]>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838109")>
-        Public Async Function TestVisualBasic_DontSimplifyToGenericName() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyToGenericName1() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -4772,7 +4772,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838109")>
-        Public Async Function TestVisualBasic_DoNotSimplifyToGenericName() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyToGenericName2() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -4823,7 +4823,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838109")>
-        Public Async Function TestVisualBasic_TestDontSimplifyAllNodes_SimplifyNestedType() As Task
+        Public Async Function TestVisualBasic_TestDoNotSimplifyAllNodes_SimplifyNestedType() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -4908,7 +4908,7 @@ End Class]]></text>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/881746")>
-        Public Async Function TestVisualBasic_DontSimplifyAlias() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyAlias() As Task
 
             Dim input =
         <Workspace>
@@ -4945,7 +4945,7 @@ End Class]]></text>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/966633")>
-        Public Async Function TestVisualBasic_DontSimplifyNullableQualifiedName() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyNullableQualifiedName() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -4979,7 +4979,7 @@ End Module]]></text>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/965240")>
-        Public Async Function TestVisualBasic_DontSimplifyOpenGenericNullable() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyOpenGenericNullable() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -5057,7 +5057,7 @@ End Module]]></text>
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/2232")>
-        Public Async Function TestVisualBasic_DontSimplifyToPredefinedTypeNameInQualifiedName() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyToPredefinedTypeNameInQualifiedName() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -5087,7 +5087,7 @@ End Module]]></text>
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4859")>
-        Public Async Function TestVisualBasic_DontSimplifyNullableInNameOfExpression() As Task
+        Public Async Function TestVisualBasic_DoNotSimplifyNullableInNameOfExpression() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -5795,11 +5795,11 @@ Class C
 End Class
 ]]></text>
 
-            Await TestAsync(input, expected, DontPreferIntrinsicPredefinedTypeKeywordInDeclaration)
+            Await TestAsync(input, expected, DoNotPreferIntrinsicPredefinedTypeKeywordInDeclaration)
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7955")>
-        Public Async Function DontUsePredefinedTypeKeyword() As Task
+        Public Async Function DoNotUsePredefinedTypeKeyword() As Task
             Dim input =
         <Workspace>
             <Project Language="Visual Basic" CommonReferences="true">
@@ -5827,7 +5827,7 @@ Class C
 End Class
 ]]></text>
 
-            Await TestAsync(input, expected, DontPreferIntrinsicPredefinedTypeKeywordInDeclaration)
+            Await TestAsync(input, expected, DoNotPreferIntrinsicPredefinedTypeKeywordInDeclaration)
         End Function
 
         <Fact>
@@ -5894,7 +5894,7 @@ End Class
             Return New OptionsCollection(languageName) From {{CodeStyleOptions2.QualifyPropertyAccess, New CodeStyleOption2(Of Boolean)(True, notification)}}
         End Function
 
-        Private Shared ReadOnly DontPreferIntrinsicPredefinedTypeKeywordInDeclaration As New OptionsCollection(LanguageNames.VisualBasic) From
+        Private Shared ReadOnly DoNotPreferIntrinsicPredefinedTypeKeywordInDeclaration As New OptionsCollection(LanguageNames.VisualBasic) From
             {{CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, CodeStyleOption2(Of Boolean).Default}}
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/AutomaticEndConstructCorrection/AutomaticEndConstructCorrectorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticEndConstructCorrection/AutomaticEndConstructCorrectorTests.vb
@@ -279,7 +279,7 @@ End Class</code>.Value
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539498")>
-        Public Sub TestDontThrowDueToSingleLineDeletion()
+        Public Sub TestDoNotThrowDueToSingleLineDeletion()
             Dim code = <code>Class A
     [|$$Sub M() : End Sub|]
 End Class</code>.Value

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -263,13 +263,13 @@ q = From"
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")>
-        Public Async Function TestDontColorThingsOtherThanFromInDeclaration(testHost As TestHost) As Task
+        Public Async Function TestDoNotColorThingsOtherThanFromInDeclaration(testHost As TestHost) As Task
             Await TestInExpressionAsync("Fro ", testHost)
         End Function
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")>
-        Public Async Function TestDontColorThingsOtherThanFromInAssignment(testHost As TestHost) As Task
+        Public Async Function TestDoNotColorThingsOtherThanFromInAssignment(testHost As TestHost) As Task
             Dim code =
 "Dim q = 3
 q = Fro "
@@ -281,7 +281,7 @@ q = Fro "
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")>
-        Public Async Function TestDontColorFromWhenBoundInDeclaration(testHost As TestHost) As Task
+        Public Async Function TestDoNotColorFromWhenBoundInDeclaration(testHost As TestHost) As Task
             Dim code =
 "Dim From = 3
 Dim q = From"
@@ -293,7 +293,7 @@ Dim q = From"
 
         <Theory, CombinatorialData>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542685")>
-        Public Async Function TestDontColorFromWhenBoundInAssignment(testHost As TestHost) As Task
+        Public Async Function TestDoNotColorFromWhenBoundInAssignment(testHost As TestHost) As Task
             Dim code =
 "Dim From = 3
 Dim q = 3

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -111,7 +111,7 @@ Console.WriteLine(0)
         End Function
 
         <Fact>
-        Public Async Function TestSingleDeclaratorDontRemoveLeadingTrivia1() As Task
+        Public Async Function TestSingleDeclaratorDoNotRemoveLeadingTrivia1() As Task
             Dim code =
 <File>
 Imports System
@@ -145,7 +145,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545259")>
-        Public Async Function TestSingleDeclaratorDontRemoveLeadingTrivia2() As Task
+        Public Async Function TestSingleDeclaratorDoNotRemoveLeadingTrivia2() As Task
             Dim code =
 <File>
 Imports System
@@ -175,7 +175,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540330")>
-        Public Async Function TestSingleDeclaratorDontMoveNextStatement() As Task
+        Public Async Function TestSingleDeclaratorDoNotMoveNextStatement() As Task
             Dim code =
 <File>
 Module Program
@@ -1146,7 +1146,7 @@ Dim f As Func(Of Integer) = Function()
         End Function
 
         <Fact>
-        Public Async Function TestDontInlineTrailingComment() As Task
+        Public Async Function TestDoNotInlineTrailingComment() As Task
             Dim code =
 <MethodBody>
 Dim [||]i As Integer = 1 + 1 ' First
@@ -1163,7 +1163,7 @@ Console.WriteLine((1 + 1) * 2)
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545544")>
-        Public Async Function TestDontRemoveLineBreakAfterComment() As Task
+        Public Async Function TestDoNotRemoveLineBreakAfterComment() As Task
             Dim code =
 <MethodBody>
 Dim [||]x = 1 ' comment
@@ -1197,7 +1197,7 @@ Console.WriteLine((1 + 1) * j)
         End Function
 
         <Fact>
-        Public Async Function TestDontInsertUnnecessaryCast1() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast1() As Task
             Dim code =
 <MethodBody>
 Dim [||]i As Object = 1 + 1
@@ -1213,7 +1213,7 @@ Dim j As Integer = 1 + 1
         End Function
 
         <Fact>
-        Public Async Function TestDontInsertUnnecessaryCast2() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast2() As Task
             Dim code =
 <MethodBody>
 Dim [||]i As Integer = 1 + 1
@@ -1231,7 +1231,7 @@ Console.WriteLine(j)
         End Function
 
         <Fact>
-        Public Async Function TestDontInsertUnnecessaryCast3() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast3() As Task
             Dim code =
 <MethodBody>
 Dim [||]x As Action = Sub()
@@ -1249,7 +1249,7 @@ Dim y As Action = Sub()
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543215")>
-        Public Async Function TestDontInsertUnnecessaryCast4() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast4() As Task
             Dim code =
 <ClassDeclaration>
 Sub S
@@ -1275,7 +1275,7 @@ End Sub
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543280")>
-        Public Async Function TestDontInsertUnnecessaryCast5() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast5() As Task
             Dim code =
 <File>
 Option Strict On
@@ -1305,7 +1305,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544973")>
-        Public Async Function TestDontInsertUnnecessaryCast6() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast6() As Task
             Dim code =
 <File>
 Option Infer On
@@ -1337,7 +1337,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545975")>
-        Public Async Function TestDontInsertUnnecessaryCast7() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast7() As Task
             Dim code =
 <File>
 Imports System
@@ -1363,7 +1363,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545846")>
-        Public Async Function TestDontInsertUnnecessaryCast8() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast8() As Task
             Dim markup =
 <File>
 Option Strict On
@@ -1391,7 +1391,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545624"), WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/799045")>
-        Public Async Function TestDontInsertUnnecessaryCast9() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast9() As Task
             Dim markup =
 <File>
 Imports System.Collections.Generic
@@ -1422,7 +1422,7 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530068")>
-        Public Async Function TestDontInsertUnnecessaryCast10() As Task
+        Public Async Function TestDoNotInsertUnnecessaryCast10() As Task
             Dim markup =
 <File>
 Imports System
@@ -2606,7 +2606,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545539")>
-        Public Async Function TestDontOverparenthesizeXmlAttributeAccessExpression() As Task
+        Public Async Function TestDoNotOverparenthesizeXmlAttributeAccessExpression() As Task
             Dim code =
 <File>
 Imports System.Xml.Linq
@@ -2649,7 +2649,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546658")>
-        Public Async Function TestDontInlineInUnterminatedBlock() As Task
+        Public Async Function TestDoNotInlineInUnterminatedBlock() As Task
             Dim markup =
 <File>
 Interface IGoo
@@ -3700,7 +3700,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/718152")>
-        Public Async Function TestBugfix_718152_DontRemoveParenthesisForAwaitExpression() As Task
+        Public Async Function TestBugfix_718152_DoNotRemoveParenthesisForAwaitExpression() As Task
             Dim code =
 <File>
 Imports System
@@ -4032,7 +4032,7 @@ End With
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4583")>
-        Public Async Function TestDontParenthesizeInterpolatedStringWithNoInterpolation() As Task
+        Public Async Function TestDoNotParenthesizeInterpolatedStringWithNoInterpolation() As Task
             Dim code =
 <MethodBody>
 Dim [||]s1 = $"hello"
@@ -4048,7 +4048,7 @@ Dim s2 = AscW($"hello")
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/4583")>
-        Public Async Function TestDontParenthesizeInterpolatedStringWithInterpolation() As Task
+        Public Async Function TestDoNotParenthesizeInterpolatedStringWithInterpolation() As Task
             Dim code =
 <MethodBody>
 Dim x = 42

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -2229,7 +2229,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/682683")>
-        Public Async Function TestDontRemoveParenthesesIfOperatorPrecedenceWouldBeBroken() As Task
+        Public Async Function TestDoNotRemoveParenthesesIfOperatorPrecedenceWouldBeBroken() As Task
             Dim code =
 "
 Imports System
@@ -2257,7 +2257,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1022458")>
-        Public Async Function TestDontSimplifyParentUnlessEntireInnerNodeIsSelected() As Task
+        Public Async Function TestDoNotSimplifyParentUnlessEntireInnerNodeIsSelected() As Task
             Dim code =
 "
 Imports System

--- a/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
@@ -141,7 +141,7 @@ End Namespace
         End Function
 
         <WpfFact>
-        Public Async Function AddMissingImports_AddImportsAboveSystem_DontPlaceSystemFirstPasteContainsMultipleMissingImports() As Task
+        Public Async Function AddMissingImports_AddImportsAboveSystem_DoNotPlaceSystemFirstPasteContainsMultipleMissingImports() As Task
             Dim code = "
 Imports System
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/HandlesClauseCompletionProviderTests.vb
@@ -220,7 +220,7 @@ End Class</text>.Value
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/8307")>
-        Public Async Function DontCrashOnDotAfterCompleteHandlesClause() As Task
+        Public Async Function DoNotCrashOnDotAfterCompleteHandlesClause() As Task
             Dim text = "
 Imports System
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/NamedParameterCompletionProviderTests.vb
@@ -202,7 +202,7 @@ End Class
         End Function
 
         <Fact>
-        Public Async Function TestDontFilterYet() As Task
+        Public Async Function TestDoNotFilterYet() As Task
             Dim markup =
 <Text>
 Class Class1

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -185,7 +185,7 @@ End Class</a>
         End Function
 
         <WpfFact>
-        Public Async Function TestDontFilterIfNothingMatchesReturnTypeVoidness() As Task
+        Public Async Function TestDoNotFilterIfNothingMatchesReturnTypeVoidness() As Task
             Dim text = <a>MustInherit Class Base
     MustOverride Function Goo() As String
     Protected NotOverridable Overrides Sub Finalize()

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -6259,7 +6259,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1079694")>
-        Public Async Function TestDontThrowForNullPropagatingOperatorInErase() As Task
+        Public Async Function TestDoNotThrowForNullPropagatingOperatorInErase() As Task
             Dim text =
 <code><![CDATA[
 Module Program
@@ -6328,7 +6328,7 @@ End Class
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1079694")>
-        Public Async Function TestDontThrowForNullPropagatingOperatorOnTypeParameter() As Task
+        Public Async Function TestDoNotThrowForNullPropagatingOperatorOnTypeParameter() As Task
             Dim text =
 <code><![CDATA[
 Module Program

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -565,7 +565,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540017")>
         <WpfFact>
-        Public Sub TestPressingEnter_DontInsertApostrophes1()
+        Public Sub TestPressingEnter_DoNotInsertApostrophes1()
             Const code = "
 ''' <summary></summary>
 ''' $$

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorIfTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterHashIfWhenEndIfExists()
+        Public Sub DoNotApplyAfterHashIfWhenEndIfExists()
             VerifyStatementEndConstructNotApplied(
                 text:="#If True Then
 #End If",
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537976")>
-        Public Sub DontApplyAfterHashElseIfWhenEndIfExists()
+        Public Sub DoNotApplyAfterHashElseIfWhenEndIfExists()
             VerifyStatementEndConstructNotApplied(
                 text:="#If True Then
 #ElseIf True Then

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorRegionsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PreprocessorRegionsTests.vb
@@ -33,14 +33,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterHashRegionWithoutStringConstant()
+        Public Sub DoNotApplyAfterHashRegionWithoutStringConstant()
             VerifyStatementEndConstructNotApplied(
                 text:="#Region",
                 caret:={0, -1})
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterHashRegionWhenEndRegionExists1()
+        Public Sub DoNotApplyAfterHashRegionWhenEndRegionExists1()
             VerifyStatementEndConstructNotApplied(
                 text:="#Region ""Goo""
 #End Region",
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterHashRegionWhenEndRegionExists2()
+        Public Sub DoNotApplyAfterHashRegionWhenEndRegionExists2()
             VerifyStatementEndConstructNotApplied(
                 text:="#Region ""Goo""
 #Region ""Bar""
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterHashRegionWhenEndRegionExists3()
+        Public Sub DoNotApplyAfterHashRegionWhenEndRegionExists3()
             VerifyStatementEndConstructNotApplied(
                 text:="#Region ""Goo""
 #Region ""Bar""

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/PropertyBlockTests.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
     <Trait(Traits.Feature, Traits.Features.EndConstructGeneration)>
     Public Class PropertyBlockTests
         <WpfFact>
-        Public Sub DontApplyForAutoProperty()
+        Public Sub DoNotApplyForAutoProperty()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     Property goo As Integer
@@ -16,7 +16,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForAutoPropertyWithEmptyParens()
+        Public Sub DoNotApplyForAutoPropertyWithEmptyParens()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     Property goo() As Integer
@@ -26,7 +26,7 @@ End Class",
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530329")>
         <WpfFact>
-        Public Sub DontApplyForMustInheritProperty()
+        Public Sub DoNotApplyForMustInheritProperty()
             VerifyStatementEndConstructNotApplied(
                 text:="MustInherit Class C
     MustOverride Property goo(x as integer) As Integer
@@ -55,7 +55,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForReadOnlyProperty()
+        Public Sub DoNotApplyForReadOnlyProperty()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -64,7 +64,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForReadOnlyPropertyAfterExistingGet()
+        Public Sub DoNotApplyForReadOnlyPropertyAfterExistingGet()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -77,7 +77,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForReadOnlyWithSecondGetPropertyAfterExistingGet()
+        Public Sub DoNotApplyForReadOnlyWithSecondGetPropertyAfterExistingGet()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -92,7 +92,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForWriteOnlyProperty()
+        Public Sub DoNotApplyForWriteOnlyProperty()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     WriteOnly Property goo As Integer
@@ -143,7 +143,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForReadOnlyPropertyIfEndPropertyMissingWhenInvokedAfterProperty()
+        Public Sub DoNotApplyForReadOnlyPropertyIfEndPropertyMissingWhenInvokedAfterProperty()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -180,7 +180,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForWriteOnlyPropertyWithTypeCharacter()
+        Public Sub DoNotApplyForWriteOnlyPropertyWithTypeCharacter()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     WriteOnly Property goo$
@@ -209,7 +209,7 @@ End Class",
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536391")>
-        Public Sub DontApplyForDuplicateGet()
+        Public Sub DoNotApplyForDuplicateGet()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -223,7 +223,7 @@ End Class",
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536391")>
-        Public Sub DontApplyForDuplicateSet()
+        Public Sub DoNotApplyForDuplicateSet()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     WriteOnly Property goo As Integer
@@ -237,7 +237,7 @@ End Class",
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536391")>
-        Public Sub DontApplyForSetInReadOnly()
+        Public Sub DoNotApplyForSetInReadOnly()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     ReadOnly Property goo As Integer
@@ -249,7 +249,7 @@ End Class",
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536391")>
         <WpfFact>
-        Public Sub DontApplyForGetInReadOnly()
+        Public Sub DoNotApplyForGetInReadOnly()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
     WriteOnly Property goo As Integer
@@ -270,7 +270,7 @@ End Class",
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544197")>
         <WpfFact>
-        Public Sub DontApplyInsideAnInterface()
+        Public Sub DoNotApplyInsideAnInterface()
             VerifyStatementEndConstructNotApplied(
                 text:="Interface IGoo
     Property Goo(x As Integer) As String
@@ -279,7 +279,7 @@ End Interface",
         End Sub
 
         <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/2096")>
-        Public Sub TestDontGenerateSetForReadonlyProperty()
+        Public Sub TestDoNotGenerateSetForReadonlyProperty()
             VerifyStatementEndConstructApplied(
                 before:="Class c1
     Readonly Property goo(arg as Integer) As Integer
@@ -296,7 +296,7 @@ End Class",
         End Sub
 
         <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/2096")>
-        Public Sub TestDontGenerateGetForWriteonlyProperty()
+        Public Sub TestDoNotGenerateGetForWriteonlyProperty()
             VerifyStatementEndConstructApplied(
                 before:="Class c1
     Writeonly Property goo(arg as Integer) As Integer

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SyncLockBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/SyncLockBlockTests.vb
@@ -26,7 +26,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedUsing()
+        Public Sub DoNotApplyForMatchedUsing()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TryBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TryBlockTests.vb
@@ -28,7 +28,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedTryWithCatch()
+        Public Sub DoNotApplyForMatchedTryWithCatch()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()
@@ -41,7 +41,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedTryWithoutCatch()
+        Public Sub DoNotApplyForMatchedTryWithoutCatch()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TypeBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/TypeBlockTests.vb
@@ -29,7 +29,7 @@ End Module",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedClass()
+        Public Sub DoNotApplyForMatchedClass()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 End Class",

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/UsingBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/UsingBlockTests.vb
@@ -26,7 +26,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedUsing()
+        Public Sub DoNotApplyForMatchedUsing()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhileLoopTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WhileLoopTests.vb
@@ -26,7 +26,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedWith()
+        Public Sub DoNotApplyForMatchedWith()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WithBlockTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/WithBlockTests.vb
@@ -26,7 +26,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyForMatchedWith()
+        Public Sub DoNotApplyForMatchedWith()
             VerifyStatementEndConstructNotApplied(
                 text:="Class c1
 Sub goo()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/XmlLiteralTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/XmlLiteralTests.vb
@@ -60,7 +60,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyInParameterDeclaration1()
+        Public Sub DoNotApplyInParameterDeclaration1()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1(<xml>)
@@ -70,7 +70,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyInParameterDeclaration2()
+        Public Sub DoNotApplyInParameterDeclaration2()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1(i As Integer,
@@ -81,7 +81,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterXmlStartElementWithEndElement()
+        Public Sub DoNotApplyAfterXmlStartElementWithEndElement()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1()
@@ -92,7 +92,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterXmlEndElement()
+        Public Sub DoNotApplyAfterXmlEndElement()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1()
@@ -103,7 +103,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterSingleXmlTag()
+        Public Sub DoNotApplyAfterSingleXmlTag()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1()
@@ -114,7 +114,7 @@ End Class",
         End Sub
 
         <WpfFact>
-        Public Sub DontApplyAfterProcessingInstruction()
+        Public Sub DoNotApplyAfterProcessingInstruction()
             VerifyXmlElementEndConstructNotApplied(
                 text:="Class C1
     Sub M1()

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
@@ -5051,7 +5051,7 @@ End Module</text>
             End Function
 
             <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541409"), WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542687")>
-            Public Async Function DontCrashOnInvalidAddressOf() As Task
+            Public Async Function DoNotCrashOnInvalidAddressOf() As Task
                 Dim code = <text>Module Program
     Sub Main(args As String())
     End Sub
@@ -5064,7 +5064,7 @@ End Module</text>
             End Function
 
             <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541515")>
-            Public Async Function TestDontCrashWhenCanFindOutContainingScopeType() As Task
+            Public Async Function TestDoNotCrashWhenCanFindOutContainingScopeType() As Task
                 Dim code = <text>Class Program
     Sub Main()
         Dim x As New List(Of Program) From {[|New Program|]}

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
@@ -2066,7 +2066,7 @@ End Module</text>
 
             <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
             <WorkItem(10341, "DevDiv_Projects/Roslyn")>
-            Public Async Function TestTryCatchPartDontCrash() As Task
+            Public Async Function TestTryCatchPartDoNotCrash() As Task
                 Dim code = <text>Module Program
     Sub Main(nwindConn As String())
         Dim nwindTxn As SqlTransaction = nwindConn.BeginTransaction()
@@ -3247,7 +3247,7 @@ End Module
             End Function
 
             <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
-            Public Async Function TestDontPutOutOrRefOnStructOff() As Task
+            Public Async Function TestDoNotPutOutOrRefOnStructOff() As Task
                 Dim code =
 <text>
 Imports System.Threading.Tasks
@@ -3277,7 +3277,7 @@ End Namespace
             End Function
 
             <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
-            Public Async Function TestDontPutOutOrRefOnStructOn() As Task
+            Public Async Function TestDoNotPutOutOrRefOnStructOn() As Task
                 Dim code =
 <text>
 Imports System.Threading.Tasks

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.SelectionValidator.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.SelectionValidator.vb
@@ -611,7 +611,7 @@ End Class</text>
             End Function
 
             <Fact>
-            Public Async Function TestSelectValidSubexpressionAndHenceDontExpand() As Task
+            Public Async Function TestSelectValidSubexpressionAndHenceDoNotExpand() As Task
                 Dim code = <text>Class A
     Public Sub method(a As Integer, b As Integer, c As Integer)
         Dim d = {|b:a + b|} + c
@@ -945,7 +945,7 @@ End Class</text>
 
             <Fact, WorkItem(10071, "DevDiv_Projects/Roslyn")>
             <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544602")>
-            Public Async Function TestDontCrash() As Task
+            Public Async Function TestDoNotCrash() As Task
                 Await IterateAllAsync(TestResource.AllInOneVisualBasicCode)
             End Function
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -102,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)
             Assert.NotNull(document)
 
-            Dim extractOptions = New ExtractMethodOptions() With {.DontPutOutOrRefOnStruct = dontPutOutOrRefOnStruct}
+            Dim extractOptions = New ExtractMethodOptions() With {.DoNotPutOutOrRefOnStruct = dontPutOutOrRefOnStruct}
             Dim cleanupOptions = CodeCleanupOptions.GetDefault(document.Project.Services)
 
             Dim sdocument = Await SemanticDocument.CreateAsync(document, CancellationToken.None)

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
@@ -4098,7 +4098,7 @@ End Class", index:=1)
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/951968")>
-        Public Async Function TestDontImplementDisposePatternForLocallyDefinedIDisposable() As Task
+        Public Async Function TestDoNotImplementDisposePatternForLocallyDefinedIDisposable() As Task
             Await TestInRegularAndScriptAsync(
 "Namespace System
     Interface IDisposable
@@ -4122,7 +4122,7 @@ End Namespace")
         End Function
 
         <Fact>
-        Public Async Function TestDontImplementDisposePatternForStructures() As Task
+        Public Async Function TestDoNotImplementDisposePatternForStructures() As Task
             Await TestInRegularAndScriptAsync(
 "Imports System
 Structure S : Implements [|IDisposable|]",

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -323,7 +323,7 @@ End Class
         End Sub
 
         <WpfFact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/986168")>
-        Public Sub TestDontCommitInsideStringLiteral()
+        Public Sub TestDoNotCommitInsideStringLiteral()
             Dim test = <Workspace>
                            <Project Language="Visual Basic" CommonReferences="true">
                                <Document>

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
@@ -61,7 +61,7 @@ End Class
 
         <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/1944")>
         <Trait(Traits.Feature, Traits.Features.LineCommit)>
-        Public Sub TestDontCommitOnMultiLinePasteWithPrettyListingOff()
+        Public Sub TestDoNotCommitOnMultiLinePasteWithPrettyListingOff()
             Using testData = CommitTestData.Create(
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
@@ -117,7 +117,7 @@ End Class
 
         <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/1944")>
         <Trait(Traits.Feature, Traits.Features.LineCommit)>
-        Public Sub TestDontCommitOnSavePrettyListingOff()
+        Public Sub TestDoNotCommitOnSavePrettyListingOff()
             Using testData = CommitTestData.Create(<Workspace>
                                                        <Project Language="Visual Basic" CommonReferences="true">
                                                            <Document>

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
         End Sub
 
         <WpfFact>
-        Public Sub TestDontCrashOnPastingCarriageReturnContainingString()
+        Public Sub TestDoNotCrashOnPastingCarriageReturnContainingString()
             Using testData = CommitTestData.Create(
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
@@ -834,7 +834,7 @@ end class</element>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537614")>
-        Public Async Function TestDontMoveBanner() As Task
+        Public Async Function TestDoNotMoveBanner() As Task
             Dim initial =
 <element>class Program
     ' Banner
@@ -860,7 +860,7 @@ end class</element>
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537614")>
-        Public Async Function TestDontMoveBanner2() As Task
+        Public Async Function TestDoNotMoveBanner2() As Task
             Dim initial =
 <element>class Program
     ' Banner

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -764,7 +764,7 @@ End Module]]></Text>.NormalizedValue,
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541960")>
-        Public Async Function TestDontRemoveAttributeSuffixAndProduceInvalidIdentifier1() As Task
+        Public Async Function TestDoNotRemoveAttributeSuffixAndProduceInvalidIdentifier1() As Task
             Await TestAsync(<Text><![CDATA[
 Imports System
 Class _Attribute
@@ -776,7 +776,7 @@ End Class]]></Text>.NormalizedValue,
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541960")>
-        Public Async Function TestDontRemoveAttributeSuffixAndProduceInvalidIdentifier2() As Task
+        Public Async Function TestDoNotRemoveAttributeSuffixAndProduceInvalidIdentifier2() As Task
             Await TestAsync(<Text><![CDATA[
 Imports System
 Class ClassAttribute
@@ -788,7 +788,7 @@ End Class]]></Text>.NormalizedValue,
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541960")>
-        Public Async Function TestDontRemoveAttributeSuffix1() As Task
+        Public Async Function TestDoNotRemoveAttributeSuffix1() As Task
             Await TestAsync(<Text><![CDATA[
 Imports System
 Class Class1Attribute

--- a/src/EditorFeatures/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -1598,7 +1598,7 @@ End Namespace
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/568043")>
-        Public Async Function TestDontSimplifyNamesWhenThereAreParseErrors() As Task
+        Public Async Function TestDoNotSimplifyNamesWhenThereAreParseErrors() As Task
             Dim source =
         <Code>
 Imports System
@@ -1749,7 +1749,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578686")>
-        Public Async Function TestDontUseAlias() As Task
+        Public Async Function TestDoNotUseAlias() As Task
             Dim source =
         <Code>
 Imports System
@@ -1910,7 +1910,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/686306")>
-        Public Async Function TestDontSimplifyNameSyntaxToTypeSyntaxInVBCref() As Task
+        Public Async Function TestDoNotSimplifyNameSyntaxToTypeSyntaxInVBCref() As Task
             Dim source =
         <Code>
 Imports System
@@ -1923,7 +1923,7 @@ End Module
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/721817")>
-        Public Async Function TestDontSimplifyNameSyntaxToPredefinedTypeSyntaxInVBCref() As Task
+        Public Async Function TestDoNotSimplifyNameSyntaxToPredefinedTypeSyntaxInVBCref() As Task
             Dim source =
         <Code>
 Public Class Test
@@ -1969,7 +1969,7 @@ Public Class Test_Dev11
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/736377")>
-        Public Async Function TestDontSimplifyTypeNameBrokenCode() As Task
+        Public Async Function TestDoNotSimplifyTypeNameBrokenCode() As Task
             Dim source =
         <Code>
             <![CDATA[
@@ -2007,7 +2007,7 @@ End Interface
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/813385")>
-        Public Async Function TestDontSimplifyAliases() As Task
+        Public Async Function TestDoNotSimplifyAliases() As Task
             Dim source =
         <Code>
             <![CDATA[

--- a/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
+++ b/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.StringIndentation
 
             while (nodeStack.TryPop(out var node))
             {
-                // Dont' bother recursing into nodes that don't hit the requested span, they can never contribute 
+                // DoNot' bother recursing into nodes that don't hit the requested span, they can never contribute 
                 // regions of interest.
                 if (!node.Span.IntersectsWith(textSpan))
                     continue;

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
             var collectionVariableToken = generator.Identifier(collectionVariable.ToString()).WithAdditionalAnnotations(RenameAnnotation.Create());
 
             // this expression is from user code. don't simplify this.
-            var expression = foreachCollectionExpression.WithoutAnnotations(SimplificationHelpers.DontSimplifyAnnotation);
+            var expression = foreachCollectionExpression.WithoutAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation);
             var collectionStatement = generator.LocalDeclarationStatement(
                 type,
                 collectionVariableToken,

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     return true;
                 }
 
-                if (UserDefinedValueType(model.Compilation, type) && !SelectionResult.Options.DontPutOutOrRefOnStruct)
+                if (UserDefinedValueType(model.Compilation, type) && !SelectionResult.Options.DoNotPutOutOrRefOnStruct)
                 {
                     variableStyle = AlwaysReturn(variableStyle);
                     return true;

--- a/src/Features/LanguageServer/Protocol/Features/Options/ExtractMethodOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/ExtractMethodOptionsStorage.cs
@@ -18,7 +18,7 @@ internal static class ExtractMethodOptionsStorage
     public static ExtractMethodOptions GetExtractMethodOptions(this IGlobalOptionService globalOptions, string language)
         => new()
         {
-            DontPutOutOrRefOnStruct = globalOptions.GetOption(DontPutOutOrRefOnStruct, language)
+            DoNotPutOutOrRefOnStruct = globalOptions.GetOption(DoNotPutOutOrRefOnStruct, language)
         };
 
     public static ExtractMethodGenerationOptions GetExtractMethodGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
@@ -33,6 +33,6 @@ internal static class ExtractMethodOptionsStorage
     public static ValueTask<ExtractMethodGenerationOptions> GetExtractMethodGenerationOptionsAsync(this Document document, IGlobalOptionService globalOptions, CancellationToken cancellationToken)
         => document.GetExtractMethodGenerationOptionsAsync(globalOptions.GetExtractMethodGenerationOptions(document.Project.Services), cancellationToken);
 
-    public static readonly PerLanguageOption2<bool> DontPutOutOrRefOnStruct = new(
-        "dotnet_extract_method_no_ref_or_out_structs", ExtractMethodOptions.Default.DontPutOutOrRefOnStruct);
+    public static readonly PerLanguageOption2<bool> DoNotPutOutOrRefOnStruct = new(
+        "dotnet_extract_method_no_ref_or_out_structs", ExtractMethodOptions.Default.DoNotPutOutOrRefOnStruct);
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             .AddParts(typeof(LongRunningNonMutatingRequestHandler));
 
         [Theory, CombinatorialData]
-        public async Task MutatingRequestsDontOverlap(bool mutatingLspWorkspace)
+        public async Task MutatingRequestsDoNotOverlap(bool mutatingLspWorkspace)
         {
             var requests = new[] {
                 new TestRequest(MutatingRequestHandler.MethodName),

--- a/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
         }
 
         [Theory, CombinatorialData]
-        public async Task DontShrinkValidMultilineBreakpoints(bool mutatingLspWorkspace)
+        public async Task DoNotShrinkValidMultilineBreakpoints(bool mutatingLspWorkspace)
         {
             var markup =
 @"class A

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Editor_color_scheme, ColorSchemeOptionsStorage.ColorScheme);
 
             // Extract Method
-            BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct, LanguageNames.CSharp);
+            BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct, LanguageNames.CSharp);
 
             // Implement Interface or Abstract Class
             BindToOption(with_other_members_of_the_same_kind, ImplementTypeOptionsStorage.InsertionBehavior, ImplementTypeInsertionBehavior.WithOtherMembersOfTheSameKind, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ExtractMethod.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ExtractMethod.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public int ExtractMethod_DoNotPutOutOrRefOnStruct
         {
-            get { return GetBooleanOption(ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct); }
-            set { SetBooleanOption(ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct, value); }
+            get { return GetBooleanOption(ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct); }
+            set { SetBooleanOption(ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct, value); }
         }
     }
 }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/EventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/EventCollectorTests.vb
@@ -905,7 +905,7 @@ class Program
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontFireEventForMethodAddedInsideNamespace() As Task
+        Public Async Function DoNotFireEventForMethodAddedInsideNamespace() As Task
             Dim code =
 <Code>
 namespace N
@@ -928,7 +928,7 @@ namespace N
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedMethodsInNamespace() As Task
+        Public Async Function DoNotCrashOnDuplicatedMethodsInNamespace() As Task
             Dim code =
 <Code>
 namespace N
@@ -958,7 +958,7 @@ namespace N
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedPropertiesInNamespace() As Task
+        Public Async Function DoNotCrashOnDuplicatedPropertiesInNamespace() As Task
             Dim code =
 <Code>
 namespace N
@@ -981,7 +981,7 @@ namespace N
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedEventsInNamespace1() As Task
+        Public Async Function DoNotCrashOnDuplicatedEventsInNamespace1() As Task
             Dim code =
 <Code>
 namespace N
@@ -1004,7 +1004,7 @@ namespace N
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedEventsInNamespace2() As Task
+        Public Async Function DoNotCrashOnDuplicatedEventsInNamespace2() As Task
             Dim code =
 <Code>
 namespace N

--- a/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/MethodXML/MethodXMLTests_VBAssignments.vb
@@ -877,7 +877,7 @@ End Class
         End Sub
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelMethodXml)>
-        Public Sub TestVBAssignments_DontThrowWhenLeftHandSideDoesntBind()
+        Public Sub TestVBAssignments_DoNotThrowWhenLeftHandSideDoesntBind()
             Dim definition =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/EventCollectorTests.vb
@@ -1975,7 +1975,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/575666")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function TestDontFireEventsForGarbage1() As Task
+        Public Async Function TestDoNotFireEventsForGarbage1() As Task
             Dim code =
 <Code>
 Class C
@@ -2001,7 +2001,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578249")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function TestDontFireEventsForGarbage2() As Task
+        Public Async Function TestDoNotFireEventsForGarbage2() As Task
             Dim code =
 <Code>
 Partial Class SomeClass
@@ -2265,7 +2265,7 @@ End Class
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedMethodsInNamespace() As Task
+        Public Async Function DoNotCrashOnDuplicatedMethodsInNamespace() As Task
             Dim code =
 <Code>
 Namespace N
@@ -2290,7 +2290,7 @@ End Namespace
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedPropertiesInNamespace() As Task
+        Public Async Function DoNotCrashOnDuplicatedPropertiesInNamespace() As Task
             Dim code =
 <Code>
 Namespace N
@@ -2311,7 +2311,7 @@ End Namespace
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedEventsInNamespace1() As Task
+        Public Async Function DoNotCrashOnDuplicatedEventsInNamespace1() As Task
             Dim code =
 <Code>
 Namespace N
@@ -2332,7 +2332,7 @@ End Namespace
 
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/150349")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModelEvents)>
-        Public Async Function DontCrashOnDuplicatedEventsInNamespace2() As Task
+        Public Async Function DoNotCrashOnDuplicatedEventsInNamespace2() As Task
             Dim code =
 <Code>
 Namespace N

--- a/src/VisualStudio/Core/Test/CommonControls/MemberSelectionViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/CommonControls/MemberSelectionViewModelTests.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CommonControls
         End Function
 
         <Fact>
-        Public Async Function TestMemberSelectionViewModelDont_PullDisableItem() As Task
+        Public Async Function TestMemberSelectionViewModelDoNot_PullDisableItem() As Task
             Dim markUp = <Text><![CDATA[
         interface Level2Interface
         {

--- a/src/VisualStudio/Core/Test/GenerateType/GenerateTypeViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/GenerateType/GenerateTypeViewModelTests.vb
@@ -748,7 +748,7 @@ namespace A
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/898563")>
-        Public Async Function TestGenerateType_DontGenerateIntoExistingFile() As Task
+        Public Async Function TestGenerateType_DoNotGenerateIntoExistingFile() As Task
             ' Get a Temp Folder Path
             Dim projectRootFolder = Path.GetTempPath()
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -151,7 +151,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Editor_color_scheme, ColorSchemeOptionsStorage.ColorScheme)
 
             ' Extract method
-            BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct, LanguageNames.VisualBasic)
+            BindToOption(DontPutOutOrRefOnStruct, ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct, LanguageNames.VisualBasic)
 
             ' Implement Interface or Abstract Class
             BindToOption(with_other_members_of_the_same_kind, ImplementTypeOptionsStorage.InsertionBehavior, ImplementTypeInsertionBehavior.WithOtherMembersOfTheSameKind, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.ExtractMethod.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.ExtractMethod.vb
@@ -17,10 +17,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Public Property ExtractMethod_DoNotPutOutOrRefOnStruct As Boolean
             Get
-                Return GetBooleanOption(ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct)
+                Return GetBooleanOption(ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(ExtractMethodOptionsStorage.DontPutOutOrRefOnStruct, value)
+                SetBooleanOption(ExtractMethodOptionsStorage.DoNotPutOutOrRefOnStruct, value)
             End Set
         End Property
     End Class

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                         // if the user already used the Attribute suffix in the attribute, we'll maintain it.
                         if (identifier.ValueText == name && name.EndsWith("Attribute", StringComparison.Ordinal))
                         {
-                            identifier = identifier.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation);
+                            identifier = identifier.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation);
                         }
 
                         identifier = identifier.CopyAnnotationsTo(SyntaxFactory.VerbatimIdentifier(identifier.LeadingTrivia, name, name, identifier.TrailingTrivia));

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.NodesAndTokensToReduceComputer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.NodesAndTokensToReduceComputer.cs
@@ -54,8 +54,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     if (_simplifyAllDescendants)
                     {
                         // One of the ancestor node is within a simplification span, but this node is outside all simplification spans.
-                        // Add DontSimplifyAnnotation to node to ensure it doesn't get simplified.
-                        return node.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation);
+                        // Add DoNotSimplifyAnnotation to node to ensure it doesn't get simplified.
+                        return node.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation);
                     }
                     else
                     {
@@ -92,8 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     if (_simplifyAllDescendants)
                     {
                         // One of the ancestor node is within a simplification span, but this token is outside all simplification spans.
-                        // Add DontSimplifyAnnotation to token to ensure it doesn't get simplified.
-                        return token.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation);
+                        // Add DoNotSimplifyAnnotation to token to ensure it doesn't get simplified.
+                        return token.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation);
                     }
                     else
                     {

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/AbstractCSharpReducer.AbstractReductionRewriter.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     return newNode;
                 }
 
-                if (!node.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation))
+                if (!node.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation))
                 {
                     var simplifiedNode = simplifier(node, this.SemanticModel, this.Options, this.CancellationToken);
                     if (simplifiedNode != node)

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpVarReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpVarReducer.Rewriter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 }
 
                 // Definitely do not simplify us if we were told to not simplify.
-                if (typeSyntax.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation))
+                if (typeSyntax.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation))
                 {
                     return typeSyntax;
                 }

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
@@ -487,8 +487,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                 {
                     const string AttributeName = "Attribute";
 
-                    // an attribute that should keep it (unnecessary "Attribute" suffix should be annotated with a DontSimplifyAnnotation
-                    if (identifierToken.ValueText != AttributeName && identifierToken.ValueText.EndsWith(AttributeName, StringComparison.Ordinal) && !identifierToken.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation))
+                    // an attribute that should keep it (unnecessary "Attribute" suffix should be annotated with a DoNotSimplifyAnnotation
+                    if (identifierToken.ValueText != AttributeName && identifierToken.ValueText.EndsWith(AttributeName, StringComparison.Ordinal) && !identifierToken.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation))
                     {
                         // weird. the semantic model is able to bind attribute syntax like "[as()]" although it's not valid code.
                         // so we need another check for keywords manually.

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -172,7 +172,7 @@ class C
         }
 
         [Theory, MemberData(nameof(TestAllData))]
-        public async Task TestDontAddSystemImportFirst(bool useSymbolAnnotations)
+        public async Task TestDoNotAddSystemImportFirst(bool useSymbolAnnotations)
         {
             await TestAsync(
 @"using N;

--- a/src/Workspaces/CSharpTest/Formatting/FormattingMultipleSpanTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingMultipleSpanTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
             => await AssertFormatAsync("namespace A/*1*/{}/*2*/ class A {}", "namespace A{ } class A {}");
 
         [Fact]
-        public async Task DontFormatTriviaOutsideOfSpan_IncludingTrailingTriviaOnNewLine()
+        public async Task DoNotFormatTriviaOutsideOfSpan_IncludingTrailingTriviaOnNewLine()
         {
             var content = @"namespace A
 /*1*/{

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -2308,7 +2308,7 @@ var obj = new {   X1 = 0,         Y1 = 1,
         }
 
         [Fact]
-        public async Task DontInsertLineBreaksInSingleLineEnum()
+        public async Task DoNotInsertLineBreaksInSingleLineEnum()
             => await AssertFormatAsync(@"enum E { a = 10, b, c }", @"enum E { a = 10, b, c }");
 
         [Fact]
@@ -2602,7 +2602,7 @@ goto Goo;
         }
 
         [Fact]
-        public async Task DontAddLineBreakBeforeWhere1_Bug2582()
+        public async Task DoNotAddLineBreakBeforeWhere1_Bug2582()
         {
             await AssertFormatAsync(@"class C
 {
@@ -2618,7 +2618,7 @@ goto Goo;
         }
 
         [Fact]
-        public async Task DontAddLineBreakBeforeWhere2_Bug2582()
+        public async Task DoNotAddLineBreakBeforeWhere2_Bug2582()
         {
             await AssertFormatAsync(@"class C<T> where T : I
 {
@@ -2628,7 +2628,7 @@ goto Goo;
         }
 
         [Fact]
-        public async Task DontAddSpaceAfterUnaryMinus()
+        public async Task DoNotAddSpaceAfterUnaryMinus()
         {
             await AssertFormatAsync(@"class C
 {
@@ -2646,7 +2646,7 @@ goto Goo;
         }
 
         [Fact]
-        public async Task DontAddSpaceAfterUnaryPlus()
+        public async Task DoNotAddSpaceAfterUnaryPlus()
         {
             await AssertFormatAsync(@"class C
 {
@@ -2664,7 +2664,7 @@ goto Goo;
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545909")]
-        public async Task DontAddSpaceAfterIncrement()
+        public async Task DoNotAddSpaceAfterIncrement()
         {
             var code = @"class C
 {
@@ -2677,7 +2677,7 @@ goto Goo;
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545909")]
-        public async Task DontAddSpaceBeforeIncrement()
+        public async Task DoNotAddSpaceBeforeIncrement()
         {
             var code = @"class C
 {
@@ -2690,7 +2690,7 @@ goto Goo;
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545909")]
-        public async Task DontAddSpaceAfterDecrement()
+        public async Task DoNotAddSpaceAfterDecrement()
         {
             var code = @"class C
 {
@@ -2703,7 +2703,7 @@ goto Goo;
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545909")]
-        public async Task DontAddSpaceBeforeDecrement()
+        public async Task DoNotAddSpaceBeforeDecrement()
         {
             var code = @"class C
 {
@@ -7409,7 +7409,7 @@ class C
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991547")]
-        public async Task DontWrappingTryCatchFinallyIfOnSingleLine()
+        public async Task DoNotWrappingTryCatchFinallyIfOnSingleLine()
         {
             var code = @"
 class C
@@ -8105,7 +8105,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1118")]
-        public void DontAssumeCertainNodeAreAlwaysParented()
+        public void DoNotAssumeCertainNodeAreAlwaysParented()
         {
             var block = SyntaxFactory.Block();
             Formatter.Format(block, new AdhocWorkspace().Services.SolutionServices, CSharpSyntaxFormattingOptions.Default, CancellationToken.None);
@@ -8187,7 +8187,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1298")]
-        public async Task DontforceAccessorsToNewLineWithPropertyInitializers()
+        public async Task DoNotforceAccessorsToNewLineWithPropertyInitializers()
         {
             var code = @"using System.Collections.Generic;
 
@@ -8216,7 +8216,7 @@ public class ExcludeValidation
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/1339")]
-        public async Task DontFormatAutoPropertyInitializerIfNotDifferentLine()
+        public async Task DoNotFormatAutoPropertyInitializerIfNotDifferentLine()
         {
             var code = @"class Program
 {
@@ -8396,7 +8396,7 @@ class Program
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/939")]
-        public async Task DontFormatInsideArrayInitializers()
+        public async Task DoNotFormatInsideArrayInitializers()
         {
             var code = @"class Program
 {

--- a/src/Workspaces/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
+++ b/src/Workspaces/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod;
 [DataContract]
 internal readonly record struct ExtractMethodOptions
 {
-    [DataMember] public bool DontPutOutOrRefOnStruct { get; init; } = true;
+    [DataMember] public bool DoNotPutOutOrRefOnStruct { get; init; } = true;
 
     public ExtractMethodOptions()
     {

--- a/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
@@ -196,7 +196,7 @@ End Class";
         }
 
         [Fact]
-        public async Task IdentifierMethod_DotName_DontAdd()
+        public async Task IdentifierMethod_DotName_DoNotAdd()
         {
             var code = @"Class A
     Function Test() As Integer
@@ -560,7 +560,7 @@ End Class";
         }
 
         [Fact]
-        public async Task TypeArgumentOf_Comment_DontAdd()
+        public async Task TypeArgumentOf_Comment_DoNotAdd()
         {
             var code = @"[|
         Dim a As List( ' test
@@ -729,7 +729,7 @@ End Class";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544225")]
-        public async Task StructuredTrivia_Expression_DontCrash()
+        public async Task StructuredTrivia_Expression_DoNotCrash()
         {
             var code = @"[|#Const Goo1 = 1
 #Const Goo2 = 2
@@ -933,7 +933,7 @@ End Class";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544526")]
-        public async Task DontCrash_ImplementsStatement()
+        public async Task DoNotCrash_ImplementsStatement()
         {
             var code = @"[|Class C
     Sub Main() 
@@ -994,7 +994,7 @@ End Module";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545256")]
-        public async Task HandlesClauseItem_DontAddParentheses()
+        public async Task HandlesClauseItem_DoNotAddParentheses()
         {
             var code = @"[|Structure s1
     Sub Goo() Handles Me.Goo
@@ -1011,7 +1011,7 @@ End Structure";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545380")]
-        public async Task DontAddParenthesesInForEachControlVariable()
+        public async Task DoNotAddParenthesesInForEachControlVariable()
         {
             var code = @"[|Module Module1
     Sub Main()
@@ -1034,7 +1034,7 @@ End Module";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545380")]
-        public async Task DontAddParenthesesInForControlVariable()
+        public async Task DoNotAddParenthesesInForControlVariable()
         {
             var code = @"[|Module Module1
     Sub Main()
@@ -1057,7 +1057,7 @@ End Module";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545483")]
-        public async Task DontAddParenthesesForMissingName()
+        public async Task DoNotAddParenthesesForMissingName()
         {
             var code = @"[|Class C
     Public Overrides Function|]";

--- a/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/CodeCleanupTests.cs
@@ -268,7 +268,7 @@ End Class", LanguageNames.VisualBasic);
             => VerifyRange("namespace N { class C {|r:{ {|b:void Method() { }|} }|} class C2 {|r:{ {|b:void Method() { }|} }|} }");
 
         [Fact, WorkItem(12848, "DevDiv_Projects/Roslyn")]
-        public void DontCrash_VB()
+        public void DoNotCrash_VB()
         {
             var code = @"#If DEBUG OrElse TRACE Then
 Imports System.Diagnostics
@@ -288,7 +288,7 @@ Imports System.Diagnostics
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774295")]
-        public async Task DontCrash_VB_2()
+        public async Task DoNotCrash_VB_2()
         {
             var code = @"
 Public Class Class1

--- a/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
@@ -791,7 +791,7 @@ End Class";
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544520")]
-        public async Task DontRemoveByVal()
+        public async Task DoNotRemoveByVal()
         {
             var code = @"[|Module Program
     Sub Main(

--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -1132,7 +1132,7 @@ End Class";
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530621")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/631933")]
-        public async Task DontRemoveLineContinuationAfterColonInSingleLineIfStatement()
+        public async Task DoNotRemoveLineContinuationAfterColonInSingleLineIfStatement()
         {
             var code = @"[|Module Program
     Dim x = Sub() If True Then Dim y : _
@@ -1149,7 +1149,7 @@ End Module";
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/609481")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/631933")]
-        public async Task DontRemoveLineContinuationInSingleLineIfStatement()
+        public async Task DoNotRemoveLineContinuationInSingleLineIfStatement()
         {
             var code = @"[|
 Module Program
@@ -1179,7 +1179,7 @@ End Module
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/609481")]
         [WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/631933")]
-        public async Task DontRemoveLineContinuationInNestedSingleLineIfStatement()
+        public async Task DoNotRemoveLineContinuationInNestedSingleLineIfStatement()
         {
             var code = @"[|
 Module Program
@@ -1236,7 +1236,7 @@ End Module
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/710")]
-        public async Task DontRemoveLineContinuationInStringInterpolation1()
+        public async Task DoNotRemoveLineContinuationInStringInterpolation1()
         {
             var code = @"[|
 Module Program
@@ -1255,7 +1255,7 @@ End Module
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/710")]
-        public async Task DontRemoveLineContinuationInStringInterpolation2()
+        public async Task DoNotRemoveLineContinuationInStringInterpolation2()
         {
             var code = @"[|
 Module Program
@@ -1274,7 +1274,7 @@ End Module
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/710")]
-        public async Task DontRemoveLineContinuationInStringInterpolation3()
+        public async Task DoNotRemoveLineContinuationInStringInterpolation3()
         {
             var code = @"[|
 Module Program
@@ -1299,7 +1299,7 @@ End Module
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1085887")]
-        public async Task DontRemoveLineContinuationInVisualBasic9()
+        public async Task DoNotRemoveLineContinuationInVisualBasic9()
         {
             var code = @"[|
 Module Program

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/SimplificationHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Simplification/SimplificationHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Simplification
 {
     internal static class SimplificationHelpers
     {
-        public static readonly SyntaxAnnotation DontSimplifyAnnotation = new();
+        public static readonly SyntaxAnnotation DoNotSimplifyAnnotation = new();
         public static readonly SyntaxAnnotation SimplifyModuleNameAnnotation = new();
 
         public static TNode CopyAnnotations<TNode>(SyntaxNode from, TNode to) where TNode : SyntaxNode
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Simplification
 
             if (dontSimplifyResult)
             {
-                to = to.WithAdditionalAnnotations(DontSimplifyAnnotation);
+                to = to.WithAdditionalAnnotations(DoNotSimplifyAnnotation);
             }
 
             return to;
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Simplification
 
             if (dontSimplifyResult)
             {
-                to = to.WithAdditionalAnnotations(DontSimplifyAnnotation);
+                to = to.WithAdditionalAnnotations(DoNotSimplifyAnnotation);
             }
 
             return to;

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
@@ -97,7 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                     Return newNode
                 End If
 
-                If Not node.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation) Then
+                If Not node.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation) Then
                     Dim simplifiedNode = simplifyFunc(node, _semanticModel, _simplificationOptions, CancellationToken)
                     If simplifiedNode IsNot node Then
                         _processedParentNodes.Add(parentNode)
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                     Return newToken
                 End If
 
-                If Not token.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation) Then
+                If Not token.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation) Then
                     Dim simplifiedToken = simplifyFunc(token, _semanticModel, _simplificationOptions, CancellationToken)
                     If simplifiedToken <> token Then
                         _processedParentNodes.Add(parentNode)

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Simplifiers/NameSimplifier.vb
@@ -369,8 +369,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification.Simplifiers
                 If name.Parent.Kind = SyntaxKind.Attribute OrElse name.IsRightSideOfDot() Then
                     Dim newIdentifierText = String.Empty
 
-                    ' an attribute that should keep it (unnecessary "Attribute" suffix should be annotated with a DontSimplifyAnnotation
-                    If identifierToken.HasAnnotation(SimplificationHelpers.DontSimplifyAnnotation) Then
+                    ' an attribute that should keep it (unnecessary "Attribute" suffix should be annotated with a DoNotSimplifyAnnotation
+                    If identifierToken.HasAnnotation(SimplificationHelpers.DoNotSimplifyAnnotation) Then
                         newIdentifierText = identifierToken.ValueText + "Attribute"
                     ElseIf identifierToken.ValueText.TryReduceAttributeSuffix(newIdentifierText) Then
                         issueSpan = New TextSpan(name.Span.End - 9, 9)

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -588,7 +588,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
 
                             ' if the user already used the Attribute suffix in the attribute, we'll maintain it.
                             If identifier.ValueText = name Then
-                                identifier = identifier.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation)
+                                identifier = identifier.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation)
                             End If
                         End If
                     End If

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.NodesAndTokensToReduceComputer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.NodesAndTokensToReduceComputer.vb
@@ -47,8 +47,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 If Me._isNodeOrTokenOutsideSimplifySpans(node) Then
                     If Me._simplifyAllDescendants Then
                         ' One of the ancestor nodes is within a simplification span, but this node Is outside all simplification spans.
-                        ' Add DontSimplifyAnnotation to node to ensure it doesn't get simplified.
-                        Return node.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation)
+                        ' Add DoNotSimplifyAnnotation to node to ensure it doesn't get simplified.
+                        Return node.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation)
                     Else
                         Return node
                     End If
@@ -87,8 +87,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 If Me._isNodeOrTokenOutsideSimplifySpans(token) Then
                     If Me._simplifyAllDescendants Then
                         ' One of the ancestor nodes is within a simplification span, but this token Is outside all simplification spans.
-                        ' Add DontSimplifyAnnotation to token to ensure it doesn't get simplified.
-                        Return token.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation)
+                        ' Add DoNotSimplifyAnnotation to token to ensure it doesn't get simplified.
+                        Return token.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation)
                     Else
                         Return token
                     End If
@@ -152,8 +152,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 If Me._isNodeOrTokenOutsideSimplifySpans(node) Then
                     If Me._simplifyAllDescendants Then
                         ' One of the ancestor nodes Is within a simplification span, but this node Is outside all simplification spans.
-                        ' Add DontSimplifyAnnotation to node to ensure it doesn't get simplified.
-                        Return node.WithAdditionalAnnotations(SimplificationHelpers.DontSimplifyAnnotation)
+                        ' Add DoNotSimplifyAnnotation to node to ensure it doesn't get simplified.
+                        Return node.WithAdditionalAnnotations(SimplificationHelpers.DoNotSimplifyAnnotation)
                     Else
                         Return node
                     End If

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
@@ -163,7 +163,7 @@ End Class", useSymbolAnnotations)
         End Function
 
         <Theory, MemberData(NameOf(TestAllData))>
-        Public Async Function TestDontAddSystemImportFirst(useSymbolAnnotations As Boolean) As Task
+        Public Async Function TestDoNotAddSystemImportFirst(useSymbolAnnotations As Boolean) As Task
             Await TestAsync(
 "Imports N
 
@@ -399,7 +399,7 @@ End Class", useSymbolAnnotations)
         End Function
 
         <Theory, MemberData(NameOf(TestAllData))>
-        Public Async Function TestDontAddImportWithExisitingImportDifferentCase(useSymbolAnnotations As Boolean) As Task
+        Public Async Function TestDoNotAddImportWithExisitingImportDifferentCase(useSymbolAnnotations As Boolean) As Task
             Await TestAsync(
 "Imports system.collections.generic
 

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4030,7 +4030,7 @@ End Module
         End Function
 
         <Fact>
-        Public Async Function TestDontCrashOnMissingTokenWithComment() As Task
+        Public Async Function TestDoNotCrashOnMissingTokenWithComment() As Task
             Dim code =
 <Code><![CDATA[
 Namespace NS


### PR DESCRIPTION
We use DoNot at roughly a 10:1 ratio over "Dont".  And "Dont" looks terrible in a symbol name since it's a contraction.  Most changes are in test names and can be easily skipped.  THere are a couple of internal symbol names in the worskpace layer that can be quickly reviewed.