### PR TITLE
Update publishdata for -vs-deps deletion

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -147,15 +147,6 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.6P3]"
     },
-     "release/dev17.7-vs-deps": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.7",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.7P1]"
-    },
     "main": {
       "nugetKind": [
         "Shipping",
@@ -164,17 +155,7 @@
       "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[Validation]"
-    },
-    "main-vs-deps": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[Validation]"
+      "insertionTitlePrefix": "[d17.7P1]"
     },
     "dev/jorobich/fix-pr-val": {
       "nugetKind": [


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/67617
https://github.com/dotnet/roslyn/pull/67618

to go in first.