### PR TITLE
Switch SourceNamespaceSymbol._aliasesAndUsings_doNotAccessDirectly to a non-immutable type to reduce memory allocations.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -30,17 +30,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<Symbol> _lazyAllMembers;
         private ImmutableArray<NamedTypeSymbol> _lazyTypeMembersUnordered;
 
+        private object _aliasesAndUsingsLock = new();
+
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsings(SingleNamespaceDeclaration)"/>.
         /// </summary>
-        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
-            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
+        private SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
+            new SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
 #if DEBUG
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsingsForAsserts"/>.
         /// </summary>
-        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
-            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
+        private SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
+            new SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
 #endif
         private MergedGlobalAliasesAndUsings _lazyMergedGlobalAliasesAndUsings;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -30,18 +30,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<Symbol> _lazyAllMembers;
         private ImmutableArray<NamedTypeSymbol> _lazyTypeMembersUnordered;
 
-        private object _aliasesAndUsingsLock = new();
+        private readonly object _aliasesAndUsingsLock = new();
 
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsings(SingleNamespaceDeclaration)"/>.
         /// </summary>
-        private SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
+        private readonly SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
             new SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
 #if DEBUG
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsingsForAsserts"/>.
         /// </summary>
-        private SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
+        private readonly SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
             new SegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>(ReferenceEqualityComparer.Instance);
 #endif
         private MergedGlobalAliasesAndUsings _lazyMergedGlobalAliasesAndUsings;


### PR DESCRIPTION
On a simple typing scenario in a mid-sized cs file, I saw 8% of allocations attributed to [Microsoft.CodeAnalysis.CSharp.SingleNamespaceDeclaration,Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamespaceSymbol+AliasesAndUsings][]

This immutable segmented dictionary is built up one entry at a time and isn't exposed outside of the containing class. The intent here is to switch this to a standard segmented dictionary instead, so additional adds need not reallocate so much.

With this change, I see a significant reduction in the allocation costs associated with this type.

![image](https://user-images.githubusercontent.com/6785178/231935082-a3248a91-bc4d-4204-8d3b-f72870d49827.png)
