### PR TITLE
Revert "Remove descendent node tracking from SyntaxEditor #67314" from 17.6

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
@@ -11,52 +12,14 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.Editing
 {
     /// <summary>
-    /// An editor for making changes to a syntax tree. The editor works by giving a list of changes to perform to a
-    /// particular tree <em>in order</em>.  Changes are given a <see cref="SyntaxNode"/> they will apply to in the
-    /// original tree the editor is created for.  The semantics of application are as follows:
-    /// 
-    /// <list type="number">
-    /// <item>
-    /// The original root provided is used as the 'current' root for all operations.  This 'current' root will
-    /// continually be updated, becoming the new 'current' root.  The original root is never changed.
-    /// </item>
-    /// <item>
-    /// Each change has its given <see cref="SyntaxNode"/> tracked, using a <see cref="SyntaxAnnotation"/>, producing a
-    /// 'current' root that tracks all of them.  This allows that same node to be found after prior changes are applied
-    /// which mutate the tree.
-    /// </item>
-    /// <item>
-    /// Each change is then applied in order it was added to the editor.
-    /// </item>
-    /// <item>
-    /// A change first attempts to find its <see cref="SyntaxNode"/> in the 'current' root.  If that node cannot be
-    /// found, the operation will fail with an <see cref="ArgumentException"/>.
-    /// </item>
-    /// <item>
-    /// The particular change will run on that node, removing, replacing, or inserting around it according to the
-    /// change.  If the change is passed a delegate as its 'compute' argument, it will be given the <see
-    /// cref="SyntaxNode"/> found in the current root.  The 'current' root will then be updated by replacing the current
-    /// node with the new computed node.
-    /// </item>
-    /// <item>
-    /// The 'current' root is then returned.
-    /// </item>
-    /// </list>
+    /// An editor for making changes to a syntax tree. 
     /// </summary>
-    /// <remarks>
-    /// The above editing strategy makes it an error for a client of the editor to add a change that updates a parent
-    /// node and then adds a change that updates a child node (unless the parent change is certain to contain the
-    /// child), and attempting this will throw at runtime.  If a client ever needs to update both a child and a parent,
-    /// it <em>should</em> add the child change first, and then the parent change.  And the parent change should pass an
-    /// appropriate 'compute' callback so it will see the results of the child change.
-    /// <para/> If a client wants to make a replacement, then find the <em>value</em> <see cref="SyntaxNode"/> put into
-    /// the tree, that can be done by adding a dedicated annotation to that node and then looking it back up in the
-    /// 'current' node passed to a 'compute' callback.
-    /// </remarks>
     public class SyntaxEditor
     {
         private readonly SyntaxGenerator _generator;
         private readonly List<Change> _changes = new();
+        private bool _allowEditsOnLazilyCreatedTrackedNewNodes;
+        private HashSet<SyntaxNode>? _lazyTrackedNewNodesOpt;
 
         /// <summary>
         /// Creates a new <see cref="SyntaxEditor"/> instance.
@@ -90,6 +53,32 @@ namespace Microsoft.CodeAnalysis.Editing
             _generator = generator;
         }
 
+        [return: NotNullIfNotNull(nameof(node))]
+        private SyntaxNode? ApplyTrackingToNewNode(SyntaxNode? node)
+        {
+            if (node == null)
+            {
+                return null;
+            }
+
+            _lazyTrackedNewNodesOpt ??= new HashSet<SyntaxNode>();
+            foreach (var descendant in node.DescendantNodesAndSelf())
+            {
+                _lazyTrackedNewNodesOpt.Add(descendant);
+            }
+
+            return node.TrackNodes(node.DescendantNodesAndSelf());
+        }
+
+        private IEnumerable<SyntaxNode> ApplyTrackingToNewNodes(IEnumerable<SyntaxNode> nodes)
+        {
+            foreach (var node in nodes)
+            {
+                var result = ApplyTrackingToNewNode(node);
+                yield return result;
+            }
+        }
+
         /// <summary>
         /// The <see cref="SyntaxNode"/> that was specified when the <see cref="SyntaxEditor"/> was constructed.
         /// </summary>
@@ -110,7 +99,9 @@ namespace Microsoft.CodeAnalysis.Editing
             var newRoot = OriginalRoot.TrackNodes(nodes);
 
             foreach (var change in _changes)
+            {
                 newRoot = change.Apply(newRoot, _generator);
+            }
 
             return newRoot;
         }
