### PR TITLE
Delay create AliasesAndUsings data until needed

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -29,9 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private Dictionary<string, ImmutableArray<NamedTypeSymbol>> _nameToTypeMembersMap;
         private ImmutableArray<Symbol> _lazyAllMembers;
         private ImmutableArray<NamedTypeSymbol> _lazyTypeMembersUnordered;
-        private readonly ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings;
+        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
+            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
 #if DEBUG
-        private readonly ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts;
+        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
+            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
 #endif
         private MergedGlobalAliasesAndUsings _lazyMergedGlobalAliasesAndUsings;
 
@@ -50,30 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _container = container;
             _mergedDeclaration = mergedDeclaration;
 
-            var builder = ImmutableSegmentedDictionary.CreateBuilder<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
-#if DEBUG
-            var builderForAsserts = ImmutableSegmentedDictionary.CreateBuilder<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
-#endif
             foreach (var singleDeclaration in mergedDeclaration.Declarations)
-            {
-                if (singleDeclaration.HasExternAliases || singleDeclaration.HasGlobalUsings || singleDeclaration.HasUsings)
-                {
-                    builder.Add(singleDeclaration, new AliasesAndUsings());
-                }
-#if DEBUG
-                else
-                {
-                    builderForAsserts.Add(singleDeclaration, new AliasesAndUsings());
-                }
-#endif
-
                 diagnostics.AddRange(singleDeclaration.Diagnostics);
-            }
-
-            _aliasesAndUsings = builder.ToImmutable();
-#if DEBUG
-            _aliasesAndUsingsForAsserts = builderForAsserts.ToImmutable();
-#endif
         }
 
         internal MergedNamespaceDeclaration MergedDeclaration

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -29,9 +29,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private Dictionary<string, ImmutableArray<NamedTypeSymbol>> _nameToTypeMembersMap;
         private ImmutableArray<Symbol> _lazyAllMembers;
         private ImmutableArray<NamedTypeSymbol> _lazyTypeMembersUnordered;
+
+        /// <summary>
+        /// Should only be read using <see cref="GetOrCreateAliasAndUsings"/>.
+        /// </summary>
         private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
             ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
 #if DEBUG
+        /// <summary>
+        /// Should only be read using <see cref="GetOrCreateAliasAndUsings"/>.
+        /// </summary>
         private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
             ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
 #endif

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     if (declaration.HasGlobalUsings || declaration.HasUsings || declaration.HasExternAliases)
                                     {
                                         targetDeclarationWithImports = declaration;
-                                        _aliasesAndUsings[declaration].Complete(this, declaration.SyntaxReference, cancellationToken);
+                                        GetOrCreateAliasAndUsings(ref _aliasesAndUsings_doNotAccessDirectly, declaration).Complete(this, declaration.SyntaxReference, cancellationToken);
                                     }
                                 }
                             }


### PR DESCRIPTION
Takes allocations of these in SourceNamespaceSymbol from 1.2% of all allocs (in a typing/lightbulb scenario) to 0.1%:

Before:

![image](https://user-images.githubusercontent.com/4564579/230175220-c9f40c63-15ba-434c-a96c-3c5b87f48c04.png)

After:

![image](https://user-images.githubusercontent.com/4564579/230175255-827055c4-718a-4ea1-8e22-e5671b3b044d.png)
