### PR TITLE
Fix main-vs-deps merge overwriting merge from 17.6-vs-deps

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.100-preview.1.23115.2",
     "vs": {
-      "version": "17.5.0"
+      "version": "17.4.1"
     },
-    "xcopy-msbuild": "17.5.0"
+    "xcopy-msbuild": "17.4.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23168.1",


### PR DESCRIPTION
We want this change https://github.com/dotnet/roslyn/pull/67567/ which was merged into 17.6-vs-deps, otherwise the signed build is broken.  Part of the change is present - https://github.com/dotnet/roslyn/blob/main/src/Workspaces/MSBuildTest/Utilities/DotNetSdkMSBuildInstalled.cs#L120 however part was overwritten by the merge of main-vs-deps back into main (since it happened afterwards).

This adds back in the rest of https://github.com/dotnet/roslyn/pull/67567/