### PR TITLE
Reduce allocations in ComputeReverseReferences

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
             : this(
                   projectIds,
                   RemoveItemsWithEmptyValues(referencesMap),
-                  reverseReferencesMap: null,
+                  reverseReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
                   transitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
                   reverseTransitiveReferencesMap: ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
                   default,
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis
         private ProjectDependencyGraph(
             ImmutableHashSet<ProjectId> projectIds,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> referencesMap,
-            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? reverseReferencesMap,
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseReferencesMap,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> transitiveReferencesMap,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseTransitiveReferencesMap,
             ImmutableArray<ProjectId> topologicallySortedProjects,
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
 
             _projectIds = projectIds;
             _referencesMap = referencesMap;
-            _lazyReverseReferencesMap = reverseReferencesMap ?? ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty;
+            _lazyReverseReferencesMap = reverseReferencesMap;
             _transitiveReferencesMap = transitiveReferencesMap;
             _reverseTransitiveReferencesMap = reverseTransitiveReferencesMap;
             _lazyTopologicallySortedProjects = topologicallySortedProjects;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -454,11 +454,8 @@ namespace Microsoft.CodeAnalysis
         private static void ValidateReverseReferences(
             ImmutableHashSet<ProjectId> projectIds,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> forwardReferencesMap,
-            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? reverseReferencesMap)
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> reverseReferencesMap)
         {
-            if (reverseReferencesMap is null)
-                return;
-
             Debug.Assert(projectIds.Count >= reverseReferencesMap.Count);
             Debug.Assert(reverseReferencesMap.Keys.All(projectIds.Contains));
 
@@ -466,18 +463,19 @@ namespace Microsoft.CodeAnalysis
             {
                 foreach (var referencedProject in referencedProjects)
                 {
-                    Debug.Assert(reverseReferencesMap.ContainsKey(referencedProject));
-                    Debug.Assert(reverseReferencesMap[referencedProject].Contains(project));
+                    if (reverseReferencesMap.TryGetValue(referencedProject, out var reverseReferences))
+                    {
+                        Debug.Assert(reverseReferences.Contains(project));
+                    }
                 }
             }
 
             foreach (var (project, referencingProjects) in reverseReferencesMap)
             {
-                Debug.Assert(!referencingProjects.IsEmpty, "Unexpected empty value in the reverse references map.");
                 foreach (var referencingProject in referencingProjects)
                 {
-                    Debug.Assert(forwardReferencesMap.ContainsKey(referencingProject));
-                    Debug.Assert(forwardReferencesMap[referencingProject].Contains(project));
+                    Debug.Assert(forwardReferencesMap.TryGetValue(referencingProject, out var forwardReferences));
+                    Debug.Assert(forwardReferences.Contains(project));
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
@@ -74,15 +74,11 @@ namespace Microsoft.CodeAnalysis
         /// Computes a new <see cref="_lazyReverseReferencesMap"/> for the addition of additional project references.
         /// </summary>
         /// <param name="existingReverseReferencesMap">The previous <see cref="_lazyReverseReferencesMap"/>, or
-        /// <see langword="null"/> if the reverse references map was not computed for the previous graph.</param>
-        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? ComputeNewReverseReferencesMapForAdditionalProjectReferences(
-            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? existingReverseReferencesMap,
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseReferencesMapForAdditionalProjectReferences(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseReferencesMap,
             ProjectId projectId,
             IReadOnlyList<ProjectId> referencedProjectIds)
         {
-            if (existingReverseReferencesMap is null)
-                return null;
-
             var builder = existingReverseReferencesMap.ToBuilder();
 
             foreach (var referencedProject in referencedProjectIds)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
@@ -87,7 +87,10 @@ namespace Microsoft.CodeAnalysis
 
             foreach (var referencedProject in referencedProjectIds)
             {
-                builder.MultiAdd(referencedProject, projectId);
+                if (builder.ContainsKey(referencedProject))
+                {
+                    builder.MultiAdd(referencedProject, projectId);
+                }
             }
 
             return builder.ToImmutable();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_AddProjectReference.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Computes a new <see cref="_lazyReverseReferencesMap"/> for the addition of additional project references.
         /// </summary>
-        /// <param name="existingReverseReferencesMap">The previous <see cref="_lazyReverseReferencesMap"/>, or
+        /// <param name="existingReverseReferencesMap">The previous <see cref="_lazyReverseReferencesMap"/></param>
         private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseReferencesMapForAdditionalProjectReferences(
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseReferencesMap,
             ProjectId projectId,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph_RemoveProjectReference.cs
@@ -49,18 +49,12 @@ namespace Microsoft.CodeAnalysis
         /// or <see langword="null"/> if the reverse references map was not computed for the prior graph.</param>
         /// <param name="projectId">The project ID from which a project reference is being removed.</param>
         /// <param name="referencedProjectId">The target of the project reference which is being removed.</param>
-        /// <returns>The updated (complete) reverse references map, or <see langword="null"/> if the reverse references
-        /// map could not be incrementally updated.</returns>
-        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? ComputeNewReverseReferencesMapForRemovedProjectReference(
-            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>? existingReverseReferencesMap,
+        /// <returns>The updated reverse references map.</returns>
+        private static ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> ComputeNewReverseReferencesMapForRemovedProjectReference(
+            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> existingReverseReferencesMap,
             ProjectId projectId,
             ProjectId referencedProjectId)
         {
-            if (existingReverseReferencesMap is null)
-            {
-                return null;
-            }
-
             return existingReverseReferencesMap.MultiRemove(referencedProjectId, projectId);
         }
 


### PR DESCRIPTION
A recent regression was detected by a speedometer test where the non-devenv bytes allocated in Orchard regressed significantly. I've been unable to determine the direct cause of this regression, but I believe this change should gain back most, if not more, of the regression.

The issue addressed here is that a reverse mapping is cached upon first request for all projects in the project dependency graph. However, the actual reverse mapping is used for very few of the projects for which it's calculated and stored. The optimization here is to defer computing/storing such data for a project until it's requested for this ProjectDependencyGraph.

Profiling is not working well on my machine, so I can't gather before/after data, however, some measurements I gathered on my machine showed around 98% of entries in the dictionary didn't end up getting created for the Roslyn solution. As I've seen this as measured anywhere between 1.5 and 3 GB in the orchard profiles, I'm optimistic that we can remove a significant amount of memory allocations with this change.

*** Allocation information from speedometer test addressed by this PR ***
 
![image](https://user-images.githubusercontent.com/6785178/231303374-47a67c1f-5c18-44e6-a649-7b9dc3e3c884.png)
