### PR TITLE
Add assertion to detect misbehaving completion with complex edit

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -8178,7 +8178,7 @@ namespace NS
             Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
                 context.AddItem(CompletionItem.Create(
                     "CustomItem",
-                    rules:=CompletionItemRules.Default.WithMatchPriority(1000)))
+                    rules:=CompletionItemRules.Default.WithMatchPriority(1000), isComplexTextEdit:=True))
                 Return Task.CompletedTask
             End Function
 

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -244,7 +244,8 @@ namespace Roslyn.Test.Utilities
             string? insertText = null,
             string? sortText = null,
             string? filterText = null,
-            long resultId = 0)
+            long resultId = 0,
+            bool vsResolveTextEditOnCommit = false)
         {
             var position = await document.GetPositionFromLinePositionAsync(
                 ProtocolConversions.PositionToLinePosition(request.Position), CancellationToken.None).ConfigureAwait(false);
@@ -264,7 +265,8 @@ namespace Roslyn.Test.Utilities
                 {
                     ResultId = resultId,
                 }),
-                Preselect = preselect
+                Preselect = preselect,
+                VsResolveTextEditOnCommit = vsResolveTextEditOnCommit
             };
 
             if (tags != null)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Conversions.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Conversions.cs
@@ -51,7 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 symbols: symbols,
                 rules: s_conversionRules,
                 contextPosition: position,
-                properties: properties));
+                properties: properties,
+                isComplexTextEdit: true));
         }
 
         private static (ImmutableArray<ISymbol> symbols, ImmutableDictionary<string, string> properties) GetConversionSymbolsAndProperties(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 symbols: indexers,
                 rules: CompletionItemRules.Default,
                 contextPosition: context.Position,
-                properties: IndexerProperties));
+                properties: IndexerProperties,
+                isComplexTextEdit: true));
         }
 
         // Remove the dot, but leave the ? if one is there.  Place the caret one space back so it is between the braces.

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Operators.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Operators.cs
@@ -113,7 +113,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 symbols: operators.ToImmutableArray(),
                 rules: s_operatorRules,
                 contextPosition: context.Position,
-                properties: OperatorProperties.Add(OperatorName, opName)));
+                properties: OperatorProperties.Add(OperatorName, opName),
+                isComplexTextEdit: true));
         }
 
         private static string GetOperatorText(string opName)

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -81,6 +81,8 @@ namespace Microsoft.CodeAnalysis.Completion
         /// 
         /// The span identifies the text in the document that is used to filter the initial list presented to the user,
         /// and typically represents the region of the document that will be changed if this item is committed.
+        /// The latter is not always true because individual provider is free to make more complex changes to the document.
+        /// If this is the case, the provider should set <see cref="IsComplexTextEdit"/> to true.
         /// </summary>
         public TextSpan Span { get; internal set; }
 
@@ -101,17 +103,11 @@ namespace Microsoft.CodeAnalysis.Completion
         public CompletionItemRules Rules { get; }
 
         /// <summary>
-        /// Returns true if this item's text edit requires complex resolution that
-        /// may impact performance. For example, an edit may be complex if it needs
-        /// to format or type check the resulting code, or make complex non-local
-        /// changes to other parts of the file.
-        /// Complex resolution is used so we only do the minimum amount of work
-        /// needed to display completion items. It is performed only for the
-        /// committed item just prior to commit. Thus, it is ideal for any expensive
-        /// completion work that does not affect the display of the item in the
-        /// completion list, but is necessary for committing the item.
-        /// An example of an item type requiring complex resolution is C#/VB
-        /// override completion.
+        /// Returns true if this item's text edit requires complex resolution.
+        /// For example, an edit may be complex if it makes changes outside the range
+        /// specified by <see cref="Span"/>.
+        /// 
+        /// Example of an item type requiring complex resolution is C#/VB override completion.
         /// </summary>
         public bool IsComplexTextEdit { get; }
 

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
         /// <summary>
         /// Returns true if this item's text edit requires complex resolution.
-        /// For example, an edit may be complex if it makes changes outside the range
+        /// An edit is considered complex if the span of the change is different from
         /// specified by <see cref="Span"/>.
         /// 
         /// Example of an item type requiring complex resolution is C#/VB override completion.

--- a/src/Features/Core/Portable/Completion/CompletionList.cs
+++ b/src/Features/Core/Portable/Completion/CompletionList.cs
@@ -46,6 +46,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// The span identifies the text in the document that is used to filter the initial list 
         /// presented to the user, and typically represents the region of the document that will 
         /// be changed if this item is committed.
+        /// The latter is not always the case because each provider is free to make more complex changes 
+        /// to the document. If this is the case, <see cref="CompletionItem.IsComplexTextEdit"/> must be
+        /// set to <see langword="true"/>.
         /// </summary>
         public TextSpan Span { get; }
 

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -226,6 +226,8 @@ namespace Microsoft.CodeAnalysis.Completion
                 (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
                 var change = await provider.GetChangeAsync(document, item, commitCharacter, cancellationToken).ConfigureAwait(false);
                 GC.KeepAlive(semanticModel);
+
+                Debug.Assert(item.Span.Contains(change.TextChange.Span) || item.IsComplexTextEdit);
                 return change;
             }
             else

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 var change = await provider.GetChangeAsync(document, item, commitCharacter, cancellationToken).ConfigureAwait(false);
                 GC.KeepAlive(semanticModel);
 
