### PR TITLE
Do not realize all Document instances in a solution when walking it to create/update indices

### DIFF
--- a/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
@@ -885,7 +885,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             await using (var storage = await GetStorageAsync(solution))
             {
                 var index = await SyntaxTreeIndex.GetRequiredIndexAsync(document, default);
-                await index.SaveAsync(_storageService!, document, default);
+                await index.SaveAsync(document, _storageService!);
 
                 var index2 = await SyntaxTreeIndex.LoadAsync(_storageService!, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
                 Assert.NotNull(index2);
@@ -905,7 +905,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             await using (var storage = await GetStorageAsync(solution))
             {
                 var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, default);
-                await index.SaveAsync(_storageService!, document, default);
+                await index.SaveAsync(document, _storageService!);
 
                 var index2 = await TopLevelSyntaxTreeIndex.LoadAsync(_storageService!, DocumentKey.ToDocumentKey(document), checksum: null, new StringTable(), default);
                 Assert.NotNull(index2);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -240,15 +240,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 }
 
                 async Task AddMatchingTypesAsync(
-                    MultiDictionary<Document, DeclaredSymbolInfo> documentToInfos,
+                    MultiDictionary<DocumentId, DeclaredSymbolInfo> documentToInfos,
                     SymbolSet result,
                     Func<INamedTypeSymbol, bool>? predicateOpt)
                 {
-                    foreach (var (document, infos) in documentToInfos)
+                    foreach (var (documentId, infos) in documentToInfos)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         Debug.Assert(infos.Count > 0);
+                        var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                         cachedModels.Add(semanticModel);
 
@@ -271,10 +272,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 async Task AddSourceTypesThatDeriveFromNameAsync(SymbolSet result, string name)
                 {
-                    foreach (var (document, info) in projectIndex.NamedTypes[name])
+                    foreach (var (documentId, info) in projectIndex.NamedTypes[name])
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
+                        var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                         cachedModels.Add(semanticModel);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         private sealed class ProjectIndex
         {
-            private static readonly ConditionalWeakTable<Project, AsyncLazy<ProjectIndex>> s_projectToIndex = new();
+            private static readonly ConditionalWeakTable<ProjectState, AsyncLazy<ProjectIndex>> s_projectToIndex = new();
 
             public readonly MultiDictionary<DocumentId, DeclaredSymbolInfo> ClassesAndRecordsThatMayDeriveFromSystemObject;
             public readonly MultiDictionary<DocumentId, DeclaredSymbolInfo> ValueTypes;
@@ -40,11 +40,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public static Task<ProjectIndex> GetIndexAsync(
                 Project project, CancellationToken cancellationToken)
             {
-                if (!s_projectToIndex.TryGetValue(project, out var lazyIndex))
+                if (!s_projectToIndex.TryGetValue(project.State, out var lazyIndex))
                 {
                     lazyIndex = s_projectToIndex.GetValue(
-                        project, p => new AsyncLazy<ProjectIndex>(
-                            c => ProjectIndex.CreateIndexAsync(p, c), cacheResult: true));
+                        project.State, p => new AsyncLazy<ProjectIndex>(
+                            c => ProjectIndex.CreateIndexAsync(project, c), cacheResult: true));
                 }
 
                 return lazyIndex.GetValueAsync(cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     lazyIndex = s_projectToIndex.GetValue(
                         project.State, p => new AsyncLazy<ProjectIndex>(
-                            c => ProjectIndex.CreateIndexAsync(project, c), cacheResult: true));
+                            c => CreateIndexAsync(project, c), cacheResult: true));
                 }
 
                 return lazyIndex.GetValueAsync(cancellationToken);
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var namedTypes = new MultiDictionary<string, (DocumentId, DeclaredSymbolInfo)>(
                     project.Services.GetRequiredService<ISyntaxFactsService>().StringComparer);
 
-                foreach (var documentId in project.DocumentIds)
+                foreach (var (documentId, document) in project.State.DocumentStates.States)
                 {
-                    var syntaxTreeIndex = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(project, documentId, cancellationToken).ConfigureAwait(false);
+                    var syntaxTreeIndex = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(project, document, cancellationToken).ConfigureAwait(false);
                     foreach (var info in syntaxTreeIndex.DeclaredSymbolInfos)
                     {
                         switch (info.Kind)

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
@@ -49,11 +49,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             if (!document.SupportsSyntaxTree)
                 return null;
 
-            // See if we already have this index cached for this doc state.
+            // See if we already cached an index with this direct document index.  If so we can just
+            // return it with no additional work.
             if (!s_documentStateToIndex.TryGetValue(document, out var index))
             {
-                // See if we already cached an index with this direct document index.  If so we can just
-                // return it with no additional work.
                 index = await GetIndexWorkerAsync(solutionKey, project, document, loadOnly, read, create, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfFalse(index != null || loadOnly == true, "Result can only be null if 'loadOnly: true' was passed.");
 

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             IndexCreator create,
             CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(project.SupportsCompilation);
+            Contract.ThrowIfFalse(document.SupportsSyntaxTree);
 
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -124,13 +124,34 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return (textChecksum, textAndDirectivesChecksum);
         }
 
-        private async Task<bool> SaveAsync(
+        private Task<bool> SaveAsync(
             SolutionKey solutionKey,
             ProjectState project,
             DocumentState document,
             CancellationToken cancellationToken)
         {
             var persistentStorageService = project.LanguageServices.SolutionServices.GetPersistentStorageService();
+            return SaveAsync(solutionKey, project, document, persistentStorageService, cancellationToken);
+        }
+
+        public Task<bool> SaveAsync(
+            Document document, IChecksummedPersistentStorageService persistentStorageService)
+        {
+            return SaveAsync(
+                SolutionKey.ToSolutionKey(document.Project.Solution),
+                document.Project.State,
+                (DocumentState)document.State,
+                persistentStorageService,
+                CancellationToken.None);
+        }
+
+        private async Task<bool> SaveAsync(
+            SolutionKey solutionKey,
+            ProjectState project,
+            DocumentState document,
+            IChecksummedPersistentStorageService persistentStorageService,
+            CancellationToken cancellationToken)
+        {
             try
             {
                 var storage = await persistentStorageService.GetStorageAsync(solutionKey, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -19,14 +19,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly string s_persistenceName = typeof(TIndex).Name;
         private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("37");
 
-        public readonly Checksum? Checksum;
-
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained
         /// within.  Useful so we don't have to continually reenumerate and regenerate the checksum given how rarely
         /// these ever change.
         /// </summary>
         private static readonly ConditionalWeakTable<ParseOptions, Checksum> s_ppDirectivesToChecksum = new();
+
+        public readonly Checksum? Checksum;
 
         protected static async Task<TIndex?> LoadAsync(
             SolutionKey solutionKey,

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             var storageService = project.Solution.Services.GetPersistentStorageService();
             var documentKey = DocumentKey.ToDocumentKey(project, documentId);
-            var stringTable = SyntaxTreeIndex.GetStringTable(project);
+            var stringTable = SyntaxTreeIndex.GetStringTable(project.State);
 
             // Try to read from the DB using either checksum.  If the writer determined there were no pp-directives,
             // then we may match it using textChecksum.  If there were pp directives, then we may match is using

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -30,21 +30,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document.Project, document.Id, cancellationToken);
+            => GetRequiredIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, cancellationToken); 
+            => GetIndexAsync(document.Project, (DocumentState)document.State, cancellationToken); 
 
-        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, loadOnly: false, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
+            => GetIndexAsync(project, document, loadOnly: false, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, loadOnly, cancellationToken);
+            => GetIndexAsync(document.Project, (DocumentState)document.State, loadOnly, cancellationToken);
 
-        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Storage;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -30,21 +31,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
+            => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, (DocumentState)document.State, cancellationToken); 
+            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken); 
 
-        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
-            => GetIndexAsync(project, document, loadOnly: false, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
+            => GetIndexAsync(solutionKey, project, document, loadOnly: false, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, (DocumentState)document.State, loadOnly, cancellationToken);
+            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, cancellationToken);
 
-        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken); 
+            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
             => GetIndexAsync(solutionKey, project, document, loadOnly: false, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -31,13 +30,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document, ReadIndex, CreateIndex, cancellationToken);
+            => GetRequiredIndexAsync(document.Project, document.Id, cancellationToken);
+
+        public static ValueTask<SyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document, loadOnly: false, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, cancellationToken); 
 
-        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
+            => GetIndexAsync(project, documentId, loadOnly: false, cancellationToken);
+
         public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, loadOnly, cancellationToken);
+
+        public static ValueTask<SyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(project, documentId, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -40,9 +40,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly ConditionalWeakTable<Project, StringTable> s_projectStringTable = new();
 
         private static SyntaxTreeIndex CreateIndex(
-            Document document, SyntaxNode root, Checksum checksum, CancellationToken _)
+            Project project, SyntaxNode root, Checksum checksum, CancellationToken _)
         {
-            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = project.GetRequiredLanguageService<ISyntaxFactsService>();
             var ignoreCase = !syntaxFacts.IsCaseSensitive;
             var isCaseSensitive = !ignoreCase;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// this string table.  The table will have already served its purpose at that point and 
         /// doesn't need to be kept around further.
         /// </summary>
-        private static readonly ConditionalWeakTable<Project, StringTable> s_projectStringTable = new();
+        private static readonly ConditionalWeakTable<ProjectState, StringTable> s_projectStringTable = new();
 
         private static SyntaxTreeIndex CreateIndex(
             Project project, SyntaxNode root, Checksum checksum, CancellationToken _)
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        public static StringTable GetStringTable(Project project)
+        public static StringTable GetStringTable(ProjectState project)
             => s_projectStringTable.GetValue(project, static _ => StringTable.GetInstance());
 
         private static void GetIdentifierSet(bool ignoreCase, out HashSet<string> identifiers, out HashSet<string> escapedIdentifiers)

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -40,9 +40,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly ConditionalWeakTable<ProjectState, StringTable> s_projectStringTable = new();
 
         private static SyntaxTreeIndex CreateIndex(
-            Project project, SyntaxNode root, Checksum checksum, CancellationToken _)
+            ProjectState project, SyntaxNode root, Checksum checksum, CancellationToken _)
         {
-            var syntaxFacts = project.GetRequiredLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = project.LanguageServices.GetRequiredService<ISyntaxFactsService>();
             var ignoreCase = !syntaxFacts.IsCaseSensitive;
             var isCaseSensitive = !ignoreCase;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/IDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/IDeclaredSymbolInfoFactoryService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         // `rootNamespace` is required for VB projects that has non-global namespace as root namespace,
         // otherwise we would not be able to get correct data from syntax.
-        void AddDeclaredSymbolInfos(Project project, SyntaxNode root, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
+        void AddDeclaredSymbolInfos(ProjectState project, SyntaxNode root, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/IDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/IDeclaredSymbolInfoFactoryService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         // `rootNamespace` is required for VB projects that has non-global namespace as root namespace,
         // otherwise we would not be able to get correct data from syntax.
-        void AddDeclaredSymbolInfos(Document document, SyntaxNode root, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
+        void AddDeclaredSymbolInfos(Project project, SyntaxNode root, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -44,13 +44,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => _extensionMethodInfo.ContainsExtensionMethod;
 
         public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document, ReadIndex, CreateIndex, cancellationToken);
+            => GetRequiredIndexAsync(document.Project, document.Id, document, cancellationToken);
+
+        public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(project, documentId, document: null, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document, ReadIndex, CreateIndex, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, document, cancellationToken);
 
-        [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1224834", OftenCompletesSynchronously = true)]
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
+            => GetIndexAsync(project, documentId, doucment: null, ReadIndex, CreateIndex, cancellationToken);
+
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, document, loadOnly, cancellationToken);
+
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(project, documentId, document: null, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -44,21 +44,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => _extensionMethodInfo.ContainsExtensionMethod;
 
         public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document.Project, document.Id, document, cancellationToken);
+            => GetRequiredIndexAsync(document.Project, document.Id, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(project, documentId, document: null, ReadIndex, CreateIndex, cancellationToken);
+            => GetRequiredIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, document, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, doucment: null, ReadIndex, CreateIndex, cancellationToken);
+            => GetIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, document, loadOnly, cancellationToken);
+            => GetIndexAsync(document.Project, document.Id, loadOnly, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, document: null, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+            => GetIndexAsync(project, documentId, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -44,21 +44,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => _extensionMethodInfo.ContainsExtensionMethod;
 
         public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document.Project, document.Id, cancellationToken);
+            => GetRequiredIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, cancellationToken);
+            => GetIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
+            => GetIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, document.Id, loadOnly, cancellationToken);
+            => GetIndexAsync(document.Project, (DocumentState)document.State, loadOnly, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentId documentId, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(project, documentId, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Storage;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
@@ -44,21 +45,21 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => _extensionMethodInfo.ContainsExtensionMethod;
 
         public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
+            => GetRequiredIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
-            => GetRequiredIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex> GetRequiredIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
+            => GetRequiredIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, (DocumentState)document.State, cancellationToken);
+            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, CancellationToken cancellationToken)
-            => GetIndexAsync(project, document, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, CancellationToken cancellationToken)
+            => GetIndexAsync(solutionKey, project, document, ReadIndex, CreateIndex, cancellationToken);
 
         public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Document document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(document.Project, (DocumentState)document.State, loadOnly, cancellationToken);
+            => GetIndexAsync(SolutionKey.ToSolutionKey(document.Project.Solution), document.Project.State, (DocumentState)document.State, loadOnly, cancellationToken);
 
-        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(Project project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
-            => GetIndexAsync(project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
+        public static ValueTask<TopLevelSyntaxTreeIndex?> GetIndexAsync(SolutionKey solutionKey, ProjectState project, DocumentState document, bool loadOnly, CancellationToken cancellationToken)
+            => GetIndexAsync(solutionKey, project, document, loadOnly, ReadIndex, CreateIndex, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Create.cs
@@ -15,16 +15,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class TopLevelSyntaxTreeIndex
     {
         private static TopLevelSyntaxTreeIndex CreateIndex(
-            Document document, SyntaxNode root, Checksum checksum, CancellationToken cancellationToken)
+            Project project, SyntaxNode root, Checksum checksum, CancellationToken cancellationToken)
         {
-            var infoFactory = document.GetRequiredLanguageService<IDeclaredSymbolInfoFactoryService>();
+            var infoFactory = project.GetRequiredLanguageService<IDeclaredSymbolInfoFactoryService>();
 
             using var _1 = ArrayBuilder<DeclaredSymbolInfo>.GetInstance(out var declaredSymbolInfos);
             using var _2 = PooledDictionary<string, ArrayBuilder<int>>.GetInstance(out var extensionMethodInfo);
             try
             {
                 infoFactory.AddDeclaredSymbolInfos(
-                    document, root, declaredSymbolInfos, extensionMethodInfo, cancellationToken);
+                    project, root, declaredSymbolInfos, extensionMethodInfo, cancellationToken);
 
                 return new TopLevelSyntaxTreeIndex(
                     checksum,

--- a/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/TopLevelSyntaxTree/TopLevelSyntaxTreeIndex_Create.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class TopLevelSyntaxTreeIndex
     {
         private static TopLevelSyntaxTreeIndex CreateIndex(
-            Project project, SyntaxNode root, Checksum checksum, CancellationToken cancellationToken)
+            ProjectState project, SyntaxNode root, Checksum checksum, CancellationToken cancellationToken)
         {
-            var infoFactory = project.GetRequiredLanguageService<IDeclaredSymbolInfoFactoryService>();
+            var infoFactory = project.LanguageServices.GetRequiredService<IDeclaredSymbolInfoFactoryService>();
 
             using var _1 = ArrayBuilder<DeclaredSymbolInfo>.GetInstance(out var declaredSymbolInfos);
             using var _2 = PooledDictionary<string, ArrayBuilder<int>>.GetInstance(out var extensionMethodInfo);

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
             CancellationToken cancellationToken)
         {
-            var stringTable = SyntaxTreeIndex.GetStringTable(project);
+            var stringTable = SyntaxTreeIndex.GetStringTable(project.State);
             var rootNamespace = this.GetRootNamespace(project.CompilationOptions!);
 
             using var _1 = PooledDictionary<string, string?>.GetInstance(out var aliases);

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -150,13 +150,12 @@ namespace Microsoft.CodeAnalysis.LanguageService
         }
 
         public void AddDeclaredSymbolInfos(
-            Document document,
+            Project project,
             SyntaxNode root,
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
             CancellationToken cancellationToken)
         {
-            var project = document.Project;
             var stringTable = SyntaxTreeIndex.GetStringTable(project);
             var rootNamespace = this.GetRootNamespace(project.CompilationOptions!);
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -150,13 +150,13 @@ namespace Microsoft.CodeAnalysis.LanguageService
         }
 
         public void AddDeclaredSymbolInfos(
-            Project project,
+            ProjectState project,
             SyntaxNode root,
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
             Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
             CancellationToken cancellationToken)
         {
-            var stringTable = SyntaxTreeIndex.GetStringTable(project.State);
+            var stringTable = SyntaxTreeIndex.GetStringTable(project);
             var rootNamespace = this.GetRootNamespace(project.CompilationOptions!);
 
             using var _1 = PooledDictionary<string, string?>.GetInstance(out var aliases);

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
@@ -41,6 +41,9 @@ namespace Microsoft.CodeAnalysis.Storage
         public static DocumentKey ToDocumentKey(Document document)
             => ToDocumentKey(ProjectKey.ToProjectKey(document.Project), document.State);
 
+        public static DocumentKey ToDocumentKey(Project project, DocumentId documentId)
+            => ToDocumentKey(ProjectKey.ToProjectKey(project), project.State.DocumentStates.GetRequiredState(documentId));
+
         public static DocumentKey ToDocumentKey(ProjectKey projectKey, TextDocumentState state)
             => new(projectKey, state.Id, state.FilePath, state.Name);
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
@@ -41,9 +41,6 @@ namespace Microsoft.CodeAnalysis.Storage
         public static DocumentKey ToDocumentKey(Document document)
             => ToDocumentKey(ProjectKey.ToProjectKey(document.Project), document.State);
 
-        public static DocumentKey ToDocumentKey(Project project, DocumentId documentId)
-            => ToDocumentKey(ProjectKey.ToProjectKey(project), project.State.DocumentStates.GetRequiredState(documentId));
-
         public static DocumentKey ToDocumentKey(ProjectKey projectKey, TextDocumentState state)
             => new(projectKey, state.Id, state.FilePath, state.Name);
 


### PR DESCRIPTION
Saves about .7% memory in a simple typing/lighbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231027143-b3a7c648-47e6-43ae-b969-c582498acb3e.png)
