### PR TITLE
Cache the names of assembly symbols for PEReferences

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -300,8 +300,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     compilation ??= CreateCompilation();
 
-                    if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol { Name: string assemblyName })
-                        name = ImmutableInterlocked.GetOrAdd(ref s_metadataIdToAssemblyName, metadataId, assemblyName);
+                    if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol { Name: string metadataAssemblyName })
+                        name = ImmutableInterlocked.GetOrAdd(ref s_metadataIdToAssemblyName, metadataId, metadataAssemblyName);
                 }
 
                 if (name == assemblyName)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Cache from the <see cref="MetadataId"/> for a particular <see cref="PortableExecutableReference"/> to the
         /// name of the <see cref="IAssemblySymbol"/> defined by it.
         /// </summary>
-        private static ImmutableDictionary<MetadataId, string?> s_metadataIdToAssemblyName = ImmutableDictionary<MetadataId, string?>.Empty;
+        private static ImmutableDictionary<MetadataId, string> s_metadataIdToAssemblyName = ImmutableDictionary<MetadataId, string>.Empty;
 
         public static async Task<ImmutableArray<Project>> GetDependentProjectsAsync(
             Solution solution, ImmutableArray<ISymbol> symbols, IImmutableSet<Project> projects, CancellationToken cancellationToken)
@@ -300,10 +300,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     compilation ??= CreateCompilation();
 
-                    name = ImmutableInterlocked.GetOrAdd(
-                        ref s_metadataIdToAssemblyName,
-                        metadataId,
-                        (compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol)?.Name);
+                    if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol { Name: string assemblyName })
+                        name = ImmutableInterlocked.GetOrAdd(ref s_metadataIdToAssemblyName, metadataId, assemblyName);
                 }
 
                 if (name == assemblyName)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -338,15 +338,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     return;
 
                 // Use the project's compilation if it has one.
-                if (!project.TryGetCompilation(out compilation))
-                {
-                    // WORKAROUND:
-                    // perf check metadata reference using newly created empty compilation with only metadata references.
-                    var factory = project.Services.GetRequiredService<ICompilationFactoryService>();
-                    compilation = factory
-                        .CreateCompilation(project.AssemblyName, project.CompilationOptions!)
-                        .AddReferences(project.MetadataReferences);
-                }
+                if (project.TryGetCompilation(out compilation))
+                    return;
+
+                // Perf: check metadata reference using newly created empty compilation with only metadata references.
+                var factory = project.Services.GetRequiredService<ICompilationFactoryService>();
+                compilation = factory
+                    .CreateCompilation(project.AssemblyName, project.CompilationOptions!)
+                    .AddReferences(project.MetadataReferences);
             }
         }
     }


### PR DESCRIPTION
Found by @sharwell.  This is used when we looking downstream for which projects may have a reference to a metadata symbol we're looking for.  We know what assembly the metadata symbol is from, and we want to know if a downstream project potentially references that same metadata dll.  Previously this required going back through compilations every time.  We can cache prior results though and reuse those to avoid that.