### PR TITLE
Revert for #67392 ([Lightbulb Perf] Add support for prioritized diagnostic computation requests in OOP)

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -1126,7 +1126,7 @@ class A
 
                 throw ExceptionUtilities.Unreachable();
             }
-            catch (OperationCanceledException) when (analyzer.CancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (ex.CancellationToken == analyzer.CancellationToken)
             {
             }
 

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -1067,7 +1067,7 @@ class A
             var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
                 document, project, Checksum.Null, ideAnalyzerOptions, span: null, analyzerIdsToRequestDiagnostics,
                 AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
-                isExplicit: false, reportSuppressedDiagnostics: false, logPerformanceInfo: false, getTelemetryInfo: false,
+                reportSuppressedDiagnostics: false, logPerformanceInfo: false, getTelemetryInfo: false,
                 cancellationToken: CancellationToken.None);
             Assert.False(analyzer2.ReceivedSymbolCallback);
 
@@ -1121,7 +1121,7 @@ class A
             try
             {
                 _ = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, ideAnalyzerOptions, span: null,
-                    analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, isExplicit: false, reportSuppressedDiagnostics: false,
+                    analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, reportSuppressedDiagnostics: false,
                     logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: analyzer.CancellationToken);
 
                 throw ExceptionUtilities.Unreachable();
@@ -1134,7 +1134,7 @@ class A
 
             // Then invoke analysis without cancellation token, and verify non-cancelled diagnostic.
             var diagnosticsMap = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, ideAnalyzerOptions, span: null,
-                analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, isExplicit: false, reportSuppressedDiagnostics: false,
+                analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, reportSuppressedDiagnostics: false,
                 logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: CancellationToken.None);
             var builder = diagnosticsMap.Diagnostics.Single().diagnosticMap;
             var diagnostic = kind == AnalysisKind.Syntax ? builder.Syntax.Single().Item2.Single() : builder.Semantic.Single().Item2.Single();

--- a/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, bool includeNonLocalDocumentDiagnostics = true, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, DiagnosticKind diagnosticKind = DiagnosticKind.All, bool isExplicit = false, CancellationToken cancellationToken = default)
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, DiagnosticKind diagnosticKind = DiagnosticKind.All, CancellationToken cancellationToken = default)
             => Task.FromResult(_diagnosticsWithKindFilter.Where(d => diagnosticKind == d.KindFilter).Select(d => d.Diagnostic).ToImmutableArray());
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, bool includeNonLocalDocumentDiagnostics = true, CancellationToken cancellationToken = default)
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public Task<ImmutableArray<DiagnosticData>> GetSpecificCachedDiagnosticsAsync(Workspace workspace, object id, bool includeSuppressedDiagnostics = false, bool includeNonLocalDocumentDiagnostics = true, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, DiagnosticKind diagnosticKind = DiagnosticKind.All, bool isExplicit = false, CancellationToken cancellationToken = default)
+        public Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, DiagnosticKind diagnosticKind = DiagnosticKind.All, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
@@ -71,13 +71,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [DataMember(Order = 8)]
         public IdeAnalyzerOptions IdeOptions;
 
-        /// <summary>
-        /// Indicates diagnostic computation for an explicit user-invoked request,
-        /// such as a user-invoked Ctrl + Dot operation to bring up the light bulb.
-        /// </summary>
-        [DataMember(Order = 9)]
-        public bool IsExplicit;
-
         public DiagnosticArguments(
             bool reportSuppressedDiagnostics,
             bool logPerformanceInfo,
@@ -87,8 +80,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalysisKind? documentAnalysisKind,
             ProjectId projectId,
             string[] analyzerIds,
-            IdeAnalyzerOptions ideOptions,
-            bool isExplicit)
+            IdeAnalyzerOptions ideOptions)
         {
             Debug.Assert(documentId != null || documentSpan == null);
             Debug.Assert(documentId != null || documentAnalysisKind == null);
@@ -105,7 +97,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ProjectId = projectId;
             AnalyzerIds = analyzerIds;
             IdeOptions = ideOptions;
-            IsExplicit = isExplicit;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     project, ideOptions, analyzers, includeSuppressedDiagnostics: false, cancellationToken).ConfigureAwait(false);
 
                 var analysisScope = new DocumentAnalysisScope(document, span: null, analyzers, kind);
-                var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, isExplicit: false, logPerformanceInfo: true);
+                var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, logPerformanceInfo: true);
 
                 using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var builder);
                 foreach (var analyzer in analyzers)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         private readonly CompilationWithAnalyzers? _compilationWithAnalyzers;
         private readonly InProcOrRemoteHostAnalyzerRunner _diagnosticAnalyzerRunner;
-        private readonly bool _isExplicit;
         private readonly bool _logPerformanceInfo;
         private readonly Action? _onAnalysisException;
 
@@ -40,14 +39,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DocumentAnalysisScope analysisScope,
             CompilationWithAnalyzers? compilationWithAnalyzers,
             InProcOrRemoteHostAnalyzerRunner diagnosticAnalyzerRunner,
