### PR TITLE
Avoid allocations in 'add import' fixers

### DIFF
--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.AddImport
         : IAddImportFeatureService, IEqualityComparer<PortableExecutableReference>
         where TSimpleNameSyntax : SyntaxNode
     {
+        private static ConcurrentDictionary<MetadataId, bool> s_isInPackagesDirectory = new();
+
         private static ImmutableArray<string> s_packagesDirectoryComponent = ImmutableArray.Create(
             "packages",
             "packs",

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -28,6 +28,10 @@ namespace Microsoft.CodeAnalysis.AddImport
         : IAddImportFeatureService, IEqualityComparer<PortableExecutableReference>
         where TSimpleNameSyntax : SyntaxNode
     {
+        /// <summary>
+        /// Cache of information about whether a <see cref="PortableExecutableReference"/> is likely contained within a
+        /// NuGet packages directory.
+        /// </summary>
         private static readonly ConcurrentDictionary<MetadataId, bool> s_isInPackagesDirectory = new();
 
         protected abstract bool CanAddImport(SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken);


### PR DESCRIPTION
PathUtilities.ContainsPathComponent allocates heavily (as it breaks up a path into individual pieces).  Just cache results to avoid doing that more htan once per metadata.

Note: i considered just moving to a non-allocating form of doign the path checks.  BUt it's still a lot of linear string operations done over and over again.  Caching seems better here as the results will never change, so best to just only do it once and then reuse hte results after that.

Saves around 27% of the strings allocated in a large typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/228895657-9bfd1427-be05-4437-987d-57aa48aa82e8.png)
