### PR TITLE
Avoid allocating enumerators in symbol usage analysis

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -115,6 +115,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 using var _ = PooledHashSet<ISymbol>.GetInstance(out var uniqueSymbols);
 
                 // Check if both _reachingWrites maps have same set of keys.
+#if NET
+                uniqueSymbols.EnsureCapacity(Math.Max(_reachingWrites.Keys.Count, other._reachingWrites.Keys.Count));
+#endif
+
                 uniqueSymbols.AddRange(_reachingWrites.Keys);
                 uniqueSymbols.AddRange(other._reachingWrites.Keys);
                 if (uniqueSymbols.Count != _reachingWrites.Count)
@@ -183,6 +187,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 }
 
                 var mergedData = GetInstance();
+
                 AddEntries(mergedData._reachingWrites, data1);
                 AddEntries(mergedData._reachingWrites, data2);
 
@@ -213,6 +218,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                             result.Add(symbol, values);
                         }
 
+#if NET
+                        values.EnsureCapacity(operations.Count);
+#endif
                         values.AddRange(operations);
                     }
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -112,35 +112,44 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     return false;
                 }
 
-                var uniqueSymbols = PooledHashSet<ISymbol>.GetInstance();
-                try
+                using var _ = PooledHashSet<ISymbol>.GetInstance(out var uniqueSymbols);
+
+                // Check if both _reachingWrites maps have same set of keys.
+                uniqueSymbols.AddRange(_reachingWrites.Keys);
+                uniqueSymbols.AddRange(other._reachingWrites.Keys);
+                if (uniqueSymbols.Count != _reachingWrites.Count)
+                    return false;
+
+                // Check if both _reachingWrites maps have same set of write operations for each tracked symbol.
+                foreach (var symbol in uniqueSymbols)
                 {
-                    // Check if both _reachingWrites maps have same set of keys.
-                    uniqueSymbols.AddRange(_reachingWrites.Keys);
-                    uniqueSymbols.AddRange(other._reachingWrites.Keys);
-                    if (uniqueSymbols.Count != _reachingWrites.Count)
-                    {
+                    var writes1 = _reachingWrites[symbol];
+                    var writes2 = other._reachingWrites[symbol];
+                    if (!SetEquals(writes1, writes2))
                         return false;
-                    }
-
-                    // Check if both _reachingWrites maps have same set of write
-                    // operations for each tracked symbol.
-                    foreach (var symbol in uniqueSymbols)
-                    {
-                        var writes1 = _reachingWrites[symbol];
-                        var writes2 = other._reachingWrites[symbol];
-                        if (!writes1.SetEquals(writes2))
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
                 }
-                finally
+
+                return true;
+            }
+
+            /// <summary>
+            /// Same as <see cref="HashSet{T}.SetEquals(IEnumerable{T})"/>, except this avoids allocations by
+            /// enumerating the set directly with a no-alloc enumerator.
+            /// </summary>
+            private static bool SetEquals<T>(HashSet<T> set1, HashSet<T> set2)
+            {
+                // same logic as https://github.com/dotnet/runtime/blob/62d6a8fe599ea3a77ef7af3c7660d398d692f062/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs#L1192
+
+                if (set1.Count != set2.Count)
+                    return false;
+
+                foreach (var operation in set1)
                 {
-                    uniqueSymbols.Free();
+                    if (!set2.Contains(operation))
+                        return false;
                 }
+
+                return true;
             }
 
             private bool IsEmpty => _reachingWrites.Count == 0;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICollectionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ICollectionExtensions.cs
@@ -38,6 +38,18 @@ namespace Roslyn.Utilities
             }
         }
 
+        public static void AddRange<TKey, TValue>(this ICollection<TKey> collection, Dictionary<TKey, TValue>.KeyCollection? keyCollection) where TKey : notnull
+        {
+            if (collection == null)
+                throw new ArgumentNullException(nameof(collection));
+
+            if (keyCollection != null)
+            {
+                foreach (var key in keyCollection)
+                    collection.Add(key);
+            }
+        }
+
         public static void AddRange<T>(this ICollection<T> collection, ImmutableArray<T> values)
         {
             if (collection == null)


### PR DESCRIPTION
Removes 60MB of allocs in a simple typing/lightbulb scenario.  This is 1.5% of all allocs in that scenario: 

![image](https://user-images.githubusercontent.com/4564579/228962564-88877de0-b666-4310-98e6-aa1e29c6642b.png)

After this change, this allocation is gone.