### PR TITLE
Pool more formatting collections

### DIFF
--- a/src/Dependencies/PooledObjects/ObjectPool`1.cs
+++ b/src/Dependencies/PooledObjects/ObjectPool`1.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         // than "new T()".
         private readonly Factory _factory;
 
+        public readonly bool TrimOnFree;
+
 #if DETECT_LEAKS
         private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
 
@@ -104,15 +106,17 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         }
 #endif      
 
-        internal ObjectPool(Factory factory)
-            : this(factory, Environment.ProcessorCount * 2)
-        { }
+        internal ObjectPool(Factory factory, bool trimOnFree = true)
+            : this(factory, Environment.ProcessorCount * 2, trimOnFree)
+        {
+        }
 
-        internal ObjectPool(Factory factory, int size)
+        internal ObjectPool(Factory factory, int size, bool trimOnFree = true)
         {
             Debug.Assert(size >= 1);
             _factory = factory;
             _items = new Element[size - 1];
+            TrimOnFree = trimOnFree;
         }
 
         internal ObjectPool(Func<ObjectPool<T>, T> factory, int size)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         // files as we edit them and this will produce a lot of garbage as we free the internal array backing the list
         // over and over again.
         private static readonly ObjectPool<SegmentedList<SyntaxNode>> s_nodeIteratorPool = new(() => new(), trimOnFree: false);
+        private static readonly ObjectPool<SegmentedList<TokenPairWithOperations>> s_tokenPairListPool = new(() => new(), trimOnFree: false);
 
         private readonly ChainedFormattingRules _formattingRules;
 
@@ -94,7 +95,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                 var nodeOperations = CreateNodeOperations(cancellationToken);
 
                 var tokenStream = new TokenStream(this.TreeData, Options, this.SpanToFormat, CreateTriviaFactory());
-                var tokenOperation = CreateTokenOperation(tokenStream, cancellationToken);
+                using var tokenOperations = s_tokenPairListPool.GetPooledObject();
+                AddTokenOperations(tokenStream, tokenOperations.Object, cancellationToken);
 
                 // initialize context
                 var context = CreateFormattingContext(tokenStream, cancellationToken);
@@ -107,8 +109,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                 ApplyBeginningOfTreeTriviaOperation(context, cancellationToken);
 
-                ApplyTokenOperations(context, nodeOperations,
-                    tokenOperation, cancellationToken);
+                ApplyTokenOperations(context, nodeOperations, tokenOperations.Object, cancellationToken);
 
                 ApplyTriviaOperations(context, cancellationToken);
 
@@ -202,17 +203,15 @@ namespace Microsoft.CodeAnalysis.Formatting
             return operations;
         }
 
