### PR TITLE
Add info to let named types quickly return 'null' when they have no primary constructor

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -618,6 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (hasPrimaryCtor)
             {
                 declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.HasAnyNontypeMembers;
+                declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.HasPrimaryConstructor;
             }
 
             var memberNames = GetNonTypeMemberNames(((Syntax.InternalSyntax.TypeDeclarationSyntax)(node.Green)).Members,

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // A type with parameters at least has a primary constructor
-            bool hasPrimaryCtor = node is TypeDeclarationSyntax { ParameterList: { } };
+            var hasPrimaryCtor = node.ParameterList != null;
             if (hasPrimaryCtor)
             {
                 declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.HasAnyNontypeMembers;

--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -129,6 +129,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public bool HasPrimaryConstructor
+        {
+            get
+            {
+                foreach (var decl in this.Declarations)
+                {
+                    if (decl.HasPrimaryConstructor)
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
         public bool AnyMemberHasAttributes
         {
             get

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -58,6 +58,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             IsSimpleProgram = 1 << 9,
 
             HasRequiredMembers = 1 << 10,
+
+            HasPrimaryConstructor = 1 << 11,
         }
 
         internal SingleTypeDeclaration(
@@ -192,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public bool HasRequiredMembers => (_flags & TypeDeclarationFlags.HasRequiredMembers) != 0;
+
+        public bool HasPrimaryConstructor => (_flags & TypeDeclarationFlags.HasPrimaryConstructor) != 0;
 
         protected override ImmutableArray<SingleNamespaceOrTypeDeclaration> GetNamespaceOrTypeDeclarationChildren()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -30,15 +30,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // We current pack everything into one 32-bit int; layout is given below.
             //
-            // |             |ss|vvv|zzzz|f|d|yy|wwwwww|
+            // |           p|ss|vvv|zzzz|f|d|yy|wwwwww|
             //
             // w = special type.  6 bits.
             // y = IsManagedType.  2 bits.
-            // d = FieldDefinitionsNoted. 1 bit
+            // d = FieldDefinitionsNoted. 1 bit.
             // f = FlattenedMembersIsSorted.  1 bit.
             // z = TypeKind. 4 bits.
             // v = NullableContext. 3 bits.
             // s = DeclaredRequiredMembers. 2 bits
+            // p = HasPrimaryConstructor. 1 bit.
             private int _flags;
 
             private const int SpecialTypeOffset = 0;
@@ -60,7 +61,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int NullableContextSize = 3;
 
             private const int HasDeclaredRequiredMembersOffset = NullableContextOffset + NullableContextSize;
-            //private const int HasDeclaredRequiredMembersSize = 2;
+            private const int HasDeclaredRequiredMembersSize = 2;
+
+            private const int HasPrimaryConstructorOffset = HasDeclaredRequiredMembersOffset + HasDeclaredRequiredMembersSize;
+            private const int HasPrimaryConstructorSize = 1;
 
             private const int SpecialTypeMask = (1 << SpecialTypeSize) - 1;
             private const int ManagedKindMask = (1 << ManagedKindSize) - 1;
@@ -72,6 +76,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             private const int HasDeclaredMembersBit = (1 << HasDeclaredRequiredMembersOffset);
             private const int HasDeclaredMembersBitSet = (1 << (HasDeclaredRequiredMembersOffset + 1));
+
+            private const int HasPrimaryConstructorBit = 1 << HasPrimaryConstructorOffset;
 
             public SpecialType SpecialType
             {
@@ -108,12 +114,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 #endif
 
-            public Flags(SpecialType specialType, TypeKind typeKind)
+            public Flags(SpecialType specialType, TypeKind typeKind, bool hasPrimaryConstructor)
             {
                 int specialTypeInt = ((int)specialType & SpecialTypeMask) << SpecialTypeOffset;
                 int typeKindInt = ((int)typeKind & TypeKindMask) << TypeKindOffset;
+                int hasPrimaryConstructorInt = hasPrimaryConstructor ? HasPrimaryConstructorBit : 0;
 
-                _flags = specialTypeInt | typeKindInt;
+                _flags = specialTypeInt | typeKindInt | hasPrimaryConstructorInt;
             }
 
             public void SetFieldDefinitionsNoted()
@@ -166,6 +173,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return ThreadSafeFlagOperations.Set(ref _flags, HasDeclaredMembersBitSet | (value ? HasDeclaredMembersBit : 0));
             }
+
+            public readonly bool HasPrimaryConstructor => (_flags & HasPrimaryConstructorBit) != 0;
         }
 
         private static readonly ObjectPool<PooledDictionary<Symbol, Symbol>> s_duplicateRecordMemberSignatureDictionary =
@@ -242,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ? MakeSpecialType()
                 : SpecialType.None;
 
-            _flags = new Flags(specialType, typeKind);
+            _flags = new Flags(specialType, typeKind, declaration.HasPrimaryConstructor);
 
             var containingType = this.ContainingType;
             if (containingType?.IsSealed == true && this.DeclaredAccessibility.HasProtected())
@@ -3192,6 +3201,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (!this._flags.HasPrimaryConstructor)
+                    return null;
+
                 var declared = Volatile.Read(ref _lazyDeclaredMembersAndInitializers);
                 if (declared is not null && declared != DeclaredMembersAndInitializers.UninitializedSentinel)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int HasDeclaredRequiredMembersSize = 2;
 
             private const int HasPrimaryConstructorOffset = HasDeclaredRequiredMembersOffset + HasDeclaredRequiredMembersSize;
-            private const int HasPrimaryConstructorSize = 1;
+            // private const int HasPrimaryConstructorSize = 1;
 
             private const int SpecialTypeMask = (1 << SpecialTypeSize) - 1;
             private const int ManagedKindMask = (1 << ManagedKindSize) - 1;


### PR DESCRIPTION
Traces show several places in the compiler where code wants to determine if a type has a primary constructor to choose a path to take.  Currently, this can only be computed by actually generating all members, then looking up if there's a primary constructor in them.  This PR allows hte question to be answered (in the common case, where there is no primary constructor) by storing a bit in the flags of the type.