### PR TITLE
[Infra] Disable tests that depend on `DotNetSdkMSBuildInstalled` and downgrade MSBuild version

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.100-preview.1.23115.2",
     "vs": {
-      "version": "17.5.0"
+      "version": "17.4.1"
     },
-    "xcopy-msbuild": "17.5.0"
+    "xcopy-msbuild": "17.4.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23168.1",

--- a/src/Workspaces/MSBuildTest/Utilities/DotNetSdkMSBuildInstalled.cs
+++ b/src/Workspaces/MSBuildTest/Utilities/DotNetSdkMSBuildInstalled.cs
@@ -117,8 +117,10 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
         {
         }
 
+        // Eventually should revert condition to 'SdkPath is null' after MSBuild issue is fixed:
+        // https://github.com/dotnet/roslyn/issues/67566
         public override bool ShouldSkip
-            => SdkPath is null;
+            => true;
 
         public override string SkipReason
 #if NETCOREAPP


### PR DESCRIPTION
Unblocks CI
Tracking issue: https://github.com/dotnet/roslyn/issues/67566