### PR TITLE
Pool lists used when reusing assembly symbols

### DIFF
--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -704,235 +704,249 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        private static readonly ObjectPool<Queue<AssemblyReferenceCandidate>> s_candidatesToExaminePool = new ObjectPool<Queue<AssemblyReferenceCandidate>>(() => new Queue<AssemblyReferenceCandidate>());
+        private static readonly ObjectPool<List<TAssemblySymbol?>> s_candidateReferencedSymbolsPool = new ObjectPool<List<TAssemblySymbol?>>(() => new List<TAssemblySymbol?>(capacity: 1024));
+
         private void ReuseAssemblySymbols(BoundInputAssembly[] boundInputs, TAssemblySymbol[] candidateInputAssemblySymbols, ImmutableArray<AssemblyData> assemblies, int corLibraryIndex)
         {
             // Queue of references we need to examine for consistency
-            Queue<AssemblyReferenceCandidate> candidatesToExamine = new Queue<AssemblyReferenceCandidate>();
-            int totalAssemblies = assemblies.Length;
+            Queue<AssemblyReferenceCandidate> candidatesToExamine = s_candidatesToExaminePool.Allocate();
 
             // A reusable buffer to contain the AssemblySymbols a candidate symbol refers to
             // ⚠ PERF: https://github.com/dotnet/roslyn/issues/47471
-            List<TAssemblySymbol?> candidateReferencedSymbols = new List<TAssemblySymbol?>(1024);
-
-            for (int i = 1; i < totalAssemblies; i++)
+            List<TAssemblySymbol?> candidateReferencedSymbols = s_candidateReferencedSymbolsPool.Allocate();
+            try
             {
-                // We could have a match already
-                if (boundInputs[i].AssemblySymbol != null || assemblies[i].ContainsNoPiaLocalTypes)
+                int totalAssemblies = assemblies.Length;
+
+                for (int i = 1; i < totalAssemblies; i++)
                 {
-                    continue;
-                }
-
-                foreach (TAssemblySymbol candidateAssembly in assemblies[i].AvailableSymbols)
-                {
-                    bool match = true;
-
-                    // We should examine this candidate, all its references that are supposed to 
-                    // match one of the given assemblies and do the same for their references, etc. 
-                    // The whole set of symbols we get at the end should be consistent with the set 
-                    // of assemblies we are given. The whole set of symbols should be accepted or rejected.
-
-                    // The set of symbols is accumulated in candidateInputAssemblySymbols. It is merged into 
-                    // boundInputs after consistency is confirmed. 
-                    Array.Clear(candidateInputAssemblySymbols, 0, candidateInputAssemblySymbols.Length);
-
-                    // Symbols and index of the corresponding assembly to match against are accumulated in the
-                    // candidatesToExamine queue. They are examined one by one. 
-                    candidatesToExamine.Clear();
-
-                    // This is a queue of symbols that we are picking up as a result of using
-                    // symbols from candidateAssembly
-                    candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(i, candidateAssembly));
-
-                    while (match && candidatesToExamine.Count > 0)
+                    // We could have a match already
+                    if (boundInputs[i].AssemblySymbol != null || assemblies[i].ContainsNoPiaLocalTypes)
                     {
-                        AssemblyReferenceCandidate candidate = candidatesToExamine.Dequeue();
+                        continue;
+                    }
 
-                        Debug.Assert(candidate.DefinitionIndex >= 0);
-                        Debug.Assert(candidate.AssemblySymbol is object);
+                    foreach (TAssemblySymbol candidateAssembly in assemblies[i].AvailableSymbols)
+                    {
+                        bool match = true;
 
-                        int candidateIndex = candidate.DefinitionIndex;
+                        // We should examine this candidate, all its references that are supposed to 
+                        // match one of the given assemblies and do the same for their references, etc. 
+                        // The whole set of symbols we get at the end should be consistent with the set 
+                        // of assemblies we are given. The whole set of symbols should be accepted or rejected.
 
-                        // Have we already chosen symbols for the corresponding assembly?
-                        Debug.Assert(boundInputs[candidateIndex].AssemblySymbol == null ||
-                                              candidateInputAssemblySymbols[candidateIndex] == null);
+                        // The set of symbols is accumulated in candidateInputAssemblySymbols. It is merged into 
+                        // boundInputs after consistency is confirmed. 
+                        Array.Clear(candidateInputAssemblySymbols, 0, candidateInputAssemblySymbols.Length);
 
-                        TAssemblySymbol? inputAssembly = boundInputs[candidateIndex].AssemblySymbol;
-                        if (inputAssembly == null)
+                        // Symbols and index of the corresponding assembly to match against are accumulated in the
+                        // candidatesToExamine queue. They are examined one by one. 
+                        candidatesToExamine.Clear();
+
+                        // This is a queue of symbols that we are picking up as a result of using
+                        // symbols from candidateAssembly
+                        candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(i, candidateAssembly));
+
+                        while (match && candidatesToExamine.Count > 0)
                         {
-                            inputAssembly = candidateInputAssemblySymbols[candidateIndex];
-                        }
+                            AssemblyReferenceCandidate candidate = candidatesToExamine.Dequeue();
 
-                        if (inputAssembly != null)
-                        {
-                            if (Object.ReferenceEquals(inputAssembly, candidate.AssemblySymbol))
+                            Debug.Assert(candidate.DefinitionIndex >= 0);
+                            Debug.Assert(candidate.AssemblySymbol is object);
+
+                            int candidateIndex = candidate.DefinitionIndex;
+
+                            // Have we already chosen symbols for the corresponding assembly?
+                            Debug.Assert(boundInputs[candidateIndex].AssemblySymbol == null ||
+                                                  candidateInputAssemblySymbols[candidateIndex] == null);
+
+                            TAssemblySymbol? inputAssembly = boundInputs[candidateIndex].AssemblySymbol;
+                            if (inputAssembly == null)
                             {
-                                // We already checked this AssemblySymbol, no reason to check it again
-                                continue; // Proceed with the next assembly in candidatesToExamine queue.
+                                inputAssembly = candidateInputAssemblySymbols[candidateIndex];
                             }
 
-                            // We are using different AssemblySymbol for this assembly
-                            match = false;
-                            break; // Stop processing items from candidatesToExamine queue.
-                        }
-
-                        // Candidate should be referenced the same way (/r or /l) by the compilation, 
-                        // which originated the symbols. We need this restriction in order to prevent 
-                        // non-interface generic types closed over NoPia local types from crossing 
-                        // assembly boundaries.
-                        if (IsLinked(candidate.AssemblySymbol) != assemblies[candidateIndex].IsLinked)
-                        {
-                            match = false;
-                            break; // Stop processing items from candidatesToExamine queue.
-                        }
-
-                        // Add symbols to the set at corresponding index
-                        Debug.Assert(candidateInputAssemblySymbols[candidateIndex] == null);
-                        candidateInputAssemblySymbols[candidateIndex] = candidate.AssemblySymbol;
-
-                        // Now process references of the candidate.
-
-                        // how we bound the candidate references for this compilation:
-                        var candidateReferenceBinding = boundInputs[candidateIndex].ReferenceBinding;
-
-                        // get the AssemblySymbols the candidate symbol refers to into candidateReferencedSymbols
-                        candidateReferencedSymbols.Clear();
-                        GetActualBoundReferencesUsedBy(candidate.AssemblySymbol, candidateReferencedSymbols);
-
-                        Debug.Assert(candidateReferenceBinding is object);
-                        Debug.Assert(candidateReferenceBinding.Length == candidateReferencedSymbols.Count);
-                        int referencesCount = candidateReferencedSymbols.Count;
-
-                        for (int k = 0; k < referencesCount; k++)
-                        {
-                            // All candidate's references that were /l-ed by the compilation, 
-                            // which originated the symbols, must be /l-ed by this compilation and 
-                            // other references must be either /r-ed or not referenced. 
-                            // We need this restriction in order to prevent non-interface generic types 
-                            // closed over NoPia local types from crossing assembly boundaries.
-
-                            // if target reference isn't resolved against given assemblies, 
-                            // we cannot accept a candidate that has the reference resolved.
-                            if (!candidateReferenceBinding[k].IsBound)
+                            if (inputAssembly != null)
                             {
-                                if (candidateReferencedSymbols[k] != null)
+                                if (Object.ReferenceEquals(inputAssembly, candidate.AssemblySymbol))
+                                {
+                                    // We already checked this AssemblySymbol, no reason to check it again
+                                    continue; // Proceed with the next assembly in candidatesToExamine queue.
+                                }
+
+                                // We are using different AssemblySymbol for this assembly
+                                match = false;
+                                break; // Stop processing items from candidatesToExamine queue.
+                            }
+
+                            // Candidate should be referenced the same way (/r or /l) by the compilation, 
+                            // which originated the symbols. We need this restriction in order to prevent 
+                            // non-interface generic types closed over NoPia local types from crossing 
+                            // assembly boundaries.
+                            if (IsLinked(candidate.AssemblySymbol) != assemblies[candidateIndex].IsLinked)
+                            {
+                                match = false;
+                                break; // Stop processing items from candidatesToExamine queue.
+                            }
+
+                            // Add symbols to the set at corresponding index
+                            Debug.Assert(candidateInputAssemblySymbols[candidateIndex] == null);
+                            candidateInputAssemblySymbols[candidateIndex] = candidate.AssemblySymbol;
+
+                            // Now process references of the candidate.
+
+                            // how we bound the candidate references for this compilation:
+                            var candidateReferenceBinding = boundInputs[candidateIndex].ReferenceBinding;
+
+                            // get the AssemblySymbols the candidate symbol refers to into candidateReferencedSymbols
+                            candidateReferencedSymbols.Clear();
+                            GetActualBoundReferencesUsedBy(candidate.AssemblySymbol, candidateReferencedSymbols);
+
+                            Debug.Assert(candidateReferenceBinding is object);
+                            Debug.Assert(candidateReferenceBinding.Length == candidateReferencedSymbols.Count);
+                            int referencesCount = candidateReferencedSymbols.Count;
+
+                            for (int k = 0; k < referencesCount; k++)
+                            {
+                                // All candidate's references that were /l-ed by the compilation, 
+                                // which originated the symbols, must be /l-ed by this compilation and 
+                                // other references must be either /r-ed or not referenced. 
+                                // We need this restriction in order to prevent non-interface generic types 
+                                // closed over NoPia local types from crossing assembly boundaries.
+
+                                // if target reference isn't resolved against given assemblies, 
+                                // we cannot accept a candidate that has the reference resolved.
+                                if (!candidateReferenceBinding[k].IsBound)
+                                {
+                                    if (candidateReferencedSymbols[k] != null)
+                                    {
+                                        // can't use symbols 
+
+                                        // If we decide do go back to accepting references like this,
+                                        // we should still not do this if the reference is a /l-ed assembly.
+                                        match = false;
+                                        break; // Stop processing references.
+                                    }
+
+                                    continue; // Proceed with the next reference.
+                                }
+
+                                // We resolved the reference, candidate must have that reference resolved too.
+                                var currentCandidateReferencedSymbol = candidateReferencedSymbols[k];
+                                if (currentCandidateReferencedSymbol == null)
                                 {
                                     // can't use symbols 
-
-                                    // If we decide do go back to accepting references like this,
-                                    // we should still not do this if the reference is a /l-ed assembly.
                                     match = false;
                                     break; // Stop processing references.
                                 }
 
-                                continue; // Proceed with the next reference.
-                            }
-
-                            // We resolved the reference, candidate must have that reference resolved too.
-                            var currentCandidateReferencedSymbol = candidateReferencedSymbols[k];
-                            if (currentCandidateReferencedSymbol == null)
-                            {
-                                // can't use symbols 
-                                match = false;
-                                break; // Stop processing references.
-                            }
-
-                            int definitionIndex = candidateReferenceBinding[k].DefinitionIndex;
-                            if (definitionIndex == 0)
-                            {
-                                // We can't reuse any assembly that refers to the assembly being built.
-                                match = false;
-                                break;
-                            }
-
-                            // Make sure symbols represent the same assembly/binary
-                            if (!assemblies[definitionIndex].IsMatchingAssembly(currentCandidateReferencedSymbol))
-                            {
-                                // Mismatch between versions?
-                                match = false;
-                                break; // Stop processing references.
-                            }
-
-                            if (assemblies[definitionIndex].ContainsNoPiaLocalTypes)
-                            {
-                                // We already know that we cannot reuse any existing symbols for 
-                                // this assembly
-                                match = false;
-                                break; // Stop processing references.
-                            }
-
-                            if (IsLinked(currentCandidateReferencedSymbol) != assemblies[definitionIndex].IsLinked)
-                            {
-                                // Mismatch between reference kind.
-                                match = false;
-                                break; // Stop processing references.
-                            }
-
-                            // Add this reference to the queue so that we consider it as a candidate too 
-                            candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(definitionIndex, currentCandidateReferencedSymbol));
-                        }
-
-                        // Check that the COR library used by the candidate assembly symbol is the same as the one use by this compilation.
-                        if (match)
-                        {
-                            TAssemblySymbol? candidateCorLibrary = GetCorLibrary(candidate.AssemblySymbol);
-
-                            if (candidateCorLibrary == null)
-                            {
-                                // If the candidate didn't have a COR library, that is fine as long as we don't have one either.
-                                if (corLibraryIndex >= 0)
+                                int definitionIndex = candidateReferenceBinding[k].DefinitionIndex;
+                                if (definitionIndex == 0)
                                 {
+                                    // We can't reuse any assembly that refers to the assembly being built.
                                     match = false;
-                                    break; // Stop processing references.
-                                }
-                            }
-                            else
-                            {
-                                // We can't be compiling corlib and have a corlib reference at the same time:
-                                Debug.Assert(corLibraryIndex != 0);
-
-                                Debug.Assert(ReferenceEquals(candidateCorLibrary, GetCorLibrary(candidateCorLibrary)));
-
-                                // Candidate has COR library, we should have one too.
-                                if (corLibraryIndex < 0)
-                                {
-                                    match = false;
-                                    break; // Stop processing references.
+                                    break;
                                 }
 
-                                // Make sure candidate COR library represent the same assembly/binary
-                                if (!assemblies[corLibraryIndex].IsMatchingAssembly(candidateCorLibrary))
+                                // Make sure symbols represent the same assembly/binary
+                                if (!assemblies[definitionIndex].IsMatchingAssembly(currentCandidateReferencedSymbol))
                                 {
                                     // Mismatch between versions?
                                     match = false;
                                     break; // Stop processing references.
                                 }
 
-                                Debug.Assert(!assemblies[corLibraryIndex].ContainsNoPiaLocalTypes);
-                                Debug.Assert(!assemblies[corLibraryIndex].IsLinked);
-                                Debug.Assert(!IsLinked(candidateCorLibrary));
+                                if (assemblies[definitionIndex].ContainsNoPiaLocalTypes)
+                                {
+                                    // We already know that we cannot reuse any existing symbols for 
+                                    // this assembly
+                                    match = false;
+                                    break; // Stop processing references.
+                                }
 
-                                // Add the candidate COR library to the queue so that we consider it as a candidate.
-                                candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(corLibraryIndex, candidateCorLibrary));
+                                if (IsLinked(currentCandidateReferencedSymbol) != assemblies[definitionIndex].IsLinked)
+                                {
+                                    // Mismatch between reference kind.
+                                    match = false;
+                                    break; // Stop processing references.
+                                }
+
+                                // Add this reference to the queue so that we consider it as a candidate too 
+                                candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(definitionIndex, currentCandidateReferencedSymbol));
                             }