-                Debug.Assert(item.Span.Contains(change.TextChange.Span) || item.IsComplexTextEdit);
+                Debug.Assert(item.Span == change.TextChange.Span || item.IsComplexTextEdit);
                 return change;
             }
             else

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Completion
             (document, var semanticModel) = await GetDocumentWithFrozenPartialSemanticsAsync(document, cancellationToken).ConfigureAwait(false);
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var defaultItemSpan = GetDefaultCompletionListSpan(text, caretPosition);
+            var completionListSpan = GetDefaultCompletionListSpan(text, caretPosition);
 
             var providers = _providerManager.GetFilteredProviders(document.Project, roles, trigger, options);
 
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Completion
             // Now, ask all the triggered providers, in parallel, to populate a completion context.
             // Note: we keep any context with items *or* with a suggested item.  
             var triggeredContexts = await ComputeNonEmptyCompletionContextsAsync(
-                document, caretPosition, trigger, options, defaultItemSpan, triggeredProviders, sharedContext, cancellationToken).ConfigureAwait(false);
+                document, caretPosition, trigger, options, completionListSpan, triggeredProviders, sharedContext, cancellationToken).ConfigureAwait(false);
 
             // Nothing to do if we didn't even get any regular items back (i.e. 0 items or suggestion item only.)
             if (!triggeredContexts.Any(static cc => cc.Items.Count > 0))
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Completion
             // that's all we'll return.
             var exclusiveContexts = triggeredContexts.Where(t => t.IsExclusive).ToImmutableArray();
             if (!exclusiveContexts.IsEmpty)
-                return MergeAndPruneCompletionLists(exclusiveContexts, defaultItemSpan, options, isExclusive: true);
+                return MergeAndPruneCompletionLists(exclusiveContexts, options, isExclusive: true);
 
             // Great!  We had some items.  Now we want to see if any of the other providers 
             // would like to augment the completion list.  For example, we might trigger
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var augmentingProviders = providers.Except(triggeredProviders).ToImmutableArray();
 
             var augmentingContexts = await ComputeNonEmptyCompletionContextsAsync(
-                document, caretPosition, trigger, options, defaultItemSpan, augmentingProviders, sharedContext, cancellationToken).ConfigureAwait(false);
+                document, caretPosition, trigger, options, completionListSpan, augmentingProviders, sharedContext, cancellationToken).ConfigureAwait(false);
 
             GC.KeepAlive(semanticModel);
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var allContexts = triggeredContexts.Concat(augmentingContexts)
                 .Sort((p1, p2) => completionProviderToIndex[p1.Provider] - completionProviderToIndex[p2.Provider]);
 
-            return MergeAndPruneCompletionLists(allContexts, defaultItemSpan, options, isExclusive: false);
+            return MergeAndPruneCompletionLists(allContexts, options, isExclusive: false);
 
             ImmutableArray<CompletionProvider> GetTriggeredProviders(
                 Document document, ConcatImmutableArray<CompletionProvider> providers, int caretPosition, CompletionOptions options, CompletionTrigger trigger, ImmutableHashSet<string>? roles, SourceText text)
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
         private static async Task<ImmutableArray<CompletionContext>> ComputeNonEmptyCompletionContextsAsync(
             Document document, int caretPosition, CompletionTrigger trigger,
-            CompletionOptions options, TextSpan defaultItemSpan,
+            CompletionOptions options, TextSpan completionListSpan,
             ImmutableArray<CompletionProvider> providers,
             SharedSyntaxContextsWithSpeculativeModel sharedContext,
             CancellationToken cancellationToken)
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Completion
             {
                 completionContextTasks.Add(GetContextAsync(
                     provider, document, caretPosition, trigger,
-                    options, defaultItemSpan, sharedContext, cancellationToken));
+                    options, completionListSpan, sharedContext, cancellationToken));
             }
 
             var completionContexts = await Task.WhenAll(completionContextTasks).ConfigureAwait(false);
