### PR TITLE
Better recover from missing closing `}` or `]` in switch statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -128,7 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     case TerminatorState.IsEndOfFunctionPointerParameterListErrored when this.IsEndOfFunctionPointerParameterList(errored: true):
                     case TerminatorState.IsEndOfFunctionPointerCallingConvention when this.IsEndOfFunctionPointerCallingConvention():
                     case TerminatorState.IsEndOfRecordOrClassOrStructOrInterfaceSignature when this.IsEndOfRecordOrClassOrStructOrInterfaceSignature():
-                    case TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement:
                         return true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -85,9 +85,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             IsEndOfFunctionPointerParameterListErrored = 1 << 24,
             IsEndOfFunctionPointerCallingConvention = 1 << 25,
             IsEndOfRecordOrClassOrStructOrInterfaceSignature = 1 << 26,
+            IsExpressionOrPatternInCaseLabelOfSwitchStatement = 1 << 27
         }
 
-        private const int LastTerminatorState = (int)TerminatorState.IsEndOfRecordOrClassOrStructOrInterfaceSignature;
+        private const int LastTerminatorState = (int)TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement;
 
         private bool IsTerminator()
         {
@@ -127,6 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     case TerminatorState.IsEndOfFunctionPointerParameterListErrored when this.IsEndOfFunctionPointerParameterList(errored: true):
                     case TerminatorState.IsEndOfFunctionPointerCallingConvention when this.IsEndOfFunctionPointerCallingConvention():
                     case TerminatorState.IsEndOfRecordOrClassOrStructOrInterfaceSignature when this.IsEndOfRecordOrClassOrStructOrInterfaceSignature():
+                    case TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement:
                         return true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             IsEndOfFunctionPointerParameterListErrored = 1 << 24,
             IsEndOfFunctionPointerCallingConvention = 1 << 25,
             IsEndOfRecordOrClassOrStructOrInterfaceSignature = 1 << 26,
-            IsExpressionOrPatternInCaseLabelOfSwitchStatement = 1 << 27
+            IsExpressionOrPatternInCaseLabelOfSwitchStatement = 1 << 27,
         }
 
         private const int LastTerminatorState = (int)TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -429,9 +429,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private CSharpSyntaxNode ParseExpressionOrPatternForSwitchStatement()
         {
+            var savedState = _termState;
             _termState |= TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement;
             var pattern = ParsePattern(Precedence.Conditional, whenIsKeyword: true);
-            _termState ^= TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement;
+            _termState = savedState;
             return ConvertPatternToExpressionIfPossible(pattern);
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return PostSkipAction.Abort;
 
             // `:` is usually treated as incorrect separation token. This helps for error recovery in basic typing scenarios like `{ Prop:$$ Prop1: { ... } }`.
-            // However, such behavior isn't much desirable when parsing pattern of a case label in a switch statement. For instance, consider this case: `case { Prop: { }: case ...`.
+            // However, such behavior isn't much desirable when parsing pattern of a case label in a switch statement. For instance, consider the following example: `case { Prop: { }: case ...`.
             // Normally we would skip second `:` and `case` keyword after it as a bad tokens and continue parsing pattern, which produces a lot of noise errors.
             // In order to avoid that and produce single error of missing `}` we exit on unexpected `:` in such cases.
             if (@this._termState.HasFlag(TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement) && @this.CurrentToken.Kind is SyntaxKind.ColonToken)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // `:` is usually treated as incorrect separation token. This helps for error recovery in basic typing scenarios like `{ Prop:$$ Prop1: { ... } }`.
             // However, such behavior isn't much desirable when parsing pattern of a case label in a switch statement. For instance, consider the following example: `case { Prop: { }: case ...`.
-            // Normally we would skip second `:` and `case` keyword after it as a bad tokens and continue parsing pattern, which produces a lot of noise errors.
+            // Normally we would skip second `:` and `case` keyword after it as bad tokens and continue parsing pattern, which produces a lot of noise errors.
             // In order to avoid that and produce single error of missing `}` we exit on unexpected `:` in such cases.
             if (@this._termState.HasFlag(TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement) && @this.CurrentToken.Kind is SyntaxKind.ColonToken)
                 return PostSkipAction.Abort;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -2155,32 +2155,20 @@ case KeyValuePair<String, DateTime>[] pairs2:
                 // (1,30): error CS0103: The name 'e' does not exist in the current context
                 // class C { void M() { switch (e) { case (: ; } } }
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "e").WithArguments("e").WithLocation(1, 30),
-                // (1,35): error CS8070: Control cannot fall out of switch from final case label ('case (: ')
+                // (1,35): error CS8070: Control cannot fall out of switch from final case label ('case (:')
                 // class C { void M() { switch (e) { case (: ; } } }
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "case (: ").WithArguments("case (: ").WithLocation(1, 35),
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "case (:").WithArguments("case (:").WithLocation(1, 35),
                 // (1,40): error CS8370: Feature 'recursive patterns' is not available in C# 7.3. Please use language version 8.0 or greater.
                 // class C { void M() { switch (e) { case (: ; } } }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "(: ").WithArguments("recursive patterns", "8.0").WithLocation(1, 40),
