### PR TITLE
Update compiler tool set to 4.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.4.0-2.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.5.0</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->


### PR DESCRIPTION
If build release/dev17.6-vs-deps locally now, it would give a set of warnings.
Like:
<img width="1850" alt="image" src="https://user-images.githubusercontent.com/24360909/230510213-c64d74ff-50bd-4667-9bf0-b8b3226acc14.png">

But build main won't give the warnings.
After a binary search in the commit history I am pretty sure this PR causes the warning disappear in main
https://github.com/dotnet/roslyn/pull/67333
And the reason is it updates the compiler tool set version.
Fix https://github.com/dotnet/roslyn/issues/67668