### PR TITLE
Flatten code actions when client doesn't have VS capability

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnifiedSuggestions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -29,51 +28,118 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
         /// <remarks>
         /// Used by CodeActionsHandler.
         /// </remarks>
-        public static async Task<VSInternalCodeAction[]> GetVSCodeActionsAsync(
+        public static async Task<LSP.CodeAction[]> GetVSCodeActionsAsync(
             CodeActionParams request,
             Document document,
             CodeActionOptionsProvider fallbackOptions,
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
+            bool generateVSCodeAction,
             CancellationToken cancellationToken)
         {
             var actionSets = await GetActionSetsAsync(
                 document, fallbackOptions, codeFixService, codeRefactoringService, request.Range, cancellationToken).ConfigureAwait(false);
             if (actionSets.IsDefaultOrEmpty)
-                return Array.Empty<VSInternalCodeAction>();
+                return Array.Empty<LSP.CodeAction>();
 
-            var documentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            // Each suggested action set should have a unique set number, which is used for grouping code actions together.
-            var currentHighestSetNumber = 0;
-
-            using var _ = ArrayBuilder<VSInternalCodeAction>.GetInstance(out var codeActions);
-            foreach (var set in actionSets)
+            using var _ = ArrayBuilder<LSP.CodeAction>.GetInstance(out var codeActions);
+            if (generateVSCodeAction)
             {
-                var currentSetNumber = ++currentHighestSetNumber;
-                foreach (var suggestedAction in set.Actions)
+                var documentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                // Each suggested action set should have a unique set number, which is used for grouping code actions together.
+                var currentHighestSetNumber = 0;
+
+                foreach (var set in actionSets)
                 {
-                    // Filter out code actions with options since they'll show dialogs and we can't remote the UI and the options.
-                    if (suggestedAction.OriginalCodeAction is CodeActionWithOptions)
-                        continue;
-
-                    // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
-                    // https://github.com/dotnet/roslyn/issues/48698
-                    if (suggestedAction.OriginalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange))
-                        continue;
-
-                    codeActions.Add(GenerateVSCodeAction(
-                        request, documentText,
-                        suggestedAction: suggestedAction,
-                        codeActionKind: GetCodeActionKindFromSuggestedActionCategoryName(set.CategoryName!),
-                        setPriority: set.Priority,
-                        applicableRange: set.ApplicableToSpan.HasValue ? ProtocolConversions.TextSpanToRange(set.ApplicableToSpan.Value, documentText) : null,
-                        currentSetNumber: currentSetNumber,
-                        currentHighestSetNumber: ref currentHighestSetNumber));
+                    var currentSetNumber = ++currentHighestSetNumber;
+                    foreach (var suggestedAction in set.Actions)
+                    {
+                        if (!IsCodeActionNotSupportedByLSP(suggestedAction))
+                        {
+                            codeActions.Add(GenerateVSCodeAction(
+                                request, documentText,
+                                suggestedAction: suggestedAction,
+                                codeActionKind: GetCodeActionKindFromSuggestedActionCategoryName(set.CategoryName!),
+                                setPriority: set.Priority,
+                                applicableRange: set.ApplicableToSpan.HasValue ? ProtocolConversions.TextSpanToRange(set.ApplicableToSpan.Value, documentText) : null,
+                                currentSetNumber: currentSetNumber,
+                                currentHighestSetNumber: ref currentHighestSetNumber));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var set in actionSets)
+                {
+                    foreach (var suggestedAction in set.Actions)
+                    {
+                        if (!IsCodeActionNotSupportedByLSP(suggestedAction))
+                        {
+                            codeActions.AddRange(GenerateCodeActions(
+                                request,
+                                suggestedAction,
+                                GetCodeActionKindFromSuggestedActionCategoryName(set.CategoryName!)));
+                        }
+                    }
                 }
             }
 
             return codeActions.ToArray();
+        }
+
+        private static bool IsCodeActionNotSupportedByLSP(IUnifiedSuggestedAction suggestedAction)
+            // Filter out code actions with options since they'll show dialogs and we can't remote the UI and the options.
+            => suggestedAction.OriginalCodeAction is CodeActionWithOptions or
+            // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
+            // https://github.com/dotnet/roslyn/issues/48698
+            || suggestedAction.OriginalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange);
+
+        private static LSP.CodeAction[] GenerateCodeActions(
+            CodeActionParams request,
+            IUnifiedSuggestedAction suggestedAction,
+            LSP.CodeActionKind codeActionKind,
+            string currentTitle = "")
+        {
+            if (!string.IsNullOrEmpty(currentTitle))
+            {
+                // Adding a delimiter for nested code actions, e.g. 'Suppress or Configure issues|Suppress IDEXXXX|in Source'
+                currentTitle += '|';
+            }
+
+            var codeAction = suggestedAction.OriginalCodeAction;
+            currentTitle += codeAction.Title;
+
+            var diagnosticsForFix = GetApplicableDiagnostics(request.Context, suggestedAction);
+
+            using var _ = ArrayBuilder<LSP.CodeAction>.GetInstance(out var builder);
+            if (suggestedAction is UnifiedSuggestedActionWithNestedActions unifiedSuggestedActions)
+            {
+                foreach (var actionSet in unifiedSuggestedActions.NestedActionSets)
+                {
+                    foreach (var action in actionSet.Actions)
+                    {
+                        builder.AddRange(GenerateCodeActions(
+                            request,
+                            action,
+                            codeActionKind,
+                            currentTitle));
+                    }
+                }
+            }
+            else
+            {
+                builder.Add(new LSP.CodeAction()
+                {
+                    Title = currentTitle,
+                    Kind = codeActionKind,
+                    Diagnostics = diagnosticsForFix,
+                    Data = new CodeActionResolveData(currentTitle, codeAction.CustomTags, request.Range, request.TextDocument)
+                });
+            }
+
+            return builder.ToArray();
         }
 
         private static VSInternalCodeAction GenerateVSCodeAction(
@@ -143,29 +209,29 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 
                 return nestedActions.ToArray();
             }
+        }
 
