### PR TITLE
Add `IsExplicitExtension`

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_globalHasErrors)
             {
                 var extensionMarker = new SynthesizedExtensionMarker(sourceExtension,
-                    sourceExtension.ExtensionUnderlyingTypeNoUseSiteDiagnostics, sourceExtension.BaseExtensionsNoUseSiteDiagnostics,
+                    sourceExtension.ExtendedTypeNoUseSiteDiagnostics, sourceExtension.BaseExtensionsNoUseSiteDiagnostics,
                     _diagnostics);
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTreeBuilder.cs
@@ -630,6 +630,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.HasPrimaryConstructor;
             }
 
+            if (node is ExtensionDeclarationSyntax extension &&
+                extension.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ExplicitKeyword))
+            {
+                declFlags |= SingleTypeDeclaration.TypeDeclarationFlags.IsExplicitExtension;
+            }
+
             var memberNames = GetNonTypeMemberNames(((Syntax.InternalSyntax.TypeDeclarationSyntax)(node.Green)).Members,
                                                     ref declFlags, hasPrimaryCtor: hasPrimaryCtor);
 

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -60,6 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             HasRequiredMembers = 1 << 10,
 
             HasPrimaryConstructor = 1 << 11,
+
+            IsExplicitExtension = 1 << 12,
         }
 
         internal SingleTypeDeclaration(
@@ -196,6 +198,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool HasRequiredMembers => (_flags & TypeDeclarationFlags.HasRequiredMembers) != 0;
 
         public bool HasPrimaryConstructor => (_flags & TypeDeclarationFlags.HasPrimaryConstructor) != 0;
+
+        public bool IsExplicitExtension => (_flags & TypeDeclarationFlags.IsExplicitExtension) != 0;
 
         protected override ImmutableArray<SingleNamespaceOrTypeDeclaration> GetNamespaceOrTypeDeclarationChildren()
         {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -751,7 +751,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
 
                         case TypeKind.Extension:
-                            // PROTOTYPE consider adding `implicit`/`explicit` too
+                            var extensionType = (NamedTypeSymbol)((Symbols.PublicModel.NamedTypeSymbol)symbol).UnderlyingSymbol;
+                            AddKeyword(extensionType.IsExplicitExtension ? SyntaxKind.ExplicitKeyword : SyntaxKind.ImplicitKeyword);
+                            AddSpace();
                             AddKeyword(SyntaxKind.ExtensionKeyword);
                             AddSpace();
                             break;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -268,6 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsRecord => false;
             internal sealed override bool IsRecordStruct => false;
             internal sealed override bool IsExtension => false;
+            internal sealed override bool IsExplicitExtension => false;
 
             internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
             internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousManager.TypeOrDelegatePublicSymbol.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExtension => false;
             internal sealed override bool IsExplicitExtension => false;
 
-            internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+            internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
             internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
                 => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsExtension => false;
             internal sealed override bool IsExplicitExtension => false;
 
-            internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+            internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
             internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
                 => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeOrDelegateTemplateSymbol.cs
@@ -313,6 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal sealed override bool IsRecordStruct => false;
 
             internal sealed override bool IsExtension => false;
+            internal sealed override bool IsExplicitExtension => false;
 
             internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
             internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -484,6 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsRecordStruct => false;
 
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -250,6 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsRecordStruct => false;
 
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -550,6 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsRecord => false;
         internal sealed override bool IsRecordStruct => false;
         internal sealed override bool IsExtension => false;
+        internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -218,6 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsRecordStruct => false;
 
         internal sealed override bool IsExtension => false;
+        internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionTypeSymbol.cs
@@ -128,6 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsRecordStruct => throw ExceptionUtilities.Unreachable();
 
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2076,7 +2076,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     else
                     {
                         // PROTOTYPE what if the base extension is nullable-annotated?
-                        // TODO2 stack overflow when getting ExtendedTypeNoUseSiteDiagnostics
                         // PROTOTYPE we should check that the extended type is compatible
                         // with the base extension's (but that causes a cycle)
                         NamedTypeSymbol baseExtension;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2076,9 +2076,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     else
                     {
                         // PROTOTYPE what if the base extension is nullable-annotated?
+                        // TODO2 stack overflow when getting ExtendedTypeNoUseSiteDiagnostics
+                        // PROTOTYPE we should check that the extended type is compatible
+                        // with the base extension's (but that causes a cycle)
                         NamedTypeSymbol baseExtension;
-                        if (type is NamedTypeSymbol { IsExtension: true } namedType
-                            && !SourceExtensionTypeSymbol.AreExtendedTypesIncompatible(underlyingType, namedType.ExtendedTypeNoUseSiteDiagnostics))
+                        if (type is NamedTypeSymbol { IsExtension: true } namedType)
                         {
                             baseExtension = namedType;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -660,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -183,6 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsRecord => false;
         internal sealed override bool IsRecordStruct => false;
         internal sealed override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -312,6 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsRecordStruct => false;
 
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
 
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
         private static NamedTypeSymbol MakeErrorType(TypeSymbol type)
         {
-            // PROTOTYPE consider using a more specific diagnosticA. Maybe ERR_MalformedExtensionInMetadata or "Extension type declaration is malformed"
+            // PROTOTYPE consider using a more specific diagnostic. Maybe ERR_MalformedExtensionInMetadata or "Extension type declaration is malformed"
             var info = new CSDiagnosticInfo(ErrorCode.ERR_ErrorInReferencedAssembly, type.ContainingAssembly?.Identity.GetDisplayName() ?? string.Empty);
             return new ExtendedErrorTypeSymbol(type, LookupResultKind.NotReferencable, info, unreported: true);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         internal sealed override bool IsExtension => _underlyingType.IsExtension;
         internal sealed override bool IsExplicitExtension => _underlyingType.IsExplicitExtension;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 }
 
                 ImmutableArray<NamedTypeSymbol> result = declaredInterfaces
-                    .SelectAsArray(t => BaseTypeAnalysis.TypeDependsOn(t, on: this) ? CyclicInheritanceError(t) : t);
+                    .SelectAsArray(t => BaseTypeAnalysis.TypeDependsOn(t, this) ? CyclicInheritanceError(t) : t);
 
                 ImmutableInterlocked.InterlockedCompareExchange(ref _lazyInterfaces, result, default(ImmutableArray<NamedTypeSymbol>));
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -466,10 +466,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return _lazyDeclaredExtendedType;
         }
 
-        private static NamedTypeSymbol MakeErrorType(TypeSymbol declaredExtendedType)
+        private static NamedTypeSymbol MakeErrorType(TypeSymbol type)
         {
-            var info = new CSDiagnosticInfo(ErrorCode.ERR_ErrorInReferencedAssembly, declaredExtendedType.ContainingAssembly?.Identity.GetDisplayName() ?? string.Empty);
-            return new ExtendedErrorTypeSymbol(declaredExtendedType, LookupResultKind.NotReferencable, info, unreported: true);
+            var info = new CSDiagnosticInfo(ErrorCode.ERR_ErrorInReferencedAssembly, type.ContainingAssembly?.Identity.GetDisplayName() ?? string.Empty);
+            return new ExtendedErrorTypeSymbol(type, LookupResultKind.NotReferencable, info, unreported: true);
         }
 
         internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #nullable enable
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -173,6 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -177,6 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var current = declaredUnderlyingType;
                     do
                     {
+                        // PROTOTYPE should this should check declaring module rather than compilations?
                         if (ReferenceEquals(current.DeclaringCompilation, this.DeclaringCompilation))
                         {
                             break;
@@ -189,6 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if (!useSiteInfo.Diagnostics.IsNullOrEmpty())
                     {
+                        // PROTOTYPE Are we dropping dependencies if we are not getting into this 'if'?
                         var location = FindUnderlyingTypeSyntax(declaredUnderlyingType) ?? Locations[0];
                         diagnostics.Add(location, useSiteInfo);
                     }
@@ -281,8 +283,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
                             declaredBaseExtension.AddUseSiteInfo(ref useSiteInfo);
 
+                            // PROTOTYPE why do we go one extra level here, and, if that is necessary, why only one level.
                             foreach (var extension in declaredBaseExtension.BaseExtensionsNoUseSiteDiagnostics)
                             {
+                                // PROTOTYPE should this should check declaring module rather than compilations?
                                 if (extension.DeclaringCompilation != this.DeclaringCompilation)
                                 {
                                     extension.AddUseSiteInfo(ref useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -545,10 +545,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return extendedType.IsStatic && !extensionType.IsStatic;
         }
 
-        internal static bool AreExtendedTypesIncompatible([NotNullWhen(true)] TypeSymbol? underlyingType, [NotNullWhen(true)] TypeSymbol? baseUnderlyingType)
+        internal static bool AreExtendedTypesIncompatible([NotNullWhen(true)] TypeSymbol? extendedType, [NotNullWhen(true)] TypeSymbol? baseExtendedType)
         {
-            return underlyingType is not null &&
-                baseUnderlyingType?.Equals(underlyingType, TypeCompareKind.ConsiderEverything) == false;
+            return extendedType is not null &&
+                baseExtendedType?.Equals(extendedType, TypeCompareKind.ConsiderEverything) == false;
         }
 
         internal static bool IsRestrictedExtensionUnderlyingType(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class SourceExtensionTypeSymbol : SourceNamedTypeSymbol
     {
         private ExtensionInfo _lazyDeclaredExtensionInfo = ExtensionInfo.Sentinel;
+        // PROTOTYPE consider renaming ExtensionUnderlyingType->ExtendedType (here and elsewhere)
         private TypeSymbol? _lazyExtensionUnderlyingType = ErrorTypeSymbol.UnknownResultType;
         private ImmutableArray<NamedTypeSymbol> _lazyBaseExtensions;
 
@@ -39,6 +40,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal override bool IsExtension => true;
+
+        internal override bool IsExplicitExtension
+            => ((ExtensionDeclarationSyntax)this.declaration.Declarations[0].SyntaxReference.GetSyntax()).ImplicitOrExplicitKeyword
+                .IsKind(SyntaxKind.ExplicitKeyword);
 
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected override void CheckUnderlyingType(BindingDiagnosticBag diagnostics)
         {
-            var underlyingType = this.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+            var underlyingType = this.ExtendedTypeNoUseSiteDiagnostics;
 
             if (underlyingType is null)
                 return;
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var corLibrary = this.ContainingAssembly.CorLibrary;
             var conversions = new TypeConversions(corLibrary);
             var location = singleDeclaration.NameLocation;
-            var underlyingType = this.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+            var underlyingType = this.ExtendedTypeNoUseSiteDiagnostics;
 
             foreach (var pair in allBaseExtensions)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     baseExtension.CheckAllConstraints(DeclaringCompilation, conversions, location, diagnostics);
 
                     // PROTOTYPE confirm what we allow in terms of variation between various underlying types
-                    var baseUnderlyingType = baseExtension.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+                    var baseUnderlyingType = baseExtension.ExtendedTypeNoUseSiteDiagnostics;
                     if (baseUnderlyingType?.Equals(underlyingType, TypeCompareKind.ConsiderEverything) == false)
                     {
                         diagnostics.Add(ErrorCode.ERR_UnderlyingTypesMismatch, location, this, underlyingType!, baseUnderlyingType);
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions()
             => GetDeclaredExtensionInfo().BaseExtensions;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1743,7 +1743,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var baseType = BaseTypeNoUseSiteDiagnostics;
             var interfaces = GetInterfacesToEmit();
-            var extendedType = ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+            var extendedType = ExtendedTypeNoUseSiteDiagnostics;
             var baseExtensions = BaseExtensionsNoUseSiteDiagnostics;
 
             if (compilation.ShouldEmitNativeIntegerAttributes())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
+
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNonExtensionNamedTypeSymbol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
 
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -441,6 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         internal sealed override bool IsExtension => _underlyingType.IsExtension;
+        internal sealed override bool IsExplicitExtension => _underlyingType.IsExplicitExtension;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics
             => _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtensionUnderlyingTypeNoUseSiteDiagnostics).Type;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -443,8 +443,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => _underlyingType.IsExtension;
         internal sealed override bool IsExplicitExtension => _underlyingType.IsExplicitExtension;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics
-            => _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtensionUnderlyingTypeNoUseSiteDiagnostics).Type;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics
+            => _unbound ? null : Map.SubstituteType(OriginalDefinition.ExtendedTypeNoUseSiteDiagnostics).Type;
 
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => _unbound ? ImmutableArray<NamedTypeSymbol>.Empty : Map.SubstituteNamedTypes(OriginalDefinition.BaseExtensionsNoUseSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Extensions/SynthesizedExtensionMarker.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Extensions/SynthesizedExtensionMarker.cs
@@ -55,7 +55,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override string Name => WellKnownMemberNames.ExtensionMarkerMethodName;
+        public override string Name => _extensionType.IsExplicitExtension
+            ? WellKnownMemberNames.ExplicitExtensionMarkerMethodName
+            : WellKnownMemberNames.ImplicitExtensionMarkerMethodName;
 
         internal override System.Reflection.MethodImplAttributes ImplementationAttributes => default;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsRecordStruct => false;
 #nullable enable
         internal sealed override bool IsExtension => false;
+        internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -166,6 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool HasPossibleWellKnownCloneMethod() => false;
 #nullable enable
         internal sealed override bool IsExtension => false;
+        internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -716,7 +716,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsExtension => false;
         internal sealed override bool IsExplicitExtension => false;
 
-        internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal sealed override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics
             => ImmutableArray<NamedTypeSymbol>.Empty;
     }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -714,6 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         internal sealed override bool IsExtension => false;
+        internal sealed override bool IsExplicitExtension => false;
 
         internal sealed override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal sealed override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2469,6 +2469,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #nullable enable
         internal abstract bool IsExtension { get; }
+        internal abstract bool IsExplicitExtension { get; }
 
         internal abstract TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2471,7 +2471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract bool IsExtension { get; }
         internal abstract bool IsExplicitExtension { get; }
 
-        internal abstract TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics { get; }
+        internal abstract TypeSymbol? ExtendedTypeNoUseSiteDiagnostics { get; }
 
         internal abstract ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics { get; }
 #nullable disable

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
@@ -5115,24 +5115,18 @@ public explicit extension R4 for C : R2 { }
 """;
 
         var comp = CreateCompilationWithIL(src, ilSource, targetFramework: TargetFramework.Net70);
+        // PROTOTYPE we should check that the extended type is compatible
+        // with the base extension's
         comp.VerifyDiagnostics(
-            // (1,27): error CS9222: Extension marker method on type 'R2' is malformed.
-            // public explicit extension R3 for object : R2 { }
-            Diagnostic(ErrorCode.ERR_MalformedExtensionInMetadata, "R3").WithArguments("R2").WithLocation(1, 27),
             // (1,27): error CS9216: Extension 'R3' has underlying type 'object' but a base extension has underlying type 'C'.
             // public explicit extension R3 for object : R2 { }
-            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R3").WithArguments("R3", "object", "C").WithLocation(1, 27),
-            // (2,27): error CS9222: Extension marker method on type 'R2' is malformed.
-            // public explicit extension R4 for C : R2 { }
-            Diagnostic(ErrorCode.ERR_MalformedExtensionInMetadata, "R4").WithArguments("R2").WithLocation(2, 27)
+            Diagnostic(ErrorCode.ERR_UnderlyingTypesMismatch, "R3").WithArguments("R3", "object", "C").WithLocation(1, 27)
             );
 
         var r2 = (PENamedTypeSymbol)comp.GlobalNamespace.GetTypeMember("R2");
         var r2BaseExtension = r2.BaseExtensionsNoUseSiteDiagnostics.Single();
         Assert.Equal("R1", r2BaseExtension.ToTestDisplayString());
-
-        AssertEx.Equal("error CS9222: Extension marker method on type 'R2' is malformed.",
-            ((ErrorTypeSymbol)r2BaseExtension).ErrorInfo.ToString());
+        Assert.False(r2BaseExtension.IsErrorType()); // PROTOTYPE
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
@@ -6521,7 +6521,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = (ExtendedErrorTypeSymbol) r1.ExtendedTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
         AssertEx.Equal("error CS9222: Extension marker method on type 'R1' is malformed.", r1ExtendedType.ErrorInfo.ToString());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ExtensionTypeTests.cs
@@ -23,7 +23,7 @@ public class ExtensionTypeTests : CompilingTestBase
         Assert.True(type is T, $"Found type '{type.GetType()}'");
         Assert.False(type.IsExtension);
         Assert.False(type.IsExplicitExtension);
-        Assert.Null(type.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(type.ExtendedTypeNoUseSiteDiagnostics);
         Assert.Empty(type.BaseExtensionsNoUseSiteDiagnostics);
     }
 
@@ -61,7 +61,7 @@ public class ExtensionTypeTests : CompilingTestBase
         Assert.False(namedType.IsInterfaceType());
         Assert.False(namedType.IsAbstract);
 
-        if (namedType.ExtensionUnderlyingTypeNoUseSiteDiagnostics is { } underlyingType)
+        if (namedType.ExtendedTypeNoUseSiteDiagnostics is { } underlyingType)
         {
             // PROTOTYPE consider whether we want to expose invalid underlying types
             // in context of public APIs
@@ -174,7 +174,7 @@ explicit extension R2 for UnderlyingClass : R { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
 
             if (!inSource)
@@ -299,7 +299,7 @@ class C<T>
             var c = module.GlobalNamespace.GetTypeMember("C");
             var r = c.GetTypeMember("R");
             Assert.Equal(1, r.Arity);
-            var underlyingType = (NamedTypeSymbol)r.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+            var underlyingType = (NamedTypeSymbol)r.ExtendedTypeNoUseSiteDiagnostics;
             Assert.Equal("UnderlyingClass<T, U>", underlyingType.ToTestDisplayString());
             Assert.Equal(2, underlyingType.TypeArguments().Length);
             Assert.Same(c.TypeArguments().Single(), underlyingType.TypeArguments()[0]);
@@ -756,7 +756,7 @@ static explicit extension R for UnderlyingClass
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         AssertEx.Equal(new[]
             {
@@ -1822,7 +1822,7 @@ explicit extension R for UnderlyingStruct
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("UnderlyingStruct", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("UnderlyingStruct", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -1863,7 +1863,7 @@ interface I { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("T", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("T", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -1904,7 +1904,7 @@ enum E { }
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: isExplicit);
             }
 
-            Assert.Equal("E", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("E", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -1931,7 +1931,7 @@ explicit extension R for object
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("System.Object", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Object", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         Assert.Empty(r.GetMembers());
         Assert.Null(r.BaseTypeNoUseSiteDiagnostics);
@@ -1970,7 +1970,7 @@ explicit extension R<U> for C<U>
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("C<U>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -2010,7 +2010,7 @@ explicit extension R for (int, int)
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("(System.Int32, System.Int32)", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -2050,7 +2050,7 @@ explicit extension R for int[]
                 VerifyExtension<PENamedTypeSymbol>(r, isExplicit: true);
             }
 
-            Assert.Equal("System.Int32[]", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("System.Int32[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
             Assert.Empty(r.GetMembers());
 
@@ -2244,7 +2244,7 @@ static explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.True(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -2261,7 +2261,7 @@ static explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.True(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -2278,7 +2278,7 @@ explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.False(r.IsStatic);
         comp.VerifyDiagnostics(
             // (2,26): error CS9206: Instance extension 'R' cannot extend type 'UnderlyingClass' because it is static.
@@ -2299,7 +2299,7 @@ explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.False(r.IsSealed);
         comp.VerifyDiagnostics();
     }
@@ -2317,7 +2317,7 @@ file explicit extension R for UnderlyingClass
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R@<tree 0>", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2336,7 +2336,7 @@ explicit extension R for UnderlyingClass
             Diagnostic(ErrorCode.ERR_FileTypeUnderlying, "R").WithArguments("UnderlyingClass", "R").WithLocation(2, 20)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass@<tree 0>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2359,7 +2359,7 @@ explicit extension R for Outer.UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2381,7 +2381,7 @@ partial explicit extension R for Outer.UnderlyingClass { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Outer@<tree 0>.UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2417,10 +2417,10 @@ implicit extension R2 for UnderlyingClass2 { } // 5
             );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        Assert.Equal("UnderlyingClass1", r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass1", r1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("UnderlyingClass1", r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass1", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2524,7 +2524,7 @@ explicit extension R for { }
             );
 
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.True(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Theory, CombinatorialData]
@@ -2557,7 +2557,7 @@ explicit extension R3 for System.IntPtr : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("nint", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("nint", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2596,7 +2596,7 @@ explicit extension R3 for System.IntPtr : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("nint", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("nint", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2637,7 +2637,7 @@ explicit extension R3 for C<System.IntPtr> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<nint>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<nint>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2676,7 +2676,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<dynamic>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<dynamic>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2730,7 +2730,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<System.Object?>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
+            Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2784,7 +2784,7 @@ explicit extension R3 for C<object> : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("C<System.Object!>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
+            Assert.Equal("C<System.Object!>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2841,7 +2841,7 @@ explicit extension R4 for (int a, int other) : R { }
         {
             var r = module.GlobalNamespace.GetTypeMember("R");
             VerifyExtension<TypeSymbol>(r, isExplicit: true);
-            Assert.Equal("(System.Int32 a, System.Int32 b)", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("(System.Int32 a, System.Int32 b)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
         }
     }
@@ -2865,7 +2865,7 @@ unsafe explicit extension R for int*
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
         Assert.Empty(r.GetMembers());
     }
 
@@ -2885,7 +2885,7 @@ explicit extension R for ref int
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("System.Int32", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Int32", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -2925,7 +2925,7 @@ explicit extension R2 for int* // 2, 3
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
     }
 
     [Fact]
@@ -2945,7 +2945,7 @@ unsafe explicit extension R for delegate*<void>
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
         Assert.Empty(r.GetMembers());
     }
 
@@ -2965,7 +2965,7 @@ explicit extension R for dynamic
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
     }
 
@@ -3041,7 +3041,7 @@ partial explicit extension R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3057,7 +3057,7 @@ partial explicit extension R for UnderlyingClass { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3076,7 +3076,7 @@ partial explicit extension R for UnderlyingClass2 { }
             Diagnostic(ErrorCode.ERR_PartialMultipleUnderlyingTypes, "R").WithArguments("R").WithLocation(3, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3097,7 +3097,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_PartialMultipleUnderlyingTypes, "R").WithArguments("R").WithLocation(4, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3120,7 +3120,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ErrorType").WithArguments("ErrorType").WithLocation(4, 34)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3143,7 +3143,7 @@ partial explicit extension R for UnderlyingClass3 { }
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "ErrorType").WithArguments("ErrorType").WithLocation(3, 34)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("ErrorType", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("ErrorType", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3161,7 +3161,7 @@ partial explicit extension R for C<object> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3181,8 +3181,8 @@ partial explicit extension R for C<dynamic> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Fact]
@@ -3202,8 +3202,8 @@ partial explicit extension R for C<(int y, int b)> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Fact]
@@ -3221,8 +3221,8 @@ partial explicit extension R for object? { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("System.Object", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
-        Assert.False(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("System.Object", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString(includeNonNullable: true));
+        Assert.False(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Fact]
@@ -3244,8 +3244,8 @@ partial explicit extension R for C<object?> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Fact]
@@ -3265,7 +3265,7 @@ partial explicit extension R for C<object?> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object?>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3284,7 +3284,7 @@ partial explicit extension R for C<object> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<System.Object?>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<System.Object?>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3318,8 +3318,8 @@ partial explicit extension R for C<
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<, >", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.True(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.Equal("C<, >", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.True(r.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
     }
 
     [Fact]
@@ -3342,7 +3342,7 @@ partial explicit extension R for UnderlyingClass { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("Error", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("Error", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3362,7 +3362,7 @@ partial explicit extension R for Error { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Theory, CombinatorialData]
@@ -3382,7 +3382,7 @@ partial {{keyword}} extension R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
     }
 
     [Fact]
@@ -3555,7 +3555,7 @@ explicit extension R for error
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        var underlyingType = r.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var underlyingType = r.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("error", underlyingType.ToTestDisplayString());
         Assert.True(underlyingType.IsErrorType());
     }
@@ -3576,7 +3576,7 @@ explicit extension R for C<error>
             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "error").WithArguments("error").WithLocation(2, 28)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        var underlyingType = r.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var underlyingType = r.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("C<error>", underlyingType.ToTestDisplayString());
     }
 
@@ -3624,7 +3624,7 @@ explicit extension R for R { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Null(r.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(r.ExtendedTypeNoUseSiteDiagnostics);
     }
 
     [Fact]
@@ -3636,7 +3636,7 @@ explicit extension R for R[] { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("R[]", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3648,7 +3648,7 @@ explicit extension R for (R, R) { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("(R, R)", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R, R)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3661,7 +3661,7 @@ explicit extension R for S<R> { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("S<R>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("S<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3678,8 +3678,8 @@ explicit extension R for S<R> { }
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("S<R>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("R", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.GetMember("field").GetTypeOrReturnType().ToTestDisplayString());
+        Assert.Equal("S<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R", r.ExtendedTypeNoUseSiteDiagnostics.GetMember("field").GetTypeOrReturnType().ToTestDisplayString());
     }
 
     [Fact]
@@ -3694,7 +3694,7 @@ explicit extension R for C<R> { }
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C<R>", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<R>", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -3822,12 +3822,12 @@ explicit extension R2 for object : R
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.True(r.IsExtension);
-        Assert.Equal("R2.Nested", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         Assert.True(r2.IsExtension);
-        Assert.Equal("System.Object", r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Object", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         Assert.True(r2.BaseExtensionsNoUseSiteDiagnostics.Single().IsErrorType());
     }
@@ -3867,7 +3867,7 @@ public explicit extension R1 for R2 { }
 
         var r1 = comp5.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        var r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("R2", r2FromR1.ToTestDisplayString());
         AssertEx.Equal("error CS9222: Extension marker method on type 'R1' is malformed.", r2FromR1.ErrorInfo.ToString());
 
@@ -3877,7 +3877,7 @@ public explicit extension R1 for R2 { }
 
         r1 = comp6.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<RetargetingNamedTypeSymbol>(r1, isExplicit: true);
-        r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        r2FromR1 = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.True(r2FromR1.IsErrorType());
         AssertEx.Equal("error CS0268: Imported type 'R2' is invalid. It contains a circular base type dependency.", r2FromR1.ErrorInfo.ToString());
     }
@@ -3896,12 +3896,12 @@ explicit extension R2 for R2.Nested[] : R
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.True(r.IsExtension);
-        Assert.Equal("R2.Nested[]", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested[]", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         Assert.True(r2.IsExtension);
-        Assert.Equal("R2.Nested[]", r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested[]", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -3918,11 +3918,11 @@ explicit extension R2 for (R2.Nested, int) : R
         var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("(R2.Nested, System.Int32)", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R2.Nested, System.Int32)", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Empty(r.BaseExtensionsNoUseSiteDiagnostics);
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("(R2.Nested, System.Int32)", r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("(R2.Nested, System.Int32)", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R" }, r2.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -3960,7 +3960,7 @@ public explicit extension R1 for R2.Nested2
 
         var r1 = comp1.GlobalNamespace.GetTypeMember("R1");
         Assert.True(r1.IsExtension);
-        Assert.Equal("R2.Nested2", r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("R2.Nested2", r1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -4035,12 +4035,12 @@ public explicit extension R3 for object : R1 { }
             );
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
-        var r1ExtendedType = r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("R2", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        var r2ExtendedType = r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r2ExtendedType = r2.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("R1", r2ExtendedType.ToTestDisplayString());
         Assert.True(r2ExtendedType.IsErrorType());
     }
@@ -4325,11 +4325,11 @@ partial explicit extension R4 for C : R2 { }
         static void validate(ModuleSymbol module)
         {
             var r3 = module.GlobalNamespace.GetTypeMember("R3");
-            Assert.Equal("C", r3.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C", r3.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Equal(new[] { "R1", "R2" }, r3.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
             var r4 = module.GlobalNamespace.GetTypeMember("R4");
-            Assert.Equal("C", r4.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Equal(new[] { "R1", "R2" }, r4.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
         }
     }
@@ -4362,12 +4362,12 @@ class D<U>
 
             var r3 = d.GetTypeMember("R3");
             Assert.Equal(1, r3.Arity);
-            Assert.Equal("C<U, V>", r3.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U, V>", r3.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r3.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
             var r4 = d.GetTypeMember("R4");
             Assert.Equal(1, r4.Arity);
-            Assert.Equal("C<U, V>", r4.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+            Assert.Equal("C<U, V>", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
             Assert.Equal(new[] { "D<U>.R1<U, V>", "D<U>.R2<U, V>" }, r4.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
 
             var r4FirstBase = r4.BaseExtensionsNoUseSiteDiagnostics.First();
@@ -4395,7 +4395,7 @@ explicit extension R for C : error
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
         Assert.True(r.IsExtension);
-        Assert.Equal("C", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         var baseExtensions = r.BaseExtensionsNoUseSiteDiagnostics;
         Assert.Equal(new[] { "error" }, baseExtensions.ToTestDisplayStrings());
         Assert.True(baseExtensions.Single().IsErrorType());
@@ -4495,7 +4495,7 @@ explicit extension R for UnderlyingClass : R1 { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R1@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -4516,7 +4516,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         Assert.Equal("R", r.ToTestDisplayString());
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R1", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -4539,7 +4539,7 @@ explicit extension R for UnderlyingClass : R1, R2 { }
             Diagnostic(ErrorCode.ERR_FileTypeBase, "R").WithArguments("R2", "R").WithLocation(4, 20)
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "R1@<tree 0>", "R2@<tree 0>" }, r.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -4896,12 +4896,12 @@ explicit extension R4<U> for C<U> : R3<U> { }
         comp.VerifyDiagnostics();
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
-        Assert.Equal("U", r2.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("U", r2.BaseExtensionsNoUseSiteDiagnostics.Single().ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("U", r2.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("U", r2.BaseExtensionsNoUseSiteDiagnostics.Single().ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
 
         var r4 = comp.GlobalNamespace.GetTypeMember("R4");
-        Assert.Equal("C<U>", r4.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
-        Assert.Equal("C<U>", r4.BaseExtensionsNoUseSiteDiagnostics.Single().ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<U>", r4.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C<U>", r4.BaseExtensionsNoUseSiteDiagnostics.Single().ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -4942,7 +4942,7 @@ partial explicit extension R
         comp.VerifyDiagnostics();
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.False(r.IsStatic);
     }
 
@@ -4962,7 +4962,7 @@ explicit extension R for C { }
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("C", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("C", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -4982,7 +4982,7 @@ unsafe explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.False(r.IsStatic);
     }
 
@@ -4999,7 +4999,7 @@ unsafe explicit extension R for UnderlyingClass
         var comp = CreateCompilation(src, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net70);
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.False(r.IsStatic);
         comp.VerifyDiagnostics();
     }
@@ -5024,7 +5024,7 @@ explicit extension DerivedExtension for UnderlyingClass : BaseExtension
         var r = comp.GlobalNamespace.GetTypeMember("DerivedExtension").GetTypeMember("R");
         Assert.Equal("DerivedExtension.R", r.ToTestDisplayString());
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass2", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass2", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         // PROTOTYPE verify hiding in usages/lookups
     }
 
@@ -5317,7 +5317,7 @@ internal internal explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(Accessibility.Internal, r.DeclaredAccessibility);
     }
 
@@ -5341,7 +5341,7 @@ public internal explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(Accessibility.Public, r.DeclaredAccessibility);
     }
 
@@ -5365,7 +5365,7 @@ internal public explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(Accessibility.Public, r.DeclaredAccessibility);
     }
 
@@ -5386,7 +5386,7 @@ abstract explicit extension R for UnderlyingClass
             );
         var r = comp.GlobalNamespace.GetTypeMember("R");
         VerifyExtension<SourceExtensionTypeSymbol>(r, isExplicit: true);
-        Assert.Equal("UnderlyingClass", r.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("UnderlyingClass", r.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
     }
 
     [Fact]
@@ -5961,7 +5961,7 @@ explicit extension E2 for int : E1 { }
 
         var e1 = comp2.GlobalNamespace.GetTypeMember("E1");
         VerifyExtension<RetargetingNamedTypeSymbol>(e1, isExplicit: isExplicit);
-        Assert.Equal("System.Int32", e1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.ToTestDisplayString());
+        Assert.Equal("System.Int32", e1.ExtendedTypeNoUseSiteDiagnostics.ToTestDisplayString());
         Assert.Equal(new[] { "E0" }, e1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
     }
 
@@ -5977,7 +5977,7 @@ class C { }
         var comp2 = CreateCompilation("", references: new[] { comp1.ToMetadataReference() }, targetFramework: TargetFramework.Mscorlib46);
         var c = comp2.GlobalNamespace.GetTypeMember("C");
         VerifyNotExtension<RetargetingNamedTypeSymbol>(c);
-        Assert.Null(c.ExtensionUnderlyingTypeNoUseSiteDiagnostics);
+        Assert.Null(c.ExtendedTypeNoUseSiteDiagnostics);
         Assert.Empty(c.BaseExtensionsNoUseSiteDiagnostics);
     }
 
@@ -6379,7 +6379,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
@@ -6483,7 +6483,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
 
@@ -6521,7 +6521,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1ExtendedType = (ExtendedErrorTypeSymbol) r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1ExtendedType = (ExtendedErrorTypeSymbol) r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("System.Object", r1ExtendedType.ToTestDisplayString());
         Assert.True(r1ExtendedType.IsErrorType());
         AssertEx.Equal("error CS9222: Extension marker method on type 'R1' is malformed.", r1ExtendedType.ErrorInfo.ToString());
@@ -6819,7 +6819,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1Underyling = r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1Underyling = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("dynamic", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
@@ -6868,7 +6868,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        var r1Underyling = (ExtendedErrorTypeSymbol)r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1Underyling = (ExtendedErrorTypeSymbol)r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("R0", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         AssertEx.Equal("error CS9222: Extension marker method on type 'R1' is malformed.", r1Underyling.ErrorInfo.ToString());
@@ -6908,7 +6908,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        var r1Underyling = r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics;
+        var r1Underyling = r1.ExtendedTypeNoUseSiteDiagnostics;
         Assert.Equal("R1", r1Underyling.ToTestDisplayString());
         Assert.True(r1Underyling.IsErrorType());
         Assert.Empty(r1.BaseExtensionsNoUseSiteDiagnostics.ToTestDisplayStrings());
@@ -7376,7 +7376,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7411,7 +7411,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7441,7 +7441,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: true);
-        Assert.False(r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.False(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7476,7 +7476,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);
@@ -7511,7 +7511,7 @@ public explicit extension R2 for object : R1 { }
 
         var r1 = comp.GlobalNamespace.GetTypeMember("R1");
         VerifyExtension<PENamedTypeSymbol>(r1, isExplicit: isExplicit);
-        Assert.True(r1.ExtensionUnderlyingTypeNoUseSiteDiagnostics.IsErrorType());
+        Assert.True(r1.ExtendedTypeNoUseSiteDiagnostics.IsErrorType());
 
         var r2 = comp.GlobalNamespace.GetTypeMember("R2");
         VerifyExtension<SourceExtensionTypeSymbol>(r2, isExplicit: true);

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -7996,7 +7996,9 @@ implicit extension R for C { }
                 findSymbol,
                 format,
                 TestOptions.RegularNext,
-                "extension R",
+                "implicit extension R",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ExtensionName);
@@ -8018,7 +8020,9 @@ explicit extension R for C { }
                 findSymbol,
                 format,
                 TestOptions.RegularNext,
-                "extension R",
+                "explicit extension R",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ExtensionName);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 #nullable enable
         internal override bool IsExtension => false;
         internal override bool IsExplicitExtension => false;
-        internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
+        internal override TypeSymbol? ExtendedTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => ImmutableArray<NamedTypeSymbol>.Empty;
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions() => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -333,6 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal override bool HasPossibleWellKnownCloneMethod() => false;
 #nullable enable
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
         internal override TypeSymbol? ExtensionUnderlyingTypeNoUseSiteDiagnostics => null;
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => ImmutableArray<NamedTypeSymbol>.Empty;
         internal override TypeSymbol? GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -400,8 +400,13 @@ namespace Microsoft.CodeAnalysis
         public const string TopLevelStatementsEntryPointTypeName = "Program";
 
         /// <summary>
-        /// The name of marker method for an extension type.
+        /// The name of marker method for an implicit extension type.
         /// </summary>
-        internal const string ExtensionMarkerMethodName = "<Extension>$"; // PROTOTYPE confirm name with WG
+        internal const string ImplicitExtensionMarkerMethodName = "<ImplicitExtension>$"; // PROTOTYPE confirm name with WG
+
+        /// <summary>
+        /// The name of marker method for an explicit extension type.
+        /// </summary>
+        internal const string ExplicitExtensionMarkerMethodName = "<ExplicitExtension>$"; // PROTOTYPE confirm name with WG
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -357,6 +357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool HasPossibleWellKnownCloneMethod() => false;
         internal override bool IsInterpolatedStringHandlerType => false;
         internal override bool IsExtension => false;
+        internal override bool IsExplicitExtension => false;
         internal override TypeSymbol GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions() => throw ExceptionUtilities.Unreachable();
         internal override TypeSymbol ExtensionUnderlyingTypeNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override bool IsExplicitExtension => false;
         internal override TypeSymbol GetDeclaredExtensionUnderlyingType() => throw ExceptionUtilities.Unreachable();
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredBaseExtensions() => throw ExceptionUtilities.Unreachable();
-        internal override TypeSymbol ExtensionUnderlyingTypeNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
+        internal override TypeSymbol ExtendedTypeNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
         internal override ImmutableArray<NamedTypeSymbol> BaseExtensionsNoUseSiteDiagnostics => throw ExceptionUtilities.Unreachable();
 
         [Conditional("DEBUG")]


### PR DESCRIPTION
First commit adds `IsExplicitExtension` and implements related extension APIs on `RetargetingNamedTypeSymbol`.
Second commit renames `ExtensionUnderlyingTypeNoUseSiteDiagnostics` to `ExtendedTypeNoUseSiteDiagnostics` 
Relates to test plan https://github.com/dotnet/roslyn/issues/66722