### PR TITLE
Reduce number of invocations to StateSet.GetOrCreateActiveFileState

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var (analyzerWithState, spanBased) = compilerAnalyzerData.Value;
                     var span = spanBased ? changedMember.FullSpan : (TextSpan?)null;
                     executor = executor.With(analysisScope.WithSpan(span));
-                    using var _ = ArrayBuilder<AnalyzerWithState>.GetInstance(out var analyzersWithState);
+                    using var _ = ArrayBuilder<AnalyzerWithState>.GetInstance(1, analyzerWithState, out var analyzersWithState);
                     await ExecuteAnalyzersAsync(executor, analyzersWithState, oldMemberSpans, builder).ConfigureAwait(false);
                 }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var (analyzerWithState, spanBased) = compilerAnalyzerData.Value;
                     var span = spanBased ? changedMember.FullSpan : (TextSpan?)null;
                     executor = executor.With(analysisScope.WithSpan(span));
-                    var analyzersWithState = SpecializedCollections.SingletonEnumerable(analyzerWithState);
+                    using var _ = ArrayBuilder<AnalyzerWithState>.GetInstance(out var analyzersWithState);
                     await ExecuteAnalyzersAsync(executor, analyzersWithState, oldMemberSpans, builder).ConfigureAwait(false);
                 }
 
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 async Task ExecuteAnalyzersAsync(
                     DocumentAnalysisExecutor executor,
-                    IEnumerable<AnalyzerWithState> analyzersWithState,
+                    ArrayBuilder<AnalyzerWithState> analyzersWithState,
                     ImmutableArray<TextSpan> oldMemberSpans,
                     PooledDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> builder)
                 {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             public async Task<ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>>> ComputeDiagnosticsAsync(
                 DocumentAnalysisExecutor executor,
-                ImmutableArray<StateSet> stateSets,
+                ImmutableArray<AnalyzerWithState> analyzersWithState,
                 VersionStamp version,
                 Func<DiagnosticAnalyzer, DocumentAnalysisExecutor, CancellationToken, Task<ImmutableArray<DiagnosticData>>> computeAnalyzerDiagnosticsAsync,
                 Func<DocumentAnalysisExecutor, CancellationToken, Task<ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>>>> computeDiagnosticsNonIncrementallyAsync,
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 Debug.Assert(!analysisScope.Span.HasValue);
 
                 // Ensure that only the analyzers that support incremental span-based analysis are provided.
-                Debug.Assert(stateSets.All(stateSet => stateSet.Analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis()));
+                Debug.Assert(analyzersWithState.All(stateSet => stateSet.Analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis()));
 
                 var document = (Document)analysisScope.TextDocument;
                 var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -75,29 +75,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var oldDocumentVersion = await GetDiagnosticVersionAsync(oldDocument.Project, cancellationToken).ConfigureAwait(false);
 
-                    using var _1 = ArrayBuilder<(DiagnosticAnalyzer, DocumentAnalysisData)>.GetInstance(out var spanBasedAnalyzers);
-                    using var _2 = ArrayBuilder<(DiagnosticAnalyzer, DocumentAnalysisData)>.GetInstance(out var documentBasedAnalyzers);
-                    (DiagnosticAnalyzer analyzer, DocumentAnalysisData existingData, bool spanBased)? compilerAnalyzerData = null;
-                    foreach (var stateSet in stateSets)
+                    using var _1 = ArrayBuilder<AnalyzerWithState>.GetInstance(out var spanBasedAnalyzers);
+                    using var _2 = ArrayBuilder<AnalyzerWithState>.GetInstance(out var documentBasedAnalyzers);
+                    (AnalyzerWithState analyzerWithState, bool spanBased)? compilerAnalyzerData = null;
+                    foreach (var analyzerWithState in analyzersWithState)
                     {
                         // Check if we have existing cached diagnostics for this analyzer whose version matches the
                         // old document version. If so, we can perform span based incremental analysis for the changed member.
                         // Otherwise, we have to perform entire document analysis.
-                        var state = stateSet.GetOrCreateActiveFileState(document.Id);
-                        var existingData = state.GetAnalysisData(analysisScope.Kind);
+                        var state = analyzerWithState.State;
+                        var existingData = analyzerWithState.ExistingData;
                         if (oldDocumentVersion == existingData.Version)
                         {
-                            if (!compilerAnalyzerData.HasValue && stateSet.Analyzer.IsCompilerAnalyzer())
-                                compilerAnalyzerData = (stateSet.Analyzer, existingData, spanBased: true);
+                            if (!compilerAnalyzerData.HasValue && analyzerWithState.Analyzer.IsCompilerAnalyzer())
+                                compilerAnalyzerData = (analyzerWithState, spanBased: true);
                             else
-                                spanBasedAnalyzers.Add((stateSet.Analyzer, existingData));
+                                spanBasedAnalyzers.Add(analyzerWithState);
                         }
                         else
                         {
-                            if (!compilerAnalyzerData.HasValue && stateSet.Analyzer.IsCompilerAnalyzer())
-                                compilerAnalyzerData = (stateSet.Analyzer, DocumentAnalysisData.Empty, spanBased: false);
+                            var analyzerWithStateAndEmptyData = new AnalyzerWithState(analyzerWithState.Analyzer, analyzerWithState.State, DocumentAnalysisData.Empty);
+                            if (!compilerAnalyzerData.HasValue && analyzerWithState.Analyzer.IsCompilerAnalyzer())
+                                compilerAnalyzerData = (analyzerWithStateAndEmptyData, spanBased: false);
                             else
-                                documentBasedAnalyzers.Add((stateSet.Analyzer, DocumentAnalysisData.Empty));
+                                documentBasedAnalyzers.Add(analyzerWithStateAndEmptyData);
                         }
                     }
 
@@ -126,47 +127,47 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 async Task ExecuteCompilerAnalyzerAsync(
-                    (DiagnosticAnalyzer analyzer, DocumentAnalysisData existingData, bool spanBased)? compilerAnalyzerData,
+                    (AnalyzerWithState analyzerWithState, bool spanBased)? compilerAnalyzerData,
                     ImmutableArray<TextSpan> oldMemberSpans,
                     PooledDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> builder)
                 {
                     if (!compilerAnalyzerData.HasValue)
                         return;
 
-                    var (analyzer, existingData, spanBased) = compilerAnalyzerData.Value;
+                    var (analyzerWithState, spanBased) = compilerAnalyzerData.Value;
                     var span = spanBased ? changedMember.FullSpan : (TextSpan?)null;
                     executor = executor.With(analysisScope.WithSpan(span));
-                    var analyzerAndExistingData = SpecializedCollections.SingletonEnumerable((analyzer, existingData));
-                    await ExecuteAnalyzersAsync(executor, analyzerAndExistingData, oldMemberSpans, builder).ConfigureAwait(false);
+                    var analyzersWithState = SpecializedCollections.SingletonEnumerable(analyzerWithState);
+                    await ExecuteAnalyzersAsync(executor, analyzersWithState, oldMemberSpans, builder).ConfigureAwait(false);
                 }
 
                 async Task ExecuteSpanBasedAnalyzersAsync(
-                    ArrayBuilder<(DiagnosticAnalyzer, DocumentAnalysisData)> analyzersAndExistingData,
+                    ArrayBuilder<AnalyzerWithState> analyzersWithState,
                     ImmutableArray<TextSpan> oldMemberSpans,
                     PooledDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> builder)
                 {
-                    if (analyzersAndExistingData.Count == 0)
+                    if (analyzersWithState.Count == 0)
                         return;
 
                     executor = executor.With(analysisScope.WithSpan(changedMember.FullSpan));
-                    await ExecuteAnalyzersAsync(executor, analyzersAndExistingData, oldMemberSpans, builder).ConfigureAwait(false);
+                    await ExecuteAnalyzersAsync(executor, analyzersWithState, oldMemberSpans, builder).ConfigureAwait(false);
                 }
 
                 async Task ExecuteDocumentBasedAnalyzersAsync(
-                    ArrayBuilder<(DiagnosticAnalyzer, DocumentAnalysisData)> analyzersAndExistingData,
+                    ArrayBuilder<AnalyzerWithState> analyzersWithState,
                     ImmutableArray<TextSpan> oldMemberSpans,
                     PooledDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> builder)
                 {
-                    if (analyzersAndExistingData.Count == 0)
+                    if (analyzersWithState.Count == 0)
                         return;
 
                     executor = executor.With(analysisScope.WithSpan(null));
-                    await ExecuteAnalyzersAsync(executor, analyzersAndExistingData, oldMemberSpans, builder).ConfigureAwait(false);
+                    await ExecuteAnalyzersAsync(executor, analyzersWithState, oldMemberSpans, builder).ConfigureAwait(false);
                 }
 
                 async Task ExecuteAnalyzersAsync(
                     DocumentAnalysisExecutor executor,
-                    IEnumerable<(DiagnosticAnalyzer, DocumentAnalysisData)> analyzersAndExistingData,
+                    IEnumerable<AnalyzerWithState> analyzersWithState,
                     ImmutableArray<TextSpan> oldMemberSpans,
                     PooledDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> builder)
                 {
@@ -175,9 +176,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     Debug.Assert(changedMember != null);
                     Debug.Assert(analysisScope.Kind == AnalysisKind.Semantic);
 
-                    foreach (var (analyzer, existingData) in analyzersAndExistingData)
+                    foreach (var analyzerWithState in analyzersWithState)
                     {
-                        var diagnostics = await computeAnalyzerDiagnosticsAsync(analyzer, executor, cancellationToken).ConfigureAwait(false);
+                        var diagnostics = await computeAnalyzerDiagnosticsAsync(analyzerWithState.Analyzer, executor, cancellationToken).ConfigureAwait(false);
 
                         // If we computed the diagnostics just for a span, then we are performing incremental analysis.
                         // We need to compute the full document diagnostics by re-using diagnostics outside the changed
@@ -187,12 +188,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             Debug.Assert(analysisScope.Span.Value == changedMember.FullSpan);
 
                             diagnostics = await GetUpdatedDiagnosticsForMemberEditAsync(
-                                diagnostics, existingData, analyzer,
+                                diagnostics, analyzerWithState.ExistingData, analyzerWithState.Analyzer,
                                 executor, changedMember, changedMemberId,
                                 oldMemberSpans, computeAnalyzerDiagnosticsAsync, cancellationToken).ConfigureAwait(false);
                         }
 
-                        builder.Add(analyzer, diagnostics);
+                        builder.Add(analyzerWithState.Analyzer, diagnostics);
                     }
                 }
             }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -162,12 +162,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private void RaiseDiagnosticsCreated(
-            Project project, StateSet stateSet, ImmutableArray<DiagnosticData> items, Action<DiagnosticsUpdatedArgs> raiseEvents)
+            Project project, DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticData> items, Action<DiagnosticsUpdatedArgs> raiseEvents)
         {
             Contract.ThrowIfFalse(project.Solution.Workspace == Workspace);
 
             raiseEvents(DiagnosticsUpdatedArgs.DiagnosticsCreated(
-                CreateId(stateSet, project.Id, AnalysisKind.NonLocal),
+                CreateId(analyzer, project.Id, AnalysisKind.NonLocal),
                 project.Solution.Workspace,
                 project.Solution,
                 project.Id,
@@ -176,12 +176,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private void RaiseDiagnosticsRemoved(
-            ProjectId projectId, Solution? solution, StateSet stateSet, Action<DiagnosticsUpdatedArgs> raiseEvents)
+            ProjectId projectId, Solution? solution, DiagnosticAnalyzer analyzer, Action<DiagnosticsUpdatedArgs> raiseEvents)
         {
             Contract.ThrowIfFalse(solution == null || solution.Workspace == Workspace);
 
             raiseEvents(DiagnosticsUpdatedArgs.DiagnosticsRemoved(
-                CreateId(stateSet, projectId, AnalysisKind.NonLocal),
+                CreateId(analyzer, projectId, AnalysisKind.NonLocal),
                 Workspace,
                 solution,
                 projectId,
@@ -189,12 +189,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private void RaiseDiagnosticsCreated(
-            TextDocument document, StateSet stateSet, AnalysisKind kind, ImmutableArray<DiagnosticData> items, Action<DiagnosticsUpdatedArgs> raiseEvents)
+            TextDocument document, DiagnosticAnalyzer analyzer, AnalysisKind kind, ImmutableArray<DiagnosticData> items, Action<DiagnosticsUpdatedArgs> raiseEvents)
         {
             Contract.ThrowIfFalse(document.Project.Solution.Workspace == Workspace);
 
             raiseEvents(DiagnosticsUpdatedArgs.DiagnosticsCreated(
-                CreateId(stateSet, document.Id, kind),
+                CreateId(analyzer, document.Id, kind),
                 document.Project.Solution.Workspace,
                 document.Project.Solution,
                 document.Project.Id,
@@ -203,23 +203,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private void RaiseDiagnosticsRemoved(
-            DocumentId documentId, Solution? solution, StateSet stateSet, AnalysisKind kind, Action<DiagnosticsUpdatedArgs> raiseEvents)
+            DocumentId documentId, Solution? solution, DiagnosticAnalyzer analyzer, AnalysisKind kind, Action<DiagnosticsUpdatedArgs> raiseEvents)
         {
             Contract.ThrowIfFalse(solution == null || solution.Workspace == Workspace);
 
             raiseEvents(DiagnosticsUpdatedArgs.DiagnosticsRemoved(
-                CreateId(stateSet, documentId, kind),
+                CreateId(analyzer, documentId, kind),
                 Workspace,
                 solution,
                 documentId.ProjectId,
                 documentId));
         }
 
-        private static object CreateId(StateSet stateSet, DocumentId documentId, AnalysisKind kind)
-            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, documentId, kind);
+        private static object CreateId(DiagnosticAnalyzer analyzer, DocumentId documentId, AnalysisKind kind)
+            => new LiveDiagnosticUpdateArgsId(analyzer, documentId, kind);
 
-        private static object CreateId(StateSet stateSet, ProjectId projectId, AnalysisKind kind)
-            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, projectId, kind);
+        private static object CreateId(DiagnosticAnalyzer analyzer, ProjectId projectId, AnalysisKind kind)
+            => new LiveDiagnosticUpdateArgsId(analyzer, projectId, kind);
 
         public static Task<VersionStamp> GetDiagnosticVersionAsync(Project project, CancellationToken cancellationToken)
             => project.GetDependentVersionAsync(cancellationToken);

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -395,19 +395,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 using var _ = ArrayBuilder<AnalyzerWithState>.GetInstance(analyzersWithState.Length, out var filteredAnalyzersWithStateBuilder);
                 foreach (var analyzerWithState in analyzersWithState)
                 {
-                    var analyzer = analyzerWithState.Analyzer;
-                    if (_priorityProvider.MatchesPriority(analyzer))
-                    {
-                        // Check if this is an expensive analyzer that needs to be de-prioritized to a lower priority bucket.
-                        // If so, we skip this analyzer from execution in the current priority bucket.
-                        // We will subsequently execute this analyzer in the lower priority bucket.
-                        if (await TryDeprioritizeAnalyzerAsync(analyzer, analyzerWithState.ExistingData).ConfigureAwait(false))
-                        {
-                            continue;
-                        }
+                    Debug.Assert(_priorityProvider.MatchesPriority(analyzerWithState.Analyzer));
 
-                        filteredAnalyzersWithStateBuilder.Add(analyzerWithState);
+                    // Check if this is an expensive analyzer that needs to be de-prioritized to a lower priority bucket.
+                    // If so, we skip this analyzer from execution in the current priority bucket.
+                    // We will subsequently execute this analyzer in the lower priority bucket.
+                    if (await TryDeprioritizeAnalyzerAsync(analyzerWithState.Analyzer, analyzerWithState.ExistingData).ConfigureAwait(false))
+                    {
+                        continue;
                     }
+
+                    filteredAnalyzersWithStateBuilder.Add(analyzerWithState);
                 }
 
                 analyzersWithState = filteredAnalyzersWithStateBuilder.ToImmutable();

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -237,14 +237,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         var lazyActiveFileState = new Lazy<ActiveFileState>(() => stateSet.GetOrCreateActiveFileState(_document.Id));
                         if (includeSyntax)
                         {
-                            var (added, existingData) = await TryAddCachedDocumentDiagnosticsAsync(stateSet, AnalysisKind.Syntax, lazyActiveFileState, list, cancellationToken).ConfigureAwait(false);
+                            var (added, existingData) = await TryAddCachedDocumentDiagnosticsAsync(stateSet.Analyzer, AnalysisKind.Syntax, lazyActiveFileState, list, cancellationToken).ConfigureAwait(false);
                             if (!added)
                                 syntaxAnalyzers.Add(new AnalyzerWithState(stateSet.Analyzer, lazyActiveFileState.Value, existingData!.Value));
                         }
 
                         if (includeSemantic && _document is Document)
                         {
-                            var (added, existingData) = await TryAddCachedDocumentDiagnosticsAsync(stateSet, AnalysisKind.Semantic, lazyActiveFileState, list, cancellationToken).ConfigureAwait(false);
+                            var (added, existingData) = await TryAddCachedDocumentDiagnosticsAsync(stateSet.Analyzer, AnalysisKind.Semantic, lazyActiveFileState, list, cancellationToken).ConfigureAwait(false);
                             if (!added)
                             {
                                 if (ShouldRunSemanticAnalysis(stateSet.Analyzer, _incrementalAnalysis, _blockForData,
@@ -344,15 +344,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             ///                     Note that this cached data may be from a prior document snapshot.
             /// </summary>
             private async Task<(bool added, DocumentAnalysisData? existingData)> TryAddCachedDocumentDiagnosticsAsync(
-                StateSet stateSet,
+                DiagnosticAnalyzer analyzer,
                 AnalysisKind kind,
                 Lazy<ActiveFileState> lazyActiveFileState,
                 ArrayBuilder<DiagnosticData> list,
                 CancellationToken cancellationToken)
             {
-                Debug.Assert(_priorityProvider.MatchesPriority(stateSet.Analyzer));
+                Debug.Assert(_priorityProvider.MatchesPriority(analyzer));
 
-                if (!stateSet.Analyzer.SupportAnalysisKind(kind))
+                if (!analyzer.SupportAnalysisKind(kind))
                 {
                     // In the case where the analyzer doesn't support the requested kind, act as if we succeeded, but just
                     // added no items to the result.  Effectively we did add the cached values, just that all the values that could have


### PR DESCRIPTION
Follow-up to #67662

Reduce the number of invocations to `StateSet.GetOrCreateActiveFileState`, which is called very frequently from all diagnostic computation paths and causes ConcurrentDictionary access. This change reduces the number of invocations to this method and subsequent `ActiveFileState.GetAnalysisData(kind)` (which takes a lock) by caching and passing around the computed state and existing data.

## Before this PR
Number of calls to this method per-analyzer, per-file
1. Background analysis - 3 times:
   a. Attempting to find already cached diagnostics
   b. If not cached, computing diagnostics
   c. If computed, caching it in active file state and raising diagnostics added/removed/updated events

2. GetDiagnosticsForSpan - 4 to 6 times (lightbulb and tagger code paths):
   a. For syntax diagnostics:
      1. Attempting to find already cached diagnostics
      2. If not cached, computing diagnostics
      3. For LSP mode, full document requests: If computed, caching it in active file state

   b. For semantic diagnostics
      1. Attempting to find already cached diagnostics
      2. If not cached, computing diagnostics
      3. For LSP mode, full document requests: If computed, caching it in active file state

## After this PR
Number of calls to this method per-analyzer, per-file:

1. Background analysis: Only once
2. GetDiagnosticsForSpan (lightbulb and tagger code paths): Only once