### PR TITLE
Avoid creating Document indices for files that we not reanalyzing in DesignerAttribute scanning

### DIFF
--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -222,28 +222,32 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             bool? hasDesignerCategoryType = null;
 
             using var _ = ArrayBuilder<(DesignerAttributeData data, VersionStamp version)>.GetInstance(out var results);
-            foreach (var document in project.Documents)
+
+            // Avoid realizing document instances until needed.
+            foreach (var documentId in project.DocumentIds)
             {
                 // If we're only analyzing a specific document, then skip the rest.
-                if (specificDocument != null && document != specificDocument)
+                if (specificDocument != null && documentId != specificDocument.Id)
                     continue;
 
                 // If we don't have a path for this document, we cant proceed with it.
                 // We need that path to inform the project system which file we're referring to.
-                if (document.FilePath == null)
+                var filePath = project.State.DocumentStates.GetRequiredState(documentId).FilePath;
+                if (filePath is null)
                     continue;
 
                 // If nothing has changed at the top level between the last time we analyzed this document and now, then
                 // no need to analyze again.
                 var projectVersion = await lazyProjectVersion.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                if (_documentToLastReportedInformation.TryGetValue(document.Id, out var existingInfo) &&
+                if (_documentToLastReportedInformation.TryGetValue(documentId, out var existingInfo) &&
                     existingInfo.projectVersion == projectVersion)
                 {
                     continue;
                 }
 
+
                 hasDesignerCategoryType ??= await HasDesignerCategoryTypeAsync(project, cancellationToken).ConfigureAwait(false);
-                var data = await ComputeDesignerAttributeDataAsync(document, hasDesignerCategoryType.Value).ConfigureAwait(false);
+                var data = await ComputeDesignerAttributeDataAsync(project, documentId, filePath, hasDesignerCategoryType.Value).ConfigureAwait(false);
                 if (data.Category != existingInfo.category)
                     results.Add((data, projectVersion));
             }
@@ -251,32 +255,33 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             return results.ToImmutable();
 
             async Task<DesignerAttributeData> ComputeDesignerAttributeDataAsync(
-                Document document, bool hasDesignerCategoryType)
+                Project project, DocumentId documentId, string filePath, bool hasDesignerCategoryType)
             {
-                Contract.ThrowIfNull(document.FilePath);
-
                 // We either haven't computed the designer info, or our data was out of date.  We need
                 // So recompute here.  Figure out what the current category is, and if that's different
                 // from what we previously stored.
                 var category = await ComputeDesignerAttributeCategoryAsync(
-                    hasDesignerCategoryType, document, cancellationToken).ConfigureAwait(false);
+                    hasDesignerCategoryType, project, documentId, cancellationToken).ConfigureAwait(false);
 
                 return new DesignerAttributeData
                 {
                     Category = category,
-                    DocumentId = document.Id,
-                    FilePath = document.FilePath,
+                    DocumentId = documentId,
+                    FilePath = filePath,
                 };
             }
         }
 
         public static async Task<string?> ComputeDesignerAttributeCategoryAsync(
-            bool hasDesignerCategoryType, Document document, CancellationToken cancellationToken)
+            bool hasDesignerCategoryType, Project project, DocumentId documentId, CancellationToken cancellationToken)
         {
             // simple case.  If there's no DesignerCategory type in this compilation, then there's definitely no
             // designable types.
             if (!hasDesignerCategoryType)
                 return null;
+
+            // Wait to realize the document to avoid unnecessary allocations when indexing documents.
+            var document = project.GetRequiredDocument(documentId);
 
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();


### PR DESCRIPTION
One of the codepaths causing:

![image](https://user-images.githubusercontent.com/4564579/231034025-1d3e76d7-aae4-413b-beb9-81b08fdc623d.png)