-                        }
-                    }
 
-                    if (match)
-                    {
-                        // Merge the set of symbols into result
-                        for (int k = 0; k < totalAssemblies; k++)
-                        {
-                            if (candidateInputAssemblySymbols[k] != null)
+                            // Check that the COR library used by the candidate assembly symbol is the same as the one use by this compilation.
+                            if (match)
                             {
-                                Debug.Assert(boundInputs[k].AssemblySymbol == null);
-                                boundInputs[k].AssemblySymbol = candidateInputAssemblySymbols[k];
+                                TAssemblySymbol? candidateCorLibrary = GetCorLibrary(candidate.AssemblySymbol);
+
+                                if (candidateCorLibrary == null)
+                                {
+                                    // If the candidate didn't have a COR library, that is fine as long as we don't have one either.
+                                    if (corLibraryIndex >= 0)
+                                    {
+                                        match = false;
+                                        break; // Stop processing references.
+                                    }
+                                }
+                                else
+                                {
+                                    // We can't be compiling corlib and have a corlib reference at the same time:
+                                    Debug.Assert(corLibraryIndex != 0);
+
+                                    Debug.Assert(ReferenceEquals(candidateCorLibrary, GetCorLibrary(candidateCorLibrary)));
+
+                                    // Candidate has COR library, we should have one too.
+                                    if (corLibraryIndex < 0)
+                                    {
+                                        match = false;
+                                        break; // Stop processing references.
+                                    }
+
+                                    // Make sure candidate COR library represent the same assembly/binary
+                                    if (!assemblies[corLibraryIndex].IsMatchingAssembly(candidateCorLibrary))
+                                    {
+                                        // Mismatch between versions?
+                                        match = false;
+                                        break; // Stop processing references.
+                                    }
+
+                                    Debug.Assert(!assemblies[corLibraryIndex].ContainsNoPiaLocalTypes);
+                                    Debug.Assert(!assemblies[corLibraryIndex].IsLinked);
+                                    Debug.Assert(!IsLinked(candidateCorLibrary));
+
+                                    // Add the candidate COR library to the queue so that we consider it as a candidate.
+                                    candidatesToExamine.Enqueue(new AssemblyReferenceCandidate(corLibraryIndex, candidateCorLibrary));
+                                }
                             }
                         }
 
-                        // No reason to examine other symbols for this assembly
-                        break; // Stop processing assemblies[i].AvailableSymbols
+                        if (match)
+                        {
+                            // Merge the set of symbols into result
+                            for (int k = 0; k < totalAssemblies; k++)
+                            {
+                                if (candidateInputAssemblySymbols[k] != null)
+                                {
+                                    Debug.Assert(boundInputs[k].AssemblySymbol == null);
+                                    boundInputs[k].AssemblySymbol = candidateInputAssemblySymbols[k];
+                                }
+                            }
+
+                            // No reason to examine other symbols for this assembly
+                            break; // Stop processing assemblies[i].AvailableSymbols
+                        }
                     }
                 }
+            }
+            finally
+            {
+                candidatesToExamine.Clear();
+                candidateReferencedSymbols.Clear();
+
+                s_candidatesToExaminePool.Free(candidatesToExamine);
+                s_candidateReferencedSymbolsPool.Free(candidateReferencedSymbols);
             }
         }
 


### PR DESCRIPTION
Addresses 0.7% of all allocations in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231238903-21b231f3-2257-40f2-9a44-abc6bd831a54.png)
