### PR TITLE
Revert "Use dictionary lookup while resolving assembly references (#6…

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -919,9 +919,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 public override AssemblyReferenceBinding[] BindAssemblyReferences(
-                    MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)> assemblies, AssemblyIdentityComparer assemblyIdentityComparer)
+                    ImmutableArray<AssemblyData> assemblies, AssemblyIdentityComparer assemblyIdentityComparer)
                 {
-                    return ResolveReferencedAssemblies(_referencedAssemblies, assemblies, resolveAgainstAssemblyBeingBuilt: true, assemblyIdentityComparer: assemblyIdentityComparer);
+                    return ResolveReferencedAssemblies(_referencedAssemblies, assemblies, definitionStartIndex: 0, assemblyIdentityComparer: assemblyIdentityComparer);
                 }
 
                 public sealed override bool IsLinked

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityExtensions.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityExtensions.cs
@@ -18,13 +18,11 @@ namespace Microsoft.CodeAnalysis
                 identity.Name.StartsWith("windows.", StringComparison.OrdinalIgnoreCase);
         }
 
-        internal const string WindowsRuntimeIdentitySimpleName = "windows";
-
         // Windows[.winmd]
         internal static bool IsWindowsRuntime(this AssemblyIdentity identity)
         {
             return (identity.ContentType == AssemblyContentType.WindowsRuntime) &&
-                string.Equals(identity.Name, WindowsRuntimeIdentitySimpleName, StringComparison.OrdinalIgnoreCase);
+                string.Equals(identity.Name, "windows", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -49,13 +48,13 @@ namespace Microsoft.CodeAnalysis
             /// In other words, match assembly identities returned by AssemblyReferences property against 
             /// assemblies described by provided AssemblyData objects.
             /// </summary>
-            /// <param name="assemblies">AssemblyData objects to match against.</param>
+            /// <param name="assemblies">An array of AssemblyData objects to match against.</param>
             /// <param name="assemblyIdentityComparer">Used to compare assembly identities.</param>
             /// <returns>
             /// For each assembly referenced by this assembly (<see cref="AssemblyReferences"/>) 
             /// a description of how it binds to one of the input assemblies.
             /// </returns>
-            public abstract AssemblyReferenceBinding[] BindAssemblyReferences(MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)> assemblies, AssemblyIdentityComparer assemblyIdentityComparer);
+            public abstract AssemblyReferenceBinding[] BindAssemblyReferences(ImmutableArray<AssemblyData> assemblies, AssemblyIdentityComparer assemblyIdentityComparer);
 
             public abstract bool ContainsNoPiaLocalTypes { get; }
 
@@ -70,17 +69,6 @@ namespace Microsoft.CodeAnalysis
             public abstract Compilation? SourceCompilation { get; }
 
             private string GetDebuggerDisplay() => $"{GetType().Name}: [{Identity.GetDisplayName()}]";
-#if DEBUG
-            public sealed override bool Equals(object? obj)
-            {
-                return base.Equals(obj);
-            }
-
-            public sealed override int GetHashCode()
-            {
-                return base.GetHashCode();
-            }
-#endif
         }
     }
 }

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
@@ -75,16 +75,19 @@ namespace Microsoft.CodeAnalysis
             }
 
             public override AssemblyReferenceBinding[] BindAssemblyReferences(
-                MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)> assemblies,
+                ImmutableArray<AssemblyData> assemblies,
                 AssemblyIdentityComparer assemblyIdentityComparer)
             {
                 var boundReferences = new AssemblyReferenceBinding[_referencedAssemblies.Length];
 
                 for (int i = 0; i < _referencedAssemblyData.Length; i++)
                 {
-                    Debug.Assert(assemblies[_referencedAssemblyData[i].Identity.Name].Contains((_referencedAssemblyData[i], i + 1)));
-                    boundReferences[i] = new AssemblyReferenceBinding(_referencedAssemblyData[i].Identity, i + 1);
+                    Debug.Assert(ReferenceEquals(_referencedAssemblyData[i], assemblies[i + 1]));
+                    boundReferences[i] = new AssemblyReferenceBinding(assemblies[i + 1].Identity, i + 1);
                 }
+
+                // references from added modules shouldn't resolve against the assembly being built (definition #0)
+                const int definitionStartIndex = 1;
 
                 // resolve references coming from linked modules:
                 for (int i = _referencedAssemblyData.Length; i < _referencedAssemblies.Length; i++)
@@ -92,7 +95,7 @@ namespace Microsoft.CodeAnalysis
                     boundReferences[i] = ResolveReferencedAssembly(
                         _referencedAssemblies[i],
                         assemblies,
-                        resolveAgainstAssemblyBeingBuilt: false, // references from added modules shouldn't resolve against the assembly being built (definition #0)
+                        definitionStartIndex,
                         assemblyIdentityComparer);
                 }
 

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis
         ///
         /// -    Result of resolving assembly references of the corresponding assembly 
         ///     against provided set of assembly definitions. Essentially, this is an array returned by
