### PR TITLE
Avoid allocations in diagnostic computation when waiting on high pri work to complete

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -298,8 +298,13 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                         return;
                     }
 
-                    // Wait for all the high priority tasks, ignoring all exceptions from it.
-                    await Task.WhenAll(highPriorityTasksToAwait).WithCancellation(cancellationToken).NoThrowAwaitable(false);
+                    // Wait for all the high priority tasks, ignoring all exceptions from it. Loop directly to avoid
+                    // expensive allocations in Task.WhenAll.
+                    foreach (var task in highPriorityTasksToAwait)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await task.WithCancellation(cancellationToken).NoThrowAwaitable(false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Addresses this allocation path, which is 4% of hte allocs in a mainline typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/228911790-2a7a332d-03aa-4ae8-a477-979c6ad38406.png)
