### PR TITLE
Remove linq allocation overhead

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -217,12 +217,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<MethodSymbol>.Empty;
             }
 
-            ArrayBuilder<MethodSymbol> operators = ArrayBuilder<MethodSymbol>.GetInstance();
-            foreach (MethodSymbol candidate in candidates.OfType<MethodSymbol>())
+            var operators = ArrayBuilder<MethodSymbol>.GetInstance(candidates.Length);
+            foreach (var candidate in candidates)
             {
-                if (candidate.MethodKind == MethodKind.UserDefinedOperator || candidate.MethodKind == MethodKind.Conversion)
+                if (candidate is MethodSymbol { MethodKind: MethodKind.UserDefinedOperator or MethodKind.Conversion } method)
                 {
-                    operators.Add(candidate);
+                    operators.Add(method);
                 }
             }
 


### PR DESCRIPTION
Reduced 0.5% of all allocs in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231009722-a3f95a8a-af95-4bcd-aa22-344a4f91892d.png)
