### PR TITLE
Only pack the shipping/non-shipping nupkgs for roslyn

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -4,7 +4,20 @@
     <GitHubRepositoryName>roslyn</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
     <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
+    <!-- Roslyn produces stable release branded and stable pre-release branded artifacts in addition to the normal non-stable artifacts.
+         Only the non-stable artifacts should flow downstream in source build -->
+    <EnableDefaultSourceBuildIntermediateItems>false</EnableDefaultSourceBuildIntermediateItems>
   </PropertyGroup>
+
+  <Target Name="GetCustomIntermediateNupkgContents" BeforeTargets="GetCategorizedIntermediateNupkgContents">
+    <ItemGroup>
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\**\*.nupkg" />
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping\**\*.nupkg" />
+      <!-- Don't pack any symbol packages: not needed for downstream source-build CI.
+          Roslyn's symbol packages come in .Symbols.<version>.nupkg instead of the standard format. -->
+      <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.Symbols.*.nupkg" />
+    </ItemGroup>
+  </Target>
 
   <!--
     The build script passes in the full path of the sln to build.  This must be overridden in order to build


### PR DESCRIPTION
Avoid packing release, pre-release stable nupkgs, and symbol nupkg.

Without this change, source build was preferencing the stable, release nupkgs when flowing between the repos. This worked until a new property showed up in the SDK bundled version props which is the net compiler toolset version. This should always be the non-stable version, based on the fact that this is the version used in the Microsoft build.