### PR TITLE
Remove AnalyzerExecutor.CancellationToken property

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -11793,7 +11793,7 @@ class C
 System.NotImplementedException: 28
    at TestAnalyzer.get_SupportedDiagnostics()
    at Microsoft.CodeAnalysis.Diagnostics.AnalyzerManager.AnalyzerExecutionContext.<>c__DisplayClass20_0.<ComputeDiagnosticDescriptors_NoLock>b__0(Object _)
-   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info)
+   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info, CancellationToken cancellationToken)
 -----
 Analyzer 'TestAnalyzer' threw the following exception:
 'System.NotImplementedException: 28

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticLocalizationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticLocalizationTests.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken> onAnalyzerException = (ex, a, diag, ct) => exceptionDiagnostics.Add(diag);
             var analyzerManager = new AnalyzerManager(analyzer);
             var analyzerExecutor = AnalyzerExecutor.CreateForSupportedDiagnostics(onAnalyzerException, analyzerManager);
-            var descriptors = analyzerManager.GetSupportedDiagnosticDescriptors(analyzer, analyzerExecutor);
+            var descriptors = analyzerManager.GetSupportedDiagnosticDescriptors(analyzer, analyzerExecutor, CancellationToken.None);
 
             Assert.Equal(1, descriptors.Length);
             Assert.Equal(descriptor.Id, descriptors[0].Id);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1215,7 +1215,7 @@ namespace Microsoft.CodeAnalysis
                         // generated in presence of diagnostics that break the build.
                         if (analyzerDriver != null && !diagnostics.IsEmptyWithoutResolution)
                         {
-                            analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation);
+                            analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation, cancellationToken);
                         }
 
                         if (HasUnsuppressedErrors(diagnostics))
@@ -1292,18 +1292,18 @@ namespace Microsoft.CodeAnalysis
                             // GetDiagnosticsAsync is called after ReportUnusedImports
                             // since that method calls EventQueue.TryComplete. Without
                             // TryComplete, we may miss diagnostics.
-                            var hostDiagnostics = analyzerDriver.GetDiagnosticsAsync(compilation).Result;
+                            var hostDiagnostics = analyzerDriver.GetDiagnosticsAsync(compilation, cancellationToken).Result;
                             diagnostics.AddRange(hostDiagnostics);
 
                             if (!diagnostics.IsEmptyWithoutResolution)
                             {
                                 // Apply diagnostic suppressions for analyzer and/or compiler diagnostics from diagnostic suppressors.
-                                analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation);
+                                analyzerDriver.ApplyProgrammaticSuppressions(diagnostics, compilation, cancellationToken);
                             }
 
                             if (errorLogger != null)
                             {
-                                errorLogger.AddAnalyzerDescriptors(analyzerDriver.GetAllDescriptors());
+                                errorLogger.AddAnalyzerDescriptors(analyzerDriver.GetAllDescriptors(cancellationToken));
                             }
                         }
                     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -184,14 +184,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public void ApplySuppressionsAndStoreAnalysisResult(AnalysisScope analysisScope, AnalyzerDriver driver, Compilation compilation, Func<DiagnosticAnalyzer, AnalyzerActionCounts> getAnalyzerActionCounts)
+        public void ApplySuppressionsAndStoreAnalysisResult(AnalysisScope analysisScope, AnalyzerDriver driver, Compilation compilation, Func<DiagnosticAnalyzer, AnalyzerActionCounts> getAnalyzerActionCounts, CancellationToken cancellationToken)
         {
             foreach (var analyzer in analysisScope.Analyzers)
             {
                 // Dequeue reported analyzer diagnostics from the driver and store them in our maps.
-                var syntaxDiagnostics = driver.DequeueLocalDiagnosticsAndApplySuppressions(analyzer, syntax: true, compilation: compilation);
-                var semanticDiagnostics = driver.DequeueLocalDiagnosticsAndApplySuppressions(analyzer, syntax: false, compilation: compilation);
-                var compilationDiagnostics = driver.DequeueNonLocalDiagnosticsAndApplySuppressions(analyzer, compilation);
+                var syntaxDiagnostics = driver.DequeueLocalDiagnosticsAndApplySuppressions(analyzer, syntax: true, compilation: compilation, cancellationToken);
+                var semanticDiagnostics = driver.DequeueLocalDiagnosticsAndApplySuppressions(analyzer, syntax: false, compilation: compilation, cancellationToken);
+                var compilationDiagnostics = driver.DequeueNonLocalDiagnosticsAndApplySuppressions(analyzer, compilation, cancellationToken);
 
                 lock (_gate)
                 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -406,11 +406,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Compute the set of effective actions based on suppression, and running the initial analyzers
                 _lazyInitializeTask = Task.Run(async () =>
                 {
-                    (_lazyAnalyzerActions, _lazyUnsuppressedAnalyzers) = await GetAnalyzerActionsAsync(Analyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter).ConfigureAwait(false);
-                    _lazyAnalyzerGateMap = await CreateAnalyzerGateMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter).ConfigureAwait(false);
-                    _lazyNonConfigurableAnalyzers = ComputeNonConfigurableAnalyzers(UnsuppressedAnalyzers);
+                    (_lazyAnalyzerActions, _lazyUnsuppressedAnalyzers) = await GetAnalyzerActionsAsync(Analyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter, cancellationToken).ConfigureAwait(false);
+                    _lazyAnalyzerGateMap = await CreateAnalyzerGateMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter, cancellationToken).ConfigureAwait(false);
+                    _lazyNonConfigurableAnalyzers = ComputeNonConfigurableAnalyzers(UnsuppressedAnalyzers, cancellationToken);
                     _lazySymbolStartAnalyzers = ComputeSymbolStartAnalyzers(UnsuppressedAnalyzers);
-                    _lazyGeneratedCodeAnalysisFlagsMap = await CreateGeneratedCodeAnalysisFlagsMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter).ConfigureAwait(false);
+                    _lazyGeneratedCodeAnalysisFlagsMap = await CreateGeneratedCodeAnalysisFlagsMapAsync(UnsuppressedAnalyzers, AnalyzerManager, analyzerExecutor, analysisScope, _severityFilter, cancellationToken).ConfigureAwait(false);
                     _lazyTreatAllCodeAsNonGeneratedCode = ComputeShouldTreatAllCodeAsNonGeneratedCode(UnsuppressedAnalyzers, GeneratedCodeAnalysisFlagsMap);
                     _lazyDoNotAnalyzeGeneratedCode = ComputeShouldSkipAnalysisOnGeneratedCode(UnsuppressedAnalyzers, GeneratedCodeAnalysisFlagsMap, TreatAllCodeAsNonGeneratedCode);
                     _lazyGeneratedCodeFilesMap = new ConcurrentDictionary<SyntaxTree, bool>();
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 compilation, analysisOptions.Options ?? AnalyzerOptions.Empty, addNotCategorizedDiagnostic, newOnAnalyzerException, analysisOptions.AnalyzerExceptionFilter,
                 IsCompilerAnalyzer, AnalyzerManager, ShouldSkipAnalysisOnGeneratedCode, ShouldSuppressGeneratedCodeDiagnostic, IsGeneratedOrHiddenCodeLocation, IsAnalyzerSuppressedForTree, GetAnalyzerGate,
                 getSemanticModel: GetOrCreateSemanticModel,
-                analysisOptions.LogAnalyzerExecutionTime, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic, s => _programmaticSuppressions!.Add(s), cancellationToken);
+                analysisOptions.LogAnalyzerExecutionTime, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic, s => _programmaticSuppressions!.Add(s));
 
             Initialize(analyzerExecutor, diagnosticQueue, compilationData, analysisScope, suppressedDiagnosticIds, cancellationToken);
         }
@@ -526,12 +526,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return null;
         }
 
-        private ImmutableHashSet<DiagnosticAnalyzer> ComputeNonConfigurableAnalyzers(ImmutableHashSet<DiagnosticAnalyzer> unsuppressedAnalyzers)
+        private ImmutableHashSet<DiagnosticAnalyzer> ComputeNonConfigurableAnalyzers(ImmutableHashSet<DiagnosticAnalyzer> unsuppressedAnalyzers, CancellationToken cancellationToken)
         {
             var builder = ImmutableHashSet.CreateBuilder<DiagnosticAnalyzer>();
             foreach (var analyzer in unsuppressedAnalyzers)
             {
-                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor);
+                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor, cancellationToken);
                 foreach (var descriptor in descriptors)
                 {
                     if (descriptor.IsNotConfigurable())
@@ -700,12 +700,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (WhenInitializedTask.IsFaulted)
             {
-                OnDriverException(WhenInitializedTask, this.AnalyzerExecutor, analysisScope.Analyzers);
+                OnDriverException(WhenInitializedTask, this.AnalyzerExecutor, analysisScope.Analyzers, cancellationToken);
             }
             else if (!WhenInitializedTask.IsCanceled)
             {
-                _lazyAnalyzerExecutor = this.AnalyzerExecutor.WithCancellationToken(cancellationToken);
-
                 await ProcessCompilationEventsAsync(analysisScope, usingPrePopulatedEventQueue, cancellationToken).ConfigureAwait(false);
 
                 // If not using pre-populated event queue (batch mode), then verify all symbol end actions were processed.
@@ -716,7 +714,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private static void OnDriverException(Task faultedTask, AnalyzerExecutor analyzerExecutor, ImmutableArray<DiagnosticAnalyzer> analyzers)
+        private static void OnDriverException(Task faultedTask, AnalyzerExecutor analyzerExecutor, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
         {
             Debug.Assert(faultedTask.IsFaulted);
 
@@ -732,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // The exception diagnostic's message and description will not include the analyzer, but explicitly state its a driver exception.
             var analyzer = analyzers[0];
 
-            analyzerExecutor.OnAnalyzerException(innerException, analyzer, diagnostic, analyzerExecutor.CancellationToken);
+            analyzerExecutor.OnAnalyzerException(innerException, analyzer, diagnostic, cancellationToken);
         }
 
         private void ExecuteSyntaxTreeActions(AnalysisScope analysisScope, CancellationToken cancellationToken)
@@ -745,7 +743,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             foreach (var tree in analysisScope.SyntaxTrees)
             {
-                var isGeneratedCode = IsGeneratedCode(tree);
+                var isGeneratedCode = IsGeneratedCode(tree, cancellationToken);
                 var file = new SourceOrAdditionalFile(tree);
                 if (isGeneratedCode && DoNotAnalyzeGeneratedCode)
                 {
@@ -762,7 +760,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // Execute actions for a given analyzer sequentially.
-                    AnalyzerExecutor.ExecuteSyntaxTreeActions(syntaxTreeActions, analyzer, file, isGeneratedCode);
+                    AnalyzerExecutor.ExecuteSyntaxTreeActions(syntaxTreeActions, analyzer, file, isGeneratedCode, cancellationToken);
                 }
             }
         }
@@ -789,7 +787,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // Execute actions for a given analyzer sequentially.
-                    AnalyzerExecutor.ExecuteAdditionalFileActions(additionalFileActions, analyzer, file);
+                    AnalyzerExecutor.ExecuteAdditionalFileActions(additionalFileActions, analyzer, file, cancellationToken);
                 }
             }
         }
@@ -864,7 +862,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// If <see cref="CompilationEventQueue"/> has been completed with all compilation events, then it waits for
         /// <see cref="WhenCompletedTask"/> task for the driver to finish processing all events and generate remaining analyzer diagnostics.
         /// </summary>
-        public async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Compilation compilation)
+        public async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Compilation compilation, CancellationToken cancellationToken)
         {
             var allDiagnostics = DiagnosticBag.GetInstance();
             if (CompilationEventQueue.IsCompleted)
@@ -873,7 +871,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (this.WhenCompletedTask.IsFaulted)
                 {
-                    OnDriverException(this.WhenCompletedTask, this.AnalyzerExecutor, this.Analyzers);
+                    OnDriverException(this.WhenCompletedTask, this.AnalyzerExecutor, this.Analyzers, cancellationToken);
                 }
             }
 
@@ -900,7 +898,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// SuppressMessageAttributes, DiagnosticSuppressors, etc. which suppresses individual instances
         /// of reported diagnostics.
         /// </summary>
-        public ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> GetAllDescriptors()
+        public ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> GetAllDescriptors(CancellationToken cancellationToken)
         {
             var uniqueDiagnosticIds = PooledHashSet<string>.GetInstance();
             var analyzersSuppressedForSomeTree = SuppressedAnalyzersForTreeMap.SelectMany(kvp => kvp.Value).ToImmutableHashSet();
@@ -908,7 +906,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var builder = ArrayBuilder<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)>.GetInstance();
             foreach (var analyzer in Analyzers)
             {
-                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor);
+                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor, cancellationToken);
 
                 // Check if this analyzer is suppressed for the entire compilation via global project level options
                 // or for one or more syntax trees via editorconfig.
@@ -944,7 +942,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SemanticModelProvider.GetSemanticModel(tree, compilation);
         }
 