-            bool isExplicit,
             bool logPerformanceInfo,
             Action? onAnalysisException = null)
         {
             AnalysisScope = analysisScope;
             _compilationWithAnalyzers = compilationWithAnalyzers;
             _diagnosticAnalyzerRunner = diagnosticAnalyzerRunner;
-            _isExplicit = isExplicit;
             _logPerformanceInfo = logPerformanceInfo;
             _onAnalysisException = onAnalysisException;
 
@@ -60,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public DocumentAnalysisScope AnalysisScope { get; }
 
         public DocumentAnalysisExecutor With(DocumentAnalysisScope analysisScope)
-            => new(analysisScope, _compilationWithAnalyzers, _diagnosticAnalyzerRunner, _isExplicit, _logPerformanceInfo, _onAnalysisException);
+            => new(analysisScope, _compilationWithAnalyzers, _diagnosticAnalyzerRunner, _logPerformanceInfo, _onAnalysisException);
 
         /// <summary>
         /// Return all local diagnostics (syntax, semantic) that belong to given document for the given analyzer by calculating them.
@@ -185,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             try
             {
                 var resultAndTelemetry = await _diagnosticAnalyzerRunner.AnalyzeDocumentAsync(analysisScope, _compilationWithAnalyzers,
-                    _isExplicit, _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
+                    _logPerformanceInfo, getTelemetryInfo: false, cancellationToken).ConfigureAwait(false);
                 return resultAndTelemetry.AnalysisResult;
             }
             catch when (_onAnalysisException != null)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -39,12 +39,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeDocumentAsync(
             DocumentAnalysisScope documentAnalysisScope,
             CompilationWithAnalyzers compilationWithAnalyzers,
-            bool isExplicit,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
             => AnalyzeAsync(documentAnalysisScope, documentAnalysisScope.TextDocument.Project, compilationWithAnalyzers,
-                isExplicit, forceExecuteAllAnalyzers: false, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+                forceExecuteAllAnalyzers: false, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
         public Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeProjectAsync(
             Project project,
@@ -54,13 +53,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool getTelemetryInfo,
             CancellationToken cancellationToken)
             => AnalyzeAsync(documentAnalysisScope: null, project, compilationWithAnalyzers,
-                isExplicit: false, forceExecuteAllAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+                forceExecuteAllAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
         private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(
             DocumentAnalysisScope? documentAnalysisScope,
             Project project,
             CompilationWithAnalyzers compilationWithAnalyzers,
-            bool isExplicit,
             bool forceExecuteAllAnalyzers,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -78,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (remoteHostClient != null)
                 {
                     return await AnalyzeOutOfProcAsync(documentAnalysisScope, project, compilationWithAnalyzers, remoteHostClient,
-                        isExplicit, forceExecuteAllAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
+                        forceExecuteAllAnalyzers, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
                 }
 
                 return await AnalyzeInProcAsync(documentAnalysisScope, project, compilationWithAnalyzers,
@@ -158,7 +156,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Project project,
             CompilationWithAnalyzers compilationWithAnalyzers,
             RemoteHostClient client,
-            bool isExplicit,
             bool forceExecuteAllAnalyzers,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -188,8 +185,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 documentAnalysisScope?.Kind,
                 project.Id,
                 analyzerMap.Keys.ToArray(),
-                ideOptions,
-                isExplicit);
+                ideOptions);
 
             var result = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService, SerializableDiagnosticAnalysisResults>(
                 project.Solution,

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly bool _includeCompilerDiagnostics;
             private readonly Func<string, IDisposable?>? _addOperationScope;
             private readonly bool _cacheFullDocumentDiagnostics;
-            private readonly bool _isExplicit;
             private readonly bool _logPerformanceInfo;
             private readonly bool _incrementalAnalysis;
             private readonly DiagnosticKind _diagnosticKind;
@@ -129,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return new LatestDiagnosticsForSpanGetter(
                     owner, compilationWithAnalyzers, document, text, stateSets, shouldIncludeDiagnostic, includeCompilerDiagnostics,
                     range, blockForData, addOperationScope, includeSuppressedDiagnostics, priority, cacheFullDocumentDiagnostics,
-                    isExplicit, logPerformanceInfo, incrementalAnalysis, diagnosticKinds);
+                    logPerformanceInfo, incrementalAnalysis, diagnosticKinds);
             }
 
             private static async Task<CompilationWithAnalyzers?> GetOrCreateCompilationWithAnalyzersAsync(
@@ -172,7 +171,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 bool includeSuppressedDiagnostics,
                 CodeActionRequestPriority priority,
                 bool cacheFullDocumentDiagnostics,
-                bool isExplicit,
                 bool logPerformanceInfo,
                 bool incrementalAnalysis,
                 DiagnosticKind diagnosticKind)
@@ -190,7 +188,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _includeSuppressedDiagnostics = includeSuppressedDiagnostics;
                 _priority = priority;
                 _cacheFullDocumentDiagnostics = cacheFullDocumentDiagnostics;
-                _isExplicit = isExplicit;
                 _logPerformanceInfo = logPerformanceInfo;
                 _incrementalAnalysis = incrementalAnalysis;
                 _diagnosticKind = diagnosticKind;
@@ -381,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 var analyzers = stateSets.SelectAsArray(stateSet => stateSet.Analyzer);
                 var analysisScope = new DocumentAnalysisScope(_document, span, analyzers, kind);
-                var executor = new DocumentAnalysisExecutor(analysisScope, _compilationWithAnalyzers, _owner._diagnosticAnalyzerRunner, _isExplicit, _logPerformanceInfo);
+                var executor = new DocumentAnalysisExecutor(analysisScope, _compilationWithAnalyzers, _owner._diagnosticAnalyzerRunner, _logPerformanceInfo);
                 var version = await GetDiagnosticVersionAsync(_document.Project, cancellationToken).ConfigureAwait(false);
 
                 ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> diagnosticsMap;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (nonCachedStateSets.Count > 0)
                 {
                     var analysisScope = new DocumentAnalysisScope(document, span: null, nonCachedStateSets.SelectAsArray(s => s.Analyzer), kind);
-                    var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, isExplicit: false, logPerformanceInfo: false, onAnalysisException: OnAnalysisException);
+                    var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, logPerformanceInfo: false, onAnalysisException: OnAnalysisException);
                     var logTelemetry = GlobalOptions.GetOption(DiagnosticOptionsStorage.LogTelemetryForBackgroundAnalyzerExecution);
                     foreach (var stateSet in nonCachedStateSets)
                     {

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -39,34 +39,35 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         private static CompilationWithAnalyzersCacheEntry? s_compilationWithAnalyzersCache = null;
 
         /// <summary>
-        /// Set of high priority diagnostic computation tasks which are currently executing.
-        /// Any new high priority diagnostic request is added to this set before the core diagnostics
+        /// List of high priority diagnostic computation tasks which are currently executing.
+        /// Any new high priority diagnostic request is added to this list before the core diagnostics
         /// compute call is performed, and removed from this list after the computation finishes.
-        /// Any new normal priority diagnostic request first waits for all the high priority tasks in this set
+        /// Any new normal priority diagnostic request first waits for all the high priority tasks in this list
         /// to complete, and moves ahead only after this list becomes empty.
         /// </summary>
         /// <remarks>
-        /// Read/write access to this set is guarded by <see cref="s_gate"/>.
+        /// Read/write access to the list is guarded by <see cref="s_gate"/>.
         /// </remarks>
-        private static ImmutableHashSet<Task> s_highPriorityComputeTasks = ImmutableHashSet<Task>.Empty;
+        private static readonly List<Task> s_highPriorityComputeTasks = new();
 
         /// <summary>
-        /// Cancellation token source for normal priority diagnostic computation tasks which are currently executing.
-        /// Any new high priority diagnostic request fires cancellation on this cancellation token source
-        /// to avoid resource contention between normal and high priority requests. It also initializes this field
-        /// with a new cancellation token source for subsequent requests.
+        /// List of cancellation token sources for normal priority diagnostic computation tasks which are currently executing.
+        /// For any new normal priority diagnostic request, a new cancellation token source is created and added to this list
+        /// before the core diagnostics compute call is performed, and removed from this list after the computation finishes.
+        /// Any new high priority diagnostic request first fires cancellation on all the cancellation token sources in this list
+        /// to avoid resource contention between normal and high priority requests.
         /// Canceled normal priority diagnostic requests are re-attempted from scratch after all the high priority requests complete.
         /// </summary>
         /// <remarks>
-        /// Read/write access to this field is guarded by <see cref="s_gate"/>.
+        /// Read/write access to the list is guarded by <see cref="s_gate"/>.
         /// </remarks>
-        private static CancellationTokenSource s_cancellationSourceForNormalPriorityComputeTasks = new();
+        private static readonly List<CancellationTokenSource> s_cancellationSourcesForNormalPriorityComputeTasks = new();
 
         /// <summary>
         /// Static gate controlling access to following static fields:
         /// - <see cref="s_compilationWithAnalyzersCache"/>
         /// - <see cref="s_highPriorityComputeTasks"/>
-        /// - <see cref="s_cancellationSourceForNormalPriorityComputeTasks"/>
+        /// - <see cref="s_cancellationSourcesForNormalPriorityComputeTasks"/>
         /// </summary>
         private static readonly object s_gate = new();
 
@@ -105,14 +106,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _analyzerInfoCache = analyzerInfoCache;
             _hostWorkspaceServices = hostWorkspaceServices;
             _performanceTracker = project.Solution.Services.GetService<IPerformanceTrackerService>();
-        }
-
-        private static CancellationToken GetCancellationTokenForNormalPriorityTasks()
-        {
-            lock (s_gate)
-            {
-                return s_cancellationSourceForNormalPriorityComputeTasks.Token;
-            }
         }
 
         public static Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
@@ -173,8 +166,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             var computeTask = GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken);
 
             // Step 2:
-            //  - Add this computeTask to the set of currently executing high priority tasks.
-            //    This set of high priority tasks is used in 'GetNormalPriorityDiagnosticsAsync'
+            //  - Add this computeTask to the list of currently executing high priority tasks.
+            //    This list of high priority tasks is used in 'GetNormalPriorityDiagnosticsAsync'
             //    method to ensure that any new or cancelled normal priority task waits for all
             //    the executing high priority tasks before starting its execution.
             //  - Note that it is critical to do this step prior to Step 3 below to ensure that
@@ -183,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             lock (s_gate)
             {
                 Debug.Assert(!s_highPriorityComputeTasks.Contains(computeTask));
-                s_highPriorityComputeTasks = s_highPriorityComputeTasks.Add(computeTask);
+                s_highPriorityComputeTasks.Add(computeTask);
             }
 
             try
@@ -204,23 +197,32 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 //  - Remove the 'computeTask' from the list of current executing high priority tasks.
                 lock (s_gate)
                 {
-                    Debug.Assert(s_highPriorityComputeTasks.Contains(computeTask));
-                    s_highPriorityComputeTasks = s_highPriorityComputeTasks.Remove(computeTask);
+                    var removed = s_highPriorityComputeTasks.Remove(computeTask);
+                    Debug.Assert(removed);
                 }
             }
 
             static void CancelNormalPriorityTasks()
             {
-                // Fire cancellation on the current token source and replace it with a new token source for future normal priority requests.
-                CancellationTokenSource currentCts;
+                ImmutableArray<CancellationTokenSource> cancellationTokenSourcesToCancel;
                 lock (s_gate)
                 {
-                    currentCts = s_cancellationSourceForNormalPriorityComputeTasks;
-                    s_cancellationSourceForNormalPriorityComputeTasks = new();
+                    cancellationTokenSourcesToCancel = s_cancellationSourcesForNormalPriorityComputeTasks.ToImmutableArrayOrEmpty();
                 }
 
-                currentCts.Cancel();
-                currentCts.Dispose();
+                foreach (var cancellationTokenSource in cancellationTokenSourcesToCancel)
+                {
+                    try
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // CancellationTokenSource might get disposed if the normal priority
+                        // task completes while we were executing this foreach loop.
+                        // Gracefully handle this case and ignore this exception.
+                    }
+                }
             }
         }
 
