### PR TITLE
Reduce allocations when producing checksums.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -23,10 +23,8 @@ namespace Microsoft.CodeAnalysis
         private static readonly ObjectPool<IncrementalHash> s_incrementalHashPool =
             new(() => IncrementalHash.CreateHash(HashAlgorithmName.SHA256), size: 20);
 
-        private static readonly ObjectPool<byte[]> s_twoChecksumByteArrayPool =
-            new(() => new byte[HashSize * 2]);
-        private static readonly ObjectPool<byte[]> s_threeChecksumByteArrayPool =
-            new(() => new byte[HashSize * 3]);
+        private static readonly ObjectPool<byte[]> s_twoChecksumByteArrayPool = new(() => new byte[HashSize * 2]);
+        private static readonly ObjectPool<byte[]> s_threeChecksumByteArrayPool = new(() => new byte[HashSize * 3]);
 
         public static Checksum Create(IEnumerable<string> values)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -23,6 +23,9 @@ namespace Microsoft.CodeAnalysis
         private static readonly ObjectPool<IncrementalHash> s_incrementalHashPool =
             new(() => IncrementalHash.CreateHash(HashAlgorithmName.SHA256), size: 20);
 
+        // Dedicated pools for the byte[]s we use to create checksums from two or three existing checksums. Sized to
+        // exactly the space needed to splat the existing checksum data into the array and then hash it.
+
         private static readonly ObjectPool<byte[]> s_twoChecksumByteArrayPool = new(() => new byte[HashSize * 2]);
         private static readonly ObjectPool<byte[]> s_threeChecksumByteArrayPool = new(() => new byte[HashSize * 3]);
 
@@ -156,6 +159,8 @@ namespace Microsoft.CodeAnalysis
         }
 
 #if NET
+
+        // Optimized helpers that do not need to allocate any arrays to combine hashes.
 
         private static Checksum CreateUsingSpans(Checksum checksum1, Checksum checksum2)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -156,35 +156,33 @@ namespace Microsoft.CodeAnalysis
 
         private static Checksum CreateUsingSpans(Checksum checksum1, Checksum checksum2)
         {
-            var hash = s_incrementalHashPool.Allocate();
+            using var hash = s_incrementalHashPool.GetPooledObject();
+
             Span<byte> bytesSpan = stackalloc byte[2 * HashSize];
-            Span<byte> hashResultSpan = stackalloc byte[hash.HashLengthInBytes];
+            Span<byte> hashResultSpan = stackalloc byte[hash.Object.HashLengthInBytes];
 
             checksum1.WriteTo(bytesSpan);
             checksum2.WriteTo(bytesSpan.Slice(HashSize));
 
-            hash.AppendData(bytesSpan);
-            hash.GetHashAndReset(hashResultSpan);
-
-            s_incrementalHashPool.Free(hash);
+            hash.Object.AppendData(bytesSpan);
+            hash.Object.GetHashAndReset(hashResultSpan);
 
             return From(hashResultSpan);
         }
 
         private static Checksum CreateUsingSpans(Checksum checksum1, Checksum checksum2, Checksum checksum3)
         {
-            var hash = s_incrementalHashPool.Allocate();
+            using var hash = s_incrementalHashPool.GetPooledObject();
+
             Span<byte> bytesSpan = stackalloc byte[3 * HashSize];
-            Span<byte> hashResultSpan = stackalloc byte[hash.HashLengthInBytes];
+            Span<byte> hashResultSpan = stackalloc byte[hash.Object.HashLengthInBytes];
 
             checksum1.WriteTo(bytesSpan);
             checksum2.WriteTo(bytesSpan.Slice(HashSize));
             checksum3.WriteTo(bytesSpan.Slice(2 * HashSize));
 
-            hash.AppendData(bytesSpan);
-            hash.GetHashAndReset(hashResultSpan);
-
-            s_incrementalHashPool.Free(hash);
+            hash.Object.AppendData(bytesSpan);
+            hash.Object.GetHashAndReset(hashResultSpan);
 
             return From(hashResultSpan);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -105,9 +106,17 @@ namespace Microsoft.CodeAnalysis
         {
 #if NET
             return CreateUsingSpans(checksum1, checksum2);
-
 #else
             return CrateUsingByteArrays(checksum1, checksum2);
+#endif
+        }
+
+        public static Checksum Create(Checksum checksum1, Checksum checksum2, Checksum checksum3)
+        {
+#if NET
+            return CreateUsingSpans(checksum1, checksum2, checksum3);
+#else
+            return CrateUsingByteArrays(checksum1, checksum2, checksum3);
 #endif
         }
 
@@ -186,21 +195,6 @@ namespace Microsoft.CodeAnalysis
         }
 
 #endif
