### PR TITLE
Add further optimization to the AliasesAndUsings allocation pattern.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
@@ -116,9 +116,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             dictionary.TryGetValue(declaration, out var result);
-            Debug.Assert(result is not null);
 
-            return result ?? new AliasesAndUsings();
+            // Caller shouldn't invoke this method with declaration that isn't added to builder above.
+            return result ?? throw ExceptionUtilities.Unreachable();
         }
 
         private AliasesAndUsings GetAliasesAndUsings(SingleNamespaceDeclaration declaration)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -33,14 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsings(SingleNamespaceDeclaration)"/>.
         /// </summary>
-        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly =
-            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
+        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsings_doNotAccessDirectly;
 #if DEBUG
         /// <summary>
         /// Should only be read using <see cref="GetAliasesAndUsingsForAsserts"/>.
         /// </summary>
-        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly =
-            ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings>.Empty.WithComparer(ReferenceEqualityComparer.Instance);
+        private ImmutableSegmentedDictionary<SingleNamespaceDeclaration, AliasesAndUsings> _aliasesAndUsingsForAsserts_doNotAccessDirectly;
 #endif
         private MergedGlobalAliasesAndUsings _lazyMergedGlobalAliasesAndUsings;
 


### PR DESCRIPTION
After https://github.com/dotnet/roslyn/pull/67655 merged, I noticed a fairly high allocation sequence due to the ImmutableSegmentedDictionary being built up a single entry at a time now. This PR attempts to keep the lazy bit of the allocations from the earlier PR, and now go ahead and rebuild the full dictionary upon the first request.

From some diagnostics I collected, I saw 18600 SourceNamespaceSymbols created, of which only 1500 ever made a request to GetOrCreateAliasAndUsings. However, the problem that I was seeing was that 17 of those SourceNamespaceSymbols objects would end up with dictionaries over 1000 declarations, which is bad when those dictionaries are built up a single element at a time.