### PR TITLE
Cache constructed Nullable<T> types for built-ins and enums

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -475,9 +475,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)underlying != null);
             Debug.Assert(underlying.SpecialType != SpecialType.None);
 
-            var nullable = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
-            var nullableEnum = nullable.Construct(enumType);
-            var nullableUnderlying = nullable.Construct(underlying);
+            var nullableEnum = MakeNullable(enumType);
+            var nullableUnderlying = MakeNullable(underlying);
 
             switch (kind)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private NamedTypeSymbol MakeNullable(TypeSymbol type)
         {
-            return Compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(type);
+            return Compilation.GetOrCreateNullableType(type);
         }
 
         public void UnaryOperatorOverloadResolution(UnaryOperatorKind kind, bool isChecked, BoundExpression operand, UnaryOperatorOverloadResolutionResult result, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -1564,6 +1565,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(result.SpecialType == specialType);
             return result;
         }
+
+        /// <summary>
+        /// Cache of T to Nullable&lt;T&gt;.
+        /// </summary>
+        private ImmutableSegmentedDictionary<TypeSymbol, NamedTypeSymbol> _typeToNullableVersion = ImmutableSegmentedDictionary<TypeSymbol, NamedTypeSymbol>.Empty;
+
+        internal NamedTypeSymbol GetOrCreateNullableType(TypeSymbol typeArgument)
+            => RoslynImmutableInterlocked.GetOrAdd(
+                ref _typeToNullableVersion,
+                typeArgument,
+                static (typeArgument, @this) => @this.GetSpecialType(SpecialType.System_Nullable_T).Construct(typeArgument),
+                this);
 
         /// <summary>
         /// Get the symbol for the predefined type member from the COR Library referenced by this compilation.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -1558,9 +1558,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression MakeNewNullableBoolean(SyntaxNode syntax, bool? value)
         {
-            NamedTypeSymbol nullableType = _compilation.GetSpecialType(SpecialType.System_Nullable_T);
             TypeSymbol boolType = _compilation.GetSpecialType(SpecialType.System_Boolean);
-            NamedTypeSymbol nullableBoolType = nullableType.Construct(boolType);
+            NamedTypeSymbol nullableBoolType = _compilation.GetOrCreateNullableType(boolType);
             if (value == null)
             {
                 return new BoundDefaultExpression(syntax, nullableBoolType);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (binaryOperatorKind.IsLifted())
             {
-                binaryOperandType = _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(binaryOperandType);
+                binaryOperandType = _compilation.GetOrCreateNullableType(binaryOperandType);
                 MethodSymbol ctor = UnsafeGetNullableMethod(node.Syntax, binaryOperandType, SpecialMember.System_Nullable_T__ctor);
                 boundOne = new BoundObjectCreationExpression(node.Syntax, ctor, boundOne);
             }


### PR DESCRIPTION
Addresses 0.7% of all allocations in a simple typing/lightbulb scenario:

Compiler routinely goes through all the built in operators and generates lifted versions of them (similarly for enum operators).  This just caches those Nullable<T> instances for a particular T to produce far less garbage while processing.

![image](https://user-images.githubusercontent.com/4564579/231334431-2ba5f08e-6c37-4fc6-ada8-e270fe91cf29.png)
