### PR TITLE
Reduce the size/cost of explicit enum symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEnumConstantSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEnumConstantSymbol.cs
@@ -23,9 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             EnumMemberDeclarationSyntax syntax,
             BindingDiagnosticBag diagnostics)
         {
-            var initializer = syntax.EqualsValue;
-            Debug.Assert(initializer != null);
-            return new ExplicitValuedEnumConstantSymbol(containingEnum, syntax, initializer, diagnostics);
+            return new ExplicitValuedEnumConstantSymbol(containingEnum, syntax, diagnostics);
         }
 
         public static SourceEnumConstantSymbol CreateImplicitValuedConstant(
@@ -157,21 +155,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private sealed class ExplicitValuedEnumConstantSymbol : SourceEnumConstantSymbol
         {
-            private readonly SyntaxReference _equalsValueNodeRef;
-
             public ExplicitValuedEnumConstantSymbol(
                 SourceMemberContainerTypeSymbol containingEnum,
                 EnumMemberDeclarationSyntax syntax,
-                EqualsValueClauseSyntax initializer,
                 BindingDiagnosticBag diagnostics) :
                 base(containingEnum, syntax, diagnostics)
             {
-                _equalsValueNodeRef = initializer.GetReference();
+                Debug.Assert(syntax.EqualsValue != null);
             }
 
             protected override ConstantValue MakeConstantValue(HashSet<SourceFieldSymbolWithSyntaxReference> dependencies, bool earlyDecodingWellKnownAttributes, BindingDiagnosticBag diagnostics)
             {
-                return ConstantValueUtils.EvaluateFieldConstant(this, (EqualsValueClauseSyntax)_equalsValueNodeRef.GetSyntax(), dependencies, earlyDecodingWellKnownAttributes, diagnostics);
+                var syntax = this.SyntaxNode;
+                Debug.Assert(syntax.EqualsValue != null);
+
+                return ConstantValueUtils.EvaluateFieldConstant(this, syntax.EqualsValue, dependencies, earlyDecodingWellKnownAttributes, diagnostics);
             }
         }
 


### PR DESCRIPTION
Drops 40MB of allocs in a simple typing/lightbulb scenario.  Before:

![image](https://user-images.githubusercontent.com/4564579/230182749-b15a1e98-6537-4287-9185-ef67abbdecfb.png)

After:

![image](https://user-images.githubusercontent.com/4564579/230182780-518b9de8-a11b-4f46-a967-a8df95579730.png)
