### PR TITLE
More source build work

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -54,7 +54,7 @@
   </PropertyGroup>
 
   <!-- 
-    There are effectively four modes that are needed for our source build TFMs and this is where
+    There are effectively three modes that are needed for our source build TFMs and this is where
     we calculate them
   -->
   <Choose>
@@ -87,20 +87,9 @@
     </When>
 
     <!--
-      3. CI normal leg: this needs to build the union of all TFMs we support. That ensures we handle all 
-         diagnostics and analyzers for all the TFMs that we support.
-    -->
-    <When Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-      <PropertyGroup>
-        <SourceBuildToolsetTargetFramework>net6.0</SourceBuildToolsetTargetFramework>
-        <SourceBuildToolsetTargetFrameworks>$(NetCurrent);$(NetPrevious);$(SourceBuildToolsetTargetFramework)</SourceBuildToolsetTargetFrameworks>
-        <SourceBuildTargetFrameworks>$(SourceBuildToolsetTargetFrameworks)</SourceBuildTargetFrameworks>
-      </PropertyGroup>
-    </When>
-
-    <!-- 
-      4. Developer build: we do not want to build TFMs that are necessary only for source build as
-         it increases build time.
+      3. Everything else including normal CI, developer machines and official builds. This brings in enough
+         TFM that source build will go smoothly but doesn't bring in all source build TFMs to avoid adding
+         too many extra compiles to our builds
     -->
     <Otherwise>
       <PropertyGroup>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <StartupObject>Sub Main</StartupObject>
-    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(SourceBuildToolsetTargetFrameworks);net472</TargetFrameworks>
     <UseAppHost Condition="'$(DotNetBuildFromSource)' == 'true'">false</UseAppHost>
     <RootNamespace></RootNamespace>
     <IsShipping>false</IsShipping>


### PR DESCRIPTION
This removes the differences between typical CI and developer builds with respect to TFM set. That will avoid anymore situations where CI is building and developer builds are not (or vice versa).

There is still the chance that developer builds and CI will succeed but the source build CI will fail. That is in unavoidable consequence of how source build works though given it explicitly builds a different TFM set than traditional build.