-                // (1,41): error CS1001: Identifier expected
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "(").WithArguments("recursive patterns", "8.0").WithLocation(1, 40),
+                // (1,41): error CS1026: ) expected
                 // class C { void M() { switch (e) { case (: ; } } }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 41),
-                // (1,43): error CS1026: ) expected
-                // class C { void M() { switch (e) { case (: ; } } }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 43),
-                // (1,43): error CS1003: Syntax error, ':' expected
-                // class C { void M() { switch (e) { case (: ; } } }
-                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(":").WithLocation(1, 43));
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 41));
 
             UsingStatement(test, TestOptions.RegularWithoutRecursivePatterns,
-                // (1,20): error CS1001: Identifier expected
+                // (1,20): error CS1026: ) expected
                 // switch (e) { case (: ; }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 20),
-                // (1,22): error CS1026: ) expected
-                // switch (e) { case (: ; }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 22),
-                // (1,22): error CS1003: Syntax error, ':' expected
-                // switch (e) { case (: ; }
-                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(":").WithLocation(1, 22));
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 20));
             N(SyntaxKind.SwitchStatement);
             {
                 N(SyntaxKind.SwitchKeyword);
@@ -2204,7 +2192,7 @@ case KeyValuePair<String, DateTime>[] pairs2:
                                 M(SyntaxKind.CloseParenToken);
                             }
                         }
-                        M(SyntaxKind.ColonToken);
+                        N(SyntaxKind.ColonToken);
                     }
                     N(SyntaxKind.EmptyStatement);
                     {
@@ -2737,25 +2725,16 @@ case KeyValuePair<String, DateTime>[] pairs2:
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "e").WithArguments("e").WithLocation(1, 30),
                 // (1,40): error CS8370: Feature 'recursive patterns' is not available in C# 7.3. Please use language version 8.0 or greater.
                 // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "T( : Q x ").WithArguments("recursive patterns", "8.0").WithLocation(1, 40),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "T( ").WithArguments("recursive patterns", "8.0").WithLocation(1, 40),
                 // (1,40): error CS0246: The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)
                 // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "T").WithArguments("T").WithLocation(1, 40),
-                // (1,43): error CS1001: Identifier expected
-                // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 43),
                 // (1,45): error CS0246: The type or namespace name 'Q' could not be found (are you missing a using directive or an assembly reference?)
                 // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Q").WithArguments("Q").WithLocation(1, 45),
-                // (1,49): error CS1026: ) expected
+                // (1,43): error CS1026: ) expected
                 // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "=").WithLocation(1, 49),
