### PR TITLE
Cache results of parsing editorconfig values, avoiding the need for repeated costly string operations

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
@@ -77,10 +77,9 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             {
                 // If we have two args, then the second must be a notification option.  If 
                 // it isn't, then this isn't a valid code style option at all.
-                var secondValue = arg.Substring(firstColonIndex + 1);
-                if (TryParseNotification(secondValue, out var localNotification))
+                if (TryParseNotification(arg.AsSpan(firstColonIndex + 1), out var localNotification))
                 {
-                    var firstValue = arg.Substring(0, firstColonIndex);
+                    var firstValue = arg[..firstColonIndex];
                     value = firstValue.Trim();
                     notification = localNotification;
                     return true;
@@ -93,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             return false;
         }
 
-        private static bool TryParseNotification(string value, out NotificationOption2 notification)
+        private static bool TryParseNotification(ReadOnlySpan<char> value, out NotificationOption2 notification)
         {
             switch (value.Trim())
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfigValueSerializer`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfigValueSerializer`1.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeStyle;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Options
 
         private readonly Func<string, Optional<T>> _parseValue;
         private readonly Func<T, string> _serializeValue;
+
+        private readonly ConcurrentDictionary<string, Optional<T>> _cachedValues = new();
 
         public EditorConfigValueSerializer(
             Func<string, Optional<T>> parseValue,
@@ -43,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Options
 
         internal bool TryParseValue(string value, [MaybeNullWhen(false)] out T result)
         {
-            var optionalValue = _parseValue(value);
+            var optionalValue = _cachedValues.GetOrAdd(value, _parseValue);
             if (optionalValue.HasValue)
             {
                 result = optionalValue.Value;


### PR DESCRIPTION
Takes string allocation costs in a simple typing/lightbulb scenario from 267MB allocated to 109MB (a 60% improvement).

![image](https://user-images.githubusercontent.com/4564579/228939743-c5cc86ae-920f-4be5-b190-84e201aee289.png)

