### PR TITLE
Add debugger display for operations

### DIFF
--- a/src/Compilers/Core/Portable/Operations/Operation.cs
+++ b/src/Compilers/Core/Portable/Operations/Operation.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
     /// Root type for representing the abstract semantics of C# and VB statements and expressions.
     /// </summary>
+    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
     internal abstract partial class Operation : IOperation
     {
         protected static readonly IOperation s_unset = new EmptyOperation(semanticModel: null, syntax: null!, isImplicit: true);
@@ -190,7 +189,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static readonly ObjectPool<Queue<IOperation>> s_queuePool =
-            new ObjectPool<Queue<IOperation>>(() => new Queue<IOperation>(), 10);
+        private string GetDebuggerDisplay() => $"{GetType().Name} Type: {(Type is null ? "null" : Type)}";
     }
 }


### PR DESCRIPTION
Before:
![UrZGYxtrqz](https://user-images.githubusercontent.com/70431552/230715208-65a7d464-cc3d-4147-b7f3-8477853e18e7.png)

After:
![kKUQZWNaFI](https://user-images.githubusercontent.com/70431552/230715213-fdedb426-09a3-4f64-95f7-99546e1144a1.png)

Tried to make it more helpful and at the same time not overload it with too much information. I think, that `Type` is the most widely used thing, so added it to quick display. Suggestions about potential improvements are welcome.

Also deleted a piece of dead code in the process.