@@ -242,30 +244,65 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
                 // Step 2:
                 //  - Create the core 'computeTask' for computing diagnostics.
-                var computeTask = CreateComputeTask(cancellationToken);
+                //  - Create a custom 'cancellationTokenSource' associated with this 'computeTask'.
+                //    This token source allows normal priority computeTasks to be cancelled when
+                //    a subsequent high priority diagnostic request is received.
+                using var cancellationTokenSource = new CancellationTokenSource();
+                var computeTask = CreateComputeTask(cancellationTokenSource, cancellationToken);
+
+                // Step 3:
+                //  - Add 'cancellationTokenSource' to the list of cancellation token sources for
+                //    currently executing normal priority tasks.
+                //    This list is used in 'GetHighPriorityDiagnosticsAsync' method to cancel all the
+                //    currently executing normal priority tasks if a new high priority diagnostic
+                //    request is subsequently received.
+                lock (s_gate)
+                {
+                    Debug.Assert(!s_cancellationSourcesForNormalPriorityComputeTasks.Contains(cancellationTokenSource));
+                    s_cancellationSourcesForNormalPriorityComputeTasks.Add(cancellationTokenSource);
+                }
 
                 try
                 {
-                    // Step 3:
+                    // Step 4:
                     //  - Execute the core 'computeTask' for diagnostic computation.
                     return await computeTask.ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
-                    // Step 4:
-                    // Attempt to re-execute this cancelled normal priority task by running the loop again,
-                    // unless cancellation was fired on the cancellationToken passed into us.
-                    cancellationToken.ThrowIfCancellationRequested();
-                    continue;
+                    // Step 5:
+                    // Check if cancellation fired on the custom 'cancellationTokenSource' that was created for
+                    // allowing cancellation of 'computeTask' from subsequent highPriority requests.
+                    if (cancellationTokenSource.IsCancellationRequested)
+                    {
+                        // Attempt to re-execute this cancelled normal priority task
+                        // by running the loop again.
+                        continue;
+                    }
+
+                    // Propagate all other OperationCanceledExceptions up the stack.
+                    throw;
+                }
+                finally
+                {
+                    // Step 6:
+                    //  - Remove the 'cancellationTokenSource' for completed or cancelled task.
+                    //    For the case where the computeTask was cancelled, we will create a new
+                    //    'cancellationTokenSource' for the retry.
+                    lock (s_gate)
+                    {
+                        var removed = s_cancellationSourcesForNormalPriorityComputeTasks.Remove(cancellationTokenSource);
+                        Debug.Assert(removed);
+                    }
                 }
             }
 