@@ -120,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// </summary>
         public void TrackNode(SyntaxNode node)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             _changes.Add(new NoChange(node));
         }
 
@@ -138,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <param name="options">Options that affect how node removal works.</param>
         public void RemoveNode(SyntaxNode node, SyntaxRemoveOptions options)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             _changes.Add(new RemoveChange(node, options));
         }
 
@@ -150,29 +141,38 @@ namespace Microsoft.CodeAnalysis.Editing
         /// The node passed into the compute function includes changes from prior edits. It will not appear as a descendant of the original root.</param>
         public void ReplaceNode(SyntaxNode node, Func<SyntaxNode, SyntaxGenerator, SyntaxNode> computeReplacement)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (computeReplacement == null)
+            {
                 throw new ArgumentNullException(nameof(computeReplacement));
+            }
 
-            _changes.Add(new ReplaceChange(node, computeReplacement));
+            _allowEditsOnLazilyCreatedTrackedNewNodes = true;
+            _changes.Add(new ReplaceChange(node, computeReplacement, this));
         }
 
         internal void ReplaceNode(SyntaxNode node, Func<SyntaxNode, SyntaxGenerator, IEnumerable<SyntaxNode>> computeReplacement)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (computeReplacement == null)
+            {
                 throw new ArgumentNullException(nameof(computeReplacement));
+            }
 
-            _changes.Add(new ReplaceWithCollectionChange(node, computeReplacement));
+            _allowEditsOnLazilyCreatedTrackedNewNodes = true;
+            _changes.Add(new ReplaceWithCollectionChange(node, computeReplacement, this));
         }
 
         internal void ReplaceNode<TArgument>(SyntaxNode node, Func<SyntaxNode, SyntaxGenerator, TArgument, SyntaxNode> computeReplacement, TArgument argument)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (computeReplacement == null)
+            {
                 throw new ArgumentNullException(nameof(computeReplacement));
+            }
 
-            _changes.Add(new ReplaceChange<TArgument>(node, computeReplacement, argument));
+            _allowEditsOnLazilyCreatedTrackedNewNodes = true;
+            _changes.Add(new ReplaceChange<TArgument>(node, computeReplacement, argument, this));
         }
 
         /// <summary>
@@ -182,11 +182,14 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <param name="newNode">The new node that will be placed into the tree in the existing node's location.</param>
         public void ReplaceNode(SyntaxNode node, SyntaxNode newNode)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (node == newNode)
+            {
                 return;
+            }
 
-            _changes.Add(new ReplaceChange(node, (n, g) => newNode));
+            newNode = ApplyTrackingToNewNode(newNode);
+            _changes.Add(new ReplaceChange(node, (n, g) => newNode, this));
         }
 
         /// <summary>
@@ -196,10 +199,13 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <param name="newNodes">The nodes to place before the existing node. These nodes must be of a compatible type to be placed in the same list containing the existing node.</param>
         public void InsertBefore(SyntaxNode node, IEnumerable<SyntaxNode> newNodes)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (newNodes == null)
+            {
                 throw new ArgumentNullException(nameof(newNodes));
+            }
 
+            newNodes = ApplyTrackingToNewNodes(newNodes);
             _changes.Add(new InsertChange(node, newNodes, isBefore: true));
         }
 
