### PR TITLE
Fix semantic tokens refresh queue to send requests

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/LanguageServerNotificationManager.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/LanguageServerNotificationManager.cs
@@ -26,11 +26,15 @@ internal class ClientLanguageServerManager : IClientLanguageServerManager
     public Task<TResponse> SendRequestAsync<TParams, TResponse>(string methodName, TParams @params, CancellationToken cancellationToken)
         => _jsonRpc.InvokeWithParameterObjectAsync<TResponse>(methodName, @params, cancellationToken);
 
+    public async ValueTask SendRequestAsync(string methodName, CancellationToken cancellationToken)
+        => await _jsonRpc.InvokeWithCancellationAsync(methodName, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask SendRequestAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
+        => await _jsonRpc.InvokeWithParameterObjectAsync(methodName, @params, cancellationToken).ConfigureAwait(false);
+
     public async ValueTask SendNotificationAsync(string methodName, CancellationToken cancellationToken)
         => await _jsonRpc.NotifyAsync(methodName).ConfigureAwait(false);
 
     public async ValueTask SendNotificationAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken)
-    {
-        await _jsonRpc.NotifyWithParameterObjectAsync(methodName, @params).ConfigureAwait(false);
-    }
+        => await _jsonRpc.NotifyWithParameterObjectAsync(methodName, @params).ConfigureAwait(false);
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
@@ -131,7 +131,7 @@ internal class SemanticTokensRefreshQueue :
         {
             if (documentUri is null || !trackedDocuments.ContainsKey(documentUri))
             {
-                return notificationManager.SendNotificationAsync(Methods.WorkspaceSemanticTokensRefreshName, cancellationToken);
+                return notificationManager.SendRequestAsync(Methods.WorkspaceSemanticTokensRefreshName, cancellationToken);
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/IClientLanguageServerManager.cs
+++ b/src/Features/LanguageServer/Protocol/IClientLanguageServerManager.cs
@@ -7,9 +7,16 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
+/// <summary>
+/// Manages sending requests or notifications to the client or server.
+/// Note - be extremely intentional about using a request or notification.  Use exactly what the LSP spec defines the method as.
+/// For example methods defined as requests even with no parameters or return value must be sent as requests regardless.
+/// </summary>
 internal interface IClientLanguageServerManager : ILspService
 {
     Task<TResponse> SendRequestAsync<TParams, TResponse>(string methodName, TParams @params, CancellationToken cancellationToken);
+    ValueTask SendRequestAsync(string methodName, CancellationToken cancellationToken);
+    ValueTask SendRequestAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken);
     ValueTask SendNotificationAsync(string methodName, CancellationToken cancellationToken);
     ValueTask SendNotificationAsync<TParams>(string methodName, TParams @params, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Previously we sent notifications, however the spec defines these as **requests** and not notifications and will not appropriately react if we send notifications.