-            Task<SerializableDiagnosticAnalysisResults> CreateComputeTask(CancellationToken cancellationToken)
+            Task<SerializableDiagnosticAnalysisResults> CreateComputeTask(CancellationTokenSource cancellationTokenSource, CancellationToken cancellationToken)
             {
                 return Task.Run(async () =>
                 {
                     // Create a linked cancellation source to allow high priority tasks to cancel normal priority tasks.
-                    using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(GetCancellationTokenForNormalPriorityTasks(), cancellationToken);
+                    using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
                     return await GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, linkedCancellationTokenSource.Token).ConfigureAwait(false);
                 }, cancellationToken);
             }
@@ -275,10 +312,10 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 // We loop continuously until we have an empty high priority task queue.
                 while (true)
                 {
-                    ImmutableHashSet<Task> highPriorityTasksToAwait;
+                    ImmutableArray<Task> highPriorityTasksToAwait;
                     lock (s_gate)
                     {
-                        highPriorityTasksToAwait = s_highPriorityComputeTasks;
+                        highPriorityTasksToAwait = s_highPriorityComputeTasks.ToImmutableArrayOrEmpty();
                     }
 
                     if (highPriorityTasksToAwait.IsEmpty)

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 //  - Force cancellation of all the executing normal priority tasks
                 //    to minimize resource and CPU contention between normal priority tasks
                 //    and the high priority computeTask in Step 4 below.
-                CancelNormalPriorityTasks();
+                CancelNormalPriorityTasks(cancellationToken);
 
                 // Step 4:
                 //  - Execute the core 'computeTask' for diagnostic computation.
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 }
             }
 
-            static void CancelNormalPriorityTasks()
+            static void CancelNormalPriorityTasks(CancellationToken cancellationToken)
             {
                 ImmutableArray<CancellationTokenSource> cancellationTokenSourcesToCancel;
                 lock (s_gate)

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -136,14 +136,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 // Fetch the cancellation token here to avoid capturing linkedCts in the computeTask lambda as the task may run after linkedCts has been disposed due to cancellation.
                 var linkedCancellationToken = linkedCancellationTokenSource.Token;
 
-                await WaitOrSuspendExecutingTasksAsync(highPriority, cancellationToken).ConfigureAwait(false);
-
                 var computeTask = Task.Run(async () =>
                 {
                     var diagnosticsComputer = new DiagnosticComputer(document, project,
                         solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
                     return await diagnosticsComputer.GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, linkedCancellationToken).ConfigureAwait(false);
                 }, linkedCancellationToken);
+
+                await WaitOrSuspendExecutingTasksAsync(highPriority, cancellationToken).ConfigureAwait(false);
 
                 StartTrackingPreCompute(computeTask, cancellationTokenSource, highPriority);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -37,8 +37,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         /// pressure when there are large number of open documents across different projects to be analyzed by background analysis.
         /// </summary>
         private static CompilationWithAnalyzersCacheEntry? s_compilationWithAnalyzersCache = null;
-        private static readonly List<Task> s_executingHighPriorityComputeTasks = new();
-        private static readonly List<CancellationTokenSource> s_cancellationSourcesForExecutingNormalPriorityComputeTasks = new();
         private static readonly object s_gate = new();
 
         /// <summary>
@@ -78,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _performanceTracker = project.Solution.Services.GetService<IPerformanceTrackerService>();
         }
 
