### PR TITLE
Fixing source build

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -105,8 +105,8 @@
     <Otherwise>
       <PropertyGroup>
         <SourceBuildToolsetTargetFramework>net6.0</SourceBuildToolsetTargetFramework>
-        <SourceBuildToolsetTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
-        <SourceBuildTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildTargetFrameworks>
+        <SourceBuildToolsetTargetFrameworks>$(SourceBuildToolsetTargetFramework);net7.0</SourceBuildToolsetTargetFrameworks>
+        <SourceBuildTargetFrameworks>$(SourceBuildToolsetTargetFrameworks)</SourceBuildTargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -59,13 +59,13 @@
   -->
   <Choose>
     <!-- 
-      CI source build leg: this needs to build the current and previous source build TFM. Both are 
-      necessary as the output of this leg is used in other CI source build legs. Those could be 
-      targeting NetCurrent or NetPrevious hence we must produce both. 
-          
-      However the toolset package we produce must target NetPrevious. This package gets used as the 
-      bootstrap toolset in other repos doing (1). Those can be using a NetPrevious runtime hence 
-      the toolset must support that.
+      1. CI source build leg: this needs to build the current and previous source build TFM. Both are 
+         necessary as the output of this leg is used in other CI source build legs. Those could be 
+         targeting NetCurrent or NetPrevious hence we must produce both. 
+
+        However the toolset package we produce must target NetPrevious. This package gets used as the 
+        bootstrap toolset in other repos doing (1). Those can be using a NetPrevious runtime hence 
+        the toolset must support that.
     -->
     <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
       <PropertyGroup>
@@ -76,7 +76,7 @@
     </When>
 
     <!--
-      Source build the product: this is the all up build of the product which needs only NetCurrent
+      2. Source build the product: this is the all up build of the product which needs only NetCurrent
     -->
     <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
       <PropertyGroup>
@@ -87,8 +87,8 @@
     </When>
 
     <!--
-      CI normal leg: this needs to build the union of all TFM we support. That ensures we handle all 
-      diagnostics and analyzers for all the TFM that we support.
+      3. CI normal leg: this needs to build the union of all TFMs we support. That ensures we handle all 
+         diagnostics and analyzers for all the TFMs that we support.
     -->
     <When Condition="'$(ContinuousIntegrationBuild)' == 'true'">
       <PropertyGroup>
@@ -99,8 +99,8 @@
     </When>
 
     <!-- 
-      Developer build: we do not want to build TFM that are necessary only for source build as
-      it increses build time.
+      4. Developer build: we do not want to build TFMs that are necessary only for source build as
+         it increases build time.
     -->
     <Otherwise>
       <PropertyGroup>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -51,25 +51,65 @@
     <PublishWindowsPdb>false</PublishWindowsPdb>
     <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
     <EnforceExtendedAnalyzerRules Condition="'$(IsAnalyzer)' == 'true'">true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <!-- 
+    There are effectively four modes that are needed for our source build TFMs and this is where
+    we calculate them
+  -->
+  <Choose>
+    <!-- 
+      CI source build leg: this needs to build the current and previous source build TFM. Both are 
+      necessary as the output of this leg is used in other CI source build legs. Those could be 
+      targeting NetCurrent or NetPrevious hence we must produce both. 
+          
+      However the toolset package we produce must target NetPrevious. This package gets used as the 
+      bootstrap toolset in other repos doing (1). Those can be using a NetPrevious runtime hence 
+      the toolset must support that.
+    -->
+    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+      <PropertyGroup>
+        <SourceBuildToolsetTargetFramework>$(NetPrevious)</SourceBuildToolsetTargetFramework>
+        <SourceBuildToolsetTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
+        <SourceBuildTargetFrameworks>$(NetCurrent);$(NetPrevious)</SourceBuildTargetFrameworks>
+      </PropertyGroup>
+    </When>
+
+    <!--
+      Source build the product: this is the all up build of the product which needs only NetCurrent
+    -->
+    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
+      <PropertyGroup>
+        <SourceBuildToolsetTargetFramework>$(NetCurrent)</SourceBuildToolsetTargetFramework>
+        <SourceBuildToolsetTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
+        <SourceBuildTargetFrameworks>$(NetCurrent)</SourceBuildTargetFrameworks>
+      </PropertyGroup>
+    </When>
+
+    <!--
+      CI normal leg: this needs to build the union of all TFM we support. That ensures we handle all 
+      diagnostics and analyzers for all the TFM that we support.
+    -->
+    <When Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+      <PropertyGroup>
+        <SourceBuildToolsetTargetFramework>net6.0</SourceBuildToolsetTargetFramework>
+        <SourceBuildToolsetTargetFrameworks>$(NetCurrent);$(NetPrevious);$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
+        <SourceBuildTargetFrameworks>$(SourceBuildToolsetTargetFrameworks)</SourceBuildTargetFrameworks>
+      </PropertyGroup>
+    </When>
 
     <!-- 