-        ///     <see cref="AssemblyData.BindAssemblyReferences"/> method.
+        ///     <see cref="AssemblyData.BindAssemblyReferences(ImmutableArray{AssemblyData}, AssemblyIdentityComparer)"/> method.
         /// </return>
         protected BoundInputAssembly[] Bind(
             ImmutableArray<AssemblyData> explicitAssemblies,
@@ -110,25 +110,17 @@ namespace Microsoft.CodeAnalysis
             var referenceBindings = ArrayBuilder<AssemblyReferenceBinding[]>.GetInstance();
             try
             {
-                var explicitAssembliesMap = new MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)>(explicitAssemblies.Length, AssemblyIdentityComparer.SimpleNameComparer);
-
-                for (int i = 0; i < explicitAssemblies.Length; i++)
-                {
-                    explicitAssembliesMap.Add(explicitAssemblies[i].Identity.Name, (explicitAssemblies[i], i));
-                }
-
                 // Based on assembly identity, for each assembly, 
                 // bind its references against the other assemblies we have.
                 for (int i = 0; i < explicitAssemblies.Length; i++)
                 {
-                    referenceBindings.Add(explicitAssemblies[i].BindAssemblyReferences(explicitAssembliesMap, IdentityComparer));
+                    referenceBindings.Add(explicitAssemblies[i].BindAssemblyReferences(explicitAssemblies, IdentityComparer));
                 }
 
                 if (resolverOpt?.ResolveMissingAssemblies == true)
                 {
                     ResolveAndBindMissingAssemblies(
                         explicitAssemblies,
-                        explicitAssembliesMap,
                         explicitModules,
                         explicitReferences,
                         explicitReferenceMap,
@@ -199,7 +191,6 @@ namespace Microsoft.CodeAnalysis
 
         private void ResolveAndBindMissingAssemblies(
             ImmutableArray<AssemblyData> explicitAssemblies,
-            MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)> explicitAssembliesMap,
             ImmutableArray<PEModule> explicitModules,
             ImmutableArray<MetadataReference> explicitReferences,
             ImmutableArray<ResolvedReference> explicitReferenceMap,
@@ -294,7 +285,7 @@ namespace Microsoft.CodeAnalysis
                         var data = CreateAssemblyDataForResolvedMissingAssembly(resolvedAssemblyMetadata, resolvedReference, importOptions);
                         implicitAssemblies.Add(data);
 
-                        var referenceBinding = data.BindAssemblyReferences(explicitAssembliesMap, IdentityComparer);
+                        var referenceBinding = data.BindAssemblyReferences(explicitAssemblies, IdentityComparer);
                         referenceBindings.Add(referenceBinding);
                         referenceBindingsToProcess.Push((resolvedReference, new ArraySegment<AssemblyReferenceBinding>(referenceBinding)));
                     }
@@ -319,15 +310,6 @@ namespace Microsoft.CodeAnalysis
                 // Rebind assembly references that were initially missing. All bindings established above
                 // are against explicitly specified references.
 
-                // We only need to resolve against implicitly resolved assemblies,
-                // since we already resolved against explicitly specified ones.
-                var implicitAssembliesMap = new MultiDictionary<string, (AssemblyData DefinitionData, int DefinitionIndex)>(implicitAssemblies.Count, AssemblyIdentityComparer.SimpleNameComparer);
-
-                for (int i = 0; i < implicitAssemblies.Count; i++)
-                {
-                    implicitAssembliesMap.Add(implicitAssemblies[i].Identity.Name, (implicitAssemblies[i], explicitAssemblyCount + i));
-                }
-
                 allAssemblies = explicitAssemblies.AddRange(implicitAssemblies);
 
                 for (int bindingsIndex = 0; bindingsIndex < referenceBindings.Count; bindingsIndex++)
@@ -350,8 +332,8 @@ namespace Microsoft.CodeAnalysis
                         Debug.Assert(binding.ReferenceIdentity is object);
                         referenceBinding[i] = ResolveReferencedAssembly(
                             binding.ReferenceIdentity,
-                            implicitAssembliesMap,
-                            resolveAgainstAssemblyBeingBuilt: false,
+                            allAssemblies,
+                            explicitAssemblyCount,
                             IdentityComparer);
                     }
                 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -782,8 +782,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End Get
                 End Property
 
-                Public Overrides Function BindAssemblyReferences(assemblies As MultiDictionary(Of String, (DefinitionData As AssemblyData, DefinitionIndex As Integer)), assemblyIdentityComparer As AssemblyIdentityComparer) As AssemblyReferenceBinding()
-                    Return ResolveReferencedAssemblies(_referencedAssemblies, assemblies, resolveAgainstAssemblyBeingBuilt:=True, assemblyIdentityComparer:=assemblyIdentityComparer)
+                Public Overrides Function BindAssemblyReferences(assemblies As ImmutableArray(Of AssemblyData), assemblyIdentityComparer As AssemblyIdentityComparer) As AssemblyReferenceBinding()
+                    Return ResolveReferencedAssemblies(_referencedAssemblies, assemblies, definitionStartIndex:=0, assemblyIdentityComparer:=assemblyIdentityComparer)
                 End Function
 
                 Public NotOverridable Overrides ReadOnly Property IsLinked As Boolean


### PR DESCRIPTION
…6430)"

This reverts commit ec485d19381b244ee20384e69bc62f91be2072b8.