-            static LSP.Diagnostic[]? GetApplicableDiagnostics(LSP.CodeActionContext context, IUnifiedSuggestedAction action)
+        private static LSP.Diagnostic[]? GetApplicableDiagnostics(CodeActionContext context, IUnifiedSuggestedAction action)
+        {
+            if (action is UnifiedCodeFixSuggestedAction codeFixAction && context.Diagnostics != null)
             {
-                if (action is UnifiedCodeFixSuggestedAction codeFixAction && context.Diagnostics != null)
+                // Associate the diagnostics from the request that match the diagnostic fixed by the code action by ID.
+                // The request diagnostics are already restricted to the code fix location by the request.
+                var diagnosticCodesFixedByAction = codeFixAction.CodeFix.Diagnostics.Select(d => d.Id);
+                using var _ = ArrayBuilder<LSP.Diagnostic>.GetInstance(out var diagnosticsBuilder);
+                foreach (var requestDiagnostic in context.Diagnostics)
                 {
-                    // Associate the diagnostics from the request that match the diagnostic fixed by the code action by ID.
-                    // The request diagnostics are already restricted to the code fix location by the request.
-                    var diagnosticCodesFixedByAction = codeFixAction.CodeFix.Diagnostics.Select(d => d.Id);
-                    using var _ = ArrayBuilder<LSP.Diagnostic>.GetInstance(out var diagnosticsBuilder);
-                    foreach (var requestDiagnostic in context.Diagnostics)
+                    var diagnosticCode = requestDiagnostic.Code?.Value?.ToString();
+                    if (diagnosticCodesFixedByAction.Contains(diagnosticCode))
                     {
-                        var diagnosticCode = requestDiagnostic.Code?.Value?.ToString();
-                        if (diagnosticCodesFixedByAction.Contains(diagnosticCode))
-                        {
-                            diagnosticsBuilder.Add(requestDiagnostic);
-                        }
+                        diagnosticsBuilder.Add(requestDiagnostic);
                     }
-
-                    return diagnosticsBuilder.ToArray();
                 }
 
-                return null;
+                return diagnosticsBuilder.ToArray();
             }
+
+            return null;
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -56,9 +56,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(document);
 
             var options = _globalOptions.GetCodeActionOptionsProvider();
-
             var clientCapability = context.GetRequiredClientCapabilities();
-            var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(request, document, options, _codeFixService, _codeRefactoringService, generateVSCodeAction: clientCapability.HasVisualStudioLspCapability(), cancellationToken).ConfigureAwait(false);
+
+            var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
+                request, document, options, _codeFixService, _codeRefactoringService, generateVSCodeAction: clientCapability.HasVisualStudioLspCapability(), cancellationToken).ConfigureAwait(false);
             return codeActions;
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var clientCapability = context.GetRequiredClientCapabilities();
 
             var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
-                request, document, options, _codeFixService, _codeRefactoringService, generateVSCodeAction: clientCapability.HasVisualStudioLspCapability(), cancellationToken).ConfigureAwait(false);
+                request, document, options, _codeFixService, _codeRefactoringService, generateVSInternalCodeAction: clientCapability.HasVisualStudioLspCapability(), cancellationToken).ConfigureAwait(false);
             return codeActions;
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -57,9 +57,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var options = _globalOptions.GetCodeActionOptionsProvider();
 
-            var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
-                request, document, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
-
+            var clientCapability = context.GetRequiredClientCapabilities();
+            var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(request, document, options, _codeFixService, _codeRefactoringService, generateVSCodeAction: clientCapability.HasVisualStudioLspCapability(), cancellationToken).ConfigureAwait(false);
             return codeActions;
         }
     }

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
         {|caret:|}int i = 1;
     }
 }";
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, initializationOptions: new InitializationOptions() { ClientCapabilities = new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true } });
 
             var caretLocation = testLspServer.GetLocations("caret").Single();
             var expected = CreateCodeAction(


### PR DESCRIPTION
Currently, our LSP code action handler would always only generate VS internal code actions.
This would cause compatible issues for nested code actions since this is not in the standard LSP.

This PR flattens the code actions by checking the client capability.
