### PR TITLE
Fix for FixAll in project and solution scopes for non-C#/VB projects

### DIFF
--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContextHelper.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContextHelper.cs
@@ -130,9 +130,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             CancellationToken cancellationToken)
         {
             var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
-            foreach (var (document, diagnosticsForDocument) in diagnostics.GroupBy(d => solution.GetDocument(d.Location.SourceTree)))
+
+            // NOTE: We use 'GetTextDocumentForLocation' extension to ensure we also handle external location diagnostics in non-C#/VB languages.
+            foreach (var (textDocument, diagnosticsForDocument) in diagnostics.GroupBy(d => solution.GetTextDocumentForLocation(d.Location)))
             {
-                if (document is null)
+                if (textDocument is not Document document)
                     continue;
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -37,6 +38,20 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static TextDocumentKind? GetDocumentKind(this Solution solution, DocumentId documentId)
             => solution.GetTextDocument(documentId)?.Kind;
+
+        internal static TextDocument? GetTextDocumentForLocation(this Solution solution, Location location)
+        {
+            switch (location.Kind)
+            {
+                case LocationKind.SourceFile:
+                    return solution.GetDocument(location.SourceTree);
+                case LocationKind.ExternalFile:
+                    var documentId = solution.GetDocumentIdsWithFilePath(location.GetLineSpan().Path).FirstOrDefault();
+                    return solution.GetTextDocument(documentId);
+                default:
+                    return null;
+            }
+        }
 
         public static Solution WithTextDocumentText(this Solution solution, DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveIdentity)
         {


### PR DESCRIPTION
F# team identified a bug in FixAll support where in FixAll works fine for Document scope, but doesn't work for Project and Solution scope. The core issue is in FixAllContextHelper code path for these scopes, where we reverse map from diagnostic location to source document. Existing code was assuming the diagnostic location has an associated source syntax tree, which is only true for C# and VB. We now handle diagnostics with external locations that map back to source documents in non-C#/VB world.

I manually verified that this fixes the F# FixAll scenario. I spent some time investigating writing an F# FixAll unit test, but that seems to have lot of missing pieces. Instead, I have requested F# team to add a FixAll unit test or integration test in their repo once this fix flows to them.