### PR TITLE
Semantic snippets: Add inline statement snippets

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
@@ -406,5 +406,66 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact]
+        public async Task InsertInlineSnippetForCorrectTypeTest()
+        {
+            var markupBeforeCommit = """
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                        arg.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                        {{ItemToCommit}} (arg)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task NoInlineSnippetForIncorrectTypeTest()
+        {
+            var markupBeforeCommit = """
+                class Program
+                {
+                    void M(int arg)
+                    {
+                        arg.$$
+                    }
+                }
+                """;
+
+            await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
+        }
+
+        [WpfFact]
+        public async Task NoInlineSnippetWhenNotDirectlyExpressionStatementTest()
+        {
+            var markupBeforeCommit = """
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                        System.Console.WriteLine(arg.$$);
+                    }
+                }
+                """;
+
+            await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -89,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         }
 
         [WpfFact]
-        public async Task InserForEachSnippetInConstructorTest()
+        public async Task InsertForEachSnippetInConstructorTest()
         {
             var markupBeforeCommit =
 @"class Program
@@ -115,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         }
 
         [WpfFact]
-        public async Task InserForEachSnippetWithCollectionTest()
+        public async Task InsertForEachSnippetWithCollectionTest()
         {
             var markupBeforeCommit =
 @"using System;
@@ -250,6 +246,74 @@ static void Main(string[] args)
     return x == y;
 };";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit, sourceCodeKind: SourceCodeKind.Script);
+        }
+
+        [WpfFact]
+        public async Task InsertInlineForEachSnippetForCorrectTypeTest()
+        {
+            var markupBeforeCommit = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(List<int> list)
+                    {
+                        list.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(List<int> list)
+                    {
+                        foreach (var item in list)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task NoInlineForEachSnippetForIncorrectTypeTest()
+        {
+            var markupBeforeCommit = """
+                class Program
+                {
+                    void M(int arg)
+                    {
+                        arg.$$
+                    }
+                }
+                """;
+
+            await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
+        }
+
+        [WpfFact]
+        public async Task NoInlineForEachSnippetWhenNotDirectlyExpressionStatementTest()
+        {
+            var markupBeforeCommit = """
+                using System;
+                using System.Collections.Generic;
+
+                class Program
+                {
+                    void M(List<int> list)
+                    {
+                        Console.WriteLine(list.$$);
+                    }
+                }
+                """;
+
+            await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -63,11 +62,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             return isAfterIfStatement && await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var elseClause = SyntaxFactory.ElseClause(SyntaxFactory.Block());
-
-            return Task.FromResult(ImmutableArray.Create(new TextChange(TextSpan.FromBounds(position, position), elseClause.ToFullString())));
+            return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), elseClause.ToFullString()));
         }
 
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
@@ -4,36 +4,29 @@
 
 using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
     /// <summary>
     /// Base class for "if" and "while" snippet providers
     /// </summary>
-    internal abstract class AbstractConditionalBlockSnippetProvider : AbstractStatementSnippetProvider
+    internal abstract class AbstractConditionalBlockSnippetProvider : AbstractInlineStatementSnippetProvider
     {
-        protected abstract TextChange GenerateSnippetTextChange(Document document, int position);
         protected abstract SyntaxNode GetCondition(SyntaxNode node);
 
-        protected override Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            var snippetTextChange = GenerateSnippetTextChange(document, position);
-            return Task.FromResult(ImmutableArray.Create(snippetTextChange));
-        }
+        protected override bool IsValidAccessingType(ITypeSymbol type)
+            => type.SpecialType == SpecialType.System_Boolean;
 
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
-            var condition = GetCondition(node);
-            arrayBuilder.Add(new SnippetPlaceholder(identifier: condition.ToString(), placeholderPositions: ImmutableArray.Create(condition.SpanStart)));
+            if (ConstructedFromInlineExpression)
+                return ImmutableArray<SnippetPlaceholder>.Empty;
 
-            return arrayBuilder.ToImmutableArray();
+            var condition = GetCondition(node);
+            var placeholder = new SnippetPlaceholder(identifier: condition.ToString(), placeholderPositions: ImmutableArray.Create(condition.SpanStart));
+
+            return ImmutableArray.Create(placeholder);
         }
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -3,21 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -45,18 +39,12 @@ namespace Microsoft.CodeAnalysis.Snippets
             return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            var snippetTextChange = await GenerateSnippetTextChangeAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return ImmutableArray.Create(snippetTextChange);
-        }
-
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         {
             return syntaxFacts.IsExpressionStatement;
         }
 
-        private async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConstructorSnippetProvider.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editing;
@@ -16,7 +14,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
-    internal abstract class AbstractConstructorSnippetProvider : AbstractSnippetProvider
+    internal abstract class AbstractConstructorSnippetProvider : AbstractSingleChangeSnippetProvider
     {
         public override string Identifier => "ctor";
 
@@ -28,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
             => ImmutableArray<SnippetPlaceholder>.Empty;
 
-        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
@@ -39,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             var constructorDeclaration = generator.ConstructorDeclaration(
                 containingTypeName: syntaxFacts.GetIdentifierOfTypeDeclaration(containingType).ToString(),
                 accessibility: Accessibility.Public);
-            return ImmutableArray.Create(new TextChange(TextSpan.FromBounds(position, position), constructorDeclaration.NormalizeWhitespace().ToFullString()));
+            return new TextChange(TextSpan.FromBounds(position, position), constructorDeclaration.NormalizeWhitespace().ToFullString());
         }
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
@@ -3,27 +3,20 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets
 {
-    internal abstract class AbstractForEachLoopSnippetProvider : AbstractStatementSnippetProvider
+    internal abstract class AbstractForEachLoopSnippetProvider : AbstractInlineStatementSnippetProvider
     {
-        protected abstract Task<SyntaxNode> CreateForEachLoopStatementSyntaxAsync(Document document, int position, CancellationToken cancellationToken);
-
         public override string Identifier => "foreach";
 
         public override string Description => FeaturesResources.foreach_loop;
 
-        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            var forEachStatementSyntax = await CreateForEachLoopStatementSyntaxAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return new TextChange(TextSpan.FromBounds(position, position), forEachStatementSyntax.NormalizeWhitespace().ToFullString());
-        }
+        protected override bool IsValidAccessingType(ITypeSymbol type)
+            => type.CanBeEnumerated();
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
@@ -3,21 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets
 {
@@ -29,11 +19,10 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         public override string Description => FeaturesResources.foreach_loop;
 
-        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var forEachStatementSyntax = await CreateForEachLoopStatementSyntaxAsync(document, position, cancellationToken).ConfigureAwait(false);
-            var snippetTextChange = new TextChange(TextSpan.FromBounds(position, position), forEachStatementSyntax.NormalizeWhitespace().ToFullString());
-            return ImmutableArray.Create(snippetTextChange);
+            return new TextChange(TextSpan.FromBounds(position, position), forEachStatementSyntax.NormalizeWhitespace().ToFullString());
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets
 {
@@ -21,12 +20,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
-        protected override TextChange GenerateSnippetTextChange(Document document, int position)
-        {
-            var generator = SyntaxGenerator.GetGenerator(document);
-            var ifStatement = generator.IfStatement(generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
-
-            return new TextChange(TextSpan.FromBounds(position, position), ifStatement.ToFullString());
-        }
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression)
+            => generator.IfStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 
 namespace Microsoft.CodeAnalysis.Snippets
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression)
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
             => generator.IfStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
+{
+    /// <summary>
+    /// Base class for snippets, that can be both executed as normal statement snippets
+    /// or constructed from a member access expression when accessing members of a specific type
+    /// </summary>
+    internal abstract class AbstractInlineStatementSnippetProvider : AbstractStatementSnippetProvider
+    {
+        /// <summary>
+        /// Tells if accessing type of a member access expression is valid for that snippet
+        /// </summary>
+        /// <param name="type">Type of right-hand side of a member access expression</param>
+        protected abstract bool IsValidAccessingType(ITypeSymbol type);
+
+        /// <summary>
+        /// Generate statement node
+        /// </summary>
+        /// <param name="inlineExpression">Right-hand side of a member access expression.<see langword="null"/> if snippet is executed in normal statement context</param>
+        protected abstract SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression);
+
+        /// <summary>
+        /// Tells whether the original snippet was constructed from member access expression.
+        /// Can be used by snippet providers to not mark that expression as a placeholder
+        /// </summary>
+        protected bool ConstructedFromInlineExpression { get; private set; }
+
+        protected sealed override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
+            var syntaxContext = document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
+            var targetToken = syntaxContext.TargetToken;
+
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            if (TryGetInlineExpression(targetToken, syntaxFacts, out var expression))
+            {
+                var accessingType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
+
+                if (accessingType is not null)
+                    return IsValidAccessingType(accessingType);
+            }
+
+            return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected sealed override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
+            var syntaxContext = document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
+            var targetToken = syntaxContext.TargetToken;
+
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            _ = TryGetInlineExpression(targetToken, syntaxFacts, out var inlineExpression);
+
+            var statement = GenerateStatement(SyntaxGenerator.GetGenerator(document), inlineExpression);
+            ConstructedFromInlineExpression = inlineExpression is not null;
+
+            var change = new TextChange(inlineExpression?.Parent?.Span ?? TextSpan.FromBounds(position, position), statement.ToFullString());
+            return ImmutableArray.Create(change);
+        }
+
+        protected sealed override SyntaxNode? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)
+        {
+            var closestNode = root.FindNode(TextSpan.FromBounds(position, position), getInnermostNodeForTie: true);
+            return closestNode.FirstAncestorOrSelf<SyntaxNode>(isCorrectContainer);
+        }
+
+        private static bool TryGetInlineExpression(SyntaxToken targetToken, ISyntaxFactsService syntaxFacts, [NotNullWhen(true)] out SyntaxNode? expression)
+        {
+            expression = null;
+
+            var parentNode = targetToken.Parent;
+
+            if (syntaxFacts.IsMemberAccessExpression(parentNode) &&
+                syntaxFacts.IsExpressionStatement(parentNode?.Parent))
+            {
+                expression = syntaxFacts.GetExpressionOfMemberAccessExpression(parentNode)!;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
         }
 
-        protected sealed override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected sealed override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
             var syntaxContext = document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
@@ -69,8 +68,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             var statement = GenerateStatement(SyntaxGenerator.GetGenerator(document), inlineExpression);
             ConstructedFromInlineExpression = inlineExpression is not null;
 
-            var change = new TextChange(inlineExpression?.Parent?.Span ?? TextSpan.FromBounds(position, position), statement.ToFullString());
-            return ImmutableArray.Create(change);
+            return new TextChange(inlineExpression?.Parent?.Span ?? TextSpan.FromBounds(position, position), statement.ToFullString());
         }
 
         protected sealed override SyntaxNode? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         /// Generate statement node
         /// </summary>
         /// <param name="inlineExpression">Right-hand side of a member access expression.<see langword="null"/> if snippet is executed in normal statement context</param>
-        protected abstract SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression);
+        protected abstract SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression);
 
         /// <summary>
         /// Tells whether the original snippet was constructed from member access expression.
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             _ = TryGetInlineExpression(targetToken, syntaxFacts, out var inlineExpression);
 
-            var statement = GenerateStatement(SyntaxGenerator.GetGenerator(document), inlineExpression);
+            var statement = GenerateStatement(SyntaxGenerator.GetGenerator(document), syntaxContext, inlineExpression);
             ConstructedFromInlineExpression = inlineExpression is not null;
 
             return new TextChange(inlineExpression?.Parent?.Span ?? TextSpan.FromBounds(position, position), statement.ToFullString());

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropertySnippetProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
@@ -11,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
-    internal abstract class AbstractPropertySnippetProvider : AbstractSnippetProvider
+    internal abstract class AbstractPropertySnippetProvider : AbstractSingleChangeSnippetProvider
     {
         /// <summary>
         /// Generates the property syntax.
@@ -20,10 +19,10 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         /// </summary>
         protected abstract Task<SyntaxNode> GenerateSnippetSyntaxAsync(Document document, int position, CancellationToken cancellationToken);
 
-        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var propertyDeclaration = await GenerateSnippetSyntaxAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return ImmutableArray.Create(new TextChange(TextSpan.FromBounds(position, position), propertyDeclaration.NormalizeWhitespace().ToFullString()));
+            return new TextChange(TextSpan.FromBounds(position, position), propertyDeclaration.NormalizeWhitespace().ToFullString());
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSingleChangeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSingleChangeSnippetProvider.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
+{
+    internal abstract class AbstractSingleChangeSnippetProvider : AbstractSnippetProvider
+    {
+        protected abstract Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken);
+
+        protected sealed override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var change = await GenerateSnippetTextChangeAsync(document, position, cancellationToken).ConfigureAwait(false);
+            return ImmutableArray.Create(change);
+        }
+    }
+}

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -86,10 +86,10 @@ namespace Microsoft.CodeAnalysis.Snippets
         {
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
-            // Generates the snippet as a list of textchanges
+            // Generates the snippet as a list of text changes
             var textChanges = await GenerateSnippetTextChangesAsync(document, position, cancellationToken).ConfigureAwait(false);
 
-            // Applies the snippet textchanges to the document 
+            // Applies the snippet text changes to the document 
             var snippetDocument = await GetDocumentWithSnippetAsync(document, textChanges, cancellationToken).ConfigureAwait(false);
 
             // Finds the inserted snippet and replaces the node in the document with a node that has added trivia
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Snippets
             // Skips the first and last token since
             // those do not need elastic trivia added to them.
             var nodeWithTrivia = node.ReplaceTokens(allTokens.Skip(1).Take(allTokens.Count - 2),
-                (oldtoken, _) => oldtoken.WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation)
+                (oldToken, _) => oldToken.WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation)
                 .WithAppendedTrailingTrivia(syntaxFacts.ElasticMarker)
                 .WithPrependedLeadingTrivia(syntaxFacts.ElasticMarker));
 
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Snippets
         }
 
         /// <summary>
-        /// Locates the snippet that was inserted. Generates trivia for every token in that syntaxnode.
+        /// Locates the snippet that was inserted. Generates trivia for every token in that SyntaxNode.
         /// Replaces the SyntaxNodes and gets back the new document.
         /// </summary>
         private async Task<Document> GetDocumentWithSnippetAndTriviaAsync(Document snippetDocument, int position, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -242,14 +241,6 @@ namespace Microsoft.CodeAnalysis.Snippets
             var closestNode = root.FindNode(TextSpan.FromBounds(position, position), getInnermostNodeForTie: true);
 
             if (!isCorrectContainer(closestNode))
-            {
-                return null;
-            }
-
-            // Checking to see if that expression statement that we found is
-            // starting at the same position as the position we inserted
-            // the if statement.
-            if (closestNode.SpanStart != position)
             {
                 return null;
             }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractStatementSnippetProvider.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -12,7 +9,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
-    internal abstract class AbstractStatementSnippetProvider : AbstractSnippetProvider
+    internal abstract class AbstractStatementSnippetProvider : AbstractSingleChangeSnippetProvider
     {
         protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -12,23 +12,21 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
-    internal abstract class AbstractTypeSnippetProvider : AbstractSnippetProvider
+    internal abstract class AbstractTypeSnippetProvider : AbstractSingleChangeSnippetProvider
     {
         protected abstract Task<bool> HasPrecedingAccessibilityModifiersAsync(Document document, int position, CancellationToken cancellationToken);
         protected abstract void GetTypeDeclarationIdentifier(SyntaxNode node, out SyntaxToken identifier);
         protected abstract Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken);
 
-        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var hasAccessibilityModifiers = await HasPrecedingAccessibilityModifiersAsync(document, position, cancellationToken).ConfigureAwait(false);
             var useAccessibility = !hasAccessibilityModifiers && await AreAccessibilityModifiersRequiredAsync(document, cancellationToken).ConfigureAwait(false);
 
             var typeDeclaration = await GenerateTypeDeclarationAsync(document, position, useAccessibility, cancellationToken).ConfigureAwait(false);
 
-            var snippetTextChange = new TextChange(TextSpan.FromBounds(position, position), typeDeclaration.NormalizeWhitespace().ToFullString());
-            return ImmutableArray.Create(snippetTextChange);
+            return new TextChange(TextSpan.FromBounds(position, position), typeDeclaration.NormalizeWhitespace().ToFullString());
         }
-
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 
             return new TextChange(TextSpan.FromBounds(position, position), typeDeclaration.NormalizeWhitespace().ToFullString());
         }
+
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
@@ -17,12 +16,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
 
-        protected override TextChange GenerateSnippetTextChange(Document document, int position)
-        {
-            var generator = SyntaxGenerator.GetGenerator(document);
-            var whileStatement = generator.WhileStatement(generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
-
-            return new TextChange(TextSpan.FromBounds(position, position), whileStatement.ToFullString());
-        }
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression)
+            => generator.WhileStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
 
-        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxNode? inlineExpression)
+        protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
             => generator.WhileStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -232,5 +232,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             return type?.Accept(new SubstituteTypesVisitor<TType1, TType2>(mapping, typeGenerator));
         }
+
+        public static bool CanBeEnumerated(this ITypeSymbol type)
+            => type.AllInterfaces.Any(s => s.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T or SpecialType.System_Collections_IEnumerable);
+
     }
 }


### PR DESCRIPTION
First commit: added all abstractions for inline statement snippets. Made `if` and `while` statements inline
Second commit: while working I noticed that all current snippets produce a single `TextChange`, so abstracted that in a separate class
Third commit: made `foreach` snippet inline as well. It required a little change in the abstraction frameork made in commit 1

Closes: https://github.com/dotnet/roslyn/issues/60628

Demo:
![foreach](https://user-images.githubusercontent.com/70431552/232069614-5e5fad6d-3ce4-4ed9-a88a-ebdb5d3952dc.gif)
