### PR TITLE
Avoid allocating UncommonData for common failure case

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -25,6 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         // in uncommon cases an instance of this class is attached to the conversion.
         private class UncommonData
         {
+            public static readonly UncommonData NoApplicableOperators = new UncommonData(
+                isExtensionMethod: false,
+                isArrayIndex: false,
+                conversionResult: UserDefinedConversionResult.NoApplicableOperators(ImmutableArray<UserDefinedConversionAnalysis>.Empty),
+                conversionMethod: null,
+                nestedConversions: default);
+
             public UncommonData(
                 bool isExtensionMethod,
                 bool isArrayIndex,
@@ -107,12 +114,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? ConversionKind.NoConversion
                 : isImplicit ? ConversionKind.ImplicitUserDefined : ConversionKind.ExplicitUserDefined;
 
-            _uncommonData = new UncommonData(
-                isExtensionMethod: false,
-                isArrayIndex: false,
-                conversionResult: conversionResult,
-                conversionMethod: null,
-                nestedConversions: default);
+            _uncommonData = conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators && conversionResult.Results.IsEmpty
+                ? UncommonData.NoApplicableOperators
+                : new UncommonData(
+                    isExtensionMethod: false,
+                    isArrayIndex: false,
+                    conversionResult: conversionResult,
+                    conversionMethod: null,
+                    nestedConversions: default);
         }
 
         // For the method group, lambda and anonymous method conversions


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67717

Seeing if this actually works.

Addresses almost 2.4% of all allocations in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231307211-5f1096bd-2286-42e2-aee6-5005a06a3f29.png)
