### PR TITLE
Move to segmented collections to avoid LOH allocations

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
@@ -7,8 +7,8 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 {
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
            SyntaxNode syntax,
            SemanticModel semanticModel,
            ClassificationOptions options,
-           ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+           SegmentedList<ClassifiedSpan> result,
+           CancellationToken cancellationToken)
         {
             if (syntax.IsKind(SyntaxKind.DiscardDesignation) || syntax.IsKind(SyntaxKind.DiscardPattern))
             {

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             SyntaxNode syntax,
             SemanticModel semanticModel,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             if (syntax is NameSyntax name)
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private void ClassifyTypeSyntax(
             NameSyntax name,
             SemanticModel semanticModel,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(name, cancellationToken);
@@ -67,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             NameSyntax name,
             SymbolInfo symbolInfo,
             SemanticModel semanticModel,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             if (symbolInfo.CandidateReason is
@@ -100,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             NameSyntax name,
             SymbolInfo symbolInfo,
             SemanticModel semanticModel,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             // If everything classifies the same way, then just pick that classification.
@@ -312,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private static bool TryClassifyFromIdentifier(
             NameSyntax name,
             SymbolInfo symbolInfo,
-            ArrayBuilder<ClassifiedSpan> result)
+            SegmentedList<ClassifiedSpan> result)
         {
             // Okay - it wasn't a type. If the syntax matches "var q = from" or "q = from", and from
             // doesn't bind to anything then optimistically color from as a keyword.
@@ -334,7 +335,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private static bool TryClassifyValueIdentifier(
             NameSyntax name,
             SymbolInfo symbolInfo,
-            ArrayBuilder<ClassifiedSpan> result)
+            SegmentedList<ClassifiedSpan> result)
         {
             if (name is IdentifierNameSyntax identifierName &&
                 symbolInfo.Symbol.IsImplicitValueParameter())
@@ -347,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         }
 
         private static bool TryClassifyNameOfIdentifier(
-            NameSyntax name, SymbolInfo symbolInfo, ArrayBuilder<ClassifiedSpan> result)
+            NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
         {
             if (name is IdentifierNameSyntax identifierName &&
                 identifierName.Identifier.IsKindOrHasMatchingText(SyntaxKind.NameOfKeyword) &&
@@ -360,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             return false;
         }
 
-        private static bool TryClassifyAsyncIdentifier(NameSyntax name, SymbolInfo symbolInfo, ArrayBuilder<ClassifiedSpan> result)
+        private static bool TryClassifyAsyncIdentifier(NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
         {
             var symbol = symbolInfo.GetAnySymbol();
 

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.cs
@@ -7,8 +7,8 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             SyntaxNode syntax,
             SemanticModel semanticModel,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(syntax, cancellationToken);

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -26,7 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             SyntaxToken lessThanToken,
             SemanticModel semanticModel,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+            SegmentedList<ClassifiedSpan> result,
+            CancellationToken cancellationToken)
         {
             var syntaxTree = semanticModel.SyntaxTree;
             if (syntaxTree.IsInPartiallyWrittenGeneric(lessThanToken.Span.End, cancellationToken, out var identifier))

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/UsingDirectiveSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/UsingDirectiveSyntaxClassifier.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             SyntaxNode syntax,
             SemanticModel semanticModel,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             if (syntax is UsingDirectiveSyntax usingDirective)
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private static void ClassifyUsingDirectiveSyntax(
             UsingDirectiveSyntax usingDirective,
             SemanticModel semanticModel,
-            ArrayBuilder<ClassifiedSpan> result,
+            SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
             // For using aliases, we bind the target on the right of the equals and use that

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractNameSyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractNameSyntaxClassifier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -30,14 +31,10 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         protected static void TryClassifyStaticSymbol(
             ISymbol symbol,
             TextSpan span,
-            ArrayBuilder<ClassifiedSpan> result)
+            SegmentedList<ClassifiedSpan> result)
         {
-            if (!IsStaticSymbol(symbol))
-            {
-                return;
-            }
-
-            result.Add(new ClassifiedSpan(span, ClassificationTypeNames.StaticSymbol));
+            if (IsStaticSymbol(symbol))
+                result.Add(new ClassifiedSpan(span, ClassificationTypeNames.StaticSymbol));
         }
 
         protected static bool IsStaticSymbol(ISymbol symbol)

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Classification
             private readonly CancellationToken _cancellationToken;
             private readonly Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> _getNodeClassifiers;
             private readonly Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> _getTokenClassifiers;
-            private readonly HashSet<ClassifiedSpan> _set;
+            private readonly SegmentedHashSet<ClassifiedSpan> _set;
             private readonly Stack<SyntaxNodeOrToken> _pendingNodes;
             private readonly ClassificationOptions _options;
 
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 _options = options;
 
                 // get one from pool
-                _set = SharedPools.Default<HashSet<ClassifiedSpan>>().AllocateAndClear();
+                _set = SharedPools.Default<SegmentedHashSet<ClassifiedSpan>>().AllocateAndClear();
                 _pendingNodes = SharedPools.Default<Stack<SyntaxNodeOrToken>>().AllocateAndClear();
             }
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 finally
                 {
                     // release collections to the pool
-                    SharedPools.Default<HashSet<ClassifiedSpan>>().ClearAndFree(worker._set);
+                    SharedPools.Default<SegmentedHashSet<ClassifiedSpan>>().ClearAndFree(worker._set);
                     SharedPools.Default<Stack<SyntaxNodeOrToken>>().ClearAndFree(worker._pendingNodes);
                 }
             }

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassifier.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Classification.Classifiers
 {
@@ -18,11 +18,11 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         protected static string? GetClassificationForType(ITypeSymbol type)
             => type.GetClassification();
 
-        public virtual void AddClassifications(SyntaxNode syntax, SemanticModel semanticModel, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public virtual void AddClassifications(SyntaxNode syntax, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
         }
 
-        public virtual void AddClassifications(SyntaxToken syntax, SemanticModel semanticModel, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public virtual void AddClassifications(SyntaxToken syntax, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Classification.Classifiers
 {
@@ -24,11 +24,11 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         /// <summary>
         /// This method will be called for all nodes that match the types specified by the <see cref="SyntaxNodeTypes"/> property.
         /// </summary>
-        void AddClassifications(SyntaxNode node, SemanticModel semanticModel, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken);
+        void AddClassifications(SyntaxNode node, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 
         /// <summary>
         /// This method will be called for all tokens that match the kinds specified by the <see cref="SyntaxTokenKinds"/> property.
         /// </summary>
-        void AddClassifications(SyntaxToken token, SemanticModel semanticModel, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken);
+        void AddClassifications(SyntaxToken token, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -5,7 +5,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/IdentifierNameSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/IdentifierNameSyntaxClassifier.vb
@@ -6,7 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
-Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Public Overrides ReadOnly Property SyntaxNodeTypes As ImmutableArray(Of Type) = ImmutableArray.Create(GetType(IdentifierNameSyntax))
 
-        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken)
+        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
             Dim identifierName = DirectCast(syntax, IdentifierNameSyntax)
             Dim identifier = identifierName.Identifier
             If CaseInsensitiveComparison.Equals(identifier.ValueText, s_awaitText) Then

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/ImportAliasClauseSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/ImportAliasClauseSyntaxClassifier.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -15,14 +16,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Public Overrides ReadOnly Property SyntaxNodeTypes As ImmutableArray(Of Type) = ImmutableArray.Create(GetType(ImportAliasClauseSyntax))
 
-        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken)
+        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
             ClassifyImportAliasClauseSyntax(DirectCast(syntax, ImportAliasClauseSyntax), semanticModel, result, cancellationToken)
         End Sub
 
         Private Shared Sub ClassifyImportAliasClauseSyntax(
                 node As ImportAliasClauseSyntax,
                 semanticModel As SemanticModel,
-                result As ArrayBuilder(Of ClassifiedSpan),
+                result As SegmentedList(Of ClassifiedSpan),
                 cancellationToken As CancellationToken)
 
             Dim symbolInfo = semanticModel.GetTypeInfo(DirectCast(node.Parent, SimpleImportsClauseSyntax).Name, cancellationToken)

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -24,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
                 syntax As SyntaxNode,
                 semanticModel As SemanticModel,
                 options As ClassificationOptions,
-                result As ArrayBuilder(Of ClassifiedSpan),
+                result As SegmentedList(Of ClassifiedSpan),
                 cancellationToken As CancellationToken)
 
             Dim nameSyntax = TryCast(syntax, NameSyntax)
@@ -67,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
         Private Sub ClassifyNameSyntax(
                 node As NameSyntax,
                 semanticModel As SemanticModel,
-                result As ArrayBuilder(Of ClassifiedSpan),
+                result As SegmentedList(Of ClassifiedSpan),
                 cancellationToken As CancellationToken)
 
             Dim classifiedSpan As ClassifiedSpan
@@ -234,7 +235,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Private Shared Sub ClassifyModifiedIdentifier(
                 modifiedIdentifier As ModifiedIdentifierSyntax,
-                result As ArrayBuilder(Of ClassifiedSpan))
+                result As SegmentedList(Of ClassifiedSpan))
 
             If modifiedIdentifier.ArrayBounds IsNot Nothing OrElse
                modifiedIdentifier.ArrayRankSpecifiers.Count > 0 OrElse
@@ -274,7 +275,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
             End Select
         End Function
 
-        Private Shared Sub ClassifyMethodStatement(methodStatement As MethodStatementSyntax, semanticModel As SemanticModel, result As ArrayBuilder(Of ClassifiedSpan))
+        Private Shared Sub ClassifyMethodStatement(methodStatement As MethodStatementSyntax, semanticModel As SemanticModel, result As SegmentedList(Of ClassifiedSpan))
             ' Ensure that extension method declarations are classified properly.
             ' Note that the method statement name is likely already classified as a method name
             ' by the syntactic classifier. However, there isn't away to determine whether a VB
@@ -287,7 +288,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Private Shared Sub ClassifyLabelSyntax(
             node As LabelSyntax,
-            result As ArrayBuilder(Of ClassifiedSpan))
+            result As SegmentedList(Of ClassifiedSpan))
 
             result.Add(New ClassifiedSpan(node.LabelToken.Span, ClassificationTypeNames.LabelName))
         End Sub

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.vb
@@ -6,7 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
-Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
@@ -21,8 +21,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
         Public Overrides Sub AddClassifications(
             syntax As SyntaxNode,
             semanticModel As SemanticModel,
-options As ClassificationOptions,
-            result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken)
+            options As ClassificationOptions,
+            result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
 
             Dim symbolInfo = semanticModel.GetSymbolInfo(syntax, cancellationToken)
             If TypeOf symbolInfo.Symbol Is IMethodSymbol AndAlso


### PR DESCRIPTION
Addresses about 10MB of allocs we're placing in the LOH:

![image](https://user-images.githubusercontent.com/4564579/230188796-9890c7ab-597a-4c13-b741-40f6b1d680e8.png)
