### PR TITLE
Move caching of classifications to non-focus priority

### DIFF
--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -32,6 +32,9 @@ namespace Microsoft.CodeAnalysis.Classification
                 },
                 static (p, list) =>
                 {
+                    // Deliberately do not call ClearAndFree for the set as we can easy have a set that goes past the
+                    // threshold simply with a single classified screen.  This allows reuse of those sets without causing
+                    // lots of **garbage.**
                     list.Clear();
                     p.Free(list);
                 });

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
@@ -63,19 +63,20 @@ namespace Microsoft.CodeAnalysis.Classification
                 ClassificationOptions options,
                 CancellationToken cancellationToken)
             {
-                var worker = new Worker(semanticModel, textSpan, list, getNodeClassifiers, getTokenClassifiers, options, cancellationToken);
+                using var worker = new Worker(semanticModel, textSpan, list, getNodeClassifiers, getTokenClassifiers, options, cancellationToken);
 
-                try
-                {
-                    worker._pendingNodes.Push(worker._syntaxTree.GetRoot(cancellationToken));
-                    worker.ProcessNodes();
-                }
-                finally
-                {
-                    // release collections to the pool
-                    SharedPools.Default<SegmentedHashSet<ClassifiedSpan>>().ClearAndFree(worker._set);
-                    SharedPools.Default<Stack<SyntaxNodeOrToken>>().ClearAndFree(worker._pendingNodes);
-                }
+                worker._pendingNodes.Push(worker._syntaxTree.GetRoot(cancellationToken));
+                worker.ProcessNodes();
+            }
+
+            public void Dispose()
+            {
+                // Deliberately do not call ClearAndFree for the set as we can easy have a set that goes past the
+                // threshold simply with a single classified screen.  This allows reuse of those sets without causing
+                // lots of garbage.
+                _set.Clear();
+                SharedPools.Default<SegmentedHashSet<ClassifiedSpan>>().Free(_set);
+                SharedPools.Default<Stack<SyntaxNodeOrToken>>().ClearAndFree(this._pendingNodes);
             }
 
             private void AddClassification(TextSpan textSpan, string type)

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Remote
             : base(arguments)
         {
             _workQueue = new AsyncBatchingWorkQueue<(Document, ClassificationType, ClassificationOptions)>(
-                DelayTimeSpan.Short,
+                DelayTimeSpan.NonFocus,
                 CacheClassificationsAsync,
                 EqualityComparer<(Document, ClassificationType, ClassificationOptions)>.Default,
                 AsynchronousOperationListenerProvider.NullListener,


### PR DESCRIPTION
We cache classifications for a document so that when you open the doc during hte next VS session you get semantic classifications Much sooner than would normally take (esp. with building compilations, etc.).  We were previously doing this at 250ms after any edit, but that sort of aggressiveness is just not needed.  Switched this to our standard 3s cadence for doing work that is helpful, but really shouldn't happen while any important work is happening related to what the user is actually interacting with.

Also, moved to just caching the collections we use to do this classification.  They're large (since we're classifying whole files), so constantly creating/throwing them away produces lots of garbage.

Reduces garbage produced in a simple typing/lightbulb scenario by around 80 MB: 

![image](https://user-images.githubusercontent.com/4564579/230979299-f67eaf46-45b7-4767-8137-837231a68758.png)
