### PR TITLE
Qualify values in the RHS of object initializers

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -30,18 +30,24 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
         protected override bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node)
         {
             if (node.GetAncestorOrThis<AttributeSyntax>() != null)
-            {
                 return false;
-            }
 
             if (node.GetAncestorOrThis<ConstructorInitializerSyntax>() != null)
+                return false;
+
+            if (node.IsKind(SyntaxKind.BaseExpression))
+                return false;
+
+            if (IsInPropertyOrFieldInitialization(containingSymbol, node))
+                return false;
+
+            if (node.Parent is AssignmentExpressionSyntax { Parent: InitializerExpressionSyntax(SyntaxKind.ObjectInitializerExpression), Left: var left } &&
+                left == node)
             {
                 return false;
             }
 
-            return !(node.IsKind(SyntaxKind.BaseExpression) ||
-                     node.GetRequiredParent().GetRequiredParent().IsKind(SyntaxKind.ObjectInitializerExpression) ||
-                     IsInPropertyOrFieldInitialization(containingSymbol, node));
+            return true;
         }
 
         private static bool IsInPropertyOrFieldInitialization(ISymbol containingSymbol, SyntaxNode node)

--- a/src/Analyzers/CSharp/Tests/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -2014,7 +2014,42 @@ CodeStyleOptions2.QualifyPropertyAccess);
                     }
                 }
                 """,
-CodeStyleOptions2.QualifyPropertyAccess);
+CodeStyleOptions2.QualifyFieldAccess);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/22776")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/64374")]
+        public async Task DoReportToQualify_InObjectInitializer2()
+        {
+            await TestAsyncWithOption(
+                """
+                public class C
+                {
+                    public string Foo;
+                    public void Bar()
+                    {
+                        var c = new C
+                        {
+                            Foo = [|Foo|]
+                        };
+                    }
+                }
+                """,
+                """
+                public class C
+                {
+                    public string Foo;
+                    public void Bar()
+                    {
+                        var c = new C
+                        {
+                            Foo = this.Foo
+                        };
+                    }
+                }
+                """,
+                CodeStyleOptions2.QualifyFieldAccess);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/26893")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64374