-        public void ApplyProgrammaticSuppressions(DiagnosticBag reportedDiagnostics, Compilation compilation)
+        public void ApplyProgrammaticSuppressions(DiagnosticBag reportedDiagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             Debug.Assert(!reportedDiagnostics.IsEmptyWithoutResolution);
             if (!_hasDiagnosticSuppressors)
@@ -952,12 +950,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            var newDiagnostics = ApplyProgrammaticSuppressionsCore(reportedDiagnostics.ToReadOnly(), compilation);
+            var newDiagnostics = ApplyProgrammaticSuppressionsCore(reportedDiagnostics.ToReadOnly(), compilation, cancellationToken);
             reportedDiagnostics.Clear();
             reportedDiagnostics.AddRange(newDiagnostics);
         }
 
-        public ImmutableArray<Diagnostic> ApplyProgrammaticSuppressions(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation)
+        public ImmutableArray<Diagnostic> ApplyProgrammaticSuppressions(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             if (reportedDiagnostics.IsEmpty ||
                 !_hasDiagnosticSuppressors)
@@ -965,10 +963,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return reportedDiagnostics;
             }
 
-            return ApplyProgrammaticSuppressionsCore(reportedDiagnostics, compilation);
+            return ApplyProgrammaticSuppressionsCore(reportedDiagnostics, compilation, cancellationToken);
         }
 
-        private ImmutableArray<Diagnostic> ApplyProgrammaticSuppressionsCore(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation)
+        private ImmutableArray<Diagnostic> ApplyProgrammaticSuppressionsCore(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             Debug.Assert(_hasDiagnosticSuppressors);
             Debug.Assert(!reportedDiagnostics.IsEmpty);
@@ -1037,12 +1035,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         foreach (var suppressor in suppressors)
                         {
                             var task = Task.Run(
-                                () => AnalyzerExecutor.ExecuteSuppressionAction(suppressor, getSuppressableDiagnostics(suppressor)),
-                                AnalyzerExecutor.CancellationToken);
+                                () => AnalyzerExecutor.ExecuteSuppressionAction(suppressor, getSuppressableDiagnostics(suppressor), cancellationToken),
+                                cancellationToken);
                             tasks.Add(task);
                         }
 
-                        Task.WaitAll(tasks.ToArray(), AnalyzerExecutor.CancellationToken);
+                        Task.WaitAll(tasks.ToArray(), cancellationToken);
                     }
                     finally
                     {
@@ -1053,7 +1051,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     foreach (var suppressor in suppressors)
                     {
-                        AnalyzerExecutor.ExecuteSuppressionAction(suppressor, getSuppressableDiagnostics(suppressor));
+                        AnalyzerExecutor.ExecuteSuppressionAction(suppressor, getSuppressableDiagnostics(suppressor), cancellationToken);
                     }
                 }
 
@@ -1061,7 +1059,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 ImmutableArray<Diagnostic> getSuppressableDiagnostics(DiagnosticSuppressor suppressor)
                 {
-                    var supportedSuppressions = AnalyzerManager.GetSupportedSuppressionDescriptors(suppressor, AnalyzerExecutor);
+                    var supportedSuppressions = AnalyzerManager.GetSupportedSuppressionDescriptors(suppressor, AnalyzerExecutor, cancellationToken);
                     if (supportedSuppressions.IsEmpty)
                     {
                         return ImmutableArray<Diagnostic>.Empty;
@@ -1104,22 +1102,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public ImmutableArray<Diagnostic> DequeueLocalDiagnosticsAndApplySuppressions(DiagnosticAnalyzer analyzer, bool syntax, Compilation compilation)
+        public ImmutableArray<Diagnostic> DequeueLocalDiagnosticsAndApplySuppressions(DiagnosticAnalyzer analyzer, bool syntax, Compilation compilation, CancellationToken cancellationToken)
         {
             var diagnostics = syntax ? DiagnosticQueue.DequeueLocalSyntaxDiagnostics(analyzer) : DiagnosticQueue.DequeueLocalSemanticDiagnostics(analyzer);
-            return FilterDiagnosticsSuppressedInSourceOrByAnalyzers(diagnostics, compilation);
+            return FilterDiagnosticsSuppressedInSourceOrByAnalyzers(diagnostics, compilation, cancellationToken);
         }
 
-        public ImmutableArray<Diagnostic> DequeueNonLocalDiagnosticsAndApplySuppressions(DiagnosticAnalyzer analyzer, Compilation compilation)
+        public ImmutableArray<Diagnostic> DequeueNonLocalDiagnosticsAndApplySuppressions(DiagnosticAnalyzer analyzer, Compilation compilation, CancellationToken cancellationToken)
         {
             var diagnostics = DiagnosticQueue.DequeueNonLocalDiagnostics(analyzer);
-            return FilterDiagnosticsSuppressedInSourceOrByAnalyzers(diagnostics, compilation);
+            return FilterDiagnosticsSuppressedInSourceOrByAnalyzers(diagnostics, compilation, cancellationToken);
         }
 
-        private ImmutableArray<Diagnostic> FilterDiagnosticsSuppressedInSourceOrByAnalyzers(ImmutableArray<Diagnostic> diagnostics, Compilation compilation)
+        private ImmutableArray<Diagnostic> FilterDiagnosticsSuppressedInSourceOrByAnalyzers(ImmutableArray<Diagnostic> diagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             diagnostics = FilterDiagnosticsSuppressedInSource(diagnostics, compilation, CurrentCompilationData.SuppressMessageAttributeState);
-            return ApplyProgrammaticSuppressionsAndFilterDiagnostics(diagnostics, compilation);
+            return ApplyProgrammaticSuppressionsAndFilterDiagnostics(diagnostics, compilation, cancellationToken);
         }
 
         private static ImmutableArray<Diagnostic> FilterDiagnosticsSuppressedInSource(
@@ -1154,14 +1152,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return builder.ToImmutable();
         }
 
-        internal ImmutableArray<Diagnostic> ApplyProgrammaticSuppressionsAndFilterDiagnostics(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation)
+        internal ImmutableArray<Diagnostic> ApplyProgrammaticSuppressionsAndFilterDiagnostics(ImmutableArray<Diagnostic> reportedDiagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             if (reportedDiagnostics.IsEmpty)
             {
                 return reportedDiagnostics;
             }
 
-            var diagnostics = ApplyProgrammaticSuppressions(reportedDiagnostics, compilation);
+            var diagnostics = ApplyProgrammaticSuppressions(reportedDiagnostics, compilation, cancellationToken);
             if (compilation.Options.ReportSuppressedDiagnostics || diagnostics.All(d => !d.IsSuppressed))
             {
                 return diagnostics;
@@ -1180,7 +1178,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Debug.Assert(location.SourceTree != null);
 
             // Check if this is a generated code location.
-            if (IsGeneratedOrHiddenCodeLocation(location.SourceTree, location.SourceSpan))
+            if (IsGeneratedOrHiddenCodeLocation(location.SourceTree, location.SourceSpan, cancellationToken))
             {
                 return true;
             }
@@ -1277,17 +1275,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private bool IsAnalyzerSuppressedForTree(DiagnosticAnalyzer analyzer, SyntaxTree tree, SyntaxTreeOptionsProvider? options)
+        private bool IsAnalyzerSuppressedForTree(DiagnosticAnalyzer analyzer, SyntaxTree tree, SyntaxTreeOptionsProvider? options, CancellationToken cancellationToken)
         {
             if (!SuppressedAnalyzersForTreeMap.TryGetValue(tree, out var suppressedAnalyzers))
             {
-                suppressedAnalyzers = SuppressedAnalyzersForTreeMap.GetOrAdd(tree, ComputeSuppressedAnalyzersForTree(tree, options));
+                suppressedAnalyzers = SuppressedAnalyzersForTreeMap.GetOrAdd(tree, ComputeSuppressedAnalyzersForTree(tree, options, cancellationToken));
             }
 
             return suppressedAnalyzers.Contains(analyzer);
         }
 
-        private ImmutableHashSet<DiagnosticAnalyzer> ComputeSuppressedAnalyzersForTree(SyntaxTree tree, SyntaxTreeOptionsProvider? options)
+        private ImmutableHashSet<DiagnosticAnalyzer> ComputeSuppressedAnalyzersForTree(SyntaxTree tree, SyntaxTreeOptionsProvider? options, CancellationToken cancellationToken)
         {
             if (options is null)
             {
@@ -1311,13 +1309,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     continue;
                 }
 
-                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor);
+                var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor, cancellationToken);
                 var hasUnsuppressedDiagnostic = false;
                 foreach (var descriptor in descriptors)
                 {
                     var configuredSeverity = descriptor.GetEffectiveSeverity(AnalyzerExecutor.Compilation.Options);
-                    if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var severityFromOptions) ||
-                        options.TryGetGlobalDiagnosticValue(descriptor.Id, AnalyzerExecutor.CancellationToken, out severityFromOptions))
+                    if (options.TryGetDiagnosticValue(tree, descriptor.Id, cancellationToken, out var severityFromOptions) ||
+                        options.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out severityFromOptions))
                     {
                         configuredSeverity = severityFromOptions;
                     }
@@ -1620,7 +1618,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (containerSymbol != null &&
                     AnalyzerExecutor.TryExecuteSymbolEndActionsForContainer(containerSymbol, processedMemberSymbol,
-                        analyzer, s_getTopmostNodeForAnalysis, IsGeneratedCodeSymbol(containerSymbol), out var processedContainerEvent))
+                        analyzer, s_getTopmostNodeForAnalysis, IsGeneratedCodeSymbol(containerSymbol, cancellationToken), cancellationToken, out var processedContainerEvent))
                 {
                     await OnEventProcessedCoreAsync(processedContainerEvent, ImmutableArray.Create(analyzer), cancellationToken).ConfigureAwait(false);
                 }
@@ -1640,15 +1638,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return await TryProcessSymbolDeclaredAsync(symbolEvent, analysisScope, cancellationToken).ConfigureAwait(false);
 
                 case CompilationUnitCompletedEvent completedEvent:
-                    ProcessCompilationUnitCompleted(completedEvent, analysisScope);
+                    ProcessCompilationUnitCompleted(completedEvent, analysisScope, cancellationToken);
                     return EventProcessedState.Processed;
 
                 case CompilationCompletedEvent endEvent:
-                    ProcessCompilationCompleted(endEvent, analysisScope);
+                    ProcessCompilationCompleted(endEvent, analysisScope, cancellationToken);
                     return EventProcessedState.Processed;
 
                 case CompilationStartedEvent startedEvent:
-                    ProcessCompilationStarted(startedEvent, analysisScope);
+                    ProcessCompilationStarted(startedEvent, analysisScope, cancellationToken);
                     return EventProcessedState.Processed;
 
                 default:
@@ -1668,7 +1666,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private async ValueTask<EventProcessedState> TryProcessSymbolDeclaredAsync(SymbolDeclaredCompilationEvent symbolEvent, AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
             var symbol = symbolEvent.Symbol;
-            var isGeneratedCodeSymbol = IsGeneratedCodeSymbol(symbol);
+            var isGeneratedCodeSymbol = IsGeneratedCodeSymbol(symbol, cancellationToken);
 
             var skipSymbolAnalysis = AnalysisScope.ShouldSkipSymbolAnalysis(symbolEvent);
             var skipDeclarationAnalysis = AnalysisScope.ShouldSkipDeclarationAnalysis(symbol);
@@ -1716,7 +1714,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Invoke symbol analyzers only for source symbols.
                 if ((int)symbol.Kind < actionsByKind.Length)
                 {
-                    AnalyzerExecutor.ExecuteSymbolActions(actionsByKind[(int)symbol.Kind], analyzer, symbolEvent, s_getTopmostNodeForAnalysis, isGeneratedCodeSymbol);
+                    AnalyzerExecutor.ExecuteSymbolActions(actionsByKind[(int)symbol.Kind], analyzer, symbolEvent, s_getTopmostNodeForAnalysis, isGeneratedCodeSymbol, cancellationToken);
                 }
             }
         }
@@ -1756,7 +1754,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     var symbolEndActionsForAnalyzer = groupedActions.ToImmutableArrayOrEmpty();
                     if (!symbolEndActionsForAnalyzer.IsEmpty &&
-                        !AnalyzerExecutor.TryExecuteSymbolEndActions(symbolEndActionsForAnalyzer, analyzer, symbolEvent, s_getTopmostNodeForAnalysis, isGeneratedCodeSymbol))
+                        !AnalyzerExecutor.TryExecuteSymbolEndActions(symbolEndActionsForAnalyzer, analyzer, symbolEvent, s_getTopmostNodeForAnalysis, isGeneratedCodeSymbol, cancellationToken))
                     {
                         success = false;
                         continue;
@@ -1810,7 +1808,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             IGroupedAnalyzerActions additionalPerSymbolActions,
             CancellationToken cancellationToken);
 
