### PR TITLE
Optimize some SegmentedArrayHelper members for JIT

### DIFF
--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -19,42 +19,51 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetSegmentSize<T>()
         {
+#if NETCOREAPP3_0_OR_NEWER
+            return InlineCalculateSegmentSize(Unsafe.SizeOf<T>());
+#else
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
             {
                 return ReferenceTypeSegmentHelper.SegmentSize;
             }
-#if NETCOREAPP
-            return InlineCalculateSegmentSize(Unsafe.SizeOf<T>());
-#else
-            return ValueTypeSegmentHelper<T>.SegmentSize;
+            else
+            {
+                return ValueTypeSegmentHelper<T>.SegmentSize;
+            }
 #endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetSegmentShift<T>()
         {
+#if NETCOREAPP3_0_OR_NEWER
+            return InlineCalculateSegmentShift(Unsafe.SizeOf<T>());
+#else
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
             {
                 return ReferenceTypeSegmentHelper.SegmentShift;
             }
-#if NETCOREAPP
-            return InlineCalculateSegmentShift(Unsafe.SizeOf<T>());
-#else
-            return ValueTypeSegmentHelper<T>.SegmentShift;
+            else
+            {
+                return ValueTypeSegmentHelper<T>.SegmentShift;
+            }
 #endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetOffsetMask<T>()
         {
+#if NETCOREAPP3_0_OR_NEWER
+            return InlineCalculateOffsetMask(Unsafe.SizeOf<T>());
+#else
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
             {
                 return ReferenceTypeSegmentHelper.OffsetMask;
             }
-#if NETCOREAPP
-            return InlineCalculateOffsetMask(Unsafe.SizeOf<T>());
-#else
-            return ValueTypeSegmentHelper<T>.OffsetMask;
+            else
+            {
+                return ValueTypeSegmentHelper<T>.OffsetMask;
+            }
 #endif
         }
 
@@ -119,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
         // Faster inline implementation for NETCOREAPP to avoid static constructors and non-inlineable
         // generics with runtime lookups
-#if NETCOREAPP
+#if NETCOREAPP3_0_OR_NEWER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int InlineCalculateSegmentSize(int elementSize)
         {

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -16,14 +16,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         // Large value types may benefit from a smaller number.
         internal const int IntrosortSizeThreshold = 16;
 
-        /// <summary>
-        /// A combination of <see cref="MethodImplOptions.AggressiveInlining"/> and
-        /// <see cref="F:System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization"/>.
-        /// </summary>
-        [SuppressMessage("Documentation", "CA1200:Avoid using cref tags with a prefix", Justification = "The field is not supported in all compilation targets.")]
-        internal const MethodImplOptions FastPathMethodImplOptions = MethodImplOptions.AggressiveInlining | (MethodImplOptions)512;
-
-        [MethodImpl(FastPathMethodImplOptions)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetSegmentSize<T>()
         {
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
@@ -32,11 +25,11 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentHelper<T>.SegmentSize;
+                return ValueTypeSegmentSizeHelper<T>.SegmentSize;
             }
         }
 
-        [MethodImpl(FastPathMethodImplOptions)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetSegmentShift<T>()
         {
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
@@ -45,11 +38,11 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentHelper<T>.SegmentShift;
+                return ValueTypeSegmentHelper.SegmentShift;
             }
         }
 
-        [MethodImpl(FastPathMethodImplOptions)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetOffsetMask<T>()
         {
             if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
@@ -58,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentHelper<T>.OffsetMask;
+                return ValueTypeSegmentHelper.OffsetMask;
             }
         }
 
@@ -140,9 +133,13 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }
 
-        private static class ValueTypeSegmentHelper<T>
+        private static class ValueTypeSegmentSizeHelper<T>
         {
             public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
+        }
+
+        private static class ValueTypeSegmentHelper
+        {
             public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);
             public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentHelper.SegmentShift;
+                return ValueTypeSegmentHelper<T>.SegmentShift;
             }
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentHelper.OffsetMask;
+                return ValueTypeSegmentHelper<T>.OffsetMask;
             }
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }
 
-        private static class ValueTypeSegmentHelper
+        private static class ValueTypeSegmentHelper<T>
         {
             public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
             public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
             else
             {
-                return ValueTypeSegmentSizeHelper<T>.SegmentSize;
+                return ValueTypeSegmentHelper<T>.SegmentSize;
             }
         }
 
@@ -133,13 +133,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }
 
-        private static class ValueTypeSegmentSizeHelper<T>
-        {
-            public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
-        }
-
         private static class ValueTypeSegmentHelper
         {
+            public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
             public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);
             public static readonly int OffsetMask = CalculateOffsetMask(SegmentSize);
         }

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -132,9 +132,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             // Default Large Object Heap size threshold
             // https://github.com/dotnet/runtime/blob/c9d69e38d0e54bea5d188593ef6c3b30139f3ab1/src/coreclr/src/gc/gc.h#L111
             const uint Threshold = 85000;