@@ -218,10 +224,13 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <param name="newNodes">The nodes to place after the existing node. These nodes must be of a compatible type to be placed in the same list containing the existing node.</param>
         public void InsertAfter(SyntaxNode node, IEnumerable<SyntaxNode> newNodes)
         {
-            CheckNodeInOriginalTree(node);
+            CheckNodeInOriginalTreeOrTracked(node);
             if (newNodes == null)
+            {
                 throw new ArgumentNullException(nameof(newNodes));
+            }
 
+            newNodes = ApplyTrackingToNewNodes(newNodes);
             _changes.Add(new InsertChange(node, newNodes, isBefore: false));
         }
 
@@ -233,13 +242,33 @@ namespace Microsoft.CodeAnalysis.Editing
         public void InsertAfter(SyntaxNode node, SyntaxNode newNode)
             => this.InsertAfter(node, new[] { newNode });
 
-        private void CheckNodeInOriginalTree(SyntaxNode node)
+        private void CheckNodeInOriginalTreeOrTracked(SyntaxNode node)
         {
             if (node == null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             if (OriginalRoot.Contains(node))
+            {
+                // Node is contained in the original tree.
                 return;
+            }
+
+            if (_allowEditsOnLazilyCreatedTrackedNewNodes)
+            {
+                // This could be a node that is handed to us lazily from one of the prior edits
+                // which support lazy replacement nodes, we conservatively avoid throwing here.
+                // If this was indeed an unsupported node, syntax editor will throw an exception later
+                // when attempting to compute changed root.
+                return;
+            }
+
+            if (_lazyTrackedNewNodesOpt?.Contains(node) == true)
+            {
+                // Node is one of the new nodes, which is already tracked and supported.
+                return;
+            }
 
             throw new ArgumentException(WorkspacesResources.The_node_is_not_part_of_the_tree, nameof(node));
         }
@@ -255,7 +284,9 @@ namespace Microsoft.CodeAnalysis.Editing
             {
                 var currentNode = root.GetCurrentNode(OriginalNode);
                 if (currentNode is null)
+                {
                     Contract.Fail($"GetCurrentNode returned null with the following node: {OriginalNode}");
+                }
 
                 return Apply(root, currentNode, generator);
             }
@@ -294,53 +325,78 @@ namespace Microsoft.CodeAnalysis.Editing
         private sealed class ReplaceChange : Change
         {
             private readonly Func<SyntaxNode, SyntaxGenerator, SyntaxNode?> _modifier;
+            private readonly SyntaxEditor _editor;
 
             public ReplaceChange(
                 SyntaxNode node,
-                Func<SyntaxNode, SyntaxGenerator, SyntaxNode?> modifier)
+                Func<SyntaxNode, SyntaxGenerator, SyntaxNode?> modifier,
+                SyntaxEditor editor)
                 : base(node)
             {
                 Contract.ThrowIfNull(node);
                 _modifier = modifier;
+                _editor = editor;
             }
 
             protected override SyntaxNode Apply(SyntaxNode root, SyntaxNode currentNode, SyntaxGenerator generator)
-                => ValidateNewRoot(generator.ReplaceNode(root, currentNode, _modifier(currentNode, generator)));
+            {
+                var newNode = _modifier(currentNode, generator);
+                newNode = _editor.ApplyTrackingToNewNode(newNode);
+                return ValidateNewRoot(generator.ReplaceNode(root, currentNode, newNode));
+            }
         }
 
         private sealed class ReplaceWithCollectionChange : Change
         {
             private readonly Func<SyntaxNode, SyntaxGenerator, IEnumerable<SyntaxNode>> _modifier;
+            private readonly SyntaxEditor _editor;
 
             public ReplaceWithCollectionChange(
                 SyntaxNode node,
-                Func<SyntaxNode, SyntaxGenerator, IEnumerable<SyntaxNode>> modifier)
+                Func<SyntaxNode, SyntaxGenerator, IEnumerable<SyntaxNode>> modifier,
+                SyntaxEditor editor)
                 : base(node)
             {
                 _modifier = modifier;
+                _editor = editor;
             }
 
             protected override SyntaxNode Apply(SyntaxNode root, SyntaxNode currentNode, SyntaxGenerator generator)