-        private SegmentedArray<TokenPairWithOperations> CreateTokenOperation(
+        private void AddTokenOperations(
             TokenStream tokenStream,
+            SegmentedList<TokenPairWithOperations> list,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             using (Logger.LogBlock(FunctionId.Formatting_CollectTokenOperation, cancellationToken))
             {
-                // pre-allocate list once. this is cheaper than re-adjusting list as items are added.
-                var list = new SegmentedArray<TokenPairWithOperations>(tokenStream.TokenCount - 1);
-
                 foreach (var (index, currentToken, nextToken) in tokenStream.TokenIterator)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -220,17 +219,15 @@ namespace Microsoft.CodeAnalysis.Formatting
                     var spaceOperation = _formattingRules.GetAdjustSpacesOperation(currentToken, nextToken);
                     var lineOperation = _formattingRules.GetAdjustNewLinesOperation(currentToken, nextToken);
 
-                    list[index] = new TokenPairWithOperations(tokenStream, index, spaceOperation, lineOperation);
+                    list.Add(new TokenPairWithOperations(tokenStream, index, spaceOperation, lineOperation));
                 }
-
-                return list;
             }
         }
 
         private void ApplyTokenOperations(
             FormattingContext context,
             NodeOperations nodeOperations,
-            SegmentedArray<TokenPairWithOperations> tokenOperations,
+            SegmentedList<TokenPairWithOperations> tokenOperations,
             CancellationToken cancellationToken)
         {
             var applier = new OperationApplier(context, _formattingRules);
@@ -358,7 +355,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private static void ApplyAnchorOperations(
             FormattingContext context,
-            SegmentedArray<TokenPairWithOperations> tokenOperations,
+            SegmentedList<TokenPairWithOperations> tokenOperations,
             OperationApplier applier,
             CancellationToken cancellationToken)
         {
@@ -370,9 +367,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (!AnchorOperationCandidate(p))
-                    {
                         continue;
-                    }
 
                     var pairIndex = p.PairIndex;
                     applier.ApplyAnchorIndentation(pairIndex, previousChangesMap, cancellationToken);
@@ -415,7 +410,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private static void ApplySpaceAndWrappingOperations(
             FormattingContext context,
-            SegmentedArray<TokenPairWithOperations> tokenOperations,
+            SegmentedList<TokenPairWithOperations> tokenOperations,
             OperationApplier applier,
             CancellationToken cancellationToken)
         {
@@ -423,9 +418,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 // go through each token pairs and apply operations
                 foreach (var operationPair in tokenOperations)
-                {
                     ApplySpaceAndWrappingOperationsBody(context, operationPair, applier, cancellationToken);
-                }
             }
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.Iterator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.Iterator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Formatting
@@ -12,20 +10,17 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         // gain of having hand written iterator seems about 50-100ms over auto generated one.
         // not sure whether it is worth it. but I already wrote it to test, so going to just keep it.
-        private class Iterator : IEnumerable<(int index, SyntaxToken currentToken, SyntaxToken nextToken)>
+        public readonly struct Iterator
         {
             private readonly SegmentedList<SyntaxToken> _tokensIncludingZeroWidth;
 
             public Iterator(SegmentedList<SyntaxToken> tokensIncludingZeroWidth)
                 => _tokensIncludingZeroWidth = tokensIncludingZeroWidth;
 
-            public IEnumerator<(int index, SyntaxToken currentToken, SyntaxToken nextToken)> GetEnumerator()
-                => new Enumerator(_tokensIncludingZeroWidth);
+            public Enumerator GetEnumerator()
+                => new(_tokensIncludingZeroWidth);
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-                => GetEnumerator();
-
-            private struct Enumerator : IEnumerator<(int index, SyntaxToken currentToken, SyntaxToken nextToken)>
+            public struct Enumerator
             {
                 private readonly SegmentedList<SyntaxToken> _tokensIncludingZeroWidth;
                 private readonly int _maxCount;
@@ -40,10 +35,6 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                     _index = 0;
                     _current = default;
-                }
-
-                public readonly void Dispose()
-                {
                 }
 
                 public bool MoveNext()
@@ -66,25 +57,6 @@ namespace Microsoft.CodeAnalysis.Formatting
                 }
 
                 public readonly (int index, SyntaxToken currentToken, SyntaxToken nextToken) Current => _current;
-
-                readonly object System.Collections.IEnumerator.Current
-                {
-                    get
-                    {
-                        if (_index == 0 || _index == _maxCount + 1)
-                        {
-                            throw new InvalidOperationException();
-                        }
-
-                        return Current;
-                    }
-                }
-
-                void System.Collections.IEnumerator.Reset()
-                {
-                    _index = 0;
-                    _current = new ValueTuple<int, SyntaxToken, SyntaxToken>();
-                }
             }
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
@@ -550,13 +550,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             return -1;
         }
 
-        public IEnumerable<(int index, SyntaxToken currentToken, SyntaxToken nextToken)> TokenIterator
-        {
-            get
-            {
-                return new Iterator(_tokens);
-            }
-        }
+        public Iterator TokenIterator
+            => new(_tokens);
 
         private sealed class TokenOrderComparer : IComparer<SyntaxToken>
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis
             pool.Free(list);
         }
 
-        public static void ClearAndFree<T>(this ObjectPool<SegmentedList<T>> pool, SegmentedList<T> list)
+        public static void ClearAndFree<T>(this ObjectPool<SegmentedList<T>> pool, SegmentedList<T> list, bool trim = true)
         {
             if (list == null)
             {
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis
 
             list.Clear();
 
-            if (list.Capacity > Threshold)
+            if (trim && list.Capacity > Threshold)
             {
                 list.Capacity = Threshold;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
             => pool.AllocateAndClear();
 
         private static void Releaser<TItem>(ObjectPool<SegmentedList<TItem>> pool, SegmentedList<TItem> obj)
-            => pool.ClearAndFree(obj);
+            => pool.ClearAndFree(obj, pool.TrimOnFree);
         #endregion
     }
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/67775.

Addresses 0.7% allocations in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/231550572-daa20658-65c9-4c6c-b55f-e4e7c871fc49.png)
