### PR TITLE
Update VB Extract Interface to use GetRelevantNode

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
@@ -1013,7 +1013,7 @@ Class$$ Program(Of T As U, U)
     Public Sub Goo(t As T, u As U)
     End Sub
 End Class</text>.NormalizedValue()
-            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=False)
+            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)>
@@ -1058,7 +1058,7 @@ $$Class Program(Of T As U, U)
     Public Sub Goo(t As T, u As U)
     End Sub
 End Class</text>.NormalizedValue()
-            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=False)
+            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)>
@@ -1088,7 +1088,7 @@ Class$$ Program(Of T As U, U)
     Public Sub Goo(t As T, u As U)
     End Sub
 End Class</text>.NormalizedValue()
-            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=False)
+            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)>
@@ -1103,7 +1103,7 @@ Class Program(Of T As U, U) $$
     Public Sub Goo(t As T, u As U)
     End Sub
 End Class</text>.NormalizedValue()
-            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=False)
+            Await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable:=True)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)>

--- a/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
+++ b/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
@@ -31,8 +31,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractInterface
             Dim span = New TextSpan(position, 0)
             Dim typeBlock = Await document.TryGetRelevantNodeAsync(Of TypeBlockSyntax)(span, cancellationToken).ConfigureAwait(False)
 
-            ' If TypeDiscoverRule Is set to TypeDeclaration, a position anywhere inside of the
-            ' declaration enclosure Is valid. In this case check to see if there Is a type declaration ancestor
+            ' If TypeDiscoverRule is set to TypeDeclaration, a position anywhere inside of the
+            ' type block is valid. In this case check to see if there is a type block ancestor
             ' of the focused node.
             If typeBlock Is Nothing And typeDiscoveryRule = TypeDiscoveryRule.TypeDeclaration Then
                 Dim relevantNode = Await document.TryGetRelevantNodeAsync(Of SyntaxNode)(span, cancellationToken).ConfigureAwait(False)

--- a/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
+++ b/src/Features/VisualBasic/Portable/ExtractInterface/VisualBasicExtractInterfaceService.vb
@@ -23,30 +23,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractInterface
         Public Sub New()
         End Sub
 
-        Protected Async Function GetTypeDeclarationAsync2(
-            document As Document, position As Integer,
-            typeDiscoveryRule As TypeDiscoveryRule,
-            cancellationToken As CancellationToken) As Task(Of SyntaxNode)
-
-            Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
-            Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
-            Dim token = root.FindToken(If(position <> tree.Length, position, Math.Max(0, position - 1)))
-            Dim typeDeclaration = token.GetAncestor(Of TypeBlockSyntax)()
-
-            If typeDeclaration Is Nothing OrElse
-               typeDeclaration.Kind = SyntaxKind.ModuleStatement Then
-                Return Nothing
-            ElseIf typeDiscoveryRule = TypeDiscoveryRule.TypeDeclaration Then
-                Return typeDeclaration
-            End If
-
-            Dim spanStart = typeDeclaration.BlockStatement.Identifier.SpanStart
-            Dim spanEnd = If(typeDeclaration.BlockStatement.TypeParameterList IsNot Nothing, typeDeclaration.BlockStatement.TypeParameterList.Span.End, typeDeclaration.BlockStatement.Identifier.Span.End)
-            Dim span = New TextSpan(spanStart, spanEnd - spanStart)
-
-            Return If(span.IntersectsWith(position), typeDeclaration, Nothing)
-        End Function
-
         Protected Overrides Async Function GetTypeDeclarationAsync(
             document As Document, position As Integer,
             typeDiscoveryRule As TypeDiscoveryRule,


### PR DESCRIPTION
Update the VB behavior to match the [new C# behavior](https://github.com/dotnet/roslyn/pull/67482). 
- Extract interface appears as a Lightbulb action anywhere from the class declaration statement line (not just the name of the class)
- Extract interface works from anywhere inside of the class, but doesn't show as a Lightbulb action

![ExtractInterfaceVB](https://user-images.githubusercontent.com/9122518/228659860-dbbe0a52-2196-49fc-9b58-ccb18cac184b.gif)


