### PR TITLE
WIP: Do not allocate conversion objects in common failure path

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -87,9 +87,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// any built-in or user-defined implicit conversion.
         /// </summary>
         public Conversion ClassifyImplicitConversionFromExpression(BoundExpression sourceExpression, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-            => ClassifyImplicitConversionFromExpression(defaultOnFailure: false, sourceExpression, destination, ref useSiteInfo);
+            => ClassifyImplicitConversionFromExpression(noConversionOnFailure: false, sourceExpression, destination, ref useSiteInfo);
 
-        public Conversion ClassifyImplicitConversionFromExpression(bool defaultOnFailure, BoundExpression sourceExpression, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public Conversion ClassifyImplicitConversionFromExpression(bool noConversionOnFailure, BoundExpression sourceExpression, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             Debug.Assert(sourceExpression != null);
             Debug.Assert(Compilation != null);
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            conversion = GetImplicitUserDefinedConversion(defaultOnFailure, sourceExpression, sourceType, destination, ref useSiteInfo);
+            conversion = GetImplicitUserDefinedConversion(noConversionOnFailure, sourceExpression, sourceType, destination, ref useSiteInfo);
             if (conversion.Exists)
             {
                 return conversion;
@@ -275,9 +275,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// In that circumstance, this method classifies the conversion as the implicit conversion or explicit depending on "forCast"
         /// </remarks>
         public Conversion ClassifyConversionFromExpression(BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast = false)
-            => ClassifyConversionFromExpression(defaultOnFailure: false, sourceExpression, destination, isChecked, ref useSiteInfo, forCast);
+            => ClassifyConversionFromExpression(noConversionOnFailure: false, sourceExpression, destination, isChecked, ref useSiteInfo, forCast);
 
-        public Conversion ClassifyConversionFromExpression(bool defaultOnFailure, BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast = false)
+        public Conversion ClassifyConversionFromExpression(bool noConversionOnFailure, BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast = false)
         {
             Debug.Assert(sourceExpression != null);
             Debug.Assert(Compilation != null);
@@ -293,13 +293,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return ClassifyConversionFromExpressionForCast(sourceExpression, destination, isChecked: isChecked, ref useSiteInfo);
             }
 
-            var result = ClassifyImplicitConversionFromExpression(defaultOnFailure, sourceExpression, destination, ref useSiteInfo);
+            var result = ClassifyImplicitConversionFromExpression(noConversionOnFailure, sourceExpression, destination, ref useSiteInfo);
             if (result.Exists)
             {
                 return result;
             }
 
-            return ClassifyExplicitOnlyConversionFromExpression(defaultOnFailure, sourceExpression, destination, isChecked: isChecked, ref useSiteInfo, forCast: false);
+            return ClassifyExplicitOnlyConversionFromExpression(noConversionOnFailure, sourceExpression, destination, isChecked: isChecked, ref useSiteInfo, forCast: false);
         }
 
         /// <summary>
@@ -758,18 +758,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.NoConversion;
         }
 
-        private Conversion GetImplicitUserDefinedConversion(bool defaultOnFailure, BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private Conversion GetImplicitUserDefinedConversion(bool noConversionOnFailure, BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var conversionResult = AnalyzeImplicitUserDefinedConversions(sourceExpression, source, destination, ref useSiteInfo);
-            if (defaultOnFailure && conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators)
-                return default;
+            if (noConversionOnFailure && conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators)
+                return Conversion.NoConversion;
 
             return new Conversion(conversionResult, isImplicit: true);
         }
 
         private Conversion GetImplicitUserDefinedConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            return GetImplicitUserDefinedConversion(defaultOnFailure: false, sourceExpression: null, source, destination, ref useSiteInfo);
+            return GetImplicitUserDefinedConversion(noConversionOnFailure: false, sourceExpression: null, source, destination, ref useSiteInfo);
         }
 
         private Conversion ClassifyExplicitBuiltInOnlyConversion(TypeSymbol source, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast)
@@ -846,18 +846,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.NoConversion;
         }
 
-        private Conversion GetExplicitUserDefinedConversion(bool defaultOnFailure, BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private Conversion GetExplicitUserDefinedConversion(bool noConversionOnFailure, BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             UserDefinedConversionResult conversionResult = AnalyzeExplicitUserDefinedConversions(sourceExpression, source, destination, isChecked: isChecked, ref useSiteInfo);
-            if (defaultOnFailure && conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators)
-                return default;
+            if (noConversionOnFailure && conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators)
+                return Conversion.NoConversion;
 
             return new Conversion(conversionResult, isImplicit: false);
         }
 
         private Conversion GetExplicitUserDefinedConversion(TypeSymbol source, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            return GetExplicitUserDefinedConversion(defaultOnFailure: false, sourceExpression: null, source, destination, isChecked, ref useSiteInfo);
+            return GetExplicitUserDefinedConversion(noConversionOnFailure: false, sourceExpression: null, source, destination, isChecked, ref useSiteInfo);
         }
 
         private Conversion DeriveStandardExplicitFromOppositeStandardImplicitConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
@@ -1337,9 +1337,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
 
         private Conversion ClassifyExplicitOnlyConversionFromExpression(BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast)
-            => ClassifyExplicitOnlyConversionFromExpression(defaultOnFailure: false, sourceExpression, destination, isChecked, ref useSiteInfo, forCast);
+            => ClassifyExplicitOnlyConversionFromExpression(noConversionOnFailure: false, sourceExpression, destination, isChecked, ref useSiteInfo, forCast);
 
-        private Conversion ClassifyExplicitOnlyConversionFromExpression(bool defaultOnFailure, BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast)
+        private Conversion ClassifyExplicitOnlyConversionFromExpression(bool noConversionOnFailure, BoundExpression sourceExpression, TypeSymbol destination, bool isChecked, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast)
         {
             Debug.Assert(sourceExpression != null);
             Debug.Assert(Compilation != null);
@@ -1376,7 +1376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return GetExplicitUserDefinedConversion(defaultOnFailure, sourceExpression, sourceType, destination, isChecked: isChecked, ref useSiteInfo);
+            return GetExplicitUserDefinedConversion(noConversionOnFailure, sourceExpression, sourceType, destination, isChecked: isChecked, ref useSiteInfo);
         }
 
         private static bool HasImplicitEnumerationConversion(BoundExpression source, TypeSymbol destination)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -776,15 +776,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hadApplicableCandidate = false;
             foreach (var op in operators)
             {
-                // Avoid excess allocations by passing 'defaultOnFailure' for the common path where we are checking all
+                // Avoid excess allocations by passing 'noConversionOnFailure' for the common path where we are checking all
                 // built in binary operators against these expressions.
-                var convLeft = Conversions.ClassifyConversionFromExpression(defaultOnFailure: true, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
-                var convRight = Conversions.ClassifyConversionFromExpression(defaultOnFailure: true, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
+                var convLeft = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: true, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
+                var convRight = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: true, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
                 if (convLeft.IsImplicit && convRight.IsImplicit)
                 {
                     // There were implicit conversions, so classify the conversions again, this time getting the true conversions with all information.
-                    convLeft = Conversions.ClassifyConversionFromExpression(defaultOnFailure: false, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
-                    convRight = Conversions.ClassifyConversionFromExpression(defaultOnFailure: false, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
+                    convLeft = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: false, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
+                    convRight = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: false, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
                     results.Add(BinaryOperatorAnalysisResult.Applicable(op, convLeft, convRight));
                     hadApplicableCandidate = true;
                 }
@@ -796,8 +796,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // information so we can report good errors.
                 foreach (var op in operators)
                 {
-                    var convLeft = Conversions.ClassifyConversionFromExpression(defaultOnFailure: false, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
-                    var convRight = Conversions.ClassifyConversionFromExpression(defaultOnFailure: false, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
+                    var convLeft = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: false, left, op.LeftType, isChecked: isChecked, ref useSiteInfo);
+                    var convRight = Conversions.ClassifyConversionFromExpression(noConversionOnFailure: false, right, op.RightType, isChecked: isChecked, ref useSiteInfo);
                     results.Add(BinaryOperatorAnalysisResult.Inapplicable(op, convLeft, convRight));
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67717

Seeing if this actually works.

Addresses almost 2.4% of all allocations in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231307211-5f1096bd-2286-42e2-aee6-5005a06a3f29.png)

What's going on here is that when the compiler is binding binary operators, it first does a fast-check against a table (i.e. it can quickly tell that `int+int` is legal).  If htat fast check fails,  it will fetch the *Entire* list of built-in binary operators (i.e. all the built-in operators for `+` when binding a `+`).  It will then compare the actual types being bound against those binary operators to see if the types could implicitly convert to the types the binary operator takes. 

However, in practice, this ends up with failures for *most* of those checks, succeeding on only one of them (since most code is correct and just has a single thing it binds to).  Unfortunately, all those failures cause a *lot* of allocations.  This PR changes things so that when we're doing this work, we first do a pass looking for success in a non-allocating fashion.  If we find any successful binary operators, we return them, allowing the higher level callers to proceed.  However, if we fail (the rare case as, again, code is normally all good), then we go and all all the failure information into the results so we can give good error messages higher up.