### PR TITLE
Avoid allocating delegates when formatting trees.

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -141,15 +141,15 @@ namespace Microsoft.CodeAnalysis.Formatting
             var alignmentOperation = new List<AlignTokensOperation>();
             var anchorIndentationOperations = new List<AnchorIndentationOperation>();
 
-            using var indentBlockOperationScratch = ListPool<IndentBlockOperation>.Pool.GetPooledObject();
-            using var suppressOperationScratch = ListPool<SuppressOperation>.Pool.GetPooledObject();
-            using var alignmentOperationScratch = ListPool<AlignTokensOperation>.Pool.GetPooledObject();
-            using var anchorIndentationOperationsScratch = ListPool<AnchorIndentationOperation>.Pool.GetPooledObject();
-
             var addIndentBlockOperations = _formattingRules.AddIndentBlockOperations;
             var addSuppressOperation = _formattingRules.AddSuppressOperations;
             var addAlignTokensOperations = _formattingRules.AddAlignTokensOperations;
             var addAnchorIndentationOperations = _formattingRules.AddAnchorIndentationOperations;
+
+            using var indentBlockOperationScratch = ListPool<IndentBlockOperation>.Pool.GetPooledObject();
+            using var suppressOperationScratch = ListPool<SuppressOperation>.Pool.GetPooledObject();
+            using var alignmentOperationScratch = ListPool<AlignTokensOperation>.Pool.GetPooledObject();
+            using var anchorIndentationOperationsScratch = ListPool<AnchorIndentationOperation>.Pool.GetPooledObject();
 
             // iterating tree is very expensive. only do it once.
             foreach (var node in _commonRoot.DescendantNodesAndSelf(this.SpanToFormat))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -146,15 +146,20 @@ namespace Microsoft.CodeAnalysis.Formatting
             using var alignmentOperationScratch = ListPool<AlignTokensOperation>.Pool.GetPooledObject();
             using var anchorIndentationOperationsScratch = ListPool<AnchorIndentationOperation>.Pool.GetPooledObject();
 
+            var addIndentBlockOperations = _formattingRules.AddIndentBlockOperations;
+            var addSuppressOperation = _formattingRules.AddSuppressOperations;
+            var addAlignTokensOperations = _formattingRules.AddAlignTokensOperations;
+            var addAnchorIndentationOperations = _formattingRules.AddAnchorIndentationOperations;
+
             // iterating tree is very expensive. only do it once.
             foreach (var node in _commonRoot.DescendantNodesAndSelf(this.SpanToFormat))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                AddOperations(indentBlockOperation, indentBlockOperationScratch.Object, node, _formattingRules.AddIndentBlockOperations);
-                AddOperations(suppressOperation, suppressOperationScratch.Object, node, _formattingRules.AddSuppressOperations);
-                AddOperations(alignmentOperation, alignmentOperationScratch.Object, node, _formattingRules.AddAlignTokensOperations);
-                AddOperations(anchorIndentationOperations, anchorIndentationOperationsScratch.Object, node, _formattingRules.AddAnchorIndentationOperations);
+                AddOperations(indentBlockOperation, indentBlockOperationScratch.Object, node, addIndentBlockOperations);
+                AddOperations(suppressOperation, suppressOperationScratch.Object, node, addSuppressOperation);
+                AddOperations(alignmentOperation, alignmentOperationScratch.Object, node, addAlignTokensOperations);
+                AddOperations(anchorIndentationOperations, anchorIndentationOperationsScratch.Object, node, addAnchorIndentationOperations);
             }
 
             // make sure we order align operation from left to right

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -158,6 +158,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             // make sure we order align operation from left to right
             alignmentOperation.Sort(static (o1, o2) => o1.BaseToken.Span.CompareTo(o2.BaseToken.Span));
+
+            return nodeOperations;
         }
 
         private static void AddOperations<T>(List<T> operations, List<T> scratch, SyntaxNode node, Action<List<T>, SyntaxNode> addOperations)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/NodeOperations.cs
@@ -14,25 +14,9 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         public static NodeOperations Empty = new();
 
-        public List<IndentBlockOperation> IndentBlockOperation { get; }
-        public List<SuppressOperation> SuppressOperation { get; }
-        public List<AlignTokensOperation> AlignmentOperation { get; }
-        public List<AnchorIndentationOperation> AnchorIndentationOperations { get; }
-
-        public NodeOperations(List<IndentBlockOperation> indentBlockOperation, List<SuppressOperation> suppressOperation, List<AnchorIndentationOperation> anchorIndentationOperations, List<AlignTokensOperation> alignmentOperation)
-        {
-            this.IndentBlockOperation = indentBlockOperation;
-            this.SuppressOperation = suppressOperation;
-            this.AlignmentOperation = alignmentOperation;
-            this.AnchorIndentationOperations = anchorIndentationOperations;
-        }
-
-        private NodeOperations()
-        {
-            this.IndentBlockOperation = new List<IndentBlockOperation>();
-            this.SuppressOperation = new List<SuppressOperation>();
-            this.AlignmentOperation = new List<AlignTokensOperation>();
-            this.AnchorIndentationOperations = new List<AnchorIndentationOperation>();
-        }
+        public List<IndentBlockOperation> IndentBlockOperation { get; } = new();
+        public List<SuppressOperation> SuppressOperation { get; } = new();
+        public List<AlignTokensOperation> AlignmentOperation { get; } = new();
+        public List<AnchorIndentationOperation> AnchorIndentationOperations { get; } = new();
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis
             pool.Free(map);
         }
 
-        public static void ClearAndFree<T>(this ObjectPool<List<T>> pool, List<T> list)
+        public static void ClearAndFree<T>(this ObjectPool<List<T>> pool, List<T> list, bool trim = true)
         {
             if (list == null)
             {
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis
 
             list.Clear();
 
-            if (list.Capacity > Threshold)
+            if (trim && list.Capacity > Threshold)
             {
                 list.Capacity = Threshold;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/PooledObject.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis
             => pool.AllocateAndClear();
 
         private static void Releaser<TItem>(ObjectPool<List<TItem>> pool, List<TItem> obj)
-            => pool.ClearAndFree(obj);
+            => pool.ClearAndFree(obj, pool.TrimOnFree);
 
         private static SegmentedList<TItem> Allocator<TItem>(ObjectPool<SegmentedList<TItem>> pool)
             => pool.AllocateAndClear();


### PR DESCRIPTION
Fixes regression of about 5%:

![image](https://user-images.githubusercontent.com/4564579/231901941-12d869d9-91c4-499b-84de-fef5901f0d84.png)