-        private void ProcessCompilationUnitCompleted(CompilationUnitCompletedEvent completedEvent, AnalysisScope analysisScope)
+        private void ProcessCompilationUnitCompleted(CompilationUnitCompletedEvent completedEvent, AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
             // When the compiler is finished with a compilation unit, we can run user diagnostics which
             // might want to ask the compiler for all the diagnostics in the source file, for example
@@ -1822,7 +1820,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            var isGeneratedCode = IsGeneratedCode(semanticModel.SyntaxTree);
+            var isGeneratedCode = IsGeneratedCode(semanticModel.SyntaxTree, cancellationToken);
             if (isGeneratedCode && DoNotAnalyzeGeneratedCode)
             {
                 return;
@@ -1836,24 +1834,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 // Execute actions for a given analyzer sequentially.
-                AnalyzerExecutor.ExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, analysisScope, isGeneratedCode);
+                AnalyzerExecutor.ExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, analysisScope, isGeneratedCode, cancellationToken);
             }
         }
 
-        private void ProcessCompilationStarted(CompilationStartedEvent startedEvent, AnalysisScope analysisScope)
+        private void ProcessCompilationStarted(CompilationStartedEvent startedEvent, AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            ExecuteCompilationActions(_lazyCompilationActions, startedEvent, analysisScope);
+            ExecuteCompilationActions(_lazyCompilationActions, startedEvent, analysisScope, cancellationToken);
         }
 
-        private void ProcessCompilationCompleted(CompilationCompletedEvent endEvent, AnalysisScope analysisScope)
+        private void ProcessCompilationCompleted(CompilationCompletedEvent endEvent, AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            ExecuteCompilationActions(_lazyCompilationEndActions, endEvent, analysisScope);
+            ExecuteCompilationActions(_lazyCompilationEndActions, endEvent, analysisScope, cancellationToken);
         }
 
         private void ExecuteCompilationActions(
             ImmutableArray<(DiagnosticAnalyzer, ImmutableArray<CompilationAnalyzerAction>)> compilationActionsMap,
             CompilationEvent compilationEvent,
-            AnalysisScope analysisScope)
+            AnalysisScope analysisScope,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(compilationEvent is CompilationStartedEvent || compilationEvent is CompilationCompletedEvent);
 
@@ -1864,7 +1863,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     continue;
                 }
 
-                AnalyzerExecutor.ExecuteCompilationActions(compilationActions, analyzer, compilationEvent);
+                AnalyzerExecutor.ExecuteCompilationActions(compilationActions, analyzer, compilationEvent, cancellationToken);
             }
         }
 
@@ -1939,17 +1938,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             AnalyzerExecutor analyzerExecutor,
             AnalysisScope analysisScope,
-            SeverityFilter severityFilter)
+            SeverityFilter severityFilter,
+            CancellationToken cancellationToken)
         {
             var allAnalyzerActions = AnalyzerActions.Empty;
             var unsuppressedAnalyzersBuilder = PooledHashSet<DiagnosticAnalyzer>.GetInstance();
             foreach (var analyzer in analyzers)
             {
-                if (!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter))
+                if (!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter, cancellationToken))
                 {
                     unsuppressedAnalyzersBuilder.Add(analyzer);
 
-                    var analyzerActions = await analyzerManager.GetAnalyzerActionsAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
+                    var analyzerActions = await analyzerManager.GetAnalyzerActionsAsync(analyzer, analyzerExecutor, cancellationToken).ConfigureAwait(false);
                     allAnalyzerActions = allAnalyzerActions.Append(in analyzerActions);
                 }
             }
@@ -2081,7 +2081,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var inheritedActions = await getInheritedActionsAsync(driver, symbol, analyzer, cancellationToken).ConfigureAwait(false);
 
                 // Execute the symbol start actions for this symbol to compute additional actions for its members.
-                AnalyzerActions myActions = await getSymbolActionsCoreAsync(driver, symbol, analyzer).ConfigureAwait(false);
+                AnalyzerActions myActions = await getSymbolActionsCoreAsync(driver, symbol, analyzer, cancellationToken).ConfigureAwait(false);
                 if (myActions.IsEmpty)
                 {
                     return inheritedActions;
@@ -2115,20 +2115,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return EmptyGroupedActions;
             }
 
-            static async ValueTask<AnalyzerActions> getSymbolActionsCoreAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer)
+            static async ValueTask<AnalyzerActions> getSymbolActionsCoreAsync(AnalyzerDriver driver, ISymbol symbol, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
             {
                 if (!driver.UnsuppressedAnalyzers.Contains(analyzer))
                 {
                     return AnalyzerActions.Empty;
                 }
 
-                var isGeneratedCodeSymbol = driver.IsGeneratedCodeSymbol(symbol);
+                var isGeneratedCodeSymbol = driver.IsGeneratedCodeSymbol(symbol, cancellationToken);
                 if (isGeneratedCodeSymbol && driver.ShouldSkipAnalysisOnGeneratedCode(analyzer))
                 {
                     return AnalyzerActions.Empty;
                 }
 
-                return await driver.AnalyzerManager.GetPerSymbolAnalyzerActionsAsync(symbol, isGeneratedCodeSymbol, analyzer, driver.AnalyzerExecutor).ConfigureAwait(false);
+                return await driver.AnalyzerManager.GetPerSymbolAnalyzerActionsAsync(symbol, isGeneratedCodeSymbol, analyzer, driver.AnalyzerExecutor, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -2137,14 +2137,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             AnalyzerExecutor analyzerExecutor,
             AnalysisScope analysisScope,
-            SeverityFilter severityFilter)
+            SeverityFilter severityFilter,
+            CancellationToken cancellationToken)
         {
             var builder = ImmutableSegmentedDictionary.CreateBuilder<DiagnosticAnalyzer, SemaphoreSlim>();
             foreach (var analyzer in analyzers)
             {
-                Debug.Assert(!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter));
+                Debug.Assert(!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter, cancellationToken));
 
-                var isConcurrent = await analyzerManager.IsConcurrentAnalyzerAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
+                var isConcurrent = await analyzerManager.IsConcurrentAnalyzerAsync(analyzer, analyzerExecutor, cancellationToken).ConfigureAwait(false);
                 if (!isConcurrent)
                 {
                     // Non-concurrent analyzers need their action callbacks from the analyzer driver to be guarded by a gate.
@@ -2161,14 +2162,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             AnalyzerExecutor analyzerExecutor,
             AnalysisScope analysisScope,
-            SeverityFilter severityFilter)
+            SeverityFilter severityFilter,
+            CancellationToken cancellationToken)
         {
             var builder = ImmutableSegmentedDictionary.CreateBuilder<DiagnosticAnalyzer, GeneratedCodeAnalysisFlags>();
             foreach (var analyzer in analyzers)
             {
-                Debug.Assert(!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter));
+                Debug.Assert(!IsDiagnosticAnalyzerSuppressed(analyzer, analyzerExecutor.Compilation.Options, analyzerManager, analyzerExecutor, analysisScope, severityFilter, cancellationToken));
 
-                var generatedCodeAnalysisFlags = await analyzerManager.GetGeneratedCodeAnalysisFlagsAsync(analyzer, analyzerExecutor).ConfigureAwait(false);
+                var generatedCodeAnalysisFlags = await analyzerManager.GetGeneratedCodeAnalysisFlagsAsync(analyzer, analyzerExecutor, cancellationToken).ConfigureAwait(false);
                 builder.Add(analyzer, generatedCodeAnalysisFlags);
             }
 
@@ -2178,7 +2180,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://github.com/dotnet/roslyn/pull/23637",
             AllowLocks = false)]
-        private bool IsGeneratedCodeSymbol(ISymbol symbol)
+        private bool IsGeneratedCodeSymbol(ISymbol symbol, CancellationToken cancellationToken)
         {
             return IsGeneratedCodeSymbolMap.TryGetValue(symbol, out bool isGeneratedCodeSymbol) ?
                 isGeneratedCodeSymbol :
@@ -2193,7 +2195,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 foreach (var declaringRef in symbol.DeclaringSyntaxReferences)
                 {
-                    if (!IsGeneratedOrHiddenCodeLocation(declaringRef.SyntaxTree, declaringRef.Span))
+                    if (!IsGeneratedOrHiddenCodeLocation(declaringRef.SyntaxTree, declaringRef.Span, cancellationToken))
                     {
                         return false;
                     }
@@ -2206,7 +2208,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://github.com/dotnet/roslyn/pull/23637",
             AllowLocks = false)]
-        protected bool IsGeneratedCode(SyntaxTree tree)
+        protected bool IsGeneratedCode(SyntaxTree tree, CancellationToken cancellationToken)
         {
             if (!GeneratedCodeFilesMap.TryGetValue(tree, out var isGenerated))
             {
@@ -2223,7 +2225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // If there is no explicit user configuration, fallback to our generated code heuristic.
                 var options = AnalyzerExecutor.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);
                 return GeneratedCodeUtilities.GetIsGeneratedCodeFromOptions(options) ??
-                    _isGeneratedCode(tree, AnalyzerExecutor.CancellationToken);
+                    _isGeneratedCode(tree, cancellationToken);
             }
         }
 
@@ -2237,8 +2239,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         // Location is in generated code if either the containing tree is a generated code file OR if it is a hidden source location.
-        protected bool IsGeneratedOrHiddenCodeLocation(SyntaxTree syntaxTree, TextSpan span)
-            => IsGeneratedCode(syntaxTree) || IsHiddenSourceLocation(syntaxTree, span);
+        protected bool IsGeneratedOrHiddenCodeLocation(SyntaxTree syntaxTree, TextSpan span, CancellationToken cancellationToken)
+            => IsGeneratedCode(syntaxTree, cancellationToken) || IsHiddenSourceLocation(syntaxTree, span);
 
         protected bool IsHiddenSourceLocation(SyntaxTree syntaxTree, TextSpan span)
             => HasHiddenRegions(syntaxTree) &&
@@ -2266,13 +2268,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal async Task<AnalyzerActionCounts> GetAnalyzerActionCountsAsync(DiagnosticAnalyzer analyzer, CompilationOptions compilationOptions, AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            var executor = AnalyzerExecutor.WithCancellationToken(cancellationToken);
-            if (IsDiagnosticAnalyzerSuppressed(analyzer, compilationOptions, AnalyzerManager, executor, analysisScope, _severityFilter))
+            if (IsDiagnosticAnalyzerSuppressed(analyzer, compilationOptions, AnalyzerManager, AnalyzerExecutor, analysisScope, _severityFilter, cancellationToken))
             {
                 return AnalyzerActionCounts.Empty;
             }
 
-            var analyzerActions = await AnalyzerManager.GetAnalyzerActionsAsync(analyzer, executor).ConfigureAwait(false);
+            var analyzerActions = await AnalyzerManager.GetAnalyzerActionsAsync(analyzer, AnalyzerExecutor, cancellationToken).ConfigureAwait(false);
             if (analyzerActions.IsEmpty)
             {
                 return AnalyzerActionCounts.Empty;
@@ -2290,9 +2291,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             AnalyzerExecutor analyzerExecutor,
             AnalysisScope? analysisScope,
-            SeverityFilter severityFilter)
+            SeverityFilter severityFilter,
+            CancellationToken cancellationToken)
         {
-            return analyzerManager.IsDiagnosticAnalyzerSuppressed(analyzer, options, s_IsCompilerAnalyzerFunc, analyzerExecutor, analysisScope, severityFilter);
+            return analyzerManager.IsDiagnosticAnalyzerSuppressed(analyzer, options, s_IsCompilerAnalyzerFunc, analyzerExecutor, analysisScope, severityFilter, cancellationToken);
         }
 
         private static bool IsCompilerAnalyzer(DiagnosticAnalyzer analyzer) => analyzer is CompilerDiagnosticAnalyzer;
@@ -2429,7 +2431,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    var isInGeneratedCode = isGeneratedCodeSymbol || IsGeneratedOrHiddenCodeLocation(decl.SyntaxTree, decl.Span);
+                    var isInGeneratedCode = isGeneratedCodeSymbol || IsGeneratedOrHiddenCodeLocation(decl.SyntaxTree, decl.Span, cancellationToken);
                     if (isInGeneratedCode && DoNotAnalyzeGeneratedCode)
                     {
                         continue;
@@ -2457,7 +2459,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<DeclarationInfo> declarationInfos = builder.ToImmutableAndFree();
 
             bool isPartialDeclAnalysis = analysisScope.FilterSpanOpt.HasValue && !analysisScope.ContainsSpan(topmostNodeForAnalysis.FullSpan);
-            ImmutableArray<SyntaxNode> nodesToAnalyze = GetSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, semanticModel, AnalyzerExecutor);
+            ImmutableArray<SyntaxNode> nodesToAnalyze = GetSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, semanticModel, cancellationToken);
             return new DeclarationAnalysisData(declaringReferenceSyntax, topmostNodeForAnalysis, declarationInfos, nodesToAnalyze, isPartialDeclAnalysis);
         }
 