-        public static async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
+        public static Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
             TextDocument? document,
             Project project,
             Checksum solutionChecksum,
@@ -88,7 +86,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             AnalysisKind? analysisKind,
             DiagnosticAnalyzerInfoCache analyzerInfoCache,
             HostWorkspaceServices hostWorkspaceServices,
-            bool isExplicit,
             bool reportSuppressedDiagnostics,
             bool logPerformanceInfo,
             bool getTelemetryInfo,
@@ -114,162 +111,9 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 }
             }
 
-            // We perform prioritized execution of diagnostic computation requests based on the
-            // 'highPriority' boolean parameter.
-            //   - High priority requests forces suspension of all the executing normal priority requests,
-            //     which are re-attempted once the high priority request completes.
-            //   - Normal priority requests wait for all the executing high priority requests to complete
-            //     before starting the compute.
-            //   - Suspended normal priority requests are re-attempted in the below loop.
-            bool suspended;
-
-            do
-            {
-                suspended = false;
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Create a linked cancellation source to allow high priority tasks to cancel normal priority tasks.
-                using var cancellationTokenSource = new CancellationTokenSource();
-                using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
-
-                // Fetch the cancellation token here to avoid capturing linkedCts in the computeTask lambda as the task may run after linkedCts has been disposed due to cancellation.
-                var linkedCancellationToken = linkedCancellationTokenSource.Token;
-
-                var computeTask = Task.Run(async () =>
-                {
-                    var diagnosticsComputer = new DiagnosticComputer(document, project,
-                        solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
-                    return await diagnosticsComputer.GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, linkedCancellationToken).ConfigureAwait(false);
-                }, linkedCancellationToken);
-
-                await WaitOrSuspendExecutingTasksAsync(highPriority, cancellationToken).ConfigureAwait(false);
-
-                StartTrackingPreCompute(computeTask, cancellationTokenSource, highPriority);
-
-                try
-                {
-                    return await computeTask.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    if (!cancellationTokenSource.IsCancellationRequested)
-                    {
-                        throw;
-                    }
-
-                    // Normal priority task that was suspended by a high priority task.
-                    Debug.Assert(!highPriority);
-                    suspended = true;
-                }
-                finally
-                {
-                    StopTrackingPostCompute(computeTask, cancellationTokenSource, highPriority);
-                }
-            } while (suspended);
-
-            throw ExceptionUtilities.Unreachable();
-
-            static async Task WaitOrSuspendExecutingTasksAsync(bool highPriority, CancellationToken cancellationToken)
-            {
-                // High priority task forces suspension of all the executing normal priority tasks.
-                // Normal priority task waits for all the executing high priority tasks to complete.
-                if (highPriority)
-                {
-                    SuspendNormalPriorityExecutingTasks(cancellationToken);
-                }
-                else
-                {
-                    await WaitForHighPriorityExecutingTasksAsync(cancellationToken).ConfigureAwait(false);
-                }
-
-                return;
-
-                static void SuspendNormalPriorityExecutingTasks(CancellationToken cancellationToken)
-                {
-                    ImmutableArray<CancellationTokenSource> cancellationTokenSourcesToCancel;
-                    lock (s_gate)
-                    {
-                        cancellationTokenSourcesToCancel = s_cancellationSourcesForExecutingNormalPriorityComputeTasks.ToImmutableArrayOrEmpty();
-                    }
-
-                    foreach (var cancellationTokenSource in cancellationTokenSourcesToCancel)
-                    {
-                        try
-                        {
-                            cancellationTokenSource.Cancel();
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // CancellationTokenSource might get disposed if the normal priority
-                            // task completes while we were executing this foreach loop.
-                            // Gracefully handle this case and ignore this exception.
-                        }
-                    }
-                }
-
-                static async Task WaitForHighPriorityExecutingTasksAsync(CancellationToken cancellationToken)
-                {
-                    while (true)
-                    {
-                        ImmutableArray<Task> highPriorityTasksToAwait;
-                        lock (s_gate)
-                        {
-                            highPriorityTasksToAwait = s_executingHighPriorityComputeTasks.ToImmutableArrayOrEmpty();
-                        }
-
-                        if (highPriorityTasksToAwait.IsEmpty)
-                        {
-                            return;
-                        }
-
-                        foreach (var task in highPriorityTasksToAwait)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            try
-                            {
-                                await task.ConfigureAwait(false);
-                            }
-                            catch (OperationCanceledException)
-                            {
-                                // Gracefully ignore cancellations for high priority tasks.
-                            }
-                        }
-                    }
-                }
-            }
-
-            static void StartTrackingPreCompute(Task computeTask, CancellationTokenSource tokenSource, bool highPriority)
-            {
-                lock (s_gate)
-                {
-                    if (highPriority)
-                    {
-                        s_executingHighPriorityComputeTasks.Add(computeTask);
-                    }
-                    else
-                    {
-                        s_cancellationSourcesForExecutingNormalPriorityComputeTasks.Add(tokenSource);
-                    }
-                }
-            }
-
-            static void StopTrackingPostCompute(Task computeTask, CancellationTokenSource tokenSource, bool highPriority)
-            {
-                lock (s_gate)
-                {
-                    if (highPriority)
-                    {
-                        s_executingHighPriorityComputeTasks.Remove(computeTask);
-                    }
-                    else
-                    {
-                        s_cancellationSourcesForExecutingNormalPriorityComputeTasks.Remove(tokenSource);
-                    }
-                }
-            }
+            var diagnosticsComputer = new DiagnosticComputer(document, project,
+                solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
+            return diagnosticsComputer.GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken);
         }
 
         private async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _performanceTracker = project.Solution.Services.GetService<IPerformanceTrackerService>();
         }
 
