### PR TITLE
Include matched spans in our 'container' pattern matcher

### DIFF
--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             CancellationToken cancellationToken)
         {
             var containerMatcher = patternContainer != null
-                ? PatternMatcher.CreateDotSeparatedContainerMatcher(patternContainer)
+                ? PatternMatcher.CreateDotSeparatedContainerMatcher(patternContainer, includeMatchedSpans: true)
                 : null;
 
             using var nameMatcher = PatternMatcher.CreatePatternMatcher(patternName, includeMatchedSpans: true, allowFuzzyMatching: true);

--- a/src/Workspaces/Core/Portable/PatternMatching/ContainerPatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/ContainerPatternMatcher.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using System.Linq;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 
 namespace Microsoft.CodeAnalysis.PatternMatching
@@ -21,9 +18,10 @@ namespace Microsoft.CodeAnalysis.PatternMatching
 
             public ContainerPatternMatcher(
                 string[] patternParts, char[] containerSplitCharacters,
-                CultureInfo culture,
+                bool includeMatchedSpans,
+                CultureInfo? culture,
                 bool allowFuzzyMatching = false)
-                : base(false, culture, allowFuzzyMatching)
+                : base(includeMatchedSpans, culture, allowFuzzyMatching)
             {
                 _containerSplitCharacters = containerSplitCharacters;
 
@@ -44,7 +42,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                 }
             }
 
-            public override bool AddMatches(string container, ref TemporaryArray<PatternMatch> matches)
+            public override bool AddMatches(string? container, ref TemporaryArray<PatternMatch> matches)
             {
                 if (SkipMatch(container))
                 {

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared;
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         /// <param name="allowFuzzyMatching">Whether or not close matches should count as matches.</param>
         protected PatternMatcher(
             bool includeMatchedSpans,
-            CultureInfo culture,
+            CultureInfo? culture,
             bool allowFuzzyMatching = false)
         {
             culture ??= CultureInfo.CurrentCulture;
@@ -74,21 +75,23 @@ namespace Microsoft.CodeAnalysis.PatternMatching
         public static PatternMatcher CreateContainerPatternMatcher(
             string[] patternParts,
             char[] containerSplitCharacters,
+            bool includeMatchedSpans = false,
             CultureInfo? culture = null,
             bool allowFuzzyMatching = false)
         {
             return new ContainerPatternMatcher(
-                patternParts, containerSplitCharacters, culture, allowFuzzyMatching);
+                patternParts, containerSplitCharacters, includeMatchedSpans, culture, allowFuzzyMatching);
         }
 
         public static PatternMatcher CreateDotSeparatedContainerMatcher(
             string pattern,
+            bool includeMatchedSpans = false,
             CultureInfo? culture = null,
             bool allowFuzzyMatching = false)
         {
             return CreateContainerPatternMatcher(
                 pattern.Split(s_dotCharacterArray, StringSplitOptions.RemoveEmptyEntries),
-                s_dotCharacterArray, culture, allowFuzzyMatching);
+                s_dotCharacterArray, includeMatchedSpans, culture, allowFuzzyMatching);
         }
 
         internal static (string name, string? containerOpt) GetNameAndContainer(string pattern)
@@ -102,7 +105,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
 
         public abstract bool AddMatches(string? candidate, ref TemporaryArray<PatternMatch> matches);
 
-        private bool SkipMatch(string? candidate)
+        private bool SkipMatch([NotNullWhen(false)] string? candidate)
             => _invalidPattern || string.IsNullOrWhiteSpace(candidate);
 
         private static bool ContainsUpperCaseLetter(string pattern)


### PR DESCRIPTION
This is the pattern matcher that is involved when you search for `Goo.Bar`.  First, we do the normal sweep of hte index with `Bar` as the search term.  Then for any match there, we check it's 'container' (e.g. `"System.Collections.Goo"`) string for matches against `Goo`.  

THis has always worked, but we never included the 'matched span' in the result as on the roslyn side we didn't need it.  However, the platform wants this information so they can make better sorting choices.  e.g. a container match that matches larger sections is better than one that doesn't.  

So adding this in for them to help them out :)