@@ -2538,7 +2540,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     AnalyzerExecutor.ExecuteSyntaxNodeActions(filteredNodesToAnalyze, nodeActionsByKind,
                         analyzer, semanticModel, _getKind, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
-                        symbol, isInGeneratedCode, hasCodeBlockStartOrSymbolStartActions: groupedActionsForAnalyzer.HasCodeBlockStartActions || arePerSymbolActions);
+                        symbol, isInGeneratedCode, hasCodeBlockStartOrSymbolStartActions: groupedActionsForAnalyzer.HasCodeBlockStartActions || arePerSymbolActions,
+                        cancellationToken);
                 }
             }
 
@@ -2646,7 +2649,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     AnalyzerExecutor.ExecuteOperationActions(filteredOperationsToAnalyze, operationActionsByKind,
                         analyzer, semanticModel, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
-                        symbol, isInGeneratedCode, hasOperationBlockStartOrSymbolStartActions: groupedActionsForAnalyzer.HasOperationBlockStartActions || arePerSymbolActions);
+                        symbol, isInGeneratedCode, hasOperationBlockStartOrSymbolStartActions: groupedActionsForAnalyzer.HasOperationBlockStartActions || arePerSymbolActions,
+                        cancellationToken);
                 }
             }
 
@@ -2674,7 +2678,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     AnalyzerExecutor.ExecuteOperationBlockActions(
                         analyzerActions.OperationBlockStartActions, analyzerActions.OperationBlockActions,
                         analyzerActions.OperationBlockEndActions, analyzerActions.Analyzer, declarationAnalysisData.TopmostNodeForAnalysis, symbol,
-                        operationBlocksToAnalyze, operationsToAnalyze, semanticModel, isInGeneratedCode);
+                        operationBlocksToAnalyze, operationsToAnalyze, semanticModel, isInGeneratedCode, cancellationToken);
                 }
             }
 
@@ -2702,7 +2706,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     AnalyzerExecutor.ExecuteCodeBlockActions(
                         analyzerActions.CodeBlockStartActions, analyzerActions.CodeBlockActions,
                         analyzerActions.CodeBlockEndActions, analyzerActions.Analyzer, declarationAnalysisData.TopmostNodeForAnalysis, symbol,
-                        executableCodeBlocks, semanticModel, _getKind, isInGeneratedCode);
+                        executableCodeBlocks, semanticModel, _getKind, isInGeneratedCode, cancellationToken);
                 }
             }
 
@@ -2727,7 +2731,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol declaredSymbol,
             ImmutableArray<DeclarationInfo> declarationsInNode,
             SemanticModel semanticModel,
-            AnalyzerExecutor analyzerExecutor)
+            CancellationToken cancellationToken)
         {
             // Eliminate descendant member declarations within declarations.
             // There will be separate symbols declared for the members.
@@ -2735,7 +2739,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool first = true;
             foreach (var declInNode in declarationsInNode)
             {
-                analyzerExecutor.CancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (declInNode.DeclaredNode != declaredNode)
                 {
@@ -2756,7 +2760,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     // Compute the topmost node representing the syntax declaration for the member that needs to be skipped.
                     var declarationNodeToSkip = declInNode.DeclaredNode;
-                    var declaredSymbolOfDeclInNode = declInNode.DeclaredSymbol ?? semanticModel.GetDeclaredSymbol(declInNode.DeclaredNode, analyzerExecutor.CancellationToken);
+                    var declaredSymbolOfDeclInNode = declInNode.DeclaredSymbol ?? semanticModel.GetDeclaredSymbol(declInNode.DeclaredNode, cancellationToken);
                     if (declaredSymbolOfDeclInNode != null)
                     {
                         declarationNodeToSkip = semanticModel.GetTopmostNodeForDiagnosticAnalysis(declaredSymbolOfDeclInNode, declInNode.DeclaredNode);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -45,15 +45,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Func<SyntaxTree, SemanticModel>? _getSemanticModel;
         private readonly Func<DiagnosticAnalyzer, bool> _shouldSkipAnalysisOnGeneratedCode;
         private readonly Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> _shouldSuppressGeneratedCodeDiagnostic;
-        private readonly Func<SyntaxTree, TextSpan, bool> _isGeneratedCodeLocation;
-        private readonly Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool>? _isAnalyzerSuppressedForTree;
+        private readonly Func<SyntaxTree, TextSpan, CancellationToken, bool> _isGeneratedCodeLocation;
+        private readonly Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, CancellationToken, bool>? _isAnalyzerSuppressedForTree;
 
         /// <summary>
         /// The values in this map convert to <see cref="TimeSpan"/> using <see cref="TimeSpan.FromTicks(long)"/>.
         /// </summary>
         private readonly ConcurrentDictionary<DiagnosticAnalyzer, StrongBox<long>>? _analyzerExecutionTimeMap;
         private readonly CompilationAnalysisValueProviderFactory _compilationAnalysisValueProviderFactory;
-        private readonly CancellationToken _cancellationToken;
 
         private Func<IOperation, ControlFlowGraph>? _lazyGetControlFlowGraph;
 
@@ -62,10 +61,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private Func<IOperation, ControlFlowGraph> GetControlFlowGraph
             => _lazyGetControlFlowGraph ??= GetControlFlowGraphImpl;
 
-        private bool IsAnalyzerSuppressedForTree(DiagnosticAnalyzer analyzer, SyntaxTree tree)
+        private bool IsAnalyzerSuppressedForTree(DiagnosticAnalyzer analyzer, SyntaxTree tree, CancellationToken cancellationToken)
         {
             Debug.Assert(_isAnalyzerSuppressedForTree != null);
-            return _isAnalyzerSuppressedForTree(analyzer, tree, Compilation.Options.SyntaxTreeOptionsProvider);
+            return _isAnalyzerSuppressedForTree(analyzer, tree, Compilation.Options.SyntaxTreeOptionsProvider, cancellationToken);
         }
 
         /// <summary>
@@ -99,7 +98,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="addCategorizedLocalDiagnostic">Optional delegate to add categorized local analyzer diagnostics.</param>
         /// <param name="addCategorizedNonLocalDiagnostic">Optional delegate to add categorized non-local analyzer diagnostics.</param>
         /// <param name="addSuppression">Optional thread-safe delegate to add diagnostic suppressions from suppressors.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         public static AnalyzerExecutor Create(
             Compilation compilation,
             AnalyzerOptions analyzerOptions,
@@ -110,15 +108,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             Func<DiagnosticAnalyzer, bool> shouldSkipAnalysisOnGeneratedCode,
             Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
-            Func<SyntaxTree, TextSpan, bool> isGeneratedCodeLocation,
-            Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool> isAnalyzerSuppressedForTree,
+            Func<SyntaxTree, TextSpan, CancellationToken, bool> isGeneratedCodeLocation,
+            Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, CancellationToken, bool> isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?> getAnalyzerGate,
             Func<SyntaxTree, SemanticModel> getSemanticModel,
             bool logExecutionTime = false,
             Action<Diagnostic, DiagnosticAnalyzer, bool, CancellationToken>? addCategorizedLocalDiagnostic = null,
             Action<Diagnostic, DiagnosticAnalyzer, CancellationToken>? addCategorizedNonLocalDiagnostic = null,
-            Action<Suppression>? addSuppression = null,
-            CancellationToken cancellationToken = default)
+            Action<Suppression>? addSuppression = null)
         {
             // We can either report categorized (local/non-local) diagnostics or non-categorized diagnostics.
             Debug.Assert((addNonCategorizedDiagnostic != null) ^ (addCategorizedLocalDiagnostic != null));
@@ -129,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return new AnalyzerExecutor(compilation, analyzerOptions, addNonCategorizedDiagnostic, onAnalyzerException, analyzerExceptionFilter,
                 isCompilerAnalyzer, analyzerManager, shouldSkipAnalysisOnGeneratedCode, shouldSuppressGeneratedCodeDiagnostic, isGeneratedCodeLocation,
                 isAnalyzerSuppressedForTree, getAnalyzerGate, getSemanticModel, analyzerExecutionTimeMap, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic,
-                addSuppression, cancellationToken);
+                addSuppression);
         }
 
         /// <summary>
@@ -140,11 +137,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Delegate can do custom tasks such as report the given analyzer exception diagnostic, report a non-fatal watson for the exception, etc.
         /// </param>
         /// <param name="analyzerManager">Analyzer manager to fetch supported diagnostics.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         public static AnalyzerExecutor CreateForSupportedDiagnostics(
             Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken>? onAnalyzerException,
-            AnalyzerManager analyzerManager,
-            CancellationToken cancellationToken = default)
+            AnalyzerManager analyzerManager)
         {
             onAnalyzerException ??= (ex, analyzer, diagnostic, cancellationToken) => { };
             return new AnalyzerExecutor(
@@ -154,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 isCompilerAnalyzer: null,
                 shouldSkipAnalysisOnGeneratedCode: _ => false,
                 shouldSuppressGeneratedCodeDiagnostic: (diagnostic, analyzer, compilation, ct) => false,
-                isGeneratedCodeLocation: (_1, _2) => false,
+                isGeneratedCodeLocation: (_1, _2, _3) => false,
                 isAnalyzerSuppressedForTree: null,
                 getAnalyzerGate: null,
                 getSemanticModel: null,
@@ -164,8 +159,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 analyzerExecutionTimeMap: null,
                 addCategorizedLocalDiagnostic: null,
                 addCategorizedNonLocalDiagnostic: null,
-                addSuppression: null,
-                cancellationToken: cancellationToken);
+                addSuppression: null);
         }
 
         private AnalyzerExecutor(
@@ -178,15 +172,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerManager analyzerManager,
             Func<DiagnosticAnalyzer, bool> shouldSkipAnalysisOnGeneratedCode,
             Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
-            Func<SyntaxTree, TextSpan, bool> isGeneratedCodeLocation,
-            Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, bool>? isAnalyzerSuppressedForTree,
+            Func<SyntaxTree, TextSpan, CancellationToken, bool> isGeneratedCodeLocation,
+            Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, CancellationToken, bool>? isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?>? getAnalyzerGate,
             Func<SyntaxTree, SemanticModel>? getSemanticModel,
             ConcurrentDictionary<DiagnosticAnalyzer, StrongBox<long>>? analyzerExecutionTimeMap,
             Action<Diagnostic, DiagnosticAnalyzer, bool, CancellationToken>? addCategorizedLocalDiagnostic,
             Action<Diagnostic, DiagnosticAnalyzer, CancellationToken>? addCategorizedNonLocalDiagnostic,
-            Action<Suppression>? addSuppression,
-            CancellationToken cancellationToken)
+            Action<Suppression>? addSuppression)
         {
             _compilation = compilation;
             _analyzerOptions = analyzerOptions;
@@ -205,22 +198,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _addCategorizedLocalDiagnostic = addCategorizedLocalDiagnostic;
             _addCategorizedNonLocalDiagnostic = addCategorizedNonLocalDiagnostic;
             _addSuppression = addSuppression;
-            _cancellationToken = cancellationToken;
 
             _compilationAnalysisValueProviderFactory = new CompilationAnalysisValueProviderFactory();
-        }
-
-        public AnalyzerExecutor WithCancellationToken(CancellationToken cancellationToken)
-        {
-            if (cancellationToken == _cancellationToken)
-            {
-                return this;
-            }
-
-            return new AnalyzerExecutor(_compilation, _analyzerOptions, _addNonCategorizedDiagnostic, _onAnalyzerException, _analyzerExceptionFilter,
-                _isCompilerAnalyzer, _analyzerManager, _shouldSkipAnalysisOnGeneratedCode, _shouldSuppressGeneratedCodeDiagnostic, _isGeneratedCodeLocation,
-                _isAnalyzerSuppressedForTree, _getAnalyzerGate, _getSemanticModel, _analyzerExecutionTimeMap, _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic,
-                _addSuppression, cancellationToken);
         }
 
         internal bool TryGetCompilationAndAnalyzerOptions(
@@ -249,7 +228,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal CancellationToken CancellationToken => _cancellationToken;
         internal Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken> OnAnalyzerException => _onAnalyzerException;
         internal ImmutableDictionary<DiagnosticAnalyzer, TimeSpan> AnalyzerExecutionTimes
         {
@@ -267,10 +245,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="sessionScope">Session scope to store register session wide analyzer actions.</param>
         /// <remarks>
         /// Note that this API doesn't execute any <see cref="CompilationStartAnalyzerAction"/> registered by the Initialize invocation.
-        /// Use <see cref="ExecuteCompilationStartActions(ImmutableArray{CompilationStartAnalyzerAction}, HostCompilationStartAnalysisScope)"/> API
+        /// Use <see cref="ExecuteCompilationStartActions(ImmutableArray{CompilationStartAnalyzerAction}, HostCompilationStartAnalysisScope, CancellationToken)"/> API
         /// to get execute these actions to get the per-compilation analyzer actions.
         /// </remarks>
-        public void ExecuteInitializeMethod(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope sessionScope)
+        public void ExecuteInitializeMethod(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope sessionScope, CancellationToken cancellationToken)
         {
             var context = new AnalyzerAnalysisContext(analyzer, sessionScope);
 
@@ -278,7 +256,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ExecuteAndCatchIfThrows(
                 analyzer,
                 data => data.analyzer.Initialize(data.context),
-                (analyzer, context));
+                (analyzer, context),
+                contextInfo: null,
+                cancellationToken);
         }
 
         /// <summary>
@@ -286,20 +266,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="actions"><see cref="AnalyzerActions"/> whose compilation start actions are to be executed.</param>
         /// <param name="compilationScope">Compilation scope to store the analyzer actions.</param>
-        public void ExecuteCompilationStartActions(ImmutableArray<CompilationStartAnalyzerAction> actions, HostCompilationStartAnalysisScope compilationScope)
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public void ExecuteCompilationStartActions(ImmutableArray<CompilationStartAnalyzerAction> actions, HostCompilationStartAnalysisScope compilationScope, CancellationToken cancellationToken)
         {
             foreach (var startAction in actions)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var context = new AnalyzerCompilationStartAnalysisContext(startAction.Analyzer, compilationScope,
-                    Compilation, AnalyzerOptions, _compilationAnalysisValueProviderFactory, _cancellationToken);
+                    Compilation, AnalyzerOptions, _compilationAnalysisValueProviderFactory, cancellationToken);
 
                 ExecuteAndCatchIfThrows(
                     startAction.Analyzer,
                     data => data.action(data.context),
                     (action: startAction.Action, context),
-                    new AnalysisContextInfo(Compilation));
+                    new AnalysisContextInfo(Compilation),
+                    cancellationToken);
             }
         }
 
