### PR TITLE
Provide a no-alloc way to get the first location of a symbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_NameConflicts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_NameConflicts.cs
@@ -22,10 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private static Location GetLocation(Symbol symbol)
-        {
-            var locations = symbol.Locations;
-            return locations.Length != 0 ? locations[0] : symbol.ContainingSymbol.Locations[0];
-        }
+            => symbol.TryGetFirstLocation() ?? symbol.ContainingSymbol.GetFirstLocation();
 
         internal void ValidateParameterNameConflicts(
             ImmutableArray<TypeParameterSymbol> typeParameters,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // It is an error for the same modifier to appear multiple times.
                     if (!modifierErrors)
                     {
-                        modifierErrors = ModifierUtils.CheckAccessibility(mods, this, isExplicitInterfaceImplementation: false, diagnostics, Locations[0]);
+                        modifierErrors = ModifierUtils.CheckAccessibility(mods, this, isExplicitInterfaceImplementation: false, diagnostics, this.GetFirstLocation());
                     }
                 }
 
@@ -972,6 +972,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override ImmutableArray<Location> Locations
             => ImmutableArray<Location>.CastUp(declaration.NameLocations.ToImmutable());
+
+        public override Location? TryGetFirstLocation()
+            => declaration.Declarations[0].NameLocation;
 
         public ImmutableArray<SyntaxReference> SyntaxReferences
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -99,6 +99,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override Location TryGetFirstLocation()
+            => _mergedDeclaration.Declarations[0].NameLocation;
+
         private static readonly Func<SingleNamespaceDeclaration, SyntaxReference> s_declaringSyntaxReferencesSelector = d =>
             new NamespaceDeclarationSyntaxReference(d.SyntaxReference);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -331,6 +331,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public abstract ImmutableArray<Location> Locations { get; }
 
+#nullable enable
+
+        public virtual Location? TryGetFirstLocation()
+        {
+            // Simple (but allocating) impl that can be overridden in subtypes if they show up in traces.
+            var locations = this.Locations;
+            return locations.IsEmpty ? null : locations[0];
+        }
+
+        public Location GetFirstLocation()
+            => TryGetFirstLocation() ?? throw new InvalidOperationException("Symbol has no locations");
+
+#nullable disable
+
         /// <summary>
         /// <para>
         /// Get the syntax node(s) where this symbol was declared in source. Some symbols (for

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static void CheckUnsafeModifier(this Symbol symbol, DeclarationModifiers modifiers, BindingDiagnosticBag diagnostics)
         {
-            symbol.CheckUnsafeModifier(modifiers, symbol.Locations[0], diagnostics);
+            symbol.CheckUnsafeModifier(modifiers, symbol.GetFirstLocation(), diagnostics);
         }
 
         internal static void CheckUnsafeModifier(this Symbol symbol, DeclarationModifiers modifiers, Location errorLocation, BindingDiagnosticBag diagnostics)


### PR DESCRIPTION
Extracted out of https://github.com/dotnet/roslyn/pull/67661 while we work on hte parameter-locations question.

This removes 30mb of allocs for sourcenamedtypes:

![image](https://user-images.githubusercontent.com/4564579/230458163-e7a873e2-de9f-4c4b-a286-e2d7aa63db2e.png)


