### PR TITLE
Use OneOrMany in the node->BoundNode map

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -74,8 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         var existing = map[key];
                         var added = additionMap[key];
-                        Debug.Assert(existing.Length == added.Length, "existing.Length == added.Length");
-                        for (int i = 0; i < existing.Length; i++)
+                        Debug.Assert(existing.Count == added.Length, "existing.Count == added.Length");
+                        for (int i = 0; i < existing.Count; i++)
                         {
                             // TODO: it would be great if we could check !ReferenceEquals(existing[i], added[i]) (DevDiv #11584).
                             // Known impediments include:

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <param name="root">The root of the bound tree.</param>
             /// <param name="map">The cache.</param>
             /// <param name="node">The syntax node where to add bound nodes for.</param>
-            public static void AddToMap(BoundNode root, Dictionary<SyntaxNode, ImmutableArray<BoundNode>> map, SyntaxTree tree, SyntaxNode node = null)
+            public static void AddToMap(BoundNode root, Dictionary<SyntaxNode, OneOrMany<BoundNode>> map, SyntaxTree tree, SyntaxNode node = null)
             {
                 Debug.Assert(node == null || root == null || !(root.Syntax is StatementSyntax), "individually added nodes are not supposed to be statements.");
 
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        map[key] = additionMap[key];
+                        map[key] = additionMap.GetAsOneOrMany(key);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly CSharpSyntaxNode _root;
         private readonly ReaderWriterLockSlim _nodeMapLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
         // The bound nodes associated with a syntax node, from highest in the tree to lowest.
-        private readonly Dictionary<SyntaxNode, ImmutableArray<BoundNode>> _guardedBoundNodeMap = new Dictionary<SyntaxNode, ImmutableArray<BoundNode>>();
+        private readonly Dictionary<SyntaxNode, OneOrMany<BoundNode>> _guardedBoundNodeMap = new Dictionary<SyntaxNode, OneOrMany<BoundNode>>();
         private readonly Dictionary<SyntaxNode, IOperation> _guardedIOperationNodeMap = new Dictionary<SyntaxNode, IOperation>();
         private Dictionary<SyntaxNode, BoundStatement> _lazyGuardedSynthesizedStatementsMap;
         private NullableWalker.SnapshotManager _lazySnapshotManager;
@@ -522,7 +522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // The bound nodes are stored in the map from highest to lowest, so the first bound node is the highest.
             var boundNodes = GetBoundNodes(node);
 
-            if (boundNodes.Length == 0)
+            if (boundNodes.Count == 0)
             {
                 return null;
             }
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // The bound nodes are stored in the map from highest to lowest, so the last bound node is the lowest.
             var boundNodes = GetBoundNodes(node);
 
-            if (boundNodes.Length == 0)
+            if (boundNodes.Count == 0)
             {
                 return null;
             }
@@ -553,9 +553,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static BoundNode GetLowerBoundNode(ImmutableArray<BoundNode> boundNodes)
+        private static BoundNode GetLowerBoundNode(OneOrMany<BoundNode> boundNodes)
         {
-            return boundNodes[boundNodes.Length - 1];
+            return boundNodes[boundNodes.Count - 1];
         }
 
         public sealed override ImmutableArray<Diagnostic> GetSyntaxDiagnostics(TextSpan? span = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -1420,25 +1420,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private ImmutableArray<BoundNode> GuardedGetBoundNodesFromMap(CSharpSyntaxNode node)
+        private OneOrMany<BoundNode> GuardedGetBoundNodesFromMap(CSharpSyntaxNode node)
         {
             Debug.Assert(_nodeMapLock.IsWriteLockHeld || _nodeMapLock.IsReadLockHeld);
-            ImmutableArray<BoundNode> result;
-            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
+            OneOrMany<BoundNode> result;
+            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : OneOrMany<BoundNode>.Empty;
         }
 
         /// <summary>
         /// Internal for test purposes only
         /// </summary>
-        internal ImmutableArray<BoundNode> TestOnlyTryGetBoundNodesFromMap(CSharpSyntaxNode node)
+        internal OneOrMany<BoundNode> TestOnlyTryGetBoundNodesFromMap(CSharpSyntaxNode node)
         {
-            ImmutableArray<BoundNode> result;
-            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : default(ImmutableArray<BoundNode>);
+            OneOrMany<BoundNode> result;
+            return _guardedBoundNodeMap.TryGetValue(node, out result) ? result : OneOrMany<BoundNode>.Empty;
         }
 
         // Adds every syntax/bound pair in a tree rooted at the given bound node to the map, and the
         // performs a lookup of the given syntax node in the map. 
-        private ImmutableArray<BoundNode> GuardedAddBoundTreeAndGetBoundNodeFromMap(CSharpSyntaxNode syntax, BoundNode bound)
+        private OneOrMany<BoundNode> GuardedAddBoundTreeAndGetBoundNodeFromMap(CSharpSyntaxNode syntax, BoundNode bound)
         {
             Debug.Assert(_nodeMapLock.IsWriteLockHeld);
 
@@ -1457,8 +1457,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(syntax != _root || _guardedBoundNodeMap.ContainsKey(bound.Syntax));
             }
 
-            ImmutableArray<BoundNode> result;
-            return _guardedBoundNodeMap.TryGetValue(syntax, out result) ? result : default(ImmutableArray<BoundNode>);
+            OneOrMany<BoundNode> result;
+            return _guardedBoundNodeMap.TryGetValue(syntax, out result) ? result : OneOrMany<BoundNode>.Empty;
         }
 
         protected void UnguardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null, ImmutableDictionary<Symbol, Symbol> remappedSymbols = null)
@@ -1620,7 +1620,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Have we already cached a bound node for it?
             // If not, bind the outermost expression containing the lambda and then fill in the map.
-            ImmutableArray<BoundNode> nodes;
+            OneOrMany<BoundNode> nodes;
 
             EnsureNullabilityAnalysisPerformedIfNecessary();
 
@@ -1629,7 +1629,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 nodes = GuardedGetBoundNodesFromMap(lambdaOrQuery);
             }
 