@@ -316,10 +298,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             ImmutableArray<SymbolStartAnalyzerAction> actions,
             HostSymbolStartAnalysisScope symbolScope,
-            bool isGeneratedCodeSymbol)
+            bool isGeneratedCodeSymbol,
+            CancellationToken cancellationToken)
         {
             if (isGeneratedCodeSymbol && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForSymbol(analyzer, symbol))
+                IsAnalyzerSuppressedForSymbol(analyzer, symbol, cancellationToken))
             {
                 return;
             }
@@ -327,16 +310,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             foreach (var startAction in actions)
             {
                 Debug.Assert(startAction.Analyzer == analyzer);
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var context = new AnalyzerSymbolStartAnalysisContext(startAction.Analyzer, symbolScope,
-                    symbol, Compilation, AnalyzerOptions, isGeneratedCodeSymbol, _cancellationToken);
+                    symbol, Compilation, AnalyzerOptions, isGeneratedCodeSymbol, cancellationToken);
 
                 ExecuteAndCatchIfThrows(
                     startAction.Analyzer,
                     data => data.action(data.context),
                     (action: startAction.Action, context),
-                    new AnalysisContextInfo(Compilation, symbol));
+                    new AnalysisContextInfo(Compilation, symbol),
+                    cancellationToken);
             }
         }
 
@@ -345,7 +329,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="suppressor">Suppressor to be executed.</param>
         /// <param name="reportedDiagnostics">Reported analyzer/compiler diagnostics that can be suppressed.</param>
-        public void ExecuteSuppressionAction(DiagnosticSuppressor suppressor, ImmutableArray<Diagnostic> reportedDiagnostics)
+        public void ExecuteSuppressionAction(DiagnosticSuppressor suppressor, ImmutableArray<Diagnostic> reportedDiagnostics, CancellationToken cancellationToken)
         {
             Debug.Assert(_addSuppression != null);
             Debug.Assert(_getSemanticModel != null);
@@ -355,19 +339,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            _cancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
-            var supportedSuppressions = _analyzerManager.GetSupportedSuppressionDescriptors(suppressor, this);
+            var supportedSuppressions = _analyzerManager.GetSupportedSuppressionDescriptors(suppressor, this, cancellationToken);
             Func<SuppressionDescriptor, bool> isSupportedSuppression = supportedSuppressions.Contains;
             Action<SuppressionAnalysisContext> action = suppressor.ReportSuppressions;
             var context = new SuppressionAnalysisContext(Compilation, AnalyzerOptions,
-                reportedDiagnostics, _addSuppression, isSupportedSuppression, _getSemanticModel, _cancellationToken);
+                reportedDiagnostics, _addSuppression, isSupportedSuppression, _getSemanticModel, cancellationToken);
 
             ExecuteAndCatchIfThrows(
                 suppressor,
                 data => data.action(data.context),
                 (action, context),
-                new AnalysisContextInfo(Compilation));
+                new AnalysisContextInfo(Compilation),
+                cancellationToken);
         }
 
         /// <summary>
@@ -379,27 +364,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void ExecuteCompilationActions(
             ImmutableArray<CompilationAnalyzerAction> compilationActions,
             DiagnosticAnalyzer analyzer,
-            CompilationEvent compilationEvent)
+            CompilationEvent compilationEvent,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(compilationEvent is CompilationStartedEvent || compilationEvent is CompilationCompletedEvent);
 
-            var addDiagnostic = GetAddCompilationDiagnostic(analyzer);
+            var addDiagnostic = GetAddCompilationDiagnostic(analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var endAction in compilationActions)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var context = new CompilationAnalysisContext(
                         Compilation, AnalyzerOptions, addDiagnostic,
-                        isSupportedDiagnostic, _compilationAnalysisValueProviderFactory, _cancellationToken);
+                        isSupportedDiagnostic, _compilationAnalysisValueProviderFactory, cancellationToken);
 
                 ExecuteAndCatchIfThrows(
                     endAction.Analyzer,
                     data => data.action(data.context),
                     (action: endAction.Action, context),
-                    new AnalysisContextInfo(Compilation));
+                    new AnalysisContextInfo(Compilation),
+                    cancellationToken);
             }
         }
 
@@ -416,20 +403,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
             Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
-            bool isGeneratedCodeSymbol)
+            bool isGeneratedCodeSymbol,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(getTopMostNodeForAnalysis != null);
 
             if (isGeneratedCodeSymbol && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForSymbol(analyzer, symbolDeclaredEvent.Symbol))
+                IsAnalyzerSuppressedForSymbol(analyzer, symbolDeclaredEvent.Symbol, cancellationToken))
             {
                 return;
             }
 
             var symbol = symbolDeclaredEvent.Symbol;
-            var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis);
+            var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var symbolAction in symbolActions)
             {
@@ -438,16 +426,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (kinds.Contains(symbol.Kind))
                 {
-                    _cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var context = new SymbolAnalysisContext(symbol, Compilation, AnalyzerOptions, addDiagnostic,
-                        isSupportedDiagnostic, isGeneratedCodeSymbol, _cancellationToken);
+                        isSupportedDiagnostic, isGeneratedCodeSymbol, cancellationToken);
 
                     ExecuteAndCatchIfThrows(
                         symbolAction.Analyzer,
                         data => data.action(data.context),
                         (action, context),
-                        new AnalysisContextInfo(Compilation, symbol));
+                        new AnalysisContextInfo(Compilation, symbol),
+                        cancellationToken);
                 }
             }
         }
@@ -466,6 +455,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
             bool isGeneratedCode,
+            CancellationToken cancellationToken,
             [NotNullWhen(returnValue: true)] out SymbolDeclaredCompilationEvent? containingSymbolDeclaredEvent)
         {
             containingSymbolDeclaredEvent = null;
@@ -476,7 +466,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             ImmutableArray<SymbolEndAnalyzerAction> endActions = containerEndActionsAndEvent.symbolEndActions;
             containingSymbolDeclaredEvent = containerEndActionsAndEvent.symbolDeclaredEvent;
-            ExecuteSymbolEndActionsCore(endActions, analyzer, containingSymbolDeclaredEvent, getTopMostNodeForAnalysis, isGeneratedCode);
+            ExecuteSymbolEndActionsCore(endActions, analyzer, containingSymbolDeclaredEvent, getTopMostNodeForAnalysis, isGeneratedCode, cancellationToken);
             return true;
         }
 
@@ -497,12 +487,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
             Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             if (!_analyzerManager.TryStartExecuteSymbolEndActions(symbolEndActions, analyzer, symbolDeclaredEvent))
                 return false;
 
-            ExecuteSymbolEndActionsCore(symbolEndActions, analyzer, symbolDeclaredEvent, getTopMostNodeForAnalysis, isGeneratedCode);
+            ExecuteSymbolEndActionsCore(symbolEndActions, analyzer, symbolDeclaredEvent, getTopMostNodeForAnalysis, isGeneratedCode, cancellationToken);
             return true;
         }
 
@@ -511,31 +502,33 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             SymbolDeclaredCompilationEvent symbolDeclaredEvent,
             Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(getTopMostNodeForAnalysis != null);
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForSymbol(analyzer, symbolDeclaredEvent.Symbol));
+            Debug.Assert(!IsAnalyzerSuppressedForSymbol(analyzer, symbolDeclaredEvent.Symbol, cancellationToken));
 
             var symbol = symbolDeclaredEvent.Symbol;
-            var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis);
+            var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var symbolAction in symbolEndActions)
             {
                 var action = symbolAction.Action;
 
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var context = new SymbolAnalysisContext(symbol, Compilation, AnalyzerOptions, addDiagnostic,
-                    isSupportedDiagnostic, isGeneratedCode, _cancellationToken);
+                    isSupportedDiagnostic, isGeneratedCode, cancellationToken);
 
                 ExecuteAndCatchIfThrows(
                     symbolAction.Analyzer,
                     data => data.action(data.context),
                     (action, context),
-                    new AnalysisContextInfo(Compilation, symbol));
+                    new AnalysisContextInfo(Compilation, symbol),
+                    cancellationToken);
             }
 
             _analyzerManager.MarkSymbolEndAnalysisComplete(symbol, analyzer);
@@ -554,31 +547,33 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             SemanticModel semanticModel,
             AnalysisScope analysisScope,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForTree(analyzer, semanticModel.SyntaxTree))
+                IsAnalyzerSuppressedForTree(analyzer, semanticModel.SyntaxTree, cancellationToken))
             {
                 return;
             }
 
-            var diagReporter = GetAddSemanticDiagnostic(semanticModel.SyntaxTree, analyzer);
+            var diagReporter = GetAddSemanticDiagnostic(semanticModel.SyntaxTree, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var semanticModelAction in semanticModelActions)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var context = new SemanticModelAnalysisContext(semanticModel, AnalyzerOptions, diagReporter.AddDiagnosticAction,
-                    isSupportedDiagnostic, analysisScope.FilterSpanOpt, isGeneratedCode, _cancellationToken);
+                    isSupportedDiagnostic, analysisScope.FilterSpanOpt, isGeneratedCode, cancellationToken);
 
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     semanticModelAction.Analyzer,
                     data => data.action(data.context),
                     (action: semanticModelAction.Action, context),
-                    new AnalysisContextInfo(semanticModel));
+                    new AnalysisContextInfo(semanticModel),
+                    cancellationToken);
             }
 
             diagReporter.Free();
@@ -595,33 +590,35 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SyntaxTreeAnalyzerAction> syntaxTreeActions,
             DiagnosticAnalyzer analyzer,
             SourceOrAdditionalFile file,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(file.SourceTree != null);
 
             var tree = file.SourceTree;
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForTree(analyzer, tree))
+                IsAnalyzerSuppressedForTree(analyzer, tree, cancellationToken))
             {
                 return;
             }
 
-            var diagReporter = GetAddSyntaxDiagnostic(file, analyzer);
+            var diagReporter = GetAddSyntaxDiagnostic(file, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             foreach (var syntaxTreeAction in syntaxTreeActions)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                var context = new SyntaxTreeAnalysisContext(tree, AnalyzerOptions, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, Compilation, isGeneratedCode, _cancellationToken);
+                var context = new SyntaxTreeAnalysisContext(tree, AnalyzerOptions, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, Compilation, isGeneratedCode, cancellationToken);
 
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     syntaxTreeAction.Analyzer,
                     data => data.action(data.context),
                     (action: syntaxTreeAction.Action, context),
-                    new AnalysisContextInfo(Compilation, file));
+                    new AnalysisContextInfo(Compilation, file),
+                    cancellationToken);
             }
 
             diagReporter.Free();
@@ -636,26 +633,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void ExecuteAdditionalFileActions(
             ImmutableArray<AdditionalFileAnalyzerAction> additionalFileActions,
             DiagnosticAnalyzer analyzer,
-            SourceOrAdditionalFile file)
+            SourceOrAdditionalFile file,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(file.AdditionalFile != null);
             var additionalFile = file.AdditionalFile;
 