-      There are effectively three modes that are needed for our source build TFMs
-        - CI normal leg: this needs to build the union of all TFM we support. That ensures we handle all 
-          diagnostics and analyzers for all the TFM that we support.
-        - CI source build leg: this needs to build the current and previous source build TFM. Both are 
-          necessary as the output of this leg is used in other CI source build legs. Those could be 
-          targeting NetCurrent or NetPrevious hence we must produce both.
-        - Source build the product: this is the all up build of the product which needs only NetCurrent
+      Developer build: we do not want to build TFM that are necessary only for source build as
+      it increses build time.
     -->
-    <SourceBuildTargetFrameworks></SourceBuildTargetFrameworks>
-    <SourceBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">$(NetCurrent)</SourceBuildTargetFrameworks>
-    <SourceBuildTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">$(NetCurrent);$(NetPrevious)</SourceBuildTargetFrameworks>
-    <SourceBuildTargetFrameworks Condition="'$(SourceBuildTargetFrameworks)' == '' AND '$(ContinuousIntegrationBuild)' == 'true'">$(NetCurrent);$(NetPrevious);net6.0</SourceBuildTargetFrameworks>
-    <SourceBuildTargetFrameworks Condition="'$(SourceBuildTargetFrameworks)' == ''">net6.0</SourceBuildTargetFrameworks>
-
-    <SourceBuildTargetFrameworksNetFx>$(SourceBuildTargetFrameworks)</SourceBuildTargetFrameworksNetFx>
-    <SourceBuildTargetFrameworksNetFx Condition="'$(DotNetBuildFromSource)' != 'true'">$(SourceBuildTargetFrameworksNetFx);net472</SourceBuildTargetFrameworksNetFx>
-  </PropertyGroup>
+    <Otherwise>
+      <PropertyGroup>
+        <SourceBuildToolsetTargetFramework>net6.0</SourceBuildToolsetTargetFramework>
+        <SourceBuildToolsetTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
+        <SourceBuildTargetFrameworks>$(SourceBuildToolsetTargetFramework)</SourceBuildTargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <!--
     Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.

--- a/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
+++ b/src/Compilers/CSharp/csc/AnyCpu/csc.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -6,7 +6,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.BuildTasks</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!--

--- a/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/AnyCpu/VBCSCompiler.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>

--- a/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/AnyCpu/vbc.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>CSharpInteractive</RootNamespace>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
   </PropertyGroup>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <StartupObject>Sub Main</StartupObject>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks)</TargetFrameworks>
     <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
     <RootNamespace></RootNamespace>
     <IsShipping>false</IsShipping>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/AnyCpu/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -1,8 +1,7 @@
 ﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>net472;$(SourceBuildToolsetTargetFramework)</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.Net.Compilers.Toolset</NuspecPackageId>

--- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
+++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(SourceBuildTargetFrameworksNetFx)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildTargetFrameworks);net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants);WORKSPACE_MSBUILD</DefineConstants>
     <!-- NuGet -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
The Microsoft.Net.Compilers.Toolset package produced from our source build CI leg is the toolset used by other repos as part of their CI build. Those legs can be running on a previous or current .NET SDK / runtime. That means to workin all scenarios our toolset package in the CI leg must target previous runtime / SDK.

This is starting to produce an unwieldy amount of MSBuild properties for our target frameworks. I decided to remove the `NetFx` one to cut down on the complexity a bit. Source build already has solutions for stripping out `net472`. For the moment removing our custom solution to simplify a bit so I can get source build off the floor. Can revisit once we get back to a clean state.