### PR TITLE
Don't crash server if code lens cache entry does not exist

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensCache.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensCache.cs
@@ -27,7 +27,6 @@ internal sealed class CodeLensCache : ResolveCache<CodeLensCacheEntry>
     /// Cached data need to resolve a specific code lens item
     /// </summary>
     /// <param name="CodeLensMembers">the list of nodes and locations for codelens members</param>
-    /// <param name="TextDocumentIdentifier">the lsp document they came from</param>
     /// <param name="SyntaxVersion">the syntax version the codelenses were calculated against (to validate the resolve request)</param>
-    internal record CodeLensCacheEntry(ImmutableArray<CodeLensMember> CodeLensMembers, TextDocumentIdentifier TextDocumentIdentifier, VersionStamp SyntaxVersion);
+    internal record CodeLensCacheEntry(ImmutableArray<CodeLensMember> CodeLensMembers, VersionStamp SyntaxVersion);
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.CodeLens;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using static Microsoft.CodeAnalysis.LanguageServer.Handler.Completion.CompletionListCache;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeLens;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using static Microsoft.CodeAnalysis.LanguageServer.Handler.Completion.CompletionListCache;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;
@@ -49,7 +50,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
 
         // Store the members in the resolve cache so that when we get a resolve request for a particular
         // member we can re-use the syntax node and span we already computed here.
-        var resultId = codeLensCache.UpdateCache(new CodeLensCache.CodeLensCacheEntry(members, request.TextDocument, syntaxVersion));
+        var resultId = codeLensCache.UpdateCache(new CodeLensCache.CodeLensCacheEntry(members, syntaxVersion));
 
         // TODO - Code lenses need to be refreshed by the server when we detect solution/project wide changes.
         // See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1730462
@@ -63,7 +64,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
             {
                 Range = range,
                 Command = null,
-                Data = new CodeLensResolveData(resultId, i)
+                Data = new CodeLensResolveData(resultId, i, request.TextDocument)
             };
 
             codeLenses.Add(codeLens);

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveData.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensResolveData.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;
 
 /// <summary>
@@ -9,4 +11,5 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;
 /// </summary>
 /// <param name="ResultId">the resultId associated with the code lens list created on original request.</param>
 /// <param name="ListIndex">the index of the specific code lens item in the original list.</param>
-internal sealed record CodeLensResolveData(long ResultId, int ListIndex);
+/// <param name="TextDocument">the text document associated with the code lens to resolve.</param>
+internal sealed record CodeLensResolveData(long ResultId, int ListIndex, TextDocumentIdentifier TextDocument);

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
@@ -5,7 +5,10 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;
+using Newtonsoft.Json;
 using Roslyn.Test.Utilities;
+using StreamJsonRpc;
 using Xunit;
 using Xunit.Abstractions;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -189,5 +192,55 @@ public class CSharpCodeLensTests : AbstractCodeLensTests
 @"record {|codeLens:A|}(int SomeInt)";
         await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
         await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestDoesNotShutdownServerIfCacheEntryMissing(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"class A
+{
+    void {|codeLens:M|}()
+    {
+    }
+
+    void UseM()
+    {
+        M();
+    }
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var textDocument = CreateTextDocumentIdentifier(testLspServer.GetCurrentSolution().Projects.Single().Documents.Single().GetURI());
+        var codeLensParams = new LSP.CodeLensParams
+        {
+            TextDocument = textDocument
+        };
+
+        var actualCodeLenses = await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
+        var firstCodeLens = actualCodeLenses.First();
+        var data = JsonConvert.DeserializeObject<CodeLensResolveData>(firstCodeLens.Data!.ToString());
+        AssertEx.NotNull(data);
+        var firstResultId = data.ResultId;
+
+        // Verify the code lens item is in the cache.
+        var cache = testLspServer.GetRequiredLspService<CodeLensCache>();
+        Assert.NotNull(cache.GetCachedEntry(firstResultId));
+
+        // Execute a few more requests to ensure the first request is removed from the cache.
+        await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
+        await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
+        var lastCodeLenses = await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
+        Assert.True(lastCodeLenses.Any());
+
+        // Assert that the first result id is no longer in the cache.
+        Assert.Null(cache.GetCachedEntry(firstResultId));
+
+        // Assert that the request throws because the item no longer exists in the cache.
+        await Assert.ThrowsAsync<RemoteInvocationException>(async () => await testLspServer.ExecuteRequestAsync<LSP.CodeLens, LSP.CodeLens>(LSP.Methods.CodeLensResolveName, firstCodeLens, CancellationToken.None));
+
+        // Assert that the server did not shutdown and that we can resolve the latest codelens request we made.
+        var lastCodeLens = await testLspServer.ExecuteRequestAsync<LSP.CodeLens, LSP.CodeLens>(LSP.Methods.CodeLensResolveName, lastCodeLenses.First(), CancellationToken.None);
+        Assert.NotNull(lastCodeLens?.Command);
     }
 }


### PR DESCRIPTION
Sometimes we're getting requested for codelens for cache entries that don't exist.  This is not a full fix for the problem, but it does correct server behavior.  Instead of crashing during the request context creation (which takes down the entire server), we'll throw an error in the actual handling of the request (which will not take down the entire server).

Actual fix for invalid requests TBD

This is related to [AB#1778972](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1778972), but doesn't fix entirely the issue (as mentioned above).  But I kept running into the server crashing b/c of this today so I at least wanted to improve that part.