-                // (1,49): error CS1003: Syntax error, ':' expected
-                // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "=").WithArguments(":").WithLocation(1, 49),
-                // (1,49): error CS1525: Invalid expression term '='
-                // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(1, 49),
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 43),
                 // (1,51): error CS0103: The name 'n' does not exist in the current context
                 // class C { void M() { switch (e) { case T( : Q x = n; break; }  } }
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "n").WithArguments("n").WithLocation(1, 51));
@@ -2763,21 +2742,9 @@ case KeyValuePair<String, DateTime>[] pairs2:
             // This put the parser into an infinite loop at one time. The precise diagnostics and nodes
             // are not as important as the fact that it terminates.
             UsingStatement(test, TestOptions.RegularWithoutRecursivePatterns,
-                // (1,22): error CS1001: Identifier expected
+                // (1,22): error CS1026: ) expected
                 // switch (e) { case T( : Q x = n; break; } 
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ":").WithLocation(1, 22),
-                // (1,28): error CS1003: Syntax error, ',' expected
-                // switch (e) { case T( : Q x = n; break; } 
-                Diagnostic(ErrorCode.ERR_SyntaxError, "=").WithArguments(",").WithLocation(1, 28),
-                // (1,30): error CS1003: Syntax error, ',' expected
-                // switch (e) { case T( : Q x = n; break; } 
-                Diagnostic(ErrorCode.ERR_SyntaxError, "n").WithArguments(",").WithLocation(1, 30),
-                // (1,31): error CS1026: ) expected
-                // switch (e) { case T( : Q x = n; break; } 
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 31),
-                // (1,31): error CS1003: Syntax error, ':' expected
-                // switch (e) { case T( : Q x = n; break; } 
-                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(":").WithLocation(1, 31)
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ":").WithLocation(1, 22)
                 );
             N(SyntaxKind.SwitchStatement);
             {
@@ -2803,38 +2770,32 @@ case KeyValuePair<String, DateTime>[] pairs2:
                             N(SyntaxKind.PositionalPatternClause);
                             {
                                 N(SyntaxKind.OpenParenToken);
-                                N(SyntaxKind.Subpattern);
-                                {
-                                    N(SyntaxKind.DeclarationPattern);
-                                    {
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Q");
-                                        }
-                                        N(SyntaxKind.SingleVariableDesignation);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "x");
-                                        }
-                                    }
-                                }
-                                M(SyntaxKind.CommaToken);
-                                N(SyntaxKind.Subpattern);
-                                {
-                                    N(SyntaxKind.ConstantPattern);
-                                    {
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "n");
-                                        }
-                                    }
-                                }
                                 M(SyntaxKind.CloseParenToken);
                             }
                         }
-                        M(SyntaxKind.ColonToken);
+                        N(SyntaxKind.ColonToken);
                     }
