### PR TITLE
Simplify code in IncrementalMemberEditAnalyzer for computing updated …

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.IncrementalMemberEditAnalyzer.cs
@@ -381,8 +381,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     DiagnosticDataLocation UpdateLocation(DiagnosticDataLocation location)
                     {
                         var diagnosticSpan = location.UnmappedFileSpan.GetClampedTextSpan(text);
-                        var start = Math.Min(Math.Max(diagnosticSpan.Start + delta, 0), tree.Length);
-                        var newSpan = new TextSpan(start, start >= tree.Length ? 0 : diagnosticSpan.Length);
+                        var start = Math.Max(diagnosticSpan.Start + delta, 0);
+                        var end = start + diagnosticSpan.Length;
+                        if (start >= tree.Length)
+                            start = tree.Length - 1;
+                        if (end >= tree.Length)
+                            end = tree.Length - 1;
+                        var newSpan = new TextSpan(start, end - start);
                         return location.WithSpan(newSpan, tree);
                     }
                 }


### PR DESCRIPTION
…diagnostic span

Fixes [AB#1801783](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1801783)

There were couple of issues here:
1. `start` can end up being `tree.Length`, we do not want it to be greater than `tree.Length - 1`
2. If `start` is less than `tree.Length`, but `start + diagnosticSpan.Length` extends past `tree.Length`, we did not trim `end` to `tree.Length - 1`

Unfortunately, we do not have any unit tests for incremental member edit analysis. #65678 tracks this work.