@@ -243,14 +243,11 @@ namespace Microsoft.CodeAnalysis.Completion
 
         private CompletionList MergeAndPruneCompletionLists(
             ImmutableArray<CompletionContext> completionContexts,
-            TextSpan defaultSpan,
             in CompletionOptions options,
             bool isExclusive)
         {
-            // See if any contexts changed the completion list span.  If so, the first context that
-            // changed it 'wins' and picks the span that will be used for all items in the completion
-            // list.  If no contexts changed it, then just use the default span provided by the service.
-            var finalCompletionListSpan = completionContexts.FirstOrDefault(c => c.CompletionListSpan != defaultSpan)?.CompletionListSpan ?? defaultSpan;
+            Debug.Assert(!completionContexts.IsDefaultOrEmpty);
+
             using var displayNameToItemsMap = new DisplayNameToItemsMap(this);
             CompletionItem? suggestionModeItem = null;
 
@@ -272,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
 
             return CompletionList.Create(
-                finalCompletionListSpan,
+                completionContexts[0].CompletionListSpan,   // All contexts have the same completion list span.
                 displayNameToItemsMap.SortToSegmentedList(),
                 GetRules(options),
                 suggestionModeItem,

--- a/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
@@ -18,12 +17,18 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 .Add(BeforeCaretText, beforeCaretText)
                 .Add(AfterCaretText, afterCaretText);
 
+            // Set isComplexTextEdit to be always true for simplicity, even
+            // though we don't always need to make change outside the default
+            // completion list Span.
+            // See AbstractDocCommentCompletionProvider.GetChangeAsync for how
+            // the actual Span is calculated.
             return CommonCompletionItem.Create(
                 displayText: displayText,
                 displayTextSuffix: "",
                 glyph: Glyph.Keyword,
                 properties: props,
-                rules: rules);
+                rules: rules,
+                isComplexTextEdit: true);
         }
 
         public static string GetBeforeCaretText(CompletionItem item)

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
                     rules: embeddedItem.IsDefault
                         ? s_rules.WithMatchPriority(MatchPriority.Preselect)
                         : s_rules,
-                    isComplexTextEdit: !context.CompletionListSpan.Contains(textChange.Span)));
+                    isComplexTextEdit: context.CompletionListSpan != textChange.Span));
             }
 
             context.IsExclusive = true;

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -125,7 +125,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
                     properties: properties.ToImmutable(),
                     rules: embeddedItem.IsDefault
                         ? s_rules.WithMatchPriority(MatchPriority.Preselect)
-                        : s_rules));
+                        : s_rules,
+                    isComplexTextEdit: !context.CompletionListSpan.Contains(textChange.Span)));
             }
 
             context.IsExclusive = true;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
                     sortText: sortText,
                     properties: properties.ToImmutable(),
                     rules: s_rules,
-                    isComplexTextEdit: !context.CompletionListSpan.Contains(textChange.Span)));
+                    isComplexTextEdit: context.CompletionListSpan != textChange.Span));
             }
 
             context.IsExclusive = true;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
@@ -119,7 +119,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
                     inlineDescription: embeddedItem.InlineDescription,
                     sortText: sortText,
                     properties: properties.ToImmutable(),
-                    rules: s_rules));
+                    rules: s_rules,
+                    isComplexTextEdit: !context.CompletionListSpan.Contains(textChange.Span)));
             }
 
             context.IsExclusive = true;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -108,11 +108,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var snippetsSupported = completionCapabilities?.CompletionItem?.SnippetSupport ?? false;
             var itemDefaultsSupported = completionCapabilities?.CompletionListSetting?.ItemDefaults?.Contains(EditRangeSetting) == true;
 
-            // We use the first item in the completion list as our comparison point for span
-            // and range for optimization when generating the TextEdits later on.
-            var completionChange = await completionService.GetChangeAsync(
-                document, list.ItemsList[0], cancellationToken: cancellationToken).ConfigureAwait(false);
-            var defaultSpan = completionChange.TextChange.Span;
+            // We use the default completion list span as our comparison point for optimization when generating the TextEdits later on.
+            var defaultSpan = list.Span;
             var defaultRange = ProtocolConversions.TextSpanToRange(defaultSpan, documentText);
 
             var supportsCompletionListData = clientCapabilities.HasCompletionListDataCapability();

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/ILspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/ILspCompletionResultCreationService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
@@ -77,6 +78,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             }
             else
             {
+                Debug.Assert(completionChangeSpan == defaultSpan || item.IsComplexTextEdit);
                 lspItem.TextEdit = new LSP.TextEdit()
                 {
                     NewText = newText,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -493,13 +493,13 @@ class A
 
             var defaultRange = new LSP.Range
             {
-                Start = new LSP.Position { Line = 5, Character = 20 },
+                Start = new LSP.Position { Line = 5, Character = 21 },
                 End = new LSP.Position { Line = 5, Character = 21 }
             };
 
             var expected = await CreateCompletionItemAsync(
                 label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document,
-                sortText: "0000").ConfigureAwait(false);
+                sortText: "0000", vsResolveTextEditOnCommit: true).ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
@@ -530,13 +530,13 @@ class A
 
             var defaultRange = new LSP.Range
             {
-                Start = new LSP.Position { Line = 5, Character = 23 },
+                Start = new LSP.Position { Line = 5, Character = 25 },
                 End = new LSP.Position { Line = 5, Character = 25 }
             };
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, insertText: @"\\A",
-                sortText: "0000").ConfigureAwait(false);
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document,
+                sortText: "0000", vsResolveTextEditOnCommit: true).ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());


### PR DESCRIPTION
If any item would cause change outside the default Span of completion list, but `IsComplextTextEdit` is false, it will be filtered out by LSP client based on the actual change range we set in LSP completion item. Those complex edits have to be done outside the completion commit action (which will be fixed in a separate change for our completion handler)