-                    N(SyntaxKind.EmptyStatement);
+                    N(SyntaxKind.LocalDeclarationStatement);
                     {
+                        N(SyntaxKind.VariableDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Q");
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "x");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "n");
+                                    }
+                                }
+                            }
+                        }
                         N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.BreakStatement);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -4737,6 +4737,640 @@ System.Console.WriteLine(true)";
             EOF();
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedRecursivePattern1()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case Type { Prop: Type { }:
+                    case Type { Prop: Type { }:
+                       break;
+                }
+                """,
+                // (3,31): error CS1513: } expected
+                //     case Type { Prop: Type { }:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 31),
+                // (4,31): error CS1513: } expected
+                //     case Type { Prop: Type { }:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 31)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Type");
+                            }
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Type");
+                                        }
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            N(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Type");
+                            }
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Type");
+                                        }
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            N(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedRecursivePattern2()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case Type { Prop: Type {:
+                    case Type { Prop: Type {:
+                       break;
+                }
+                """,
+                // (3,29): error CS1513: } expected
+                //     case Type { Prop: Type {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 29),
+                // (3,29): error CS1513: } expected
+                //     case Type { Prop: Type {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 29),
+                // (4,29): error CS1513: } expected
+                //     case Type { Prop: Type {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 29),
+                // (4,29): error CS1513: } expected
+                //     case Type { Prop: Type {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 29)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Type");
+                            }
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Type");
+                                        }
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            M(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Type");
+                            }
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Type");
+                                        }
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            M(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedRecursivePattern3()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case { Prop: { Prop: {:
+                    case { Prop: { Prop: {:
+                       break;
+                }
+                """,
+                // (3,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 27),
+                // (3,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 27),
+                // (3,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 27),
+                // (4,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 27),
+                // (4,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 27),
+                // (4,27): error CS1513: } expected
+                //     case { Prop: { Prop: {:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 27)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            N(SyntaxKind.Subpattern);
+                                            {
+                                                N(SyntaxKind.NameColon);
+                                                {
+                                                    N(SyntaxKind.IdentifierName);
+                                                    {
+                                                        N(SyntaxKind.IdentifierToken, "Prop");
+                                                    }
+                                                    N(SyntaxKind.ColonToken);
+                                                }
+                                                N(SyntaxKind.RecursivePattern);
+                                                {
+                                                    N(SyntaxKind.PropertyPatternClause);
+                                                    {
+                                                        N(SyntaxKind.OpenBraceToken);
+                                                        M(SyntaxKind.CloseBraceToken);
+                                                    }
+                                                }
+                                            }
+                                            M(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.Subpattern);
+                                {
+                                    N(SyntaxKind.NameColon);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Prop");
+                                        }
+                                        N(SyntaxKind.ColonToken);
+                                    }
+                                    N(SyntaxKind.RecursivePattern);
+                                    {
+                                        N(SyntaxKind.PropertyPatternClause);
+                                        {
+                                            N(SyntaxKind.OpenBraceToken);
+                                            N(SyntaxKind.Subpattern);
+                                            {
+                                                N(SyntaxKind.NameColon);
+                                                {
+                                                    N(SyntaxKind.IdentifierName);
+                                                    {
+                                                        N(SyntaxKind.IdentifierToken, "Prop");
+                                                    }
+                                                    N(SyntaxKind.ColonToken);
+                                                }
+                                                N(SyntaxKind.RecursivePattern);
+                                                {
+                                                    N(SyntaxKind.PropertyPatternClause);
+                                                    {
+                                                        N(SyntaxKind.OpenBraceToken);
+                                                        M(SyntaxKind.CloseBraceToken);
+                                                    }
+                                                }
+                                            }
+                                            M(SyntaxKind.CloseBraceToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedListPattern1()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case [:
+                    case [:
+                       break;
+                }
+                """,
+                // (3,11): error CS1003: Syntax error, ']' expected
+                //     case [:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 11),
+                // (4,11): error CS1003: Syntax error, ']' expected
+                //     case [:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 11)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedListPattern2()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case [[:
+                    case [[:
+                       break;
+                }
+                """,
+                // (3,12): error CS1003: Syntax error, ']' expected
+                //     case [[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 12),
+                // (3,12): error CS1003: Syntax error, ']' expected
+                //     case [[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 12),
+                // (4,12): error CS1003: Syntax error, ']' expected
+                //     case [[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 12),
+                // (4,12): error CS1003: Syntax error, ']' expected
+                //     case [[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 12)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ListPattern);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                M(SyntaxKind.CloseBracketToken);
+                            }
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ListPattern);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                M(SyntaxKind.CloseBracketToken);
+                            }
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67757")]
+        public void ParseSwitchStatementWithUnclosedListPattern3()
+        {
+            UsingStatement("""
+                switch (obj)
+                {
+                    case [[[:
+                    case [[[:
+                       break;
+                }
+                """,
+                // (3,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 13),
+                // (3,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 13),
+                // (3,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 13),
+                // (4,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 13),
+                // (4,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 13),
+                // (4,13): error CS1003: Syntax error, ']' expected
+                //     case [[[:
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 13)
+                );
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ListPattern);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.ListPattern);
+                                {
+                                    N(SyntaxKind.OpenBracketToken);
+                                    M(SyntaxKind.CloseBracketToken);
+                                }
+                                M(SyntaxKind.CloseBracketToken);
+                            }
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.ListPattern);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.ListPattern);
+                                {
+                                    N(SyntaxKind.OpenBracketToken);
+                                    M(SyntaxKind.CloseBracketToken);
+                                }
+                                M(SyntaxKind.CloseBracketToken);
+                            }
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
         private sealed class TokenAndTriviaWalker : CSharpSyntaxWalker
         {
             public int Tokens;


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/67757

Algorithm: if we find unexpected `:` token when parsing pattern for switch statement label instead of skipping it consume it as label end. Represented as ~~`exitOnColon` flag~~ `TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement` in code.