-            if (!nodes.IsDefaultOrEmpty)
+            if (!nodes.IsEmpty)
             {
                 return GetLowerBoundNode(nodes);
             }
@@ -1666,7 +1666,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     nodes = GuardedGetBoundNodesFromMap(lambdaOrQuery);
                 }
 
-                if (!nodes.IsDefaultOrEmpty)
+                if (!nodes.IsEmpty)
                 {
                     // If everything is working as expected we should end up here because binding the enclosing lambda
                     // should also take care of binding and caching this lambda.
@@ -1688,7 +1688,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 nodes = GuardedAddBoundTreeAndGetBoundNodeFromMap(lambdaOrQuery, boundOuterExpression);
             }
 
-            if (!nodes.IsDefaultOrEmpty)
+            if (!nodes.IsEmpty)
             {
                 return GetLowerBoundNode(nodes);
             }
@@ -2037,7 +2037,7 @@ done:
         /// Get all bounds nodes associated with a node, ordered from highest to lowest in the bound tree.
         /// Strictly speaking, the order is that of a pre-order traversal of the bound tree.
         /// </summary>
-        internal ImmutableArray<BoundNode> GetBoundNodes(CSharpSyntaxNode node)
+        internal OneOrMany<BoundNode> GetBoundNodes(CSharpSyntaxNode node)
         {
             // If this method is called with a null parameter, that implies that the Root should be
             // bound, but make sure that the Root is bindable.
@@ -2061,14 +2061,14 @@ done:
             // reader-writer lock.
             //
             // Have we already got the desired bound node in the mutable map? If so, return it.
-            ImmutableArray<BoundNode> results;
+            OneOrMany<BoundNode> results;
 
             using (_nodeMapLock.DisposableRead())
             {
                 results = GuardedGetBoundNodesFromMap(node);
             }
 
-            if (!results.IsDefaultOrEmpty)
+            if (!results.IsEmpty)
             {
                 return results;
             }
@@ -2088,7 +2088,7 @@ done:
                 results = GuardedAddBoundTreeAndGetBoundNodeFromMap(node, boundStatement);
             }
 
-            if (!results.IsDefaultOrEmpty)
+            if (!results.IsEmpty)
             {
                 return results;
             }
@@ -2108,7 +2108,7 @@ done:
                 results = GuardedGetBoundNodesFromMap(node);
             }
 
-            if (results.IsDefaultOrEmpty)
+            if (results.IsEmpty)
             {
                 // https://github.com/dotnet/roslyn/issues/35038: We have to run analysis on this node in some manner
                 using (_nodeMapLock.DisposableWrite())
@@ -2118,7 +2118,7 @@ done:
                     results = GuardedGetBoundNodesFromMap(node);
                 }
 
-                if (!results.IsDefaultOrEmpty)
+                if (!results.IsEmpty)
                 {
                     return results;
                 }
