### PR TITLE
Use non-void type for `BoundAwaitOperator` in VB statement

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -4892,14 +4892,6 @@ lElseClause:
                 getResult = BadExpression(node, ErrorTypeSymbol.UnknownResultType).MakeCompilerGenerated()
             End If
 
-            Dim resultType As TypeSymbol
-
-            If bindAsStatement Then
-                resultType = GetSpecialType(SpecialType.System_Void, node, diagnostics)
-            Else
-                resultType = getResult.Type
-            End If
-
             If Not hasErrors Then
                 diagnostics.AddRange(allIgnoreDiagnostics)
             End If
@@ -4909,7 +4901,7 @@ lElseClause:
             Return New BoundAwaitOperator(node, operand,
                                           awaitableInstancePlaceholder, getAwaiter,
                                           awaiterInstancePlaceholder, isCompleted, getResult,
-                                          resultType, hasErrors)
+                                          type:=getResult.Type, hasErrors)
         End Function
 
         Private Shared Function DiagnosticBagHasErrorsOtherThanObsoleteOnes(bag As DiagnosticBag) As Boolean

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundAwaitOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundAwaitOperator.vb
@@ -2,17 +2,13 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend Class BoundAwaitOperator
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(Type.Equals(GetResult.Type) OrElse Type.SpecialType = SpecialType.System_Void)
+            Debug.Assert(Type.Equals(GetResult.Type))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -2,10 +2,16 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Generic
 Imports System.Collections.Immutable
+Imports System.Threading
+Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
@@ -93,6 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     Me.F.AssignmentExpression(Me.F.Local(resultTemp, True), rewrittenGetResult),
                                                     clearAwaiterTemp,
                                                     Me.F.Local(resultTemp, False))
+
                 Else
                     ' STMT:   $awaiterTemp.GetResult()
                     ' STMT:   $awaiterTemp = Nothing

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -2,16 +2,10 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Threading
-Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
@@ -99,7 +93,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     Me.F.AssignmentExpression(Me.F.Local(resultTemp, True), rewrittenGetResult),
                                                     clearAwaiterTemp,
                                                     Me.F.Local(resultTemp, False))
-
                 Else
                     ' STMT:   $awaiterTemp.GetResult()
                     ' STMT:   $awaiterTemp = Nothing

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IAwaitExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IAwaitExpression.vb
@@ -105,8 +105,8 @@ Class C
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IAwaitOperation (OperationKind.Await, Type: System.Void, IsInvalid) (Syntax: 'Await UndefinedTask')
-  Expression: 
+IAwaitOperation (OperationKind.Await, Type: ?, IsInvalid) (Syntax: 'Await UndefinedTask')
+  Expression:
     IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'UndefinedTask')
       Children(0)
 ]]>.Value
@@ -134,8 +134,8 @@ Class C
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IAwaitOperation (OperationKind.Await, Type: System.Void, IsInvalid) (Syntax: 'Await i')
-  Expression: 
+IAwaitOperation (OperationKind.Await, Type: ?, IsInvalid) (Syntax: 'Await i')
+  Expression:
     IParameterReferenceOperation: i (OperationKind.ParameterReference, Type: System.Int32, IsInvalid) (Syntax: 'i')
 ]]>.Value
 
@@ -162,8 +162,8 @@ Class C
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IAwaitOperation (OperationKind.Await, Type: System.Void, IsInvalid) (Syntax: 'Await')
-  Expression: 
+IAwaitOperation (OperationKind.Await, Type: ?, IsInvalid) (Syntax: 'Await')
+  Expression:
     IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
       Children(0)
 ]]>.Value
@@ -210,6 +210,38 @@ BC30800: Method arguments must be enclosed in parentheses.
 ]]>.Value
 
             VerifyOperationTreeAndDiagnosticsForTest(Of ExpressionStatementSyntax)(source, expectedOperationTree, expectedDiagnostics, useLatestFramework:=True)
+        End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67616")>
+        Public Sub TestAwaitExpression_InStatement()
+            Dim source = <![CDATA[
+Imports System.Threading.Tasks
+
+Public Module Program
+    Public Async Function M() As Task(Of Integer)
+        Await M2()'BIND:"Await M2()"
+        Return 0
+    End Function
+
+    Public Function M2() As Task(Of String)
+        Throw New System.Exception()
+    End Function
+End Module
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IAwaitOperation (OperationKind.Await, Type: System.String) (Syntax: 'Await M2()')
+  Expression:
+    IInvocationOperation (Function Program.M2() As System.Threading.Tasks.Task(Of System.String)) (OperationKind.Invocation, Type: System.Threading.Tasks.Task(Of System.String)) (Syntax: 'M2()')
+      Instance Receiver:
+        null
+      Arguments(0)
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of AwaitExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics, useLatestFramework:=True)
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IAwaitExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IAwaitExpression.vb
@@ -246,7 +246,7 @@ IAwaitOperation (OperationKind.Await, Type: System.String) (Syntax: 'Await M2()'
 
         <CompilerTrait(CompilerFeature.IOperation)>
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67616")>
-        Public Sub TestAwaitExpression_InStatement_InSub()
+        Public Sub TestAwaitExpression_InStatement_InSubLambda()
             Dim source = <![CDATA[
 Imports System
 Imports System.Threading.Tasks


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67616

I looked for places that use `BoundAwaitOperator.Type`. The main place that is affected is in [AsyncRewriter.AsyncMethodToClassRewriter.Await.vb](https://github.com/dotnet/roslyn/blob/main/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb#L93-L107) and it is still correct and covered (`Task` and `Task<T>` involve awaiters with `GetResult()` methods that return `void` and `T` respectively).