-                => SyntaxGenerator.ReplaceNode(root, currentNode, _modifier(currentNode, generator));
+            {
+                var newNodes = _modifier(currentNode, generator).ToList();
+                for (var i = 0; i < newNodes.Count; i++)
+                {
+                    newNodes[i] = _editor.ApplyTrackingToNewNode(newNodes[i]);
+                }
+
+                return SyntaxGenerator.ReplaceNode(root, currentNode, newNodes);
+            }
         }
 
         private sealed class ReplaceChange<TArgument> : Change
         {
             private readonly Func<SyntaxNode, SyntaxGenerator, TArgument, SyntaxNode> _modifier;
             private readonly TArgument _argument;
+            private readonly SyntaxEditor _editor;
 
             public ReplaceChange(
                 SyntaxNode node,
                 Func<SyntaxNode, SyntaxGenerator, TArgument, SyntaxNode> modifier,
-                TArgument argument)
+                TArgument argument,
+                SyntaxEditor editor)
                 : base(node)
             {
                 _modifier = modifier;
                 _argument = argument;
+                _editor = editor;
             }
 
             protected override SyntaxNode Apply(SyntaxNode root, SyntaxNode currentNode, SyntaxGenerator generator)
-                => ValidateNewRoot(generator.ReplaceNode(root, currentNode, _modifier(currentNode, generator, _argument)));
+            {
+                var newNode = _modifier(currentNode, generator, _argument);
+                newNode = _editor.ApplyTrackingToNewNode(newNode);
+                return ValidateNewRoot(generator.ReplaceNode(root, currentNode, newNode));
+            }
         }
 
         private sealed class InsertChange : Change

--- a/src/Workspaces/CoreTest/Editing/SyntaxEditorTests.cs
+++ b/src/Workspaces/CoreTest/Editing/SyntaxEditorTests.cs
@@ -145,6 +145,294 @@ public class C
         }
 
         [Fact]
