### PR TITLE
Pool node collections in formatter

### DIFF
--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         // than "new T()".
         private readonly Factory _factory;
 
+        public readonly bool TrimOnFree;
+
 #if DETECT_LEAKS
         private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
 
@@ -104,15 +106,17 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 #endif      
 
-        internal ObjectPool(Factory factory)
-            : this(factory, Environment.ProcessorCount * 2)
-        { }
+        internal ObjectPool(Factory factory, bool trimOnFree = true)
+            : this(factory, Environment.ProcessorCount * 2, trimOnFree)
+        {
+        }
 
-        internal ObjectPool(Factory factory, int size)
+        internal ObjectPool(Factory factory, int size, bool trimOnFree = true)
         {
             Debug.Assert(size >= 1);
             _factory = factory;
             _items = new Element[size - 1];
+            TrimOnFree = trimOnFree;
         }
 
         internal ObjectPool(Func<ObjectPool<T>, T> factory, int size)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis
             pool.Free(list);
         }
 
-        public static void ClearAndFree<T>(this ObjectPool<SegmentedList<T>> pool, SegmentedList<T> list)
+        public static void ClearAndFree<T>(this ObjectPool<SegmentedList<T>> pool, SegmentedList<T> list, bool trim = true)
         {
             if (list == null)
             {
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis
 
             list.Clear();
 
-            if (list.Capacity > Threshold)
+            if (trim && list.Capacity > Threshold)
             {
                 list.Capacity = Threshold;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
             => pool.AllocateAndClear();
 
         private static void Releaser<TItem>(ObjectPool<SegmentedList<TItem>> pool, SegmentedList<TItem> obj)
-            => pool.ClearAndFree(obj);
+            => pool.ClearAndFree(obj, pool.TrimOnFree);
         #endregion
     }
 }


### PR DESCRIPTION
Addresses 0.3% of all allocations during typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231537409-4f6322df-2f24-4293-a6d7-59be69414a0f.png)