-            return System.Numerics.BitOperations.Log2((uint)((Threshold / elementSize) - (2 * IntPtr.Size)));
+            return System.Numerics.BitOperations.Log2((uint)((Threshold / elementSize) - (2 * Unsafe.SizeOf<object>())));
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int InlineCalculateOffsetMask(int elementSize)
         {

--- a/src/Dependencies/Collections/SegmentedArray`1.cs
+++ b/src/Dependencies/Collections/SegmentedArray`1.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </remarks>
         private static int SegmentSize
         {
-            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
                 return SegmentedArrayHelper.GetSegmentSize<T>();
@@ -44,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         private static int SegmentShift
         {
-            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
                 return SegmentedArrayHelper.GetSegmentShift<T>();
@@ -56,7 +54,6 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         private static int OffsetMask
         {
-            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
             get
             {
                 return SegmentedArrayHelper.GetOffsetMask<T>();
@@ -115,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
         public ref T this[int index]
         {
-            [MethodImpl(SegmentedArrayHelper.FastPathMethodImplOptions)]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return ref _items[index >> SegmentShift][index & OffsetMask];


### PR DESCRIPTION
These properties pop up in perf traces while it is expected that they should be folded to constants. There are two problems here:
1) `AggressiveOptimization` (`(MethodImplOptions)512`) attribute often ruins `static readonly` related optimizations because JIT is forced to compile a method straight to Tier1 so some types might not be statically initialized yet.
Example:
```csharp
class MyProg
{
    static readonly int Size = int.Parse("42");

    [MethodImpl(MethodImplOptions.NoInlining | 
                MethodImplOptions.AggressiveOptimization)]
    static int GetSize() => Size; 

    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            GetSize();
            Thread.Sleep(16);
        }
    }
}
```
Codegen for `GetSize` function:
```asm
; Assembly listing for method MyProg:GetSize():int
       4883EC28             sub      rsp, 40
       48B9F045ABE3F87F0000 mov      rcx, 0x7FF8E3AB45F0
       BA06000000           mov      edx, 6
       E86865865F           call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       8B052EF01C00         mov      eax, dword ptr [(reloc 0x7ff8e3ab462c)]
       4883C428             add      rsp, 40
       C3                   ret
```
Now, if I remove `AggressiveOptimization` and run it again:
```asm
; Assembly listing for method MyProg:GetSize():int
       B82A000000           mov      eax, 42
       C3                   ret 
```
As a bonus, JIT won't waste time on jitting these functions during startup as R2R is expected to be picked up (it doesn't exist for methods with `AggressiveOptimization`).

2) The next issue is a bit more complicated - if your input type is a struct with a shared generic type, e.g.
```csharp
public struct MyStruct<T>
{
    public T t1;
    public T t2;
}
```
Then `ValueTypeSegmentHelper<T>.field` can't be inlined as is (needs dictionary runtime lookup and jit gives up on those). ~~I moved `SegmentShift` and `OffsetMask` to a non generic type since those don't depend on `T`, but I can't do the same for `SegmentSize`.~~

As I workaround we can record which sizes are the most popular and add fast paths probably. Or use a dictionary, cc @jkotas 

Here is a minimal repro:
```csharp
using System.Runtime.CompilerServices;

public struct MyStruct<T>
{
    public T t1;
    public T t2;
}

static class Program
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Foo<T>()
    {
        return SegmentedArrayHelper.GetSegmentSize<T>();
    }

    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            Foo<MyStruct<string>>();
            Thread.Sleep(15);
        }
    }
}

internal static class SegmentedArrayHelper
{
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    internal static int GetSegmentSize<T>()
    {
        if (Unsafe.SizeOf<T>() == Unsafe.SizeOf<object>())
        {
            return ReferenceTypeSegmentHelper.SegmentSize;
        }
        else
        {
            return ValueTypeSegmentSizeHelper<T>.SegmentSize;
        }
    }

    private static class ValueTypeSegmentSizeHelper<T>
    {
        public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());

        private static int CalculateSegmentSize(int elementSize)
        {
            const int Threshold = 85000;
            var segmentSize = 2;
            while (ArraySize(elementSize, segmentSize << 1) < Threshold)
            {
                segmentSize <<= 1;
            }
            return segmentSize;
            static int ArraySize(int elementSize, int segmentSize)
            {
                return (2 * IntPtr.Size) + (elementSize * segmentSize);
            }
        }
    }

    private static class ReferenceTypeSegmentHelper
    {
        public static readonly int SegmentSize = CalculateSegmentSize(IntPtr.Size);

        private static int CalculateSegmentSize(int elementSize)
        {
            const int Threshold = 85000;
            var segmentSize = 2;
            while (ArraySize(elementSize, segmentSize << 1) < Threshold)
            {
                segmentSize <<= 1;
            }
            return segmentSize;
            static int ArraySize(int elementSize, int segmentSize)
            {
                return (2 * IntPtr.Size) + (elementSize * segmentSize);
            }
        }
    }
}
```
Codegen for `Foo`:
```asm
; Assembly listing for method Program:Foo[MyStruct`1[System.__Canon]]():int
G_M32814_IG01:              
       4883EC28             sub      rsp, 40
       48894C2420           mov      qword ptr [rsp+20H], rcx
G_M32814_IG02:              
       488B5138             mov      rdx, qword ptr [rcx+38H]
       488B5210             mov      rdx, qword ptr [rdx+10H]
       4885D2               test     rdx, rdx
       7402                 je       SHORT G_M32814_IG04
G_M32814_IG03:             
       EB12                 jmp      SHORT G_M32814_IG05
G_M32814_IG04:            
       48BA587CEEE3F87F0000 mov      rdx, 0x7FF8E3EE7C58      ; global ptr
       E8B901525F           call     CORINFO_HELP_RUNTIMEHANDLE_METHOD
       488BD0               mov      rdx, rax
G_M32814_IG05:              
       488BCA               mov      rcx, rdx
       FF15CDE25F00         call     [SegmentedArrayHelper:GetSegmentSize[MyStruct`1[System.__Canon]]():int]
       90                   nop      
G_M32814_IG06:              
       4883C428             add      rsp, 40
       C3                   ret
```