### PR TITLE
Adjust solution crawler logic to choose next best project to reduce expensive allocations

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -51,11 +51,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         Task ForceAnalyzeAsync(Solution solution, Action<Project> onProjectAnalyzed, ProjectId? projectId, CancellationToken cancellationToken);
 
         /// <summary>
-        /// True if given project has any diagnostics
-        /// </summary>
-        bool ContainsDiagnostics(Workspace workspace, ProjectId projectId);
-
-        /// <summary>
         /// Get diagnostics of the given diagnostic ids from the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
         /// Note that for project case, this method returns diagnostics from all project documents as well. Use <see cref="GetProjectDiagnosticsForIdsAsync(Solution, ProjectId, ImmutableHashSet{string}, bool, bool, CancellationToken)"/>
         /// if you want to fetch only project diagnostics without source locations.

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 protected override bool TryTakeAnyWork_NoLock(
-                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph, IDiagnosticAnalyzerService? service,
+                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph,
                     out WorkItem workItem)
                 {
                     // there must be at least one item in the map when this is called unless host is shutting down.
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return false;
                     }
 
-                    var documentId = GetBestDocumentId_NoLock(preferableProjectId, dependencyGraph, service);
+                    var documentId = GetBestDocumentId_NoLock(preferableProjectId, dependencyGraph);
                     if (TryTake_NoLock(documentId, out workItem))
                     {
                         return true;
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 private DocumentId GetBestDocumentId_NoLock(
-                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph, IDiagnosticAnalyzerService? analyzerService)
+                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph)
                 {
-                    var projectId = GetBestProjectId_NoLock(_documentWorkQueue, preferableProjectId, dependencyGraph, analyzerService);
+                    var projectId = GetBestProjectId_NoLock(_documentWorkQueue, preferableProjectId, dependencyGraph);
 
                     var documentMap = _documentWorkQueue[projectId];
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
 
                 protected override bool TryTakeAnyWork_NoLock(
-                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph, IDiagnosticAnalyzerService? analyzerService,
+                    ProjectId? preferableProjectId, ProjectDependencyGraph dependencyGraph,
                     out WorkItem workItem)
                 {
                     // there must be at least one item in the map when this is called unless host is shutting down.
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return false;
                     }
 
-                    var projectId = GetBestProjectId_NoLock(_projectWorkQueue, preferableProjectId, dependencyGraph, analyzerService);
+                    var projectId = GetBestProjectId_NoLock(_projectWorkQueue, preferableProjectId, dependencyGraph);
                     if (TryTake_NoLock(projectId, out workItem))
                     {
                         return true;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -174,7 +174,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return _workItemQueue.TryTakeAnyWork(
                             preferableProjectId: null,
                             dependencyGraph: _processor.DependencyGraph,
-                            analyzerService: _processor.DiagnosticAnalyzerService,
                             workItem: out workItem,
                             cancellationToken: out cancellationToken);
                     }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                                 : null;
 
                             if (_workItemQueue.TryTakeAnyWork(
-                                preferableProjectId, Processor.DependencyGraph, Processor.DiagnosticAnalyzerService,
+                                preferableProjectId, Processor.DependencyGraph,
                                 out var workItem, out var projectCancellation))
                             {
                                 await ProcessProjectAsync(Analyzers, workItem, projectCancellation).ConfigureAwait(false);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                             // process one of documents remaining
                             if (!_workItemQueue.TryTakeAnyWork(
-                                _currentProjectProcessing, Processor.DependencyGraph, Processor.DiagnosticAnalyzerService,
+                                _currentProjectProcessing, Processor.DependencyGraph,
                                 out var workItem, out var documentCancellation))
                             {
                                 return;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -200,15 +200,5 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();
         }
-
-        public bool ContainsDiagnostics(Workspace workspace, ProjectId projectId)
-        {
-            if (_map.TryGetValue(workspace, out var analyzer))
-            {
-                return analyzer.ContainsDiagnostics(projectId);
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -191,52 +191,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return stateSets.ToImmutable();
             }
 
-            /// <summary>
-            /// Determines if any of the state sets in <see cref="GetAllHostStateSets()"/> match a specified predicate.
-            /// </summary>
-            /// <remarks>
-            /// This method avoids the performance overhead of calling <see cref="GetAllHostStateSets()"/> for the
-            /// specific case where the result is only used for testing if any element meets certain conditions.
-            /// </remarks>
-            public bool HasAnyHostStateSet<TArg>(Func<StateSet, TArg, bool> match, TArg arg)
-            {
-                foreach (var (_, hostStateSet) in _hostAnalyzerStateMap)
-                {
-                    foreach (var stateSet in hostStateSet.OrderedStateSets)
-                    {
-                        if (match(stateSet, arg))
-                            return true;
-                    }
-                }
-
-                return false;
-            }
-
-            /// <summary>
-            /// Determines if any of the state sets in <see cref="_projectAnalyzerStateMap"/> for a specific project
-            /// match a specified predicate.
-            /// </summary>
-            /// <remarks>
-            /// <para>This method avoids the performance overhead of calling <see cref="GetStateSets(Project)"/> for the
-            /// specific case where the result is only used for testing if any element meets certain conditions.</para>
-            ///
-            /// <para>Note that host state sets (i.e. ones retured by <see cref="GetAllHostStateSets()"/> are not tested
-            /// by this method.</para>
-            /// </remarks>
-            public bool HasAnyProjectStateSet<TArg>(ProjectId projectId, Func<StateSet, TArg, bool> match, TArg arg)
-            {
-                if (_projectAnalyzerStateMap.TryGetValue(projectId, out var entry))
-                {
-                    foreach (var (_, stateSet) in entry.StateSetMap)
-                    {
-                        if (match(stateSet, arg))
-                            return true;
-                    }
-                }
-
-                return false;
-            }
-
             public bool OnProjectRemoved(IEnumerable<StateSet> stateSets, ProjectId projectId)
             {
                 var removed = false;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -37,20 +37,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
             }
 
-            [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/34761", AllowCaptures = false, AllowGenericEnumeration = false)]
-            public bool ContainsAnyDocumentOrProjectDiagnostics(ProjectId projectId)
-            {
-                foreach (var (documentId, state) in _activeFileStates)
-                {
-                    if (documentId.ProjectId == projectId && !state.IsEmpty)
-                    {
-                        return true;
-                    }
-                }
-
-                return _projectStates.TryGetValue(projectId, out var projectState) && !projectState.IsEmpty();
-            }
-
             public IEnumerable<ProjectId> GetProjectsWithDiagnostics()
             {
                 // quick bail out

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -87,13 +87,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         internal IGlobalOptionService GlobalOptions => AnalyzerService.GlobalOptions;
         internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache => _diagnosticAnalyzerRunner.AnalyzerInfoCache;
 
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54400", Constraint = "Avoid calling GetAllHostStateSets on this hot path.")]
-        public bool ContainsDiagnostics(ProjectId projectId)
-        {
-            return _stateManager.HasAnyHostStateSet(static (stateSet, arg) => stateSet.ContainsAnyDocumentOrProjectDiagnostics(arg), projectId)
-                || _stateManager.HasAnyProjectStateSet(projectId, static (stateSet, arg) => stateSet.ContainsAnyDocumentOrProjectDiagnostics(arg), projectId);
-        }
-
         private void OnProjectAnalyzerReferenceChanged(object? sender, ProjectAnalyzerReferenceChangedEventArgs e)
         {
             if (e.Removed.Length == 0)

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -691,10 +691,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)()
             End Function
 
-            Public Function ContainsDiagnostics(workspace As Workspace, projectId As ProjectId) As Boolean Implements IDiagnosticAnalyzerService.ContainsDiagnostics
-                Throw New NotImplementedException()
-            End Function
-
             Public Function ForceAnalyzeAsync(solution As Solution, onProjectAnalyzed As Action(Of Project), projectId As ProjectId, cancellationToken As CancellationToken) As Task Implements IDiagnosticAnalyzerService.ForceAnalyzeAsync
                 Throw New NotImplementedException()
             End Function


### PR DESCRIPTION
Fixes #22609

Background analysis in solution crawler currently chooses the documents/projects to analyze using the following priority order:
1. Active document
2. Open documents in a project processed based on the project dependency graph that had one or more diagnostics in prior snapshot
3. Open documents on the remaining dependent projects of the active document project based on the project dependency graph
4. Rest of the open documents
5. Projects processed based on the project dependency graph of the active document project that had one or more diagnostics (If FSA is enabled)
6. Remaining dependent projects of the active document project based on the project dependency graph (If FSA is enabled)
7. Rest of the projects (If FSA is enabled)

The logic to compute if a project had any diagnostics in the prior snapshot has been known to be pretty expensive causing lot of allocations. Additionally, we are not sure if that is really providing any additional user experience improvement for error list refresh. This change removes the checks in 2. and 6. above.