### PR TITLE
Remove excessive allocations of SourceLocations with mergedecls

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -154,25 +154,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return sortKey;
         }
 
-        public ImmutableArray<SourceLocation> NameLocations
+        public OneOrMany<SourceLocation> NameLocations
         {
             get
             {
                 if (Declarations.Length == 1)
-                {
-                    return ImmutableArray.Create(Declarations[0].NameLocation);
-                }
-                else
-                {
-                    var builder = ArrayBuilder<SourceLocation>.GetInstance();
-                    foreach (var decl in Declarations)
-                    {
-                        SourceLocation loc = decl.NameLocation;
-                        if (loc != null)
-                            builder.Add(loc);
-                    }
-                    return builder.ToImmutableAndFree();
-                }
+                    return OneOrMany.Create(Declarations[0].NameLocation);
+
+                var builder = ArrayBuilder<SourceLocation>.GetInstance(Declarations.Length);
+                foreach (var decl in Declarations)
+                    builder.AddIfNotNull(decl.NameLocation);
+
+                return builder.ToOneOrManyAndFree();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -962,12 +962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         public sealed override ImmutableArray<Location> Locations
-        {
-            get
-            {
-                return declaration.NameLocations.Cast<SourceLocation, Location>();
-            }
-        }
+            => ImmutableArray<Location>.CastUp(declaration.NameLocations.ToImmutable());
 
         public ImmutableArray<SyntaxReference> SyntaxReferences
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -148,6 +148,8 @@ namespace Roslyn.Utilities
             }
         }
 
+        public T First() => this[0];
+
         public T? FirstOrDefault(Func<T, bool> predicate)
         {
             if (HasOne)
@@ -183,6 +185,41 @@ namespace Roslyn.Utilities
 
             return default;
         }
+
+        public static OneOrMany<T> CastUp<TDerived>(OneOrMany<TDerived> from) where TDerived : class, T
+        {
+            return from.HasOne
+                ? new OneOrMany<T>(from._one)
+                : new OneOrMany<T>(ImmutableArray<T>.CastUp(from._many));
+        }
+
+        public bool All(Func<T, bool> predicate)
+        {
+            foreach (var value in this)
+            {
+                if (!predicate(value))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public bool Any()
+            => this.Count > 0;
+
+        public bool Any<TData>(Func<T, TData, bool> predicate, TData data)
+        {
+            foreach (var value in this)
+            {
+                if (predicate(value, data))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public ImmutableArray<T> ToImmutable()
+            => this.HasOne ? ImmutableArray.Create(_one) : _many;
 
         public Enumerator GetEnumerator()
             => new(this);


### PR DESCRIPTION
Saves roughly 95MB of allocations (roughly 2% of all allocs) of SourceLocation[] objects in a simple typing/lightbulb scenario.

![image](https://user-images.githubusercontent.com/4564579/229641047-1a15212a-3c4b-4954-9932-683a56641678.png)

Nearly all named types in a compilatino are non-partial.  However, our internal representation for a named-type would always return an array of SourceLocations, even for the case where there the type only has a single part.  This was doubly silly given that this array was returned for MakeAndCheckTypeModifiers, which then only uses it to access the first item in the list:

![image](https://user-images.githubusercontent.com/4564579/229641304-73679afc-f333-4284-9114-0afd21e37da7.png)

I considered just having MergedTypeDeclaration (which you *always* have, regardless of it there is a single part or not), have a special 'FirstLocation'.  But i decided to just change Locations to be a OneOrMany so that anyone using this property gets the win.