@@ -2128,7 +2128,7 @@ done:
                 return results;
             }
 
-            return ImmutableArray<BoundNode>.Empty;
+            return OneOrMany<BoundNode>.Empty;
         }
 
         // some nodes don't have direct semantic meaning by themselves and so we need to bind a different node that does
@@ -2430,9 +2430,9 @@ foundParent:;
             {
                 if (node.SyntaxTree == _semanticModel.SyntaxTree)
                 {
-                    ImmutableArray<BoundNode> boundNodes = _semanticModel.GuardedGetBoundNodesFromMap(node);
+                    OneOrMany<BoundNode> boundNodes = _semanticModel.GuardedGetBoundNodesFromMap(node);
 
-                    if (!boundNodes.IsDefaultOrEmpty)
+                    if (!boundNodes.IsEmpty)
                     {
                         // Already bound. Return the top-most bound node associated with the statement. 
                         return boundNodes[0];

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -18818,10 +18818,10 @@ public class Cls
 
                 MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[constructorDeclaration];
 
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration).IsDefaultOrEmpty);
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.Initializer).IsDefaultOrEmpty);
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.Body).IsDefaultOrEmpty);
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.ExpressionBody).IsDefaultOrEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration).IsEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.Initializer).IsEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.Body).IsEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(constructorDeclaration.ExpressionBody).IsEmpty);
 
                 var x1Decl = GetOutVarDeclaration(tree, "x1");
                 var x1Ref = GetReferences(tree, "x1").ToArray();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -6445,7 +6445,7 @@ class B : A
 
                 MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[globalStatement.Parent];
 
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(globalStatement.Statement).IsDefaultOrEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(globalStatement.Statement).IsEmpty);
 
                 Assert.Same(mm, syntaxTreeModel.GetMemberModel(globalStatement.Statement));
             }
@@ -6923,7 +6923,7 @@ class B : A
 
                 MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[unit];
 
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(unit).IsDefaultOrEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(unit).IsEmpty);
 
                 Assert.Same(mm, syntaxTreeModel.GetMemberModel(unit));
             }
@@ -6991,7 +6991,7 @@ class B : A
 
                 MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[unit];
 
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(unit).IsDefaultOrEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(unit).IsEmpty);
 
                 Assert.Same(mm, syntaxTreeModel.GetMemberModel(unit));
             }
@@ -7077,7 +7077,7 @@ class Test
 
                 MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[decl];
 
-                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(node).IsDefaultOrEmpty);
+                Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(node).IsEmpty);
 
                 Assert.Same(mm, syntaxTreeModel.GetMemberModel(node));
             }

--- a/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
@@ -151,6 +152,17 @@ namespace Microsoft.CodeAnalysis.Collections
 
                 return ImmutableArray<V>.Empty;
             }
+        }
+
+        public OneOrMany<V> GetAsOneOrMany(K k)
+        {
+            if (_dictionary is object && _dictionary.TryGetValue(k, out var valueSet))
+            {
+                Debug.Assert(valueSet.Count >= 1);
+                return valueSet.Count == 1 ? OneOrMany.Create(valueSet[0]) : OneOrMany.Create(valueSet.Items);
+            }
+
+            return OneOrMany<V>.Empty;
         }
 
         public bool Contains(K key, V value)

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -139,6 +139,15 @@ namespace Roslyn.Utilities
                 OneOrMany.Create(_many.SelectAsArray(selector, arg));
         }
 
+        public IEnumerable<TResult> OfType<TResult>()
+        {
+            foreach (var item in this)
+            {
+                if (item is TResult result)
+                    yield return result;
+            }
+        }
+
         public T? FirstOrDefault(Func<T, bool> predicate)
         {
             if (HasOne)


### PR DESCRIPTION
Internally, the compiler has a mapping from syntax nodes to potentially multiple bound nodes.  Teh multiple case is rarer, but happens with things like hidden conversions.  Because there might be multiple bound nodes associated with a syntax node, the values are stored in an ImmutableArray.  This causes a lot of unnecessary overheadgiven the common case of just a single item.  

Looking at traces in a simple typing test show 80MB for just these arrays in a simple typing test:

![image](https://user-images.githubusercontent.com/4564579/229244151-1ddcfc2d-9098-46e3-8b3f-de62726984dd.png)

After hte change, this this gets reduced to 500k:

![image](https://user-images.githubusercontent.com/4564579/229244274-a92fd194-1e91-4389-92ca-0b0a82410e71.png)