-        public static Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
+        public static async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
             TextDocument? document,
             Project project,
             Checksum solutionChecksum,
@@ -144,62 +144,104 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 }
             }
 
-            // We execute explicit, user-invoked diagnostics requests with higher priority compared to implicit requests
-            // from clients such as editor diagnostic tagger to show squiggles, background analysis to populate the error list, etc.
-            var diagnosticsComputer = new DiagnosticComputer(document, project, solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
-            return isExplicit
-                ? diagnosticsComputer.GetHighPriorityDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken)
-                : diagnosticsComputer.GetNormalPriorityDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-        }
+            // We perform prioritized execution of diagnostic computation requests based on the
+            // 'highPriority' boolean parameter.
+            //   - High priority requests forces cancellation of all the executing normal priority requests,
+            //     which are re-attempted once the high priority request completes.
+            //   - Normal priority requests wait for all the executing high priority requests to complete
+            //     before starting the compute.
+            //   - Canceled normal priority requests are re-attempted in the below loop.
 
-        private async Task<SerializableDiagnosticAnalysisResults> GetHighPriorityDiagnosticsAsync(
-            IEnumerable<string> analyzerIds,
-            bool reportSuppressedDiagnostics,
-            bool logPerformanceInfo,
-            bool getTelemetryInfo,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Step 1:
-            //  - Create the core 'computeTask' for computing diagnostics.
-            var computeTask = GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken);
-
-            // Step 2:
-            //  - Add this computeTask to the list of currently executing high priority tasks.
-            //    This list of high priority tasks is used in 'GetNormalPriorityDiagnosticsAsync'
-            //    method to ensure that any new or cancelled normal priority task waits for all
-            //    the executing high priority tasks before starting its execution.
-            //  - Note that it is critical to do this step prior to Step 3 below to ensure that
-            //    any canceled normal priority tasks in Step 3 do not resume execution prior to
-            //    completion of this high priority computeTask. 
-            lock (s_gate)
+            while (true)
             {
-                Debug.Assert(!s_highPriorityComputeTasks.Contains(computeTask));
-                s_highPriorityComputeTasks.Add(computeTask);
-            }
+                cancellationToken.ThrowIfCancellationRequested();
 
-            try
-            {
-                // Step 3:
-                //  - Force cancellation of all the executing normal priority tasks
-                //    to minimize resource and CPU contention between normal priority tasks
-                //    and the high priority computeTask in Step 4 below.
-                CancelNormalPriorityTasks(cancellationToken);
-
-                // Step 4:
-                //  - Execute the core 'computeTask' for diagnostic computation.
-                return await computeTask.ConfigureAwait(false);
-            }
-            finally
-            {
-                // Step 5:
-                //  - Remove the 'computeTask' from the list of current executing high priority tasks.
-                lock (s_gate)
+                // Step 1:
+                //  - High priority task forces cancellation of all the executing normal priority tasks
+                //    to minimize resource and CPU contention with normal priority tasks.
+                //  - Normal priority task waits for all the executing high priority tasks to complete.
+                if (highPriority)
                 {
-                    var removed = s_highPriorityComputeTasks.Remove(computeTask);
-                    Debug.Assert(removed);
+                    CancelNormalPriorityTasks(cancellationToken);
                 }
+                else
+                {
+                    await WaitForHighPriorityTasksAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                // Step 2:
+                //  - Create the core 'computeTask' for computing diagnostics.
+                //  - Create a custom 'cancellationTokenSource' associated with this 'computeTask'.
+                //    This token source allows normal priority computeTasks to be cancelled when
+                //    a high priority diagnostic request is received.
+                var (computeTask, cancellationTokenSource) = CreateComputeTaskAndCancellationSource(cancellationToken);
+
+                // Step 3:
+                //  - Start tracking the 'computeTask' and 'cancellationTokenSource' prior to invoking the computation.
+                //    These are used in Step 1 if a new diagnostic request is received while this computeTask is running.
+                StartTrackingPreCompute(computeTask, cancellationTokenSource, highPriority);
+
+                try
+                {
+                    // Step 4:
+                    //  - Execute the core 'computeTask' for diagnostic computation.
+                    return await computeTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Step 5:
+                    // Check if cancellation fired on the custom 'cancellationTokenSource' that was created for
+                    // allowing cancellation of 'computeTask' from subsequent highPriority requests.
+                    if (cancellationTokenSource.IsCancellationRequested)
+                    {
+                        // We expect only normal priority tasks to get forcefully cancelled
+                        // by firing cancellation on our custom 'cancellationTokenSource'.
+                        Debug.Assert(!highPriority);
+
+                        // Attempt to re-execute this cancelled normal priority task
+                        // by running the loop again.
+                        continue;
+                    }
+
+                    // Propagate all other OperationCanceledExceptions up the stack.
+                    throw;
+                }
+                finally
+                {
+                    // Step 6:
+                    //  - Stop tracking the 'computeTask' and 'cancellationTokenSource' for
+                    //    completed or cancelled task. For the case where the computeTask was
+                    //    cancelled, we will create a new 'computeTask' and 'cancellationTokenSource'
+                    //    for the retry.
+                    StopTrackingPostCompute(computeTask, cancellationTokenSource, highPriority);
+                    cancellationTokenSource.Dispose();
+                }
+            }
+
+            throw ExceptionUtilities.Unreachable();
+
+            (Task<SerializableDiagnosticAnalysisResults>, CancellationTokenSource) CreateComputeTaskAndCancellationSource(CancellationToken cancellationToken)
+            {
+                // Create a linked cancellation source to allow high priority tasks to cancel normal priority tasks.
+                var cancellationTokenSource = new CancellationTokenSource();
+                var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
+                cancellationToken = linkedCancellationTokenSource.Token;
+
+                var computeTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var diagnosticsComputer = new DiagnosticComputer(document, project,
+                            solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
+                        return await diagnosticsComputer.GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        linkedCancellationTokenSource.Dispose();
+                    }
+                }, cancellationToken);
+
+                return (computeTask, cancellationTokenSource);
             }
 
             static void CancelNormalPriorityTasks(CancellationToken cancellationToken)
