### PR TITLE
Only modify the linked document once in LSP code action

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -108,6 +108,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 }
 
                 var changes = applyChangesOperation.ChangedSolution.GetChanges(solution);
+                var newSolution = await applyChangesOperation.ChangedSolution.WithMergedLinkedFileChangesAsync(solution, changes, cancellationToken: cancellationToken).ConfigureAwait(false);
+                changes = newSolution.GetChanges(solution);
+
                 var projectChanges = changes.GetProjectChanges();
 
                 // Don't apply changes in the presence of any non-document changes for now.  Note though that LSP does
@@ -204,34 +207,34 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // Added documents
                 await AddTextDocumentAdditionsAsync(
                     projectChanges.SelectMany(pc => pc.GetAddedDocuments()),
-                    applyChangesOperation.ChangedSolution.GetDocument).ConfigureAwait(false);
+                    newSolution.GetDocument).ConfigureAwait(false);
 
                 // Added analyzer config documents
                 await AddTextDocumentAdditionsAsync(
                     projectChanges.SelectMany(pc => pc.GetAddedAnalyzerConfigDocuments()),
-                    applyChangesOperation.ChangedSolution.GetAnalyzerConfigDocument).ConfigureAwait(false);
+                    newSolution.GetAnalyzerConfigDocument).ConfigureAwait(false);
 
                 // Added additional documents
                 await AddTextDocumentAdditionsAsync(
                     projectChanges.SelectMany(pc => pc.GetAddedAdditionalDocuments()),
-                    applyChangesOperation.ChangedSolution.GetAdditionalDocument).ConfigureAwait(false);
+                    newSolution.GetAdditionalDocument).ConfigureAwait(false);
 
                 // Changed documents
                 await AddTextDocumentEditsAsync(
                     projectChanges.SelectMany(pc => pc.GetChangedDocuments()),
-                    applyChangesOperation.ChangedSolution.GetDocument,
+                    newSolution.GetDocument,
                     solution.GetDocument).ConfigureAwait(false);
 
                 // Changed analyzer config documents
                 await AddTextDocumentEditsAsync(
                     projectChanges.SelectMany(pc => pc.GetChangedAnalyzerConfigDocuments()),
-                    applyChangesOperation.ChangedSolution.GetAnalyzerConfigDocument,
+                    newSolution.GetAnalyzerConfigDocument,
                     solution.GetAnalyzerConfigDocument).ConfigureAwait(false);
 
                 // Changed additional documents
                 await AddTextDocumentEditsAsync(
                     projectChanges.SelectMany(pc => pc.GetChangedAdditionalDocuments()),
-                    applyChangesOperation.ChangedSolution.GetAdditionalDocument,
+                    newSolution.GetAdditionalDocument,
                     solution.GetAdditionalDocument).ConfigureAwait(false);
             }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
@@ -136,6 +136,109 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
             AssertJsonEquals(expectedResolvedAction, actualResolvedAction);
         }
 
+        [WpfTheory, CombinatorialData]
+        public async Task Test(bool mutatingLspWorkspace)
+        {
+            var xmlWorkspace = @"
+                <Workspace>
+                    <Project Language='C#' CommonReferences='true' AssemblyName='LinkedProj' Name='CSProj.1'>
+                        <Document FilePath='C:\C.cs'>class C
+{
+    public static readonly int {|caret:_value|} = 10;
+}
+                        </Document>
+                    </Project>
+                    <Project Language='C#' CommonReferences='true' AssemblyName='LinkedProj' Name='CSProj.2'>
+                        <Document IsLinkFile='true' LinkProjectName='CSProj.1' LinkFilePath='C:\C.cs'/>
+                    </Project>
+                </Workspace>
+";
+            await using var testLspServer = await CreateXmlTestLspServerAsync(xmlWorkspace, mutatingLspWorkspace);
+
+            var unresolvedCodeAction = CodeActionsTests.CreateCodeAction(
+                title: string.Format(FeaturesResources.Encapsulate_field_colon_0_and_use_property, "_value"),
+                kind: CodeActionKind.Refactor,
+                children: Array.Empty<LSP.VSInternalCodeAction>(),
+                data: CreateCodeActionResolveData(
+                    string.Format(FeaturesResources.Encapsulate_field_colon_0_and_use_property, "_value"),
+                    testLspServer.GetLocations("caret").Single()),
+                priority: VSInternalPriorityLevel.Normal,
+                groupName: "Roslyn2",
+                applicableRange: new LSP.Range { Start = new Position { Line = 2, Character = 33 }, End = new Position { Line = 39, Character = 2 } },
+                diagnostics: null);
+
+            var actualResolvedAction = await RunGetCodeActionResolveAsync(testLspServer, unresolvedCodeAction);
+            var edits = new TextEdit[]
+            {
+                new TextEdit()
+                {
+                    NewText = "private",
+                    Range = new LSP.Range()
+                    {
+                        Start = new Position
+                        {
+                            Line = 2,
+                            Character = 4
+                        },
+                        End = new Position
+                        {
+                            Line = 2,
+                            Character = 10
+                        }
+                    }
+                },
+                new TextEdit
+                {
+                    NewText = string.Empty,
+                    Range = new LSP.Range
+                    {
+                        Start = new Position
+                        {
+                            Line = 2,
+                            Character = 31
+                        },
+                        End = new Position
+                        {
+                            Line = 2,
+                            Character = 32
+                        }
+                    }
+                },
+                new TextEdit
+                {
+                    NewText = @"
+
+    public static int Value => value;",
+                    Range = new LSP.Range
+                    {
+                        Start = new Position
+                        {
+                            Line = 2,
+                            Character = 43
+                        },
+                        End = new Position
+                        {
+                            Line = 2,
+                            Character = 43
+                        }
+                    }
+                }
+            };
+            var expectedCodeAction = CodeActionsTests.CreateCodeAction(
+                title: string.Format(FeaturesResources.Encapsulate_field_colon_0_and_use_property, "_value"),
+                kind: CodeActionKind.Refactor,
+                children: Array.Empty<LSP.VSInternalCodeAction>(),
+                data: CreateCodeActionResolveData(
+                    string.Format(FeaturesResources.Encapsulate_field_colon_0_and_use_property, "_value"),
+                    testLspServer.GetLocations("caret").Single()),
+                priority: VSInternalPriorityLevel.Normal,
+                groupName: "Roslyn2",
+                applicableRange: new LSP.Range { Start = new Position { Line = 2, Character = 33 }, End = new Position { Line = 39, Character = 2 } },
+                diagnostics: null,
+                edit: GenerateWorkspaceEdit(testLspServer.GetLocations("caret"), edits));
+            AssertJsonEquals(expectedCodeAction, actualResolvedAction);
+        }
+
         private static async Task<LSP.VSInternalCodeAction> RunGetCodeActionResolveAsync(
             TestLspServer testLspServer,
             VSInternalCodeAction unresolvedCodeAction)


### PR DESCRIPTION
Currently, the LSP code action handler would generate code action based on the different documents in the solution.
Basically, it is mapping document changes to LSP `Uri` and `TextDocumentEdits`.

However, if the document lives in an multi-TFM project, and the code refactoring handler is generating the code action by calling `GetLinkedDocuments()`(Example, https://github.com/dotnet/roslyn/blob/f0f0a97928c545fa14b9797f97b98f499638f6b0/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs#L182) , the LSP code action hander would generate the same document edits multiple times, 
And this is not allowed in LSP. 

<img width="548" alt="image" src="https://user-images.githubusercontent.com/24360909/231598996-623171af-3eed-47b9-b848-7a3811512a67.png">