-
-        public static Checksum Create(Checksum checksum1, Checksum checksum2, Checksum checksum3)
-        {
-            using var stream = SerializableBytes.CreateWritableStream();
-
-            using (var writer = new ObjectWriter(stream, leaveOpen: true))
-            {
-                checksum1.WriteTo(writer);
-                checksum2.WriteTo(writer);
-                checksum3.WriteTo(writer);
-            }
-
-            stream.Position = 0;
-            return Create(stream);
-        }
 
         public static Checksum Create(IEnumerable<Checksum> checksums)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis
 #if NET
             return CreateUsingSpans(checksum1, checksum2);
 #else
-            return CrateUsingByteArrays(checksum1, checksum2);
+            return CreateUsingByteArrays(checksum1, checksum2);
 #endif
         }
 
@@ -117,11 +117,11 @@ namespace Microsoft.CodeAnalysis
 #if NET
             return CreateUsingSpans(checksum1, checksum2, checksum3);
 #else
-            return CrateUsingByteArrays(checksum1, checksum2, checksum3);
+            return CreateUsingByteArrays(checksum1, checksum2, checksum3);
 #endif
         }
 
-        private static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2)
+        private static Checksum CreateUsingByteArrays(Checksum checksum1, Checksum checksum2)
         {
             using var hash = s_incrementalHashPool.GetPooledObject();
             using var bytes = s_twoChecksumByteArrayPool.GetPooledObject();
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis
             return From(hash.Object.GetHashAndReset());
         }
 
-        private static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2, Checksum checksum3)
+        private static Checksum CreateUsingByteArrays(Checksum checksum1, Checksum checksum2, Checksum checksum3)
         {
             using var hash = s_incrementalHashPool.GetPooledObject();
             using var bytes = s_threeChecksumByteArrayPool.GetPooledObject();
@@ -264,11 +264,11 @@ namespace Microsoft.CodeAnalysis
 
         public static class TestAccessor
         {
-            public static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2)
-                => Checksum.CrateUsingByteArrays(checksum1, checksum2);
+            public static Checksum CreateUsingByteArrays(Checksum checksum1, Checksum checksum2)
+                => Checksum.CreateUsingByteArrays(checksum1, checksum2);
 
-            public static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2, Checksum checksum3)
-                => Checksum.CrateUsingByteArrays(checksum1, checksum2, checksum3);
+            public static Checksum CreateUsingByteArrays(Checksum checksum1, Checksum checksum2, Checksum checksum3)
+                => Checksum.CreateUsingByteArrays(checksum1, checksum2, checksum3);
 
 #if NET
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -123,39 +123,31 @@ namespace Microsoft.CodeAnalysis
 
         private static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2)
         {
-            var hash = s_incrementalHashPool.Allocate();
+            using var hash = s_incrementalHashPool.GetPooledObject();
+            using var bytes = s_twoChecksumByteArrayPool.GetPooledObject();
 
-            var bytes = s_twoChecksumByteArrayPool.Allocate();
-            var bytesSpan = bytes.AsSpan();
+            var bytesSpan = bytes.Object.AsSpan();
             checksum1.WriteTo(bytesSpan);
             checksum2.WriteTo(bytesSpan.Slice(HashSize));
 
-            hash.AppendData(bytes);
-            var hashResult = hash.GetHashAndReset();
+            hash.Object.AppendData(bytes.Object);
 
-            s_incrementalHashPool.Free(hash);
-            s_twoChecksumByteArrayPool.Free(bytes);
-
-            return From(hashResult);
+            return From(hash.Object.GetHashAndReset());
         }
 
         private static Checksum CrateUsingByteArrays(Checksum checksum1, Checksum checksum2, Checksum checksum3)
         {
-            var hash = s_incrementalHashPool.Allocate();
+            using var hash = s_incrementalHashPool.GetPooledObject();
+            using var bytes = s_threeChecksumByteArrayPool.GetPooledObject();
 
-            var bytes = s_threeChecksumByteArrayPool.Allocate();
-            var bytesSpan = bytes.AsSpan();
+            var bytesSpan = bytes.Object.AsSpan();
             checksum1.WriteTo(bytesSpan);
             checksum2.WriteTo(bytesSpan.Slice(HashSize));
             checksum3.WriteTo(bytesSpan.Slice(2 * HashSize));
 
-            hash.AppendData(bytes);
-            var hashResult = hash.GetHashAndReset();
+            hash.Object.AppendData(bytes.Object);
 
-            s_incrementalHashPool.Free(hash);
-            s_threeChecksumByteArrayPool.Free(bytes);
-
-            return From(hashResult);
+            return From(hash.Object.GetHashAndReset());
         }
 
 #if NET

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var checksum1 = Checksum.Create("Goo");
             var checksum2 = Checksum.Create("Bar");
 
