### PR TITLE
Also check project path when add new document in LSP

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -45,6 +45,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return ProtocolConversions.GetUriFromFilePath(path);
         }
 
+        /// <summary>
+        /// Generate the Uri of a document based on the name and the project path of the document.
+        /// </summary>
+        public static Uri GetUriFromProjectPath(this TextDocument document)
+        {
+            Contract.ThrowIfNull(document.Name);
+            Contract.ThrowIfNull(document.Project.FilePath);
+            var directoryName = Path.GetDirectoryName(document.Project.FilePath);
+            Contract.ThrowIfNull(directoryName);
+
+            var path = Path.Combine(directoryName, document.Name);
+            return ProtocolConversions.GetUriFromFilePath(path);
+        }
+
         public static Uri? TryGetURI(this TextDocument document, RequestContext? context = null)
             => ProtocolConversions.TryGetUriFromFilePath(document.FilePath, context);
 

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -283,13 +283,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     Contract.ThrowIfNull(newTextDoc);
 
                     // Create the document as empty
-                    textDocumentEdits.Add(new CreateFile { Uri = newTextDoc.GetURI() });
+                    var uri = newTextDoc.FilePath != null
+                        ? newTextDoc.GetURI()
+                        : newTextDoc.GetUriFromProjectPath();
+                    textDocumentEdits.Add(new CreateFile { Uri = uri });
 
                     // And then give it content
                     var newText = await newTextDoc.GetTextAsync(cancellationToken).ConfigureAwait(false);
                     var emptyDocumentRange = new LSP.Range { Start = new Position { Line = 0, Character = 0 }, End = new Position { Line = 0, Character = 0 } };
                     var edit = new TextEdit { Range = emptyDocumentRange, NewText = newText.ToString() };
-                    var documentIdentifier = new OptionalVersionedTextDocumentIdentifier { Uri = newTextDoc.GetURI() };
+                    var documentIdentifier = new OptionalVersionedTextDocumentIdentifier { Uri = uri };
                     textDocumentEdits.Add(new TextDocumentEdit { TextDocument = documentIdentifier, Edits = new[] { edit } });
                 }
             }


### PR DESCRIPTION
Depends on https://github.com/dotnet/roslyn/pull/67868

In VS we also check the project path when adding a document https://sourceroslyn.io/#Microsoft.VisualStudio.LanguageServices/ProjectSystem/VisualStudioWorkspaceImpl.cs,887

But in LSP we only check document path, this would cause problem when the document is added the the project by using 
https://sourceroslyn.io/#Microsoft.CodeAnalysis.Workspaces/Workspace/Solution/Project.cs,664
Because the file path is not required.