### PR TITLE
Skip compiler tests that includes localizable error messages or arguments or error messages in non-English locales

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
@@ -3727,7 +3727,7 @@ public ref struct S
 ");
     }
 
-    [Theory]
+    [ConditionalTheory(typeof(IsEnglishLocal))]
     [InlineData(@"$""""""{new S { Field = """"""Field"""""" }}""""""")]
     [InlineData(@"$""""""{new S { Field = """"""Field"""""" }}"""""" + $""""""
 
@@ -4052,7 +4052,7 @@ public partial struct CustomHandler
             Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(System.Func<bool, string>)", "C.M(System.Func<bool, CustomHandler>)").WithLocation(3, 3));
     }
 
-    [Theory]
+    [ConditionalTheory(typeof(IsEnglishLocal))]
     [InlineData(@"$""""""{1}""""""")]
     [InlineData(@"$""""""{1}"""""" + $""""""{2}""""""")]
     public void LambdaInference_AmbiguousInOlderLangVersions(string expression)

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -485,7 +485,7 @@ class C { }
             Assert.Equal(2, outputCompilation.SyntaxTrees.Count());
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), typeof(IsEnglishLocal), Reason = "Desktop CLR displays argument exceptions differently")]
         public void Generator_HintName_MustBe_Unique_Across_Outputs()
         {
             var source = @"
@@ -758,7 +758,7 @@ class C
             Assert.Same(oldDriver, driver);
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), typeof(IsEnglishLocal), Reason = "Desktop CLR displays argument exceptions differently")]
         public void Adding_A_Source_Text_Without_Encoding_Fails_Generation()
         {
             var source = @"
@@ -1471,7 +1471,7 @@ class C { }
             Assert.Equal(e, runResults.Results[0].Exception);
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67386")]
+        [ConditionalFact(typeof(IsEnglishLocal)), WorkItem("https://github.com/dotnet/roslyn/issues/67386")]
         public void Incremental_Generators_Exception_In_Comparer()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -3106,7 +3106,7 @@ class C
             Assert.Equal(2, comp.Assembly.Modules.Length);
         }
 
-        [Fact, WorkItem(65499, "https://github.com/dotnet/roslyn/issues/65499")]
+        [ConditionalFact(typeof(IsEnglishLocal)), WorkItem(65499, "https://github.com/dotnet/roslyn/issues/65499")]
         public void NetModuleReference_AssemblySpecifiedAsModule()
         {
             var module = CreateCompilation(string.Empty);
@@ -3125,7 +3125,7 @@ class C
             Assert.Equal(1, comp.Assembly.Modules.Length);
         }
 
-        [Fact, WorkItem(65499, "https://github.com/dotnet/roslyn/issues/65499")]
+        [ConditionalFact(typeof(IsEnglishLocal)), WorkItem(65499, "https://github.com/dotnet/roslyn/issues/65499")]
         public void NetModuleReference_ModuleSpecifiedAsAssembly()
         {
             var module = CreateCompilation(string.Empty, options: TestOptions.ReleaseDll.WithOutputKind(OutputKind.NetModule));


### PR DESCRIPTION
This shows some weaknesses of current CI system. The only no-English pipeline is `Test_Windows_Desktop_Spanish_Release_64` (at least according to its name), which skips tests restricted by `MonoOrCoreClrOnly`. I have no idea though, how it passes lambda-related tests, since they include 'raw string literals' message argument and are not restricted in any other way.

All in all, it might be a good idea to add some CoreClr non-English test pipeline to eliminate such cases.