+        public void TestReplaceWithTracking()
+        {
+            // ReplaceNode overload #1
+            TestReplaceWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.ReplaceNode(node, newNode);
+            });
+
+            // ReplaceNode overload #2
+            TestReplaceWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.ReplaceNode(node, computeReplacement: (originalNode, generator) => newNode);
+            });
+
+            // ReplaceNode overload #3
+            TestReplaceWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.ReplaceNode(node,
+                     computeReplacement: (originalNode, generator, argument) => newNode,
+                     argument: (object)null);
+            });
+        }
+
+        private void TestReplaceWithTrackingCore(Action<SyntaxNode, SyntaxNode, SyntaxEditor> replaceNodeWithTracking)
+        {
+            var code = @"
+public class C
+{
+    public int X;
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var fieldX = editor.Generator.GetMembers(cls)[0];
+            var newFieldY = editor.Generator.FieldDeclaration("Y", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            replaceNodeWithTracking(fieldX, newFieldY, editor);
+
+            var newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public string Y;
+}");
+            var newFieldYType = newFieldY.DescendantNodes().Single(n => n.ToString() == "string");
+            var newType = editor.Generator.TypeExpression(SpecialType.System_Char);
+            replaceNodeWithTracking(newFieldYType, newType, editor);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public char Y;
+}");
+
+            editor.RemoveNode(newFieldY);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+}");
+        }
+
+        [Fact]
+        public void TestReplaceWithTracking_02()
+        {
+            var code = @"
+public class C
+{
+    public int X;
+    public string X2;
+    public char X3;
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+
+            var editor = GetEditor(cu);
+
+            var cls = cu.Members[0];
+            var fieldX = editor.Generator.GetMembers(cls)[0];
+            var fieldX2 = editor.Generator.GetMembers(cls)[1];
+            var fieldX3 = editor.Generator.GetMembers(cls)[2];
+
+            var newFieldY = editor.Generator.FieldDeclaration("Y", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            editor.ReplaceNode(fieldX, newFieldY);
+
+            var newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public string Y;
+    public string X2;
+    public char X3;
+}");
+            var newFieldYType = newFieldY.DescendantNodes().Single(n => n.ToString() == "string");
+            var newType = editor.Generator.TypeExpression(SpecialType.System_Char);
+            editor.ReplaceNode(newFieldYType, newType);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public char Y;
+    public string X2;
+    public char X3;
+}");
+
+            var newFieldY2 = editor.Generator.FieldDeclaration("Y2", editor.Generator.TypeExpression(SpecialType.System_Boolean), Accessibility.Private);
+            editor.ReplaceNode(fieldX2, newFieldY2);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public char Y;
+    private bool Y2;
+    public char X3;
+}");
+
+            var newFieldZ = editor.Generator.FieldDeclaration("Z", editor.Generator.TypeExpression(SpecialType.System_Boolean), Accessibility.Public);
+            editor.ReplaceNode(newFieldY, newFieldZ);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public bool Z;
+    private bool Y2;
+    public char X3;
+}");
+
+            var originalFieldX3Type = fieldX3.DescendantNodes().Single(n => n.ToString() == "char");
+            newType = editor.Generator.TypeExpression(SpecialType.System_Boolean);
+            editor.ReplaceNode(originalFieldX3Type, newType);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public bool Z;
+    private bool Y2;
+    public bool X3;
+}");
+
+            editor.RemoveNode(newFieldY2);
+            editor.RemoveNode(fieldX3);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public bool Z;
+}");
+        }
+
+        [Fact]
+        public void TestInsertAfterWithTracking()
+        {
+            // InsertAfter overload #1
+            TestInsertAfterWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.InsertAfter(node, newNode);
+            });
+
+            // InsertAfter overload #2
+            TestInsertAfterWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.InsertAfter(node, new[] { newNode });
+            });
+        }
+
+        private void TestInsertAfterWithTrackingCore(Action<SyntaxNode, SyntaxNode, SyntaxEditor> insertAfterWithTracking)
+        {
+            var code = @"
+public class C
+{
+    public int X;
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var fieldX = editor.Generator.GetMembers(cls)[0];
+            var newFieldY = editor.Generator.FieldDeclaration("Y", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            insertAfterWithTracking(fieldX, newFieldY, editor);
+
+            var newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public int X;
+    public string Y;
+}");
+
+            var newFieldZ = editor.Generator.FieldDeclaration("Z", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            editor.ReplaceNode(newFieldY, newFieldZ);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public int X;
+    public string Z;
+}");
+        }
+
+        [Fact]
+        public void TestInsertBeforeWithTracking()
+        {
+            // InsertBefore overload #1
+            TestInsertBeforeWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.InsertBefore(node, newNode);
+            });
+
+            // InsertBefore overload #2
+            TestInsertBeforeWithTrackingCore((SyntaxNode node, SyntaxNode newNode, SyntaxEditor editor) =>
+            {
+                editor.InsertBefore(node, new[] { newNode });
+            });
+        }
+
+        private void TestInsertBeforeWithTrackingCore(Action<SyntaxNode, SyntaxNode, SyntaxEditor> insertBeforeWithTracking)
+        {
+            var code = @"
+public class C
+{
+    public int X;
+}";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var fieldX = editor.Generator.GetMembers(cls)[0];
+            var newFieldY = editor.Generator.FieldDeclaration("Y", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            insertBeforeWithTracking(fieldX, newFieldY, editor);
+
+            var newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public string Y;
+    public int X;
+}");
+
+            var newFieldZ = editor.Generator.FieldDeclaration("Z", editor.Generator.TypeExpression(SpecialType.System_String), Accessibility.Public);
+            editor.ReplaceNode(newFieldY, newFieldZ);
+
+            newRoot = editor.GetChangedRoot();
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot,
+                @"
+public class C
+{
+    public string Z;
+    public int X;
+}");
+        }
+
+        [Fact]
         public void TestTrackNode()
         {
             var code = @"


### PR DESCRIPTION
This did hit a partner team.  While we were able to work through it quickly, we feel that we should not take this so close to the end of a cycle, and instead take through 17.7 so that the ecosystem and community can have more time to adjust if they are impacted.