-            var checksumA = Checksum.TestAccessor.CrateUsingByteArrays(checksum1, checksum2);
+            var checksumA = Checksum.TestAccessor.CreateUsingByteArrays(checksum1, checksum2);
             var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2);
 
             Assert.Equal(checksumA, checksumB);
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var checksum2 = Checksum.Create("Bar");
             var checksum3 = Checksum.Create("Baz");
 
-            var checksumA = Checksum.TestAccessor.CrateUsingByteArrays(checksum1, checksum2, checksum3);
+            var checksumA = Checksum.TestAccessor.CreateUsingByteArrays(checksum1, checksum2, checksum3);
             var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2, checksum3);
 
             Assert.Equal(checksumA, checksumB);

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class ChecksumTests
+    {
+#if NET
+        [Fact]
+        public void ValidateChecksumFromSpanSameAsChecksumFromBytes1()
+        {
+            var checksum1 = Checksum.Create("Goo");
+            var checksum2 = Checksum.Create("Bar");
+
+            var checksumA = Checksum.TestAccessor.CrateUsingByteArrays(checksum1, checksum2);
+            var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2);
+
+            Assert.Equal(checksumA, checksumB);
+        }
+#endif
+    }
+}

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -25,6 +25,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Equal(checksumA, checksumB);
         }
+
+        [Fact]
+        public void ValidateChecksumFromSpanSameAsChecksumFromBytes2()
+        {
+            var checksum1 = Checksum.Create("Goo");
+            var checksum2 = Checksum.Create("Bar");
+            var checksum3 = Checksum.Create("Baz");
+
+            var checksumA = Checksum.TestAccessor.CrateUsingByteArrays(checksum1, checksum2, checksum3);
+            var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2, checksum3);
+
+            Assert.Equal(checksumA, checksumB);
+        }
 #endif
     }
 }

--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -24,6 +24,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2);
 
             Assert.Equal(checksumA, checksumB);
+
+            Assert.NotEqual(checksum1, checksum2);
+
+            Assert.NotEqual(checksum1, checksumA);
+            Assert.NotEqual(checksum1, checksumB);
+            Assert.NotEqual(checksum2, checksumA);
+            Assert.NotEqual(checksum2, checksumB);
         }
 
         [Fact]
@@ -37,6 +44,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2, checksum3);
 
             Assert.Equal(checksumA, checksumB);
+
+            Assert.NotEqual(checksum1, checksum2);
+            Assert.NotEqual(checksum2, checksum3);
+            Assert.NotEqual(checksum3, checksum1);
+
+            Assert.NotEqual(checksum1, checksumA);
+            Assert.NotEqual(checksum1, checksumB);
+            Assert.NotEqual(checksum2, checksumA);
+            Assert.NotEqual(checksum2, checksumB);
+            Assert.NotEqual(checksum3, checksumA);
+            Assert.NotEqual(checksum3, checksumB);
         }
 #endif
     }


### PR DESCRIPTION
Saves about 100MB of allocations when on NetCore6 or above for a simple typing/lightbulb scenario: 

![image](https://user-images.githubusercontent.com/4564579/228988710-824b9755-f091-4199-a8ff-b56b4c4609f9.png)