@@ -224,88 +266,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                     }
                 }
             }
-        }
-
-        private async Task<SerializableDiagnosticAnalysisResults> GetNormalPriorityDiagnosticsAsync(
-            IEnumerable<string> analyzerIds,
-            bool reportSuppressedDiagnostics,
-            bool logPerformanceInfo,
-            bool getTelemetryInfo,
-            CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Step 1:
-                //  - Normal priority task must wait for all the executing high priority tasks to complete
-                //    before beginning execution.
-                await WaitForHighPriorityTasksAsync(cancellationToken).ConfigureAwait(false);
-
-                // Step 2:
-                //  - Create the core 'computeTask' for computing diagnostics.
-                //  - Create a custom 'cancellationTokenSource' associated with this 'computeTask'.
-                //    This token source allows normal priority computeTasks to be cancelled when
-                //    a subsequent high priority diagnostic request is received.
-                using var cancellationTokenSource = new CancellationTokenSource();
-                var computeTask = CreateComputeTask(cancellationTokenSource, cancellationToken);
-
-                // Step 3:
-                //  - Add 'cancellationTokenSource' to the list of cancellation token sources for
-                //    currently executing normal priority tasks.
-                //    This list is used in 'GetHighPriorityDiagnosticsAsync' method to cancel all the
-                //    currently executing normal priority tasks if a new high priority diagnostic
-                //    request is subsequently received.
-                lock (s_gate)
-                {
-                    Debug.Assert(!s_cancellationSourcesForNormalPriorityComputeTasks.Contains(cancellationTokenSource));
-                    s_cancellationSourcesForNormalPriorityComputeTasks.Add(cancellationTokenSource);
-                }
-
-                try
-                {
-                    // Step 4:
-                    //  - Execute the core 'computeTask' for diagnostic computation.
-                    return await computeTask.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Step 5:
-                    // Check if cancellation fired on the custom 'cancellationTokenSource' that was created for
-                    // allowing cancellation of 'computeTask' from subsequent highPriority requests.
-                    if (cancellationTokenSource.IsCancellationRequested)
-                    {
-                        // Attempt to re-execute this cancelled normal priority task
-                        // by running the loop again.
-                        continue;
-                    }
-
-                    // Propagate all other OperationCanceledExceptions up the stack.
-                    throw;
-                }
-                finally
-                {
-                    // Step 6:
-                    //  - Remove the 'cancellationTokenSource' for completed or cancelled task.
-                    //    For the case where the computeTask was cancelled, we will create a new
-                    //    'cancellationTokenSource' for the retry.
-                    lock (s_gate)
-                    {
-                        var removed = s_cancellationSourcesForNormalPriorityComputeTasks.Remove(cancellationTokenSource);
-                        Debug.Assert(removed);
-                    }
-                }
-            }
-
-            Task<SerializableDiagnosticAnalysisResults> CreateComputeTask(CancellationTokenSource cancellationTokenSource, CancellationToken cancellationToken)
-            {
-                return Task.Run(async () =>
-                {
-                    // Create a linked cancellation source to allow high priority tasks to cancel normal priority tasks.
-                    using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
-                    return await GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, linkedCancellationTokenSource.Token).ConfigureAwait(false);
-                }, cancellationToken);
-            }
 
             static async Task WaitForHighPriorityTasksAsync(CancellationToken cancellationToken)
             {
@@ -327,8 +287,48 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        // Wait for the high priority task, ignoring all exceptions from it.
-                        await task.NoThrowAwaitable(false);
+                        try
+                        {
+                            await task.ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Gracefully ignore cancellations for high priority tasks.
+                        }
+                    }
+                }
+            }
+
+            static void StartTrackingPreCompute(Task computeTask, CancellationTokenSource tokenSource, bool highPriority)
+            {
+                lock (s_gate)
+                {
+                    if (highPriority)
+                    {
+                        Debug.Assert(!s_highPriorityComputeTasks.Contains(computeTask));
+                        s_highPriorityComputeTasks.Add(computeTask);
+                    }
+                    else
+                    {
+                        Debug.Assert(!s_cancellationSourcesForNormalPriorityComputeTasks.Contains(tokenSource));
+                        s_cancellationSourcesForNormalPriorityComputeTasks.Add(tokenSource);
+                    }
+                }
+            }
+
+            static void StopTrackingPostCompute(Task computeTask, CancellationTokenSource tokenSource, bool highPriority)
+            {
+                lock (s_gate)
+                {
+                    if (highPriority)
+                    {
+                        var removed = s_highPriorityComputeTasks.Remove(computeTask);
+                        Debug.Assert(removed);
+                    }
+                    else
+                    {
+                        var removed = s_cancellationSourcesForNormalPriorityComputeTasks.Remove(tokenSource);
+                        Debug.Assert(removed);
                     }
                 }
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -46,16 +46,15 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         /// to complete, and moves ahead only after this list becomes empty.
         /// </summary>
         /// <remarks>
-        /// Read/write access to this field is guarded by <see cref="s_gate"/>.
+        /// Read/write access to this set is guarded by <see cref="s_gate"/>.
         /// </remarks>
         private static ImmutableHashSet<Task> s_highPriorityComputeTasks = ImmutableHashSet<Task>.Empty;
 
         /// <summary>
-        /// Set of cancellation token sources for normal priority diagnostic computation tasks which are currently executing.
-        /// For any new normal priority diagnostic request, a new cancellation token source is created and added to this set
-        /// before the core diagnostics compute call is performed, and removed from this set after the computation finishes.
-        /// Any new high priority diagnostic request first fires cancellation on all the cancellation token sources in this set
-        /// to avoid resource contention between normal and high priority requests.
+        /// Cancellation token source for normal priority diagnostic computation tasks which are currently executing.
+        /// Any new high priority diagnostic request fires cancellation on this cancellation token source
+        /// to avoid resource contention between normal and high priority requests. It also initializes this field
+        /// with a new cancellation token source for subsequent requests.
         /// Canceled normal priority diagnostic requests are re-attempted from scratch after all the high priority requests complete.
         /// </summary>
         /// <remarks>
@@ -194,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             finally
             {
                 // Step 5:
-                //  - Remove the 'computeTask' from the set of current executing high priority tasks.
+                //  - Remove the 'computeTask' from the list of current executing high priority tasks.
                 lock (s_gate)
                 {
                     Debug.Assert(s_highPriorityComputeTasks.Contains(computeTask));
@@ -204,13 +203,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
             static void CancelNormalPriorityTasks()
             {
+                // Fire cancellation on the current token source and replace it with a new token source for future normal priority requests.
                 ImmutableHashSet<CancellationTokenSource> cancellationTokenSources;
                 lock (s_gate)
                 {
                     cancellationTokenSources = s_normalPriorityCancellationTokenSources;
                 }
 
-                foreach (var cancellationTokenSource in cancellationTokenSources)
+                foreach (var  cancellationTokenSource in cancellationTokenSources)
                 {
                     try
                     {
@@ -218,9 +218,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                     }
                     catch (ObjectDisposedException)
                     {
-                        // CancellationTokenSource might get disposed if the normal priority
-                        // task completes while we were executing this foreach loop.
-                        // Gracefully handle this case and ignore this exception.
                     }
                 }
             }
@@ -242,44 +239,35 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 //    before beginning execution.
                 await WaitForHighPriorityTasksAsync(cancellationToken).ConfigureAwait(false);
 
-                // Step 2:
-                //  - Create a custom 'cancellationTokenSource' associated with the current normal priority
-                //    request and add it to the tracked set of normal priority cancellation token sources.
-                //    This token source allows normal priority computeTasks to be cancelled when
-                //    a subsequent high priority diagnostic request is received.
                 using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 lock (s_gate)
                 {
                     s_normalPriorityCancellationTokenSources = s_normalPriorityCancellationTokenSources.Add(cancellationTokenSource);
                 }
 
-                // Step 3:
+                // Step 2:
                 //  - Create the core 'computeTask' for computing diagnostics.
                 var computeTask = GetDiagnosticsAsync(
                     analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo,
-                    cancellationTokenSource.Token);
+                    cancellationTokenSource.Token)
 
                 try
                 {
-                    // Step 4:
+                    // Step 3:
                     //  - Execute the core 'computeTask' for diagnostic computation.
                     return await computeTask.ConfigureAwait(false);
                 }
                 catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationTokenSource.Token)
                 {
-                    // Step 5:
-                    //  - Attempt to re-execute this cancelled normal priority task by running the loop again.
+                    // Step 4:
+                    // Attempt to re-execute this cancelled normal priority task by running the loop again,
+                    // unless cancellation was fired on the cancellationToken passed into us.
                     continue;
                 }
                 finally
                 {
-                    // Step 6:
-                    //  - Remove the 'cancellationTokenSource' for completed or cancelled task.
-                    //    For the case where the computeTask was cancelled, we will create a new
-                    //    'cancellationTokenSource' for the retry.
                     lock (s_gate)
                     {
-                        Debug.Assert(s_normalPriorityCancellationTokenSources.Contains(cancellationTokenSource));
                         s_normalPriorityCancellationTokenSources = s_normalPriorityCancellationTokenSources.Remove(cancellationTokenSource);
                     }
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -225,6 +225,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 // Create a linked cancellation source to allow high priority tasks to cancel normal priority tasks.
                 var cancellationTokenSource = new CancellationTokenSource();
                 var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, cancellationToken);
+
+                // Fetch the cancellation token here to avoid capturing linkedCts in the computeTask lambda as the task may run after linkedCts has been disposed due to cancellation.
                 cancellationToken = linkedCancellationTokenSource.Token;
 
                 var computeTask = Task.Run(async () =>

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -285,8 +285,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 // We loop continuously until we have an empty high priority task queue.
                 while (true)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     ImmutableHashSet<Task> highPriorityTasksToAwait;
                     lock (s_gate)
                     {

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Remote
                             arguments.IdeOptions, documentSpan,
                             arguments.AnalyzerIds, documentAnalysisKind,
                             _analyzerInfoCache, hostWorkspaceServices,
-                            isExplicit: arguments.IsExplicit,
                             reportSuppressedDiagnostics: arguments.ReportSuppressedDiagnostics,
                             logPerformanceInfo: arguments.LogPerformanceInfo,
                             getTelemetryInfo: arguments.GetTelemetryInfo,


### PR DESCRIPTION
#67392 introduced a livelock in DiagnosticComputer in OOP. We are planning to take the fix #67597 for it in 17.6 P3. This PR is a backup revert PR in case #67597 does not fix the underlying issue.

Marking it as a draft PR so it does not get accidentally merged.