-            var diagReporter = GetAddSyntaxDiagnostic(file, analyzer);
+            var diagReporter = GetAddSyntaxDiagnostic(file, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
             foreach (var additionalFileAction in additionalFileActions)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                var context = new AdditionalFileAnalysisContext(additionalFile, AnalyzerOptions, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, Compilation, _cancellationToken);
+                var context = new AdditionalFileAnalysisContext(additionalFile, AnalyzerOptions, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, Compilation, cancellationToken);
 
                 // Catch Exception from action.
                 ExecuteAndCatchIfThrows(
                     additionalFileAction.Analyzer,
                     data => data.action(data.context),
                     (action: additionalFileAction.Action, context),
-                    new AnalysisContextInfo(Compilation, file));
+                    new AnalysisContextInfo(Compilation, file),
+                    cancellationToken);
             }
 
             diagReporter.Free();
@@ -667,21 +666,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel semanticModel,
             Action<Diagnostic> addDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
-            bool isGeneratedCode)
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
             where TLanguageKindEnum : struct
         {
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(syntaxNodeAction.Analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForTree(syntaxNodeAction.Analyzer, node.SyntaxTree));
+            Debug.Assert(!IsAnalyzerSuppressedForTree(syntaxNodeAction.Analyzer, node.SyntaxTree, cancellationToken));
 
             var syntaxNodeContext = new SyntaxNodeAnalysisContext(node, containingSymbol, semanticModel, AnalyzerOptions, addDiagnostic,
-                    isSupportedDiagnostic, isGeneratedCode, _cancellationToken);
+                    isSupportedDiagnostic, isGeneratedCode, cancellationToken);
 
             ExecuteAndCatchIfThrows(
                 syntaxNodeAction.Analyzer,
                 data => data.action(data.context),
                 (action: syntaxNodeAction.Action, context: syntaxNodeContext),
-                new AnalysisContextInfo(Compilation, node));
+                new AnalysisContextInfo(Compilation, node),
+                cancellationToken);
         }
 
         private void ExecuteOperationAction(
@@ -690,19 +691,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel semanticModel,
             Action<Diagnostic> addDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
-            bool isGeneratedCode)
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(operationAction.Analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForTree(operationAction.Analyzer, semanticModel.SyntaxTree));
+            Debug.Assert(!IsAnalyzerSuppressedForTree(operationAction.Analyzer, semanticModel.SyntaxTree, cancellationToken));
 
             var operationContext = new OperationAnalysisContext(operation, containingSymbol, semanticModel.Compilation,
-                    AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, GetControlFlowGraph, isGeneratedCode, _cancellationToken);
+                    AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, GetControlFlowGraph, isGeneratedCode, cancellationToken);
             ExecuteAndCatchIfThrows(
                 operationAction.Analyzer,
                 data => data.action(data.context),
                 (action: operationAction.Action, context: operationContext),
-                new AnalysisContextInfo(Compilation, operation));
+                new AnalysisContextInfo(Compilation, operation),
+                cancellationToken);
         }
 
         /// <summary>
@@ -718,7 +721,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SyntaxNode> executableCodeBlocks,
             SemanticModel semanticModel,
             Func<SyntaxNode, TLanguageKindEnum> getKind,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
             where TLanguageKindEnum : struct
         {
             ExecuteBlockActionsCore<CodeBlockStartAnalyzerAction<TLanguageKindEnum>, CodeBlockAnalyzerAction, SyntaxNodeAnalyzerAction<TLanguageKindEnum>, SyntaxNode, TLanguageKindEnum>(
@@ -737,7 +741,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             return cb.DescendantNodesAndSelf();
                         }
                     }),
-                semanticModel, getKind, isGeneratedCode);
+                semanticModel, getKind, isGeneratedCode, cancellationToken);
         }
 
         /// <summary>
@@ -753,12 +757,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<IOperation> operationBlocks,
             ImmutableArray<IOperation> operations,
             SemanticModel semanticModel,
-            bool isGeneratedCode)
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
         {
             ExecuteBlockActionsCore<OperationBlockStartAnalyzerAction, OperationBlockAnalyzerAction, OperationAnalyzerAction, IOperation, int>(
                 operationBlockStartActions, operationBlockActions, operationBlockEndActions, analyzer,
                 declaredNode, declaredSymbol, operationBlocks, (blocks) => operations, semanticModel,
-                getKind: null, isGeneratedCode);
+                getKind: null, isGeneratedCode, cancellationToken);
         }
 
         private void ExecuteBlockActionsCore<TBlockStartAction, TBlockAction, TNodeAction, TNode, TLanguageKindEnum>(
@@ -772,7 +777,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
            Func<ImmutableArray<TNode>, IEnumerable<TNode>> getNodesToAnalyze,
            SemanticModel semanticModel,
            Func<SyntaxNode, TLanguageKindEnum>? getKind,
-           bool isGeneratedCode)
+           bool isGeneratedCode,
+           CancellationToken cancellationToken)
            where TLanguageKindEnum : struct
            where TBlockStartAction : AnalyzerAction
            where TBlockAction : AnalyzerAction
@@ -785,7 +791,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Debug.Assert(!executableBlocks.IsEmpty);
 
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForTree(analyzer, declaredNode.SyntaxTree))
+                IsAnalyzerSuppressedForTree(analyzer, declaredNode.SyntaxTree, cancellationToken))
             {
                 return;
             }
@@ -805,7 +811,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Include the initial code block end actions.
             blockEndActions.AddAll(endActions);
 
-            var diagReporter = GetAddSemanticDiagnostic(semanticModel.SyntaxTree, declaredNode.FullSpan, analyzer);
+            var diagReporter = GetAddSemanticDiagnostic(semanticModel.SyntaxTree, declaredNode.FullSpan, analyzer, cancellationToken);
 
             // Include the stateful actions.
             foreach (var startAction in startActions)
@@ -815,7 +821,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var codeBlockEndActions = blockEndActions as PooledHashSet<CodeBlockAnalyzerAction>;
                     var codeBlockScope = new HostCodeBlockStartAnalysisScope<TLanguageKindEnum>();
                     var blockStartContext = new AnalyzerCodeBlockStartAnalysisContext<TLanguageKindEnum>(startAction.Analyzer,
-                        codeBlockScope, declaredNode, declaredSymbol, semanticModel, AnalyzerOptions, isGeneratedCode, _cancellationToken);
+                        codeBlockScope, declaredNode, declaredSymbol, semanticModel, AnalyzerOptions, isGeneratedCode, cancellationToken);
 
                     // Catch Exception from the start action.
                     ExecuteAndCatchIfThrows(
@@ -827,7 +833,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             data.syntaxNodeActions?.AddRange(data.scope.SyntaxNodeActions);
                         },
                         (action: codeBlockStartAction.Action, context: blockStartContext, scope: codeBlockScope, blockEndActions: codeBlockEndActions, syntaxNodeActions),
-                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode));
+                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
+                        cancellationToken);
                 }
                 else
                 {
@@ -837,7 +844,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         var operationBlockScope = new HostOperationBlockStartAnalysisScope();
                         var operationStartContext = new AnalyzerOperationBlockStartAnalysisContext(startAction.Analyzer,
                             operationBlockScope, operationBlocks, declaredSymbol, semanticModel.Compilation, AnalyzerOptions,
-                            GetControlFlowGraph, isGeneratedCode, _cancellationToken);
+                            GetControlFlowGraph, isGeneratedCode, cancellationToken);
 
                         // Catch Exception from the start action.
                         ExecuteAndCatchIfThrows(
@@ -849,12 +856,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 data.operationActions?.AddRange(data.scope.OperationActions);
                             },
                             (action: operationBlockStartAction.Action, context: operationStartContext, scope: operationBlockScope, blockEndActions: operationBlockEndActions, operationActions: operationActions),
-                            new AnalysisContextInfo(Compilation, declaredSymbol));
+                            new AnalysisContextInfo(Compilation, declaredSymbol),
+                            cancellationToken);
                     }
                 }
             }
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
 
             // Execute stateful executable node analyzers, if any.
             if (executableNodeActions.Any())
@@ -865,20 +873,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     var executableNodeActionsByKind = GetNodeActionsByKind(syntaxNodeActions);
                     var syntaxNodesToAnalyze = (IEnumerable<SyntaxNode>)getNodesToAnalyze(executableBlocks);
-                    ExecuteSyntaxNodeActions(syntaxNodesToAnalyze, executableNodeActionsByKind, analyzer, declaredSymbol, semanticModel, getKind, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasCodeBlockStartOrSymbolStartActions: startActions.Any());
+                    ExecuteSyntaxNodeActions(syntaxNodesToAnalyze, executableNodeActionsByKind, analyzer, declaredSymbol, semanticModel, getKind, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasCodeBlockStartOrSymbolStartActions: startActions.Any(), cancellationToken);
                 }
                 else if (operationActions != null)
                 {
                     var operationActionsByKind = GetOperationActionsByKind(operationActions);
                     var operationsToAnalyze = (IEnumerable<IOperation>)getNodesToAnalyze(executableBlocks);
-                    ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, semanticModel, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasOperationBlockStartOrSymbolStartActions: startActions.Any());
+                    ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, semanticModel, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasOperationBlockStartOrSymbolStartActions: startActions.Any(), cancellationToken);
                 }
             }
 
             executableNodeActions.Free();
 
-            ExecuteBlockActions(blockActions, declaredNode, declaredSymbol, analyzer, semanticModel, operationBlocks, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode);
-            ExecuteBlockActions(blockEndActions, declaredNode, declaredSymbol, analyzer, semanticModel, operationBlocks, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode);
+            ExecuteBlockActions(blockActions, declaredNode, declaredSymbol, analyzer, semanticModel, operationBlocks, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode, cancellationToken);
+            ExecuteBlockActions(blockEndActions, declaredNode, declaredSymbol, analyzer, semanticModel, operationBlocks, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode, cancellationToken);
 
             diagReporter.Free();
         }
@@ -891,25 +899,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             ImmutableArray<IOperation> operationBlocks,
             Action<Diagnostic> addDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
-            bool isGeneratedCode)
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
+            bool isGeneratedCode,
+            CancellationToken cancellationToken)
             where TBlockAction : AnalyzerAction
         {
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, declaredNode.SyntaxTree));
+            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, declaredNode.SyntaxTree, cancellationToken));
 
             foreach (var blockAction in blockActions)
             {
                 var codeBlockAction = blockAction as CodeBlockAnalyzerAction;
                 if (codeBlockAction != null)
                 {
-                    var context = new CodeBlockAnalysisContext(declaredNode, declaredSymbol, semanticModel, AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, isGeneratedCode, _cancellationToken);
+                    var context = new CodeBlockAnalysisContext(declaredNode, declaredSymbol, semanticModel, AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, isGeneratedCode, cancellationToken);
 
                     ExecuteAndCatchIfThrows(
                         codeBlockAction.Analyzer,
                         data => data.action(data.context),
                         (action: codeBlockAction.Action, context: context),
-                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode));
+                        new AnalysisContextInfo(Compilation, declaredSymbol, declaredNode),
+                        cancellationToken);
                 }
                 else
                 {
@@ -917,13 +927,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (operationBlockAction != null)
                     {
                         var context = new OperationBlockAnalysisContext(operationBlocks, declaredSymbol, semanticModel.Compilation,
-                            AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, GetControlFlowGraph, isGeneratedCode, _cancellationToken);
+                            AnalyzerOptions, addDiagnostic, isSupportedDiagnostic, GetControlFlowGraph, isGeneratedCode, cancellationToken);
 
                         ExecuteAndCatchIfThrows(
                             operationBlockAction.Analyzer,
                             data => data.action(data.context),
                             (action: operationBlockAction.Action, context),
-                            new AnalysisContextInfo(Compilation, declaredSymbol));
+                            new AnalysisContextInfo(Compilation, declaredSymbol),
+                            cancellationToken);
                     }
                 }
             }
@@ -969,19 +980,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
            TextSpan filterSpan,
            ISymbol declaredSymbol,
            bool isGeneratedCode,
-           bool hasCodeBlockStartOrSymbolStartActions)
+           bool hasCodeBlockStartOrSymbolStartActions,
+           CancellationToken cancellationToken)
            where TLanguageKindEnum : struct
         {
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree))
+                IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree, cancellationToken))
             {
                 return;
             }
 
-            var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, filterSpan, analyzer);
+            var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, filterSpan, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
-            ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind, analyzer, declaredSymbol, model, getKind, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasCodeBlockStartOrSymbolStartActions);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind, analyzer, declaredSymbol, model, getKind, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasCodeBlockStartOrSymbolStartActions, cancellationToken);
             diagReporter.Free();
         }
 
@@ -993,14 +1005,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel model,
             Func<SyntaxNode, TLanguageKindEnum> getKind,
             AnalyzerDiagnosticReporter diagReporter,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             bool isGeneratedCode,
-            bool hasCodeBlockStartOrSymbolStartActions)
+            bool hasCodeBlockStartOrSymbolStartActions,
+            CancellationToken cancellationToken)
             where TLanguageKindEnum : struct
         {
             Debug.Assert(nodeActionsByKind.Any());
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree));
+            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree, cancellationToken));
 
             foreach (var node in nodesToAnalyze)
             {
@@ -1010,7 +1023,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (nodeActionsByKind.TryGetValue(getKind(node), out var actionsForKind))
                 {
                     Debug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(nodeActionsByKind)}");
-                    if (ShouldExecuteNode(node, analyzer))
+                    if (ShouldExecuteNode(node, analyzer, cancellationToken))
                     {
                         // If analyzer hasn't registered any CodeBlockStart or SymbolStart actions, then update the filter span
                         // for local diagnostics to be the callback node's full span.
@@ -1021,7 +1034,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                         foreach (var action in actionsForKind)
                         {
-                            ExecuteSyntaxNodeAction(action, node, containingSymbol, model, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode);
+                            ExecuteSyntaxNodeAction(action, node, containingSymbol, model, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode, cancellationToken);
                         }
                     }
                 }
@@ -1067,18 +1080,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             TextSpan filterSpan,
             ISymbol declaredSymbol,
             bool isGeneratedCode,
-            bool hasOperationBlockStartOrSymbolStartActions)
+            bool hasOperationBlockStartOrSymbolStartActions,
+            CancellationToken cancellationToken)
         {
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
-                IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree))
+                IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree, cancellationToken))
             {
                 return;
             }
 
-            var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, filterSpan, analyzer);
+            var diagReporter = GetAddSemanticDiagnostic(model.SyntaxTree, filterSpan, analyzer, cancellationToken);
 
-            using var _ = PooledDelegates.GetPooledFunction((d, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d), (self: this, analyzer), out Func<Diagnostic, bool> isSupportedDiagnostic);
-            ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, model, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasOperationBlockStartOrSymbolStartActions);
+            using var _ = PooledDelegates.GetPooledFunction((d, ct, arg) => arg.self.IsSupportedDiagnostic(arg.analyzer, d, ct), (self: this, analyzer), out Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic);
+            ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, model, diagReporter, isSupportedDiagnostic, isGeneratedCode, hasOperationBlockStartOrSymbolStartActions, cancellationToken);
             diagReporter.Free();
         }
 
@@ -1089,14 +1103,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel model,
             AnalyzerDiagnosticReporter diagReporter,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             bool isGeneratedCode,
-            bool hasOperationBlockStartOrSymbolStartActions)
+            bool hasOperationBlockStartOrSymbolStartActions,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(operationActionsByKind != null);
             Debug.Assert(operationActionsByKind.Any());
             Debug.Assert(!isGeneratedCode || !_shouldSkipAnalysisOnGeneratedCode(analyzer));
-            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree));
+            Debug.Assert(!IsAnalyzerSuppressedForTree(analyzer, model.SyntaxTree, cancellationToken));
 
             foreach (var operation in operationsToAnalyze)
             {
@@ -1106,7 +1121,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (operationActionsByKind.TryGetValue(operation.Kind, out var actionsForKind))
                 {
                     Debug.Assert(!actionsForKind.IsEmpty, $"Unexpected empty action collection in {nameof(operationActionsByKind)}");
-                    if (ShouldExecuteOperation(operation, analyzer))
+                    if (ShouldExecuteOperation(operation, analyzer, cancellationToken))
                     {
                         // If analyzer hasn't registered any OperationBlockStart or SymbolStart actions, then update
                         // the filter span for local diagnostics to be the callback operation's full span.
@@ -1117,7 +1132,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                         foreach (var action in actionsForKind)
                         {
-                            ExecuteOperationAction(action, operation, containingSymbol, model, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode);
+                            ExecuteOperationAction(action, operation, containingSymbol, model, diagReporter.AddDiagnosticAction, isSupportedDiagnostic, isGeneratedCode, cancellationToken);
                         }
                     }
                 }
@@ -1144,7 +1159,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal void ExecuteAndCatchIfThrows<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info = null)
+        internal void ExecuteAndCatchIfThrows<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? contextInfo, CancellationToken cancellationToken)
         {
             SharedStopwatch timer = default;
             if (_analyzerExecutionTimeMap != null)
@@ -1157,12 +1172,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 lock (gate)
                 {
-                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, info);
+                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, contextInfo, cancellationToken);
                 }
             }
             else
             {
-                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, info);
+                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, contextInfo, cancellationToken);
             }
 
             if (_analyzerExecutionTimeMap != null)
@@ -1176,20 +1191,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         [PerformanceSensitive(
             "https://github.com/dotnet/roslyn/issues/23582",
             AllowCaptures = false)]
-        private void ExecuteAndCatchIfThrows_NoLock<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info)
+        private void ExecuteAndCatchIfThrows_NoLock<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info, CancellationToken cancellationToken)
         {
             try
             {
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 analyze(argument);
             }
-            catch (Exception e) when (ExceptionFilter(e))
+            catch (Exception e) when (ExceptionFilter(e, cancellationToken))
             {
                 // Diagnostic for analyzer exception.
                 var diagnostic = CreateAnalyzerExceptionDiagnostic(analyzer, e, info);
                 try
                 {
-                    _onAnalyzerException(e, analyzer, diagnostic, _cancellationToken);
+                    _onAnalyzerException(e, analyzer, diagnostic, cancellationToken);
                 }
                 catch (Exception)
                 {
@@ -1198,9 +1213,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal bool ExceptionFilter(Exception ex)
+        internal bool ExceptionFilter(Exception ex, CancellationToken cancellationToken)
         {
-            if ((ex as OperationCanceledException)?.CancellationToken == _cancellationToken)
+            if ((ex as OperationCanceledException)?.CancellationToken == cancellationToken)
             {
                 return false;
             }
@@ -1331,7 +1346,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 exceptionDiagnostic.GetMessage() == other.GetMessage();
         }
 
-        private bool IsSupportedDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic)
+        private bool IsSupportedDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             Debug.Assert(_isCompilerAnalyzer != null);
 
@@ -1341,13 +1356,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
-            return _analyzerManager.IsSupportedDiagnostic(analyzer, diagnostic, _isCompilerAnalyzer, this);
+            return _analyzerManager.IsSupportedDiagnostic(analyzer, diagnostic, _isCompilerAnalyzer, this, cancellationToken);
         }
 
-        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, ImmutableArray<SyntaxReference> cachedDeclaringReferences, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis)
+        private Action<Diagnostic> GetAddDiagnostic(ISymbol contextSymbol, ImmutableArray<SyntaxReference> cachedDeclaringReferences, DiagnosticAnalyzer analyzer, Func<ISymbol, SyntaxReference, Compilation, CancellationToken, SyntaxNode> getTopMostNodeForAnalysis, CancellationToken cancellationToken)
         {
             return GetAddDiagnostic(contextSymbol, cachedDeclaringReferences, Compilation, analyzer, _addNonCategorizedDiagnostic,
-                 _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic, getTopMostNodeForAnalysis, _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
+                 _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic, getTopMostNodeForAnalysis, _shouldSuppressGeneratedCodeDiagnostic, cancellationToken);
         }
 
         private static Action<Diagnostic> GetAddDiagnostic(
@@ -1399,11 +1414,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             };
         }
 
-        private Action<Diagnostic> GetAddCompilationDiagnostic(DiagnosticAnalyzer analyzer)
+        private Action<Diagnostic> GetAddCompilationDiagnostic(DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             return diagnostic =>
             {
-                if (_shouldSuppressGeneratedCodeDiagnostic(diagnostic, analyzer, Compilation, _cancellationToken))
+                if (_shouldSuppressGeneratedCodeDiagnostic(diagnostic, analyzer, Compilation, cancellationToken))
                 {
                     return;
                 }
@@ -1411,40 +1426,40 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (_addCategorizedNonLocalDiagnostic == null)
                 {
                     Debug.Assert(_addNonCategorizedDiagnostic != null);
-                    _addNonCategorizedDiagnostic(diagnostic, _cancellationToken);
+                    _addNonCategorizedDiagnostic(diagnostic, cancellationToken);
                     return;
                 }
 
-                _addCategorizedNonLocalDiagnostic(diagnostic, analyzer, _cancellationToken);
+                _addCategorizedNonLocalDiagnostic(diagnostic, analyzer, cancellationToken);
             };
         }
 
-        private AnalyzerDiagnosticReporter GetAddSemanticDiagnostic(SyntaxTree tree, DiagnosticAnalyzer analyzer)
+        private AnalyzerDiagnosticReporter GetAddSemanticDiagnostic(SyntaxTree tree, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             return AnalyzerDiagnosticReporter.GetInstance(new SourceOrAdditionalFile(tree), span: null, Compilation, analyzer, isSyntaxDiagnostic: false,
                 _addNonCategorizedDiagnostic, _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic,
-                _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
+                _shouldSuppressGeneratedCodeDiagnostic, cancellationToken);
         }
 
-        private AnalyzerDiagnosticReporter GetAddSemanticDiagnostic(SyntaxTree tree, TextSpan? span, DiagnosticAnalyzer analyzer)
+        private AnalyzerDiagnosticReporter GetAddSemanticDiagnostic(SyntaxTree tree, TextSpan? span, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             return AnalyzerDiagnosticReporter.GetInstance(new SourceOrAdditionalFile(tree), span, Compilation, analyzer, isSyntaxDiagnostic: false,
                 _addNonCategorizedDiagnostic, _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic,
-                _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
+                _shouldSuppressGeneratedCodeDiagnostic, cancellationToken);
         }
 
-        private AnalyzerDiagnosticReporter GetAddSyntaxDiagnostic(SourceOrAdditionalFile file, DiagnosticAnalyzer analyzer)
+        private AnalyzerDiagnosticReporter GetAddSyntaxDiagnostic(SourceOrAdditionalFile file, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             return AnalyzerDiagnosticReporter.GetInstance(file, span: null, Compilation, analyzer, isSyntaxDiagnostic: true,
                 _addNonCategorizedDiagnostic, _addCategorizedLocalDiagnostic, _addCategorizedNonLocalDiagnostic,
-                _shouldSuppressGeneratedCodeDiagnostic, _cancellationToken);
+                _shouldSuppressGeneratedCodeDiagnostic, cancellationToken);
         }
 
-        private bool ShouldExecuteNode(SyntaxNode node, DiagnosticAnalyzer analyzer)
+        private bool ShouldExecuteNode(SyntaxNode node, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             // Check if the node is generated code that must be skipped.
             if (_shouldSkipAnalysisOnGeneratedCode(analyzer) &&
-                _isGeneratedCodeLocation(node.SyntaxTree, node.Span))
+                _isGeneratedCodeLocation(node.SyntaxTree, node.Span, cancellationToken))
             {
                 return false;
             }
@@ -1452,11 +1467,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return true;
         }
 
-        private bool ShouldExecuteOperation(IOperation operation, DiagnosticAnalyzer analyzer)
+        private bool ShouldExecuteOperation(IOperation operation, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             // Check if the operation syntax is generated code that must be skipped.
             if (operation.Syntax != null && _shouldSkipAnalysisOnGeneratedCode(analyzer) &&
-                _isGeneratedCodeLocation(operation.Syntax.SyntaxTree, operation.Syntax.Span))
+                _isGeneratedCodeLocation(operation.Syntax.SyntaxTree, operation.Syntax.Span, cancellationToken))
             {
                 return false;
             }
@@ -1487,12 +1502,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return _lazyControlFlowGraphMap.GetOrAdd(operation, op => ControlFlowGraphBuilder.Create(op));
         }
 
-        private bool IsAnalyzerSuppressedForSymbol(DiagnosticAnalyzer analyzer, ISymbol symbol)
+        private bool IsAnalyzerSuppressedForSymbol(DiagnosticAnalyzer analyzer, ISymbol symbol, CancellationToken cancellationToken)
         {
             foreach (var location in symbol.Locations)
             {
                 if (location.SourceTree != null &&
-                    !IsAnalyzerSuppressedForTree(analyzer, location.SourceTree))
+                    !IsAnalyzerSuppressedForTree(analyzer, location.SourceTree, cancellationToken))
                 {
                     return false;
                 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -243,6 +243,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="analyzer">Analyzer to get session wide analyzer actions.</param>
         /// <param name="sessionScope">Session scope to store register session wide analyzer actions.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>
         /// Note that this API doesn't execute any <see cref="CompilationStartAnalyzerAction"/> registered by the Initialize invocation.
         /// Use <see cref="ExecuteCompilationStartActions(ImmutableArray{CompilationStartAnalyzerAction}, HostCompilationStartAnalysisScope, CancellationToken)"/> API
@@ -293,6 +294,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="actions"><see cref="AnalyzerActions"/> whose symbol start actions are to be executed.</param>
         /// <param name="symbolScope">Symbol scope to store the analyzer actions.</param>
         /// <param name="isGeneratedCodeSymbol">Flag indicating if the symbol being analyzed is generated code.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteSymbolStartActions(
             ISymbol symbol,
             DiagnosticAnalyzer analyzer,
@@ -329,6 +331,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="suppressor">Suppressor to be executed.</param>
         /// <param name="reportedDiagnostics">Reported analyzer/compiler diagnostics that can be suppressed.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteSuppressionAction(DiagnosticSuppressor suppressor, ImmutableArray<Diagnostic> reportedDiagnostics, CancellationToken cancellationToken)
         {
             Debug.Assert(_addSuppression != null);
@@ -361,6 +364,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="compilationActions">Compilation actions to be executed.</param>
         /// <param name="analyzer">Analyzer whose actions are to be executed.</param>
         /// <param name="compilationEvent">Compilation event.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteCompilationActions(
             ImmutableArray<CompilationAnalyzerAction> compilationActions,
             DiagnosticAnalyzer analyzer,
@@ -398,6 +402,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="symbolDeclaredEvent">Symbol event to be analyzed.</param>
         /// <param name="getTopMostNodeForAnalysis">Delegate to get topmost declaration node for a symbol declaration reference.</param>
         /// <param name="isGeneratedCodeSymbol">Flag indicating if this is a generated code symbol.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteSymbolActions(
             ImmutableArray<SymbolAnalyzerAction> symbolActions,
             DiagnosticAnalyzer analyzer,
@@ -478,6 +483,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="symbolDeclaredEvent">Symbol event to be analyzed.</param>
         /// <param name="getTopMostNodeForAnalysis">Delegate to get topmost declaration node for a symbol declaration reference.</param>
         /// <param name="isGeneratedCode">Flag indicating if the symbol being analyzed is generated code.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>
         /// True, if successfully executed the actions for the given analysis scope OR all the actions have already been executed for the given analysis scope.
         /// False, if there are some pending actions.
@@ -542,6 +548,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="semanticModel">Semantic model to analyze.</param>
         /// <param name="analysisScope">Scope for analyzer execution.</param>
         /// <param name="isGeneratedCode">Flag indicating if the syntax tree being analyzed is generated code.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteSemanticModelActions(
             ImmutableArray<SemanticModelAnalyzerAction> semanticModelActions,
             DiagnosticAnalyzer analyzer,
@@ -586,6 +593,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="analyzer">Analyzer whose actions are to be executed.</param>
         /// <param name="file">Syntax tree to analyze.</param>
         /// <param name="isGeneratedCode">Flag indicating if the syntax tree being analyzed is generated code.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteSyntaxTreeActions(
             ImmutableArray<SyntaxTreeAnalyzerAction> syntaxTreeActions,
             DiagnosticAnalyzer analyzer,
@@ -630,6 +638,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="additionalFileActions">Actions to be executed.</param>
         /// <param name="analyzer">Analyzer whose actions are to be executed.</param>
         /// <param name="file">Additional file to analyze.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public void ExecuteAdditionalFileActions(
             ImmutableArray<AdditionalFileAnalyzerAction> additionalFileActions,
             DiagnosticAnalyzer analyzer,

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -301,9 +301,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 // Force compilation diagnostics and wait for analyzer execution to complete.
                 var compDiags = compilation.GetDiagnostics(cancellationToken);
-                var analyzerDiags = await driver.GetDiagnosticsAsync(compilation).ConfigureAwait(false);
+                var analyzerDiags = await driver.GetDiagnosticsAsync(compilation, cancellationToken).ConfigureAwait(false);
                 var reportedDiagnostics = compDiags.AddRange(analyzerDiags);
-                return driver.ApplyProgrammaticSuppressionsAndFilterDiagnostics(reportedDiagnostics, compilation);
+                return driver.ApplyProgrammaticSuppressionsAndFilterDiagnostics(reportedDiagnostics, compilation, cancellationToken);
             }
         }
 
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     // Wait for analyzer execution to complete.
                     await driver.WhenCompletedTask.ConfigureAwait(false);
 
-                    _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(analysisScope, driver, compilation, getAnalyzerActionCounts);
+                    _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(analysisScope, driver, compilation, getAnalyzerActionCounts, cancellationToken);
                 }
                 else
                 {
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     // Update the diagnostic results based on the diagnostics reported on the driver.
                     foreach (var (scope, _) in builder)
                     {
-                        _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(scope, driver, compilation, getAnalyzerActionCounts);
+                        _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(scope, driver, compilation, getAnalyzerActionCounts, cancellationToken);
                     }
                 }
             }
@@ -1084,7 +1084,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken>? wrappedOnAnalyzerException =
                 onAnalyzerException == null ? null : (ex, analyzer, diagnostic, _) => onAnalyzerException(ex, analyzer, diagnostic);
             var analyzerExecutor = AnalyzerExecutor.CreateForSupportedDiagnostics(wrappedOnAnalyzerException, analyzerManager);
-            return AnalyzerDriver.IsDiagnosticAnalyzerSuppressed(analyzer, options, analyzerManager, analyzerExecutor, analysisScope: null, severityFilter: SeverityFilter.None);
+            return AnalyzerDriver.IsDiagnosticAnalyzerSuppressed(analyzer, options, analyzerManager, analyzerExecutor, analysisScope: null, severityFilter: SeverityFilter.None, CancellationToken.None);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -523,7 +523,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Compilation _compilation;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CompilationAnalysisValueProviderFactory? _compilationAnalysisValueProviderFactoryOpt;
         private readonly CancellationToken _cancellationToken;
 
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public CompilationAnalysisContext(Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(compilation, options, reportDiagnostic, isSupportedDiagnostic, null, cancellationToken)
+            : this(compilation, options, reportDiagnostic, isSupportedDiagnostic: (d, c) => isSupportedDiagnostic(d), null, cancellationToken)
         {
         }
 
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Compilation compilation,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             CompilationAnalysisValueProviderFactory? compilationAnalysisValueProviderFactoryOpt,
             CancellationToken cancellationToken)
         {
@@ -570,7 +570,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -631,7 +631,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly SemanticModel _semanticModel;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SemanticModelAnalysisContext(SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(semanticModel, options, reportDiagnostic, isSupportedDiagnostic, filterSpan: null, isGeneratedCode: false, cancellationToken)
+            : this(semanticModel, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), filterSpan: null, isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -669,7 +669,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             TextSpan? filterSpan,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
@@ -689,7 +689,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Compilation _compilation;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
-        internal Func<Diagnostic, bool> IsSupportedDiagnostic => _isSupportedDiagnostic;
+        internal Func<Diagnostic, CancellationToken, bool> IsSupportedDiagnostic => _isSupportedDiagnostic;
 
         /// <summary>
         /// Indicates if the <see cref="Symbol"/> is generated code.
@@ -739,7 +739,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SymbolAnalysisContext(ISymbol symbol, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(symbol, compilation, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
+            : this(symbol, compilation, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -748,7 +748,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Compilation compilation,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
         {
@@ -767,7 +767,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1017,7 +1017,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly SemanticModel _semanticModel;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -1052,7 +1052,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public CodeBlockAnalysisContext(SyntaxNode codeBlock, ISymbol owningSymbol, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(codeBlock, owningSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
+            : this(codeBlock, owningSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -1062,7 +1062,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
         {
@@ -1082,7 +1082,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1233,7 +1233,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Compilation _compilation;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly Func<IOperation, ControlFlowGraph>? _getControlFlowGraph;
         private readonly CancellationToken _cancellationToken;
 
@@ -1279,7 +1279,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Diagnostic> reportDiagnostic,
             Func<Diagnostic, bool> isSupportedDiagnostic,
             CancellationToken cancellationToken)
-            : this(operationBlocks, owningSymbol, compilation, options, reportDiagnostic, isSupportedDiagnostic, getControlFlowGraph: null, isGeneratedCode: false, cancellationToken)
+            : this(operationBlocks, owningSymbol, compilation, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), getControlFlowGraph: null, isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -1289,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Compilation compilation,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             Func<IOperation, ControlFlowGraph>? getControlFlowGraph,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
@@ -1311,7 +1311,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1348,7 +1348,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Compilation? _compilationOpt;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -1375,7 +1375,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxTreeAnalysisContext(SyntaxTree tree, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(tree, options, reportDiagnostic, isSupportedDiagnostic, compilation: null, isGeneratedCode: false, cancellationToken)
+            : this(tree, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), compilation: null, isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -1383,7 +1383,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SyntaxTree tree,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             Compilation? compilation,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
@@ -1403,7 +1403,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilationOpt, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilationOpt, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1418,7 +1418,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     public readonly struct AdditionalFileAnalysisContext
     {
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
 
         /// <summary>
         /// <see cref="AdditionalText"/> that is the subject of the analysis.
@@ -1444,7 +1444,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AdditionalText additionalFile,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             Compilation compilation,
             CancellationToken cancellationToken)
         {
@@ -1463,7 +1463,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, _isSupportedDiagnostic, CancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1482,7 +1482,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly SemanticModel _semanticModel;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
@@ -1522,13 +1522,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxNodeAnalysisContext(SyntaxNode node, ISymbol? containingSymbol, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-            : this(node, containingSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
+            : this(node, containingSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), isGeneratedCode: false, cancellationToken)
         {
         }
 
         [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxNodeAnalysisContext(SyntaxNode node, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
-           : this(node, null, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
+           : this(node, null, semanticModel, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -1538,7 +1538,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
         {
@@ -1558,7 +1558,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _semanticModel.Compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);
@@ -1577,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Compilation _compilation;
         private readonly AnalyzerOptions _options;
         private readonly Action<Diagnostic> _reportDiagnostic;
-        private readonly Func<Diagnostic, bool> _isSupportedDiagnostic;
+        private readonly Func<Diagnostic, CancellationToken, bool> _isSupportedDiagnostic;
         private readonly Func<IOperation, ControlFlowGraph>? _getControlFlowGraph;
         private readonly CancellationToken _cancellationToken;
 
@@ -1620,7 +1620,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Diagnostic> reportDiagnostic,
             Func<Diagnostic, bool> isSupportedDiagnostic,
             CancellationToken cancellationToken)
-            : this(operation, containingSymbol, compilation, options, reportDiagnostic, isSupportedDiagnostic, getControlFlowGraph: null, isGeneratedCode: false, cancellationToken)
+            : this(operation, containingSymbol, compilation, options, reportDiagnostic, isSupportedDiagnostic: (d, _) => isSupportedDiagnostic(d), getControlFlowGraph: null, isGeneratedCode: false, cancellationToken)
         {
         }
 
@@ -1630,7 +1630,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Compilation compilation,
             AnalyzerOptions options,
             Action<Diagnostic> reportDiagnostic,
-            Func<Diagnostic, bool> isSupportedDiagnostic,
+            Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic,
             Func<IOperation, ControlFlowGraph>? getControlFlowGraph,
             bool isGeneratedCode,
             CancellationToken cancellationToken)
@@ -1652,7 +1652,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="diagnostic"><see cref="Diagnostic"/> to be reported.</param>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, _compilation, _isSupportedDiagnostic, _cancellationToken);
             lock (_reportDiagnostic)
             {
                 _reportDiagnostic(diagnostic);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContextHelpers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContextHelpers.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             VerifyOperationKinds(operationKinds);
         }
 
-        internal static void VerifyArguments(Diagnostic diagnostic, Compilation? compilation, Func<Diagnostic, bool> isSupportedDiagnostic)
+        internal static void VerifyArguments(Diagnostic diagnostic, Compilation? compilation, Func<Diagnostic, CancellationToken, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
         {
             if (diagnostic is DiagnosticWithInfo)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 VerifyDiagnosticLocationsInCompilation(diagnostic, compilation);
             }
 
-            if (!isSupportedDiagnostic(diagnostic))
+            if (!isSupportedDiagnostic(diagnostic, cancellationToken))
             {
                 throw new ArgumentException(string.Format(CodeAnalysisResources.UnsupportedDiagnosticReported, diagnostic.Id), nameof(diagnostic));
             }

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -315,11 +315,11 @@ namespace Microsoft.CodeAnalysis
                 out var newCompilation, cancellationToken);
             Debug.Assert(newCompilation.SemanticModelProvider != null);
             var compilerDiagnostics = newCompilation.GetDiagnostics(cancellationToken);
-            var analyzerDiagnostics = driver.GetDiagnosticsAsync(newCompilation).Result;
+            var analyzerDiagnostics = driver.GetDiagnosticsAsync(newCompilation, cancellationToken).Result;
             var allDiagnostics = includeCompilerDiagnostics ?
                 compilerDiagnostics.AddRange(analyzerDiagnostics) :
                 analyzerDiagnostics;
-            diagnostics = driver.ApplyProgrammaticSuppressionsAndFilterDiagnostics(allDiagnostics, newCompilation);
+            diagnostics = driver.ApplyProgrammaticSuppressionsAndFilterDiagnostics(allDiagnostics, newCompilation, cancellationToken);
 
             if (!reportSuppressedDiagnostics)
             {


### PR DESCRIPTION
Fixes #67670
Follow-up refactoring to avoid bugs such as #67084

Instead of a property on this type, cancellationToken is now threaded through all the method calls as a parameter.