### PR TITLE
Reduce allocations producing enumerators in symbol usage analysis

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICollectionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICollectionExtensions.cs
@@ -26,6 +26,18 @@ namespace Roslyn.Utilities
             }
         }
 
+        public static void AddRange<T>(this ICollection<T> collection, HashSet<T>? values)
+        {
+            if (collection == null)
+                throw new ArgumentNullException(nameof(collection));
+
+            if (values != null)
+            {
+                foreach (var item in values)
+                    collection.Add(item);
+            }
+        }
+
         public static void AddRange<T>(this ICollection<T> collection, ImmutableArray<T> values)
         {
             if (collection == null)


### PR DESCRIPTION
Addresses the huge amount of allocations here:

![image](https://user-images.githubusercontent.com/4564579/228906699-9adc1d0b-eb86-4e83-8987-579127a8bad3.png)

This is rougly 3.7% of heap allocs on a typing/lightbulb scenario.