### PR TITLE
Fix for livelock in DiagnosticComputer

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -14,11 +14,12 @@ using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
-using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
+using static Microsoft.VisualStudio.Threading.ThreadingTools;
 
 namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 {
@@ -298,8 +299,26 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                         return;
                     }
 
-                    // Wait for all the high priority tasks, ignoring all exceptions from it.
-                    await Task.WhenAll(highPriorityTasksToAwait).WithCancellation(cancellationToken).NoThrowAwaitable(false);
+                    // Wait for all the high priority tasks, ignoring all exceptions from it. Loop directly to avoid
+                    // expensive allocations in Task.WhenAll.
+                    foreach (var task in highPriorityTasksToAwait)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        await WaitForHighPriorityTaskAsync(task, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                static async Task WaitForHighPriorityTaskAsync(Task task, CancellationToken cancellationToken)
+                {
+                    if (task.IsCompleted)
+                    {
+                        // Make sure to yield so continuations of 'task' can make progress.
+                        await Task.Yield().ConfigureAwait(false);
+                        return;
+                    }
+
+                    await task.WithCancellation(cancellationToken).NoThrowAwaitableInternal(false);
                 }
             }
         }


### PR DESCRIPTION
#67392 added support for prioritized execution of diagnostic computation requests in OOP. This seems to have introduced a livelock where sometimes the high priority task has already completed, and the continuation that removes it from `s_highPriorityComputeTasks` set is scheduled but never executed. The fix suggested by Stephen Toub is inserting a guaranteed yielding point to ensure the continuation invocation is allowed.