### PR TITLE
Update ICSharpCode.Decompiler to 7.2.1.6856

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
     <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
-    <ICSharpCodeDecompilerVersion>7.1.0.6543</ICSharpCodeDecompilerVersion>
+    <ICSharpCodeDecompilerVersion>7.2.1.6856</ICSharpCodeDecompilerVersion>
     <InputSimulatorPlusVersion>1.0.7</InputSimulatorPlusVersion>
     <MicrosoftBuildLocatorVersion>1.5.5</MicrosoftBuildLocatorVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
@@ -116,7 +116,7 @@
     <MicrosoftmacOSRefVersion>12.3.300-rc.3.83</MicrosoftmacOSRefVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta3.21075.2</MicrosoftMetadataVisualizerVersion>
     <MicrosoftNETBuildExtensionsVersion>2.2.101</MicrosoftNETBuildExtensionsVersion>
-    <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETCoreAppRefVersion>5.0.0</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETFrameworkReferenceAssembliesnet461Version>1.0.0</MicrosoftNETFrameworkReferenceAssembliesnet461Version>
     <MicrosoftNETFrameworkReferenceAssembliesnet451Version>1.0.0</MicrosoftNETFrameworkReferenceAssembliesnet451Version>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
@@ -1198,7 +1198,7 @@ class C
                 instance void .ctor () cil managed
         {
                 // Method begins at RVA 0x207f
-                // Code size 7 (0x7)
+                // Code size: 7 (0x7)
                 .maxstack 8
                 IL_0000: ldarg.0
                 IL_0001: call instance void [mscorlib]System.Object::.ctor()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
@@ -63,7 +63,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x207a
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -73,7 +73,7 @@ public static class Program
 			instance int32 '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2082
-			// Code size 14 (0xe)
+			// Code size: 14 (0xe)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -88,7 +88,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 41 (0x29)
+		// Code size: 41 (0x29)
 		.maxstack 8
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -146,7 +146,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209a
-			// Code size 8 (0x8)
+			// Code size: 8 (0x8)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -168,7 +168,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209a
-			// Code size 8 (0x8)
+			// Code size: 8 (0x8)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -179,7 +179,7 @@ public static class Program
 			instance int32 '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20a3
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -195,7 +195,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 62 (0x3e)
+		// Code size: 62 (0x3e)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -280,7 +280,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2115
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -301,7 +301,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2115
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -311,7 +311,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x211d
-			// Code size 42 (0x2a)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -334,7 +334,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 185 (0xb9)
+		// Code size: 185 (0xb9)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -452,7 +452,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a7
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -473,7 +473,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a7
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -483,7 +483,7 @@ class C
 			instance int32 '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20af
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 C/'<>c__DisplayClass0_1'::i
@@ -499,7 +499,7 @@ class C
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 75 (0x4b)
+		// Code size: 75 (0x4b)
 		.maxstack 3
 		.locals init (
 			[0] class C/'<>c__DisplayClass0_0',
@@ -553,7 +553,7 @@ class C
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a7
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -604,7 +604,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -625,7 +625,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -635,7 +635,7 @@ class C
 			instance int32 '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20a8
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 C/'<>c__DisplayClass0_1'::i
@@ -651,7 +651,7 @@ class C
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 68 (0x44)
+		// Code size: 68 (0x44)
 		.maxstack 3
 		.locals init (
 			[0] class C/'<>c__DisplayClass0_0',
@@ -699,7 +699,7 @@ class C
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a0
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -753,7 +753,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x2115
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -763,7 +763,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2121
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -773,7 +773,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x2129
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -792,7 +792,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2121
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -813,7 +813,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2121
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -823,7 +823,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x212b
-			// Code size 42 (0x2a)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -846,7 +846,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 185 (0xb9)
+		// Code size: 185 (0xb9)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -971,7 +971,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2124
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -993,7 +993,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2124
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1003,7 +1003,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x212c
-			// Code size 35 (0x23)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -1023,7 +1023,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 183 (0xb7)
+		// Code size: 183 (0xb7)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -1152,7 +1152,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x2124
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -1162,7 +1162,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2130
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1172,7 +1172,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x2138
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -1190,7 +1190,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2130
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1212,7 +1212,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2130
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1222,7 +1222,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x213a
-			// Code size 35 (0x23)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -1242,7 +1242,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 183 (0xb7)
+		// Code size: 183 (0xb7)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -1385,7 +1385,7 @@ public class Program
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x209e
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -1395,7 +1395,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2053
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1405,7 +1405,7 @@ public class Program
 			instance void '<M>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x20aa
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<M>b__0_1'
@@ -1423,7 +1423,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2053
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1445,7 +1445,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2053
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1455,7 +1455,7 @@ public class Program
 			instance void '<M>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20ac
-			// Code size 35 (0x23)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -1491,7 +1491,7 @@ public class Program
 		{
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()
 			// Method begins at RVA 0x20d0
-			// Code size 416 (0x1a0)
+			// Code size: 416 (0x1a0)
 			.maxstack 4
 			.locals init (
 				[0] int32,
@@ -1654,7 +1654,7 @@ public class Program
 			)
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
 			// Method begins at RVA 0x2298
-			// Code size 13 (0xd)
+			// Code size: 13 (0xd)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
@@ -1674,7 +1674,7 @@ public class Program
 			5f 30 00 00
 		)
 		// Method begins at RVA 0x205c
-		// Code size 43 (0x2b)
+		// Code size: 43 (0x2b)
 		.maxstack 2
 		.locals init (
 			[0] valuetype Program/'<M>d__0'
@@ -1698,7 +1698,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2053
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1752,7 +1752,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20b0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1762,7 +1762,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20b8
-			// Code size 30 (0x1e)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [mscorlib]System.Collections.Generic.List`1<string> Program/'<>c__DisplayClass0_0'::strings
@@ -1781,7 +1781,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 84 (0x54)
+		// Code size: 84 (0x54)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -1860,7 +1860,7 @@ public static class Program
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20b0
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -1870,7 +1870,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20bc
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1880,7 +1880,7 @@ public static class Program
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x20c4
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -1900,7 +1900,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20bc
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -1910,7 +1910,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20c6
-			// Code size 30 (0x1e)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [mscorlib]System.Collections.Generic.List`1<string> Program/'<>c__DisplayClass0_0'::strings
@@ -1929,7 +1929,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 84 (0x54)
+		// Code size: 84 (0x54)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -2012,7 +2012,7 @@ public static class Program
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20ce
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -2022,7 +2022,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2032,7 +2032,7 @@ public static class Program
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x20e2
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -2052,7 +2052,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2062,7 +2062,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20e4
-			// Code size 30 (0x1e)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [mscorlib]System.Collections.Generic.List`1<string> Program/'<>c__DisplayClass0_0'::strings
@@ -2081,7 +2081,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 114 (0x72)
+		// Code size: 114 (0x72)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -2173,7 +2173,7 @@ one");
 			instance void Dispose () cil managed 
 		{
 			// Method begins at RVA 0x20d8
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method Disposable::Dispose
@@ -2181,7 +2181,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2203,7 +2203,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2213,7 +2213,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20e2
-			// Code size 39 (0x27)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/Disposable Program/'<>c__DisplayClass0_0'::disposable
@@ -2233,7 +2233,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 105 (0x69)
+		// Code size: 105 (0x69)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -2327,7 +2327,7 @@ one");
 			instance void Dispose () cil managed 
 		{
 			// Method begins at RVA 0x20d8
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method Disposable::Dispose
@@ -2335,7 +2335,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2356,7 +2356,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20e2
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -2366,7 +2366,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2376,7 +2376,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x20d8
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -2396,7 +2396,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2406,7 +2406,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20ee
-			// Code size 39 (0x27)
+			// Code size: 39 (0x27)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/Disposable Program/'<>c__DisplayClass0_0'::disposable
@@ -2426,7 +2426,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 105 (0x69)
+		// Code size: 105 (0x69)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -2534,7 +2534,7 @@ one");
 			instance void Dispose () cil managed 
 		{
 			// Method begins at RVA 0x21b0
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method Disposable::Dispose
@@ -2542,7 +2542,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2563,7 +2563,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x21ba
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -2573,7 +2573,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2583,7 +2583,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x21b0
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -2601,7 +2601,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2623,7 +2623,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2646,7 +2646,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2656,7 +2656,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x21c8
-			// Code size 82 (0x52)
+			// Code size: 82 (0x52)
 			.maxstack 3
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/Disposable Program/'<>c__DisplayClass0_2'::disposable
@@ -2691,7 +2691,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 310 (0x136)
+		// Code size: 310 (0x136)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -2869,7 +2869,7 @@ three");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20f2
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -2879,7 +2879,7 @@ three");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20fe
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2889,7 +2889,7 @@ three");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x2106
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -2907,7 +2907,7 @@ three");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20fe
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2929,7 +2929,7 @@ three");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20fe
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -2939,7 +2939,7 @@ three");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2108
-			// Code size 35 (0x23)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -2959,7 +2959,7 @@ three");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 150 (0x96)
+		// Code size: 150 (0x96)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3071,7 +3071,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20fa
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -3081,7 +3081,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2106
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3091,7 +3091,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x210e
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -3110,7 +3110,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2106
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3131,7 +3131,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2106
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3141,7 +3141,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2110
-			// Code size 42 (0x2a)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -3164,7 +3164,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 158 (0x9e)
+		// Code size: 158 (0x9e)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3273,7 +3273,7 @@ public static class Program
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x20df
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -3283,7 +3283,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20eb
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3293,7 +3293,7 @@ public static class Program
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x20f3
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -3312,7 +3312,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20eb
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3333,7 +3333,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20eb
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3343,7 +3343,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20f5
-			// Code size 42 (0x2a)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -3366,7 +3366,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 131 (0x83)
+		// Code size: 131 (0x83)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3469,7 +3469,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20b5
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3490,7 +3490,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20b5
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3500,7 +3500,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20bd
-			// Code size 40 (0x28)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -3521,7 +3521,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 89 (0x59)
+		// Code size: 89 (0x59)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3606,7 +3606,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20b5
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3627,7 +3627,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20b5
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3637,7 +3637,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20bd
-			// Code size 40 (0x28)
+			// Code size: 40 (0x28)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -3658,7 +3658,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 89 (0x59)
+		// Code size: 89 (0x59)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3752,7 +3752,7 @@ one");
 			void .cctor () cil managed 
 		{
 			// Method begins at RVA 0x2104
-			// Code size 11 (0xb)
+			// Code size: 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
 			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -3762,7 +3762,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2110
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3772,7 +3772,7 @@ one");
 			instance void '<Main>b__0_1' () cil managed 
 		{
 			// Method begins at RVA 0x2118
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
@@ -3791,7 +3791,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2110
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3812,7 +3812,7 @@ one");
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2110
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3822,7 +3822,7 @@ one");
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x211a
-			// Code size 42 (0x2a)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -3845,7 +3845,7 @@ one");
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 168 (0xa8)
+		// Code size: 168 (0xa8)
 		.maxstack 4
 		.entrypoint
 		.locals init (
@@ -3961,7 +3961,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2082
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -3971,7 +3971,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x208a
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -3987,7 +3987,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 38 (0x26)
+		// Code size: 38 (0x26)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4051,7 +4051,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x206a
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4061,7 +4061,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2072
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4077,7 +4077,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 14 (0xe)
+		// Code size: 14 (0xe)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4139,7 +4139,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2090
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4149,7 +4149,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2098
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4165,7 +4165,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 52 (0x34)
+		// Code size: 52 (0x34)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4243,7 +4243,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2090
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4253,7 +4253,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2098
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4269,7 +4269,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 52 (0x34)
+		// Code size: 52 (0x34)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4346,7 +4346,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2089
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4356,7 +4356,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2091
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4372,7 +4372,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 45 (0x2d)
+		// Code size: 45 (0x2d)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4442,7 +4442,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208a
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4452,7 +4452,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2092
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4468,7 +4468,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 46 (0x2e)
+		// Code size: 46 (0x2e)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4542,7 +4542,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2082
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4552,7 +4552,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x208a
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -4568,7 +4568,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 38 (0x26)
+		// Code size: 38 (0x26)
 		.maxstack 2
 		.entrypoint
 		.locals init (
@@ -4634,7 +4634,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4655,7 +4655,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4665,7 +4665,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2095
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -4682,7 +4682,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -4752,7 +4752,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4773,7 +4773,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4783,7 +4783,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2095
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -4800,7 +4800,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -4869,7 +4869,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4890,7 +4890,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -4900,7 +4900,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2095
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -4917,7 +4917,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -4988,7 +4988,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5009,7 +5009,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5019,7 +5019,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2095
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5036,7 +5036,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5108,7 +5108,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5129,7 +5129,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5139,7 +5139,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20a3
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5156,7 +5156,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 63 (0x3f)
+		// Code size: 63 (0x3f)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5238,7 +5238,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5259,7 +5259,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5269,7 +5269,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x209c
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5286,7 +5286,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 56 (0x38)
+		// Code size: 56 (0x38)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5355,7 +5355,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5365,7 +5365,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2095
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5387,7 +5387,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208d
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5397,7 +5397,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x20a2
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5414,7 +5414,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5485,7 +5485,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2077
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5495,7 +5495,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x207f
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5509,7 +5509,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x207f
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5525,7 +5525,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 38 (0x26)
+		// Code size: 38 (0x26)
 		.maxstack 8
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -5585,7 +5585,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2077
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5595,7 +5595,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x207f
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5609,7 +5609,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x2093
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::b
@@ -5622,7 +5622,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 38 (0x26)
+		// Code size: 38 (0x26)
 		.maxstack 8
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -5681,7 +5681,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5691,7 +5691,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x209c
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5713,7 +5713,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5723,7 +5723,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20a9
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5740,7 +5740,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 56 (0x38)
+		// Code size: 56 (0x38)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5817,7 +5817,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5827,7 +5827,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x20aa
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -5852,7 +5852,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a2
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5862,7 +5862,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20be
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -5879,7 +5879,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 70 (0x46)
+		// Code size: 70 (0x46)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -5959,7 +5959,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2096
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5969,7 +5969,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x209e
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::b
@@ -5991,7 +5991,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2096
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6001,7 +6001,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x20ab
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -6016,7 +6016,7 @@ public static class Program
 			instance void '<Main>b__2' () cil managed 
 		{
 			// Method begins at RVA 0x20c4
-			// Code size 36 (0x24)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -6037,7 +6037,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 58 (0x3a)
+		// Code size: 58 (0x3a)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -6112,7 +6112,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6122,7 +6122,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x209c
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -6147,7 +6147,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2094
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6157,7 +6157,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x20b0
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_0' Program/'<>c__DisplayClass0_1'::'CS$<>8__locals1'
@@ -6174,7 +6174,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 56 (0x38)
+		// Code size: 56 (0x38)
 		.maxstack 3
 		.entrypoint
 		.locals init (
@@ -6246,7 +6246,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2082
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6256,7 +6256,7 @@ public static class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x208a
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_0'::a
@@ -6278,7 +6278,7 @@ public static class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2082
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6288,7 +6288,7 @@ public static class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x2097
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_1'::b
@@ -6304,7 +6304,7 @@ public static class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size: 49 (0x31)
 		.maxstack 8
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -6380,7 +6380,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20c3
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6390,7 +6390,7 @@ public class Program
 			instance void '<Main>g__M|0' () cil managed 
 		{
 			// Method begins at RVA 0x20cc
-			// Code size 67 (0x43)
+			// Code size: 67 (0x43)
 			.maxstack 3
 			.locals init (
 				[0] class Program/'<>c__DisplayClass0_1'
@@ -6432,7 +6432,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20c3
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6442,7 +6442,7 @@ public class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x211b
-			// Code size 25 (0x19)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldarg.0
@@ -6458,7 +6458,7 @@ public class Program
 			instance void '<Main>b__2' () cil managed 
 		{
 			// Method begins at RVA 0x2135
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_1'::b
@@ -6471,7 +6471,7 @@ public class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 103 (0x67)
+		// Code size: 103 (0x67)
 		.maxstack 3
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -6510,7 +6510,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20c3
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6572,7 +6572,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20ce
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6582,7 +6582,7 @@ public class Program
 			instance void '<Main>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20d8
-			// Code size 67 (0x43)
+			// Code size: 67 (0x43)
 			.maxstack 3
 			.locals init (
 				[0] class Program/'<>c__DisplayClass0_1'
@@ -6624,7 +6624,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20ce
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6634,7 +6634,7 @@ public class Program
 			instance void '<Main>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x2127
-			// Code size 25 (0x19)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldarg.0
@@ -6650,7 +6650,7 @@ public class Program
 			instance void '<Main>b__2' () cil managed 
 		{
 			// Method begins at RVA 0x2141
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass0_1'::b
@@ -6663,7 +6663,7 @@ public class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 114 (0x72)
+		// Code size: 114 (0x72)
 		.maxstack 3
 		.entrypoint
 		IL_0000: newobj instance void Program/'<>c__DisplayClass0_0'::.ctor()
@@ -6704,7 +6704,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20ce
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6770,7 +6770,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6780,7 +6780,7 @@ public class Program
 			instance void '<M>g__M1|0' () cil managed 
 		{
 			// Method begins at RVA 0x20a3
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass1_0'::a
@@ -6805,7 +6805,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6815,7 +6815,7 @@ public class Program
 			instance void '<M>g__M2|1' () cil managed 
 		{
 			// Method begins at RVA 0x20b7
-			// Code size 23 (0x17)
+			// Code size: 23 (0x17)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass1_0' Program/'<>c__DisplayClass1_1'::'CS$<>8__locals1'
@@ -6831,7 +6831,7 @@ public class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: call class [mscorlib]System.Action Program::M()
@@ -6842,7 +6842,7 @@ public class Program
 		class [mscorlib]System.Action M () cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 51 (0x33)
+		// Code size: 51 (0x33)
 		.maxstack 3
 		.locals init (
 			[0] class Program/'<>c__DisplayClass1_0'
@@ -6870,7 +6870,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x209b
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6938,7 +6938,7 @@ target:
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6948,7 +6948,7 @@ target:
 			instance void '<M>g__M1|0' () cil managed 
 		{
 			// Method begins at RVA 0x20a3
-			// Code size 19 (0x13)
+			// Code size: 19 (0x13)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 Program/'<>c__DisplayClass1_0'::a
@@ -6973,7 +6973,7 @@ target:
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x209b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -6983,7 +6983,7 @@ target:
 			instance void '<M>g__M2|1' () cil managed 
 		{
 			// Method begins at RVA 0x20b7
-			// Code size 23 (0x17)
+			// Code size: 23 (0x17)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass1_0' Program/'<>c__DisplayClass1_1'::'CS$<>8__locals1'
@@ -6999,7 +6999,7 @@ target:
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: call class [mscorlib]System.Action Program::M()
@@ -7010,7 +7010,7 @@ target:
 		class [mscorlib]System.Action M () cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 51 (0x33)
+		// Code size: 51 (0x33)
 		.maxstack 3
 		.locals init (
 			[0] class Program/'<>c__DisplayClass1_0'
@@ -7038,7 +7038,7 @@ target:
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x209b
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7105,7 +7105,7 @@ target:
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a8
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7126,7 +7126,7 @@ target:
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a8
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7136,7 +7136,7 @@ target:
 			instance void '<M>g__M1|0' () cil managed 
 		{
 			// Method begins at RVA 0x20b0
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass1_0' Program/'<>c__DisplayClass1_1'::'CS$<>8__locals1'
@@ -7162,7 +7162,7 @@ target:
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a8
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7172,7 +7172,7 @@ target:
 			instance void '<M>g__M2|1' () cil managed 
 		{
 			// Method begins at RVA 0x20c9
-			// Code size 23 (0x17)
+			// Code size: 23 (0x17)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass1_1' Program/'<>c__DisplayClass1_2'::'CS$<>8__locals2'
@@ -7188,7 +7188,7 @@ target:
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: call class [mscorlib]System.Action Program::M()
@@ -7199,7 +7199,7 @@ target:
 		class [mscorlib]System.Action M () cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 64 (0x40)
+		// Code size: 64 (0x40)
 		.maxstack 3
 		.locals init (
 			[0] class Program/'<>c__DisplayClass1_0',
@@ -7233,7 +7233,7 @@ target:
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a8
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7282,7 +7282,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2072
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7292,7 +7292,7 @@ public class Program
 			instance void '<M>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x209c
-			// Code size 17 (0x11)
+			// Code size: 17 (0x11)
 			.maxstack 3
 			.locals init (
 				[0] int32
@@ -7322,7 +7322,7 @@ public class Program
 		instance void M () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 22 (0x16)
+		// Code size: 22 (0x16)
 		.maxstack 3
 		.locals init (
 			[0] valuetype Program/'<>c__DisplayClass0_1'
@@ -7341,7 +7341,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2072
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7356,7 +7356,7 @@ public class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x207c
-		// Code size 17 (0x11)
+		// Code size: 17 (0x11)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -7418,7 +7418,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7428,7 +7428,7 @@ public class Program
 			instance int32 '<M>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x20a8
-			// Code size 18 (0x12)
+			// Code size: 18 (0x12)
 			.maxstack 3
 			.locals init (
 				[0] int32
@@ -7458,7 +7458,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7468,7 +7468,7 @@ public class Program
 			instance int32 '<M>g__M|0' () cil managed 
 		{
 			// Method begins at RVA 0x20c8
-			// Code size 18 (0x12)
+			// Code size: 18 (0x12)
 			.maxstack 3
 			.locals init (
 				[0] int32
@@ -7499,7 +7499,7 @@ public class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a0
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7509,7 +7509,7 @@ public class Program
 			instance int32 '<M>g__M1|2' () cil managed 
 		{
 			// Method begins at RVA 0x20e6
-			// Code size 24 (0x18)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class Program/'<>c__DisplayClass0_1' Program/'<>c__DisplayClass0_2'::'CS$<>8__locals1'
@@ -7526,7 +7526,7 @@ public class Program
 		instance class [mscorlib]System.Func`1<int32> M () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 68 (0x44)
+		// Code size: 68 (0x44)
 		.maxstack 4
 		.locals init (
 			[0] class Program/'<>c__DisplayClass0_0',
@@ -7559,7 +7559,7 @@ public class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a0
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7620,7 +7620,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7642,7 +7642,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7663,7 +7663,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x2059
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7673,7 +7673,7 @@ public class C {
 			instance void '<M>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2061
-			// Code size 53 (0x35)
+			// Code size: 53 (0x35)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
@@ -7722,7 +7722,7 @@ public class C {
 				01 00 00 00
 			)
 			// Method begins at RVA 0x2097
-			// Code size 25 (0x19)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -7742,7 +7742,7 @@ public class C {
 			)
 			.override method instance void [mscorlib]System.IDisposable::Dispose()
 			// Method begins at RVA 0x20b1
-			// Code size 1 (0x1)
+			// Code size: 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
 		} // end of method '<M>d__0'::System.IDisposable.Dispose
@@ -7751,7 +7751,7 @@ public class C {
 		{
 			.override method instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
 			// Method begins at RVA 0x20b4
-			// Code size 342 (0x156)
+			// Code size: 342 (0x156)
 			.maxstack 2
 			.locals init (
 				[0] int32
@@ -7890,7 +7890,7 @@ public class C {
 			)
 			.override method instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<int32>::get_Current()
 			// Method begins at RVA 0x2216
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
@@ -7904,7 +7904,7 @@ public class C {
 			)
 			.override method instance void [mscorlib]System.Collections.IEnumerator::Reset()
 			// Method begins at RVA 0x221e
-			// Code size 6 (0x6)
+			// Code size: 6 (0x6)
 			.maxstack 8
 			IL_0000: newobj instance void [mscorlib]System.NotSupportedException::.ctor()
 			IL_0005: throw
@@ -7917,7 +7917,7 @@ public class C {
 			)
 			.override method instance object [mscorlib]System.Collections.IEnumerator::get_Current()
 			// Method begins at RVA 0x2225
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld int32 C/'<M>d__0'::'<>2__current'
@@ -7932,7 +7932,7 @@ public class C {
 			)
 			.override method instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<int32>::GetEnumerator()
 			// Method begins at RVA 0x2234
-			// Code size 43 (0x2b)
+			// Code size: 43 (0x2b)
 			.maxstack 2
 			.locals init (
 				[0] class C/'<M>d__0'
@@ -7965,7 +7965,7 @@ public class C {
 			)
 			.override method instance class [mscorlib]System.Collections.IEnumerator [mscorlib]System.Collections.IEnumerable::GetEnumerator()
 			// Method begins at RVA 0x226b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance class [mscorlib]System.Collections.Generic.IEnumerator`1<int32> C/'<M>d__0'::'System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator'()
@@ -7989,7 +7989,7 @@ public class C {
 			01 00 09 43 2b 3c 4d 3e 64 5f 5f 30 00 00
 		)
 		// Method begins at RVA 0x2050
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 		IL_0000: ldc.i4.s -2
 		IL_0002: newobj instance void C/'<M>d__0'::.ctor(int32)
@@ -7999,7 +7999,7 @@ public class C {
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2059
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -8060,7 +8060,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -8082,7 +8082,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -8103,7 +8103,7 @@ public class C {
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x208b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -8113,7 +8113,7 @@ public class C {
 			instance void '<M>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2093
-			// Code size 53 (0x35)
+			// Code size: 53 (0x35)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class C/'<>c__DisplayClass0_1' C/'<>c__DisplayClass0_2'::'CS$<>8__locals2'
@@ -8154,7 +8154,7 @@ public class C {
 		{
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()
 			// Method begins at RVA 0x20cc
-			// Code size 792 (0x318)
+			// Code size: 792 (0x318)
 			.maxstack 3
 			.locals init (
 				[0] int32,
@@ -8456,7 +8456,7 @@ public class C {
 			)
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
 			// Method begins at RVA 0x240c
-			// Code size 13 (0xd)
+			// Code size: 13 (0xd)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
@@ -8473,7 +8473,7 @@ public class C {
 			01 00 09 43 2b 3c 4d 3e 64 5f 5f 30 00 00
 		)
 		// Method begins at RVA 0x2050
-		// Code size 47 (0x2f)
+		// Code size: 47 (0x2f)
 		.maxstack 2
 		.locals init (
 			[0] valuetype C/'<M>d__0'
@@ -8497,7 +8497,7 @@ public class C {
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x208b
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [mscorlib]System.Object::.ctor()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -15530,7 +15530,7 @@ class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: ldstr """"
@@ -15541,7 +15541,7 @@ class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -15556,7 +15556,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2064
-		// Code size 81 (0x51)
+		// Code size: 81 (0x51)
 		.maxstack 3
 		IL_0000: ldsfld class [netstandard]System.Runtime.CompilerServices.CallSite`1<class [netstandard]System.Func`3<class [netstandard]System.Runtime.CompilerServices.CallSite, object, !0>> class Program/'<>o__0_0`1'<!!T>::'<>p__0'
 		IL_0005: brtrue.s IL_002b
@@ -15633,7 +15633,7 @@ class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: ldstr """"
@@ -15646,7 +15646,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call void Program::'<M1>g__M2|1_0'<!!T1, !!T2, !!T1, !!T2>(!!2)
@@ -15656,7 +15656,7 @@ class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2064
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -15671,7 +15671,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x206c
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call void Program::'<M1>g__M3|1_1'<!!T1, !!T2, !!T3, !!T4, !!T3, !!T4>(!!4)
@@ -15686,7 +15686,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2074
-		// Code size 81 (0x51)
+		// Code size: 81 (0x51)
 		.maxstack 3
 		IL_0000: ldsfld class [netstandard]System.Runtime.CompilerServices.CallSite`1<class [netstandard]System.Func`3<class [netstandard]System.Runtime.CompilerServices.CallSite, object, !4>> class Program/'<>o__1_1`6'<!!T1, !!T2, !!T3, !!T4, !!T5, !!T6>::'<>p__0'
 		IL_0005: brtrue.s IL_002b
@@ -15759,7 +15759,7 @@ class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: ldstr """"
@@ -15772,7 +15772,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call void Program::'<M1>g__M2|1_0'<!!T1>(!!0)
@@ -15782,7 +15782,7 @@ class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2064
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -15797,7 +15797,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x206c
-		// Code size 81 (0x51)
+		// Code size: 81 (0x51)
 		.maxstack 3
 		IL_0000: ldsfld class [netstandard]System.Runtime.CompilerServices.CallSite`1<class [netstandard]System.Func`3<class [netstandard]System.Runtime.CompilerServices.CallSite, object, !0>> class Program/'<>o__1`1'<!!T1>::'<>p__0'
 		IL_0005: brtrue.s IL_002b
@@ -15870,7 +15870,7 @@ class Program
 		void Main () cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		.entrypoint
 		IL_0000: ldstr """"
@@ -15881,7 +15881,7 @@ class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x205c
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -15896,7 +15896,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2064
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call void Program::'<Main>g__M2|0_1'<!!T, !!T>(!!1)
@@ -15911,7 +15911,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x206c
-		// Code size 81 (0x51)
+		// Code size: 81 (0x51)
 		.maxstack 3
 		IL_0000: ldsfld class [netstandard]System.Runtime.CompilerServices.CallSite`1<class [netstandard]System.Func`3<class [netstandard]System.Runtime.CompilerServices.CallSite, object, !1>> class Program/'<>o__1_0`2'<!!T, !!T>::'<>p__0'
 		IL_0005: brtrue.s IL_002b
@@ -15987,7 +15987,7 @@ class Class<T1>
 		void M () cil managed 
 	{
 		// Method begins at RVA 0x205f
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		IL_0000: ldstr """"
 		IL_0005: call void class Class`1<!T1>::'<M>g__M1|0_0'<string>(!!0)
@@ -15997,7 +15997,7 @@ class Class<T1>
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2057
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -16012,7 +16012,7 @@ class Class<T1>
 			01 00 00 00
 		)
 		// Method begins at RVA 0x206c
-		// Code size 81 (0x51)
+		// Code size: 81 (0x51)
 		.maxstack 3
 		IL_0000: ldsfld class [netstandard]System.Runtime.CompilerServices.CallSite`1<class [netstandard]System.Func`3<class [netstandard]System.Runtime.CompilerServices.CallSite, object, !1>> class Class`1/'<>o__0_0`1'<!T1, !!T2>::'<>p__0'
 		IL_0005: brtrue.s IL_002b

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -5682,7 +5682,7 @@ class C
     		instance void M () cil managed 
     	{
     		// Method begins at RVA 0x205a
-    		// Code size 3 (0x3)
+    		// Code size: 3 (0x3)
     		.maxstack 8
     		IL_0000: nop
     		IL_0001: nop
@@ -5692,7 +5692,7 @@ class C
     		instance void .ctor () cil managed 
     	{
     		// Method begins at RVA 0x205e
-    		// Code size 8 (0x8)
+    		// Code size: 8 (0x8)
     		.maxstack 8
     		IL_0000: ldarg.0
     		IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -5709,7 +5709,7 @@ class C
     			01 00 2a 00 00 00 00 00
     		)
     		// Method begins at RVA 0x2067
-    		// Code size 2 (0x2)
+    		// Code size: 2 (0x2)
     		.maxstack 8
     		IL_0000: nop
     		IL_0001: ret

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -1626,7 +1626,7 @@ public readonly struct S2
         instance void .ctor () cil managed
     {
         // Method begins at RVA 0x2050
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -1649,7 +1649,7 @@ public readonly struct S2
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2058
-		// Code size 1 (0x1)
+		// Code size: 1 (0x1)
 		.maxstack 8
 		IL_0000: ret
 	} // end of method S::M1
@@ -1662,7 +1662,7 @@ public readonly struct S2
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2058
-		// Code size 1 (0x1)
+		// Code size: 1 (0x1)
 		.maxstack 8
 		IL_0000: ret
 	} // end of method S::M2

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -28077,7 +28077,7 @@ namespace System
         ) cil managed
     {
         // Method begins at RVA 0x2050
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
         IL_0000: ldnull
         IL_0001: throw

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -10017,7 +10017,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a1
-			// Code size 8 (0x8)
+			// Code size: 8 (0x8)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -10028,7 +10028,7 @@ class C
 			instance int32 '<F>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20ac
-			// Code size 38 (0x26)
+			// Code size: 38 (0x26)
 			.maxstack 2
 			.locals init (
 				[0] int32,
@@ -10067,7 +10067,7 @@ class C
 		) cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 69 (0x45)
+		// Code size: 69 (0x45)
 		.maxstack 2
 		.locals init (
 			[0] class C/'<>c__DisplayClass0_0',
@@ -10111,7 +10111,7 @@ class C
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a1
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -10227,7 +10227,7 @@ class C
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x20a5
-			// Code size 8 (0x8)
+			// Code size: 8 (0x8)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [netstandard]System.Object::.ctor()
@@ -10238,7 +10238,7 @@ class C
 			instance string '<F>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x20b0
-			// Code size 78 (0x4e)
+			// Code size: 78 (0x4e)
 			.maxstack 3
 			.locals init (
 				[0] string,
@@ -10283,7 +10283,7 @@ class C
 			instance string '<F>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x210a
-			// Code size 22 (0x16)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			IL_0000: ldstr ""2""
 			IL_0005: ldarg.0
@@ -10300,7 +10300,7 @@ class C
 		) cil managed 
 	{
 		// Method begins at RVA 0x2050
-		// Code size 73 (0x49)
+		// Code size: 73 (0x49)
 		.maxstack 2
 		.locals init (
 			[0] class C/'<>c__DisplayClass0_0',
@@ -10344,7 +10344,7 @@ class C
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x20a5
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -10930,7 +10930,7 @@ class Program
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2058
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [netstandard]System.Object::.ctor()

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -1373,7 +1373,7 @@ value").VerifyDiagnostics(
                 01 00 01 70 00 00
             )
         // Method begins at RVA 0x2050
-        // Code size 9 (0x9)
+        // Code size: 9 (0x9)
         .maxstack 8
 
         IL_0000: nop
@@ -1881,7 +1881,7 @@ value").VerifyDiagnostics(
                 01 00 01 70 00 00
             )
         // Method begins at RVA 0x2050
-        // Code size 16 (0x10)
+        // Code size: 16 (0x10)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2262,7 +2262,7 @@ class Program
                 01 00 01 61 00 00
             )
         // Method begins at RVA 0x2050
-        // Code size 37 (0x25)
+        // Code size: 37 (0x25)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
@@ -6096,7 +6096,7 @@ System.Action");
         string Method () cil managed 
     {
         // Method begins at RVA 0x2050
-        // Code size 6 (0x6)
+        // Code size: 6 (0x6)
         .maxstack 8
 
         IL_0000: ldstr ""PASS""
@@ -6107,7 +6107,7 @@ System.Action");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -6125,7 +6125,7 @@ System.Action");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -6143,7 +6143,7 @@ System.Action");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x205f
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -6238,7 +6238,7 @@ class Test
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x211f
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 
 		IL_0000: ldarg.0
@@ -6257,7 +6257,7 @@ class Test
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -6275,7 +6275,7 @@ class Test
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x205f
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -10707,7 +10707,7 @@ class Program
                                 01 00 00 00
                             )
                         // Method begins at RVA 0x20a2
-                        // Code size 2 (0x2)
+                        // Code size: 2 (0x2)
                         .maxstack 8
 
                         IL_0000: nop
@@ -10749,7 +10749,7 @@ class Program
                                 01 00 00 00
                             )
                         // Method begins at RVA 0x20a2
-                        // Code size 2 (0x2)
+                        // Code size: 2 (0x2)
                         .maxstack 8
 
                         IL_0000: nop
@@ -12395,7 +12395,7 @@ $@"
         void .cctor () cil managed 
     {{
         // Method begins at RVA 0x20de
-        // Code size 11 (0xb)
+        // Code size: 11 (0xb)
         .maxstack 8
         IL_0000: newobj instance void Program/'<>c'::.ctor()
         IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -12405,7 +12405,7 @@ $@"
         instance void .ctor () cil managed 
     {{
         // Method begins at RVA 0x20d6
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
         IL_0000: ldarg.0
         IL_0001: call instance void [{s_libPrefix}]System.Object::.ctor()
@@ -12418,7 +12418,7 @@ $@"
     {{
         .param [1] = int32(30)
         // Method begins at RVA 0x20ea
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
         IL_0000: ldarg.1
         IL_0001: ret
@@ -12513,7 +12513,7 @@ $@"
 		void .cctor () cil managed 
 	{{
 		// Method begins at RVA 0x20d3
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		IL_0000: newobj instance void Program/'<>c'::.ctor()
 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -12523,7 +12523,7 @@ $@"
 		instance void .ctor () cil managed 
 	{{
 		// Method begins at RVA 0x20cb
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [{s_libPrefix}]System.Object::.ctor()
@@ -12539,7 +12539,7 @@ $@"
 		.param [2] = ""b""
 		.param [3] = ""c""
 		// Method begins at RVA 0x20df
-		// Code size 9 (0x9)
+		// Code size: 9 (0x9)
 		.maxstack 8
 		IL_0000: ldarg.1
 		IL_0001: ldarg.2
@@ -12987,7 +12987,7 @@ $@"
 		void .cctor () cil managed 
 	{{
 		// Method begins at RVA 0x20d3
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		IL_0000: newobj instance void Program/'<>c'::.ctor()
 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -12997,7 +12997,7 @@ $@"
 		instance void .ctor () cil managed 
 	{{
 		// Method begins at RVA 0x20cb
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [{s_libPrefix}]System.Object::.ctor()
@@ -13012,7 +13012,7 @@ $@"
 	{{
 		.param [3] = int32(3)
 		// Method begins at RVA 0x20df
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.2
 		IL_0001: ldarg.1
@@ -14289,7 +14289,7 @@ $$"""
                 		void .cctor () cil managed 
                 	{
                 		// Method begins at RVA 0x208d
-                		// Code size 11 (0xb)
+                		// Code size: 11 (0xb)
                 		.maxstack 8
                 		IL_0000: newobj instance void Program/'<>c'::.ctor()
                 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -14299,7 +14299,7 @@ $$"""
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x2085
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -14315,7 +14315,7 @@ $$"""
                 				01 00 00 00
                 			)
                 		// Method begins at RVA 0x2099
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<Main>b__0_0'
@@ -14382,7 +14382,7 @@ $$"""
 		void .cctor () cil managed 
 	{
 		// Method begins at RVA 0x20a2
-		// Code size 11 (0xb)
+		// Code size: 11 (0xb)
 		.maxstack 8
 		IL_0000: newobj instance void Program/'<>c'::.ctor()
 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -14392,7 +14392,7 @@ $$"""
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x209a
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -14409,7 +14409,7 @@ $$"""
 				01 00 00 00
 			)
 		// Method begins at RVA 0x20ae
-		// Code size 3 (0x3)
+		// Code size: 3 (0x3)
 		.maxstack 8
 		IL_0000: ldarg.1
 		IL_0001: ldind.i4
@@ -14590,7 +14590,7 @@ class Program
                 		void .cctor () cil managed 
                 	{
                 		// Method begins at RVA 0x20a9
-                		// Code size 11 (0xb)
+                		// Code size: 11 (0xb)
                 		.maxstack 8
                 		IL_0000: newobj instance void Program/'<>c'::.ctor()
                 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -14600,7 +14600,7 @@ class Program
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x20a1
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -14617,7 +14617,7 @@ class Program
                 				00 00
                 			)
                 		// Method begins at RVA 0x20b5
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<<Main>$>b__0_0'
@@ -14632,7 +14632,7 @@ class Program
                 				00 00
                 			)
                 		// Method begins at RVA 0x20b5
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<<Main>$>b__0_1'
@@ -14702,7 +14702,7 @@ class Program
                 		) cil managed 
                 	{
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		.entrypoint
                 		IL_0000: ret
@@ -14711,7 +14711,7 @@ class Program
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x2069
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -14731,7 +14731,7 @@ class Program
                 				00 00
                 			)
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method Program::'<<Main>$>g__local1|0_0'
@@ -14749,7 +14749,7 @@ class Program
                 				00 00
                 			)
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method Program::'<<Main>$>g__local2|0_1'
@@ -14888,7 +14888,7 @@ class Program
                 		void .cctor () cil managed 
                 	{
                 		// Method begins at RVA 0x20a9
-                		// Code size 11 (0xb)
+                		// Code size: 11 (0xb)
                 		.maxstack 8
                 		IL_0000: newobj instance void Program/'<>c'::.ctor()
                 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -14898,7 +14898,7 @@ class Program
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x20a1
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -14914,7 +14914,7 @@ class Program
                 				01 00 64 00 00 00 00 00 00 00 00 00
                 			)
                 		// Method begins at RVA 0x20b5
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<<Main>$>b__0_0'
@@ -14928,7 +14928,7 @@ class Program
                 				01 00 64 00 00 00 00 00 00 00 00 00
                 			)
                 		// Method begins at RVA 0x20b5
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<<Main>$>b__0_1'
@@ -14988,7 +14988,7 @@ class Program
                 		) cil managed 
                 	{
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		.entrypoint
                 		IL_0000: ret
@@ -14997,7 +14997,7 @@ class Program
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x2069
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -15016,7 +15016,7 @@ class Program
                  				01 00 64 00 00 00 00 00 00 00 00 00
                  			)
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method Program::'<<Main>$>g__local1|0_0'
@@ -15033,7 +15033,7 @@ class Program
                  				01 00 64 00 00 00 00 00 00 00 00 00
                  			)
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method Program::'<<Main>$>g__local2|0_1'
@@ -16032,7 +16032,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 		void .cctor () cil managed 
                 	{
                 		// Method begins at RVA 0x20a4
-                		// Code size 11 (0xb)
+                		// Code size: 11 (0xb)
                 		.maxstack 8
                 		IL_0000: newobj instance void Program/'<>c'::.ctor()
                 		IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
@@ -16042,7 +16042,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x209c
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -16055,7 +16055,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 		) cil managed 
                 	{
                 		// Method begins at RVA 0x20b0
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method '<>c'::'<<Main>$>b__0_0'
@@ -16088,7 +16088,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 		void M () cil managed 
                 	{
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method C::M
@@ -16096,7 +16096,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 		instance void .ctor () cil managed 
                 	{
                 		// Method begins at RVA 0x2069
-                		// Code size 7 (0x7)
+                		// Code size: 7 (0x7)
                 		.maxstack 8
                 		IL_0000: ldarg.0
                 		IL_0001: call instance void [{{s_libPrefix}}]System.Object::.ctor()
@@ -16112,7 +16112,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0`2[System.Int32,
                 			01 00 00 00
                 		)
                 		// Method begins at RVA 0x2067
-                		// Code size 1 (0x1)
+                		// Code size: 1 (0x1)
                 		.maxstack 8
                 		IL_0000: ret
                 	} // end of method C::'<M>g__local|0_0'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
@@ -8144,7 +8144,7 @@ class Program
 			instance void .ctor () cil managed 
 		{
 			// Method begins at RVA 0x221b
-			// Code size 7 (0x7)
+			// Code size: 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: call instance void [mscorlib]System.Object::.ctor()
@@ -8154,7 +8154,7 @@ class Program
 			instance void '<.ctor>b__0' () cil managed 
 		{
 			// Method begins at RVA 0x2224
-			// Code size 17 (0x11)
+			// Code size: 17 (0x11)
 			.maxstack 3
 			.locals init (
 				[0] int32
@@ -8173,7 +8173,7 @@ class Program
 			instance int32 '<.ctor>b__1' () cil managed 
 		{
 			// Method begins at RVA 0x2241
-			// Code size 12 (0xc)
+			// Code size: 12 (0xc)
 			.maxstack 8
 			IL_0000: ldarg.0
 			IL_0001: ldfld class C1 C1/'<>c__DisplayClass1_0'::'<>4__this'
@@ -8202,7 +8202,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x2084
-		// Code size 98 (0x62)
+		// Code size: 98 (0x62)
 		.maxstack 5
 		.locals init (
 			[0] class C1/'<>c__DisplayClass1_0'
@@ -8252,7 +8252,7 @@ class Program
 		instance int32 get_P1 () cil managed 
 	{
 		// Method begins at RVA 0x20f2
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldfld int32 C1::'<p1>P'
@@ -8262,7 +8262,7 @@ class Program
 		instance int32 get_P2 () cil managed 
 	{
 		// Method begins at RVA 0x20fc
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -8282,7 +8282,7 @@ class Program
 		instance int32 M1 () cil managed 
 	{
 		// Method begins at RVA 0x211c
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -8304,7 +8304,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x213a
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -8320,7 +8320,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x214a
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void C1::'<remove_E1>g__local|12_0'()
@@ -8335,7 +8335,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2154
-		// Code size 41 (0x29)
+		// Code size: 41 (0x29)
 		.maxstack 3
 		.locals init (
 			[0] class [mscorlib]System.Action,
@@ -8374,7 +8374,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x218c
-		// Code size 41 (0x29)
+		// Code size: 41 (0x29)
 		.maxstack 3
 		.locals init (
 			[0] class [mscorlib]System.Action,
@@ -8408,7 +8408,7 @@ class Program
 		instance class [mscorlib]System.Action M2 () cil managed 
 	{
 		// Method begins at RVA 0x21c1
-		// Code size 13 (0xd)
+		// Code size: 13 (0xd)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldftn instance void C1::'<M2>b__16_0'()
@@ -8422,7 +8422,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x21cf
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -8439,7 +8439,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x213a
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -8547,7 +8547,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x2067
-		// Code size 35 (0x23)
+		// Code size: 35 (0x23)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.1
@@ -8573,7 +8573,7 @@ class Program
 		instance int32 get_P1 () cil managed 
 	{
 		// Method begins at RVA 0x208b
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldfld int32 C1::'<p1>P'
@@ -8583,7 +8583,7 @@ class Program
 		instance int32 get_P2 () cil managed 
 	{
 		// Method begins at RVA 0x2094
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -8603,7 +8603,7 @@ class Program
 		instance int32 M1 () cil managed 
 	{
 		// Method begins at RVA 0x20b4
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -8625,7 +8625,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x20d2
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -8641,7 +8641,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x20e2
-		// Code size 1 (0x1)
+		// Code size: 1 (0x1)
 		.maxstack 8
 		IL_0000: ret
 	} // end of method C1::remove_E1
@@ -15204,7 +15204,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x2083
-		// Code size 60 (0x3c)
+		// Code size: 60 (0x3c)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.1
@@ -15238,7 +15238,7 @@ class Program
 		instance int32 get_P1 () cil managed 
 	{
 		// Method begins at RVA 0x20c0
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldfld int32 C1::'<p1>P'
@@ -15248,7 +15248,7 @@ class Program
 		instance int32 get_P2 () cil managed 
 	{
 		// Method begins at RVA 0x20c8
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -15268,7 +15268,7 @@ class Program
 		instance int32 M1 () cil managed 
 	{
 		// Method begins at RVA 0x20e8
-		// Code size 18 (0x12)
+		// Code size: 18 (0x12)
 		.maxstack 3
 		.locals init (
 			[0] int32
@@ -15290,7 +15290,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x2106
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -15306,7 +15306,7 @@ class Program
 		) cil managed 
 	{
 		// Method begins at RVA 0x2116
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: call instance void C1::'<remove_E1>g__local|12_0'()
@@ -15316,7 +15316,7 @@ class Program
 		instance class [mscorlib]System.Action M2 () cil managed 
 	{
 		// Method begins at RVA 0x211e
-		// Code size 13 (0xd)
+		// Code size: 13 (0xd)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldftn instance void C1::'<M2>b__13_0'()
@@ -15330,7 +15330,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x20c0
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldfld int32 C1::'<p1>P'
@@ -15343,7 +15343,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x212c
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0
@@ -15360,7 +15360,7 @@ class Program
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2106
-		// Code size 15 (0xf)
+		// Code size: 15 (0xf)
 		.maxstack 8
 		IL_0000: ldarg.0
 		IL_0001: ldarg.0

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -2646,7 +2646,7 @@ class C
         instance valuetype S '" + WellKnownMemberNames.CloneMethodName + @"' () cil managed 
     {
         // Method begins at RVA 0x2150
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 1
         .locals init (
             [0] valuetype S
@@ -2660,7 +2660,7 @@ class C
         instance int32 get_Property () cil managed 
     {
         // Method begins at RVA 0x215e
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
 
         IL_0000: ldnull
@@ -2673,7 +2673,7 @@ class C
         ) cil managed 
     {
         // Method begins at RVA 0x215e
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
 
         IL_0000: ldnull

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -2829,7 +2829,7 @@ Charlie");
         string Method () cil managed 
     {
         // Method begins at RVA 0x2050
-        // Code size 6 (0x6)
+        // Code size: 6 (0x6)
         .maxstack 8
 
         IL_0000: ldstr ""Method""
@@ -2840,7 +2840,7 @@ Charlie");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2858,7 +2858,7 @@ Charlie");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2876,7 +2876,7 @@ Charlie");
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x205f
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2920,7 +2920,7 @@ class Test
         string Method () cil managed 
     {
         // Method begins at RVA 0x2050
-        // Code size 6 (0x6)
+        // Code size: 6 (0x6)
         .maxstack 8
 
         IL_0000: ldstr ""Method""
@@ -2931,7 +2931,7 @@ class Test
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2949,7 +2949,7 @@ class Test
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -2967,7 +2967,7 @@ class Test
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x205f
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2441,7 +2441,7 @@ public partial class D : C
 				01 00 00 00
 			)
 		// Method begins at RVA 0x2067
-		// Code size 9 (0x9)
+		// Code size: 9 (0x9)
 		.maxstack 8
 
 		IL_0000: ldarg.1
@@ -2455,7 +2455,7 @@ public partial class D : C
 		instance void .ctor () cil managed 
 	{
 		// Method begins at RVA 0x2071
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 
 		IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -1365,7 +1365,7 @@ unsafe static class C
             01 00 00 00
         )
         // Method begins at RVA 0x205c
-        // Code size 9 (0x9)
+        // Code size: 9 (0x9)
         .maxstack 8
 
         IL_0001: ldc.i4.1

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -28959,7 +28959,7 @@ public class C3 : C2, I1<C2>
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2053
-        // Code size 8 (0x8)
+        // Code size: 8 (0x8)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolExtensionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolExtensionTests.cs
@@ -172,7 +172,7 @@ void F<T>(T t)
         string Method () cil managed 
     {
         // Method begins at RVA 0x2050
-        // Code size 6 (0x6)
+        // Code size: 6 (0x6)
         .maxstack 8
 
         IL_0000: ldstr ""Method""
@@ -183,7 +183,7 @@ void F<T>(T t)
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -201,7 +201,7 @@ void F<T>(T t)
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2057
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -219,7 +219,7 @@ void F<T>(T t)
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x205f
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -185,7 +185,22 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 		/// <param name="expected">The expected IL</param>
         public void VerifyTypeIL(string typeName, string expected)
         {
-            VerifyTypeIL(typeName, output => AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, output, escapeQuotes: false));
+            VerifyTypeIL(typeName, output =>
+            {
+                // All our tests predate ilspy adding `// Header size: ...` to the contents.  So trim that out since we
+                // really don't need to validate superfluous IL comments
+                expected = RemoveHeaderComments(expected);
+                output = RemoveHeaderComments(output);
+
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, output, escapeQuotes: false);
+            });
+        }
+
+        private static readonly Regex s_headerCommentsRegex = new("""^\s*// Header size: [0-9]+\s*$""", RegexOptions.Multiline);
+
+        private static string RemoveHeaderComments(string value)
+        {
+            return s_headerCommentsRegex.Replace(value, "");
         }
 
         /// <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -164,7 +164,7 @@ End Module
 			01 00 00 00
 		)
 		// Method begins at RVA 0x2050
-		// Code size 13 (0xd)
+		// Code size: 13 (0xd)
 		.maxstack 8
 		.entrypoint
 		IL_0000: ldc.i4.s 123
@@ -183,7 +183,7 @@ End Module
 				01 00 01 70 00 00
 			)
 		// Method begins at RVA 0x205e
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.1
 		IL_0001: call void [System.Console]System.Console::WriteLine(string)
@@ -210,7 +210,7 @@ End Module
         instance void .ctor () cil managed
     {
         // Method begins at RVA 0x2050
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -229,7 +229,7 @@ End Module
                 01 00 01 49 00 00 // I
             )
         // Method begins at RVA 0x2058
-        // Code size 9 (0x9)
+        // Code size: 9 (0x9)
         .maxstack 8
 
         IL_0000: nop
@@ -890,7 +890,7 @@ BC42504: The CallerArgumentExpressionAttribute applied to parameter 'p' will hav
                 01 00 01 70 00 00
             )
         // Method begins at RVA 0x2050
-        // Code size 9 (0x9)
+        // Code size: 9 (0x9)
         .maxstack 8
 
         IL_0000: nop
@@ -1423,7 +1423,7 @@ End Module
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2050
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 8
 
         IL_0000: ldarg.0
@@ -1442,7 +1442,7 @@ End Module
                 01 00 04 6c 65 66 74 00 00
             )
         // Method begins at RVA 0x2058
-        // Code size 7 (0x7)
+        // Code size: 7 (0x7)
         .maxstack 1
         .locals init (
             [0] class C

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -19804,7 +19804,7 @@ End Class
 		instance void .ctor () cil managed
 	{
 		// Method begins at RVA 0x2050
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 
 		IL_0000: ldarg.0
@@ -19823,7 +19823,7 @@ End Class
 		instance void .ctor () cil managed
 	{
 		// Method begins at RVA 0x2059
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 
 		IL_0000: ldarg.0
@@ -19842,7 +19842,7 @@ End Class
 		instance class Base`1<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> GetBaseWithModifiers () cil managed
 	{
 		// Method begins at RVA 0x2064
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 1
 		.locals init (
 			[0] class Base`1<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
@@ -19861,7 +19861,7 @@ End Class
 		instance class Derived`1<object> GetDerivedWithoutModifiers () cil managed
 	{
 		// Method begins at RVA 0x2078
-		// Code size 7 (0x7)
+		// Code size: 7 (0x7)
 		.maxstack 1
 		.locals init (
 			[0] class Derived`1<object>
@@ -19880,7 +19880,7 @@ End Class
 		instance void .ctor () cil managed
 	{
 		// Method begins at RVA 0x2050
-		// Code size 8 (0x8)
+		// Code size: 8 (0x8)
 		.maxstack 8
 
 		IL_0000: ldarg.0

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingMethods.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadingMethods.vb
@@ -1006,7 +1006,7 @@ BC30390: 'C2.Private Overloads Sub M2()' is not accessible in this context becau
     {
         .override method instance void class Interface`2<!T, !T>::Method(int32)
         // Method begins at RVA 0x2050
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
 
         IL_0000: nop
@@ -1021,7 +1021,7 @@ BC30390: 'C2.Private Overloads Sub M2()' is not accessible in this context becau
         .override method instance void class Interface`2<!T, !T>::Method(!0)
         .override method instance void class Interface`2<!T, !T>::Method(!1)
         // Method begins at RVA 0x2050
-        // Code size 2 (0x2)
+        // Code size: 2 (0x2)
         .maxstack 8
 
         IL_0000: nop
@@ -1032,7 +1032,7 @@ BC30390: 'C2.Private Overloads Sub M2()' is not accessible in this context becau
         instance void .ctor () cil managed 
     {
         // Method begins at RVA 0x2053
-        // Code size 8 (0x8)
+        // Code size: 8 (0x8)
         .maxstack 8
 
         IL_0000: ldarg.0

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
     [UseExportProvider]
     public abstract partial class AbstractMetadataAsSourceTests : IAsyncLifetime
     {
-        protected static readonly string ICSharpCodeDecompilerVersion = "7.1.0.6543";
+        protected static readonly string ICSharpCodeDecompilerVersion = "7.2.1.6856";
 
         public virtual Task InitializeAsync()
         {

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -208,167 +208,166 @@ namespace System
 using System.Collections;
 using System.Runtime.InteropServices;
 
-namespace System
+namespace System;
+
+[StructLayout(LayoutKind.Sequential, Size = 1)]
+public struct [|ValueTuple|] : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
 {{
-    [StructLayout(LayoutKind.Sequential, Size = 1)]
-    public struct [|ValueTuple|] : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+    int ITupleInternal.Size => 0;
+
+    public override bool Equals(object obj)
     {{
-        int ITupleInternal.Size => 0;
+        return obj is ValueTuple;
+    }}
 
-        public override bool Equals(object obj)
+    public bool Equals(ValueTuple other)
+    {{
+        return true;
+    }}
+
+    bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+    {{
+        return other is ValueTuple;
+    }}
+
+    int IComparable.CompareTo(object other)
+    {{
+        if (other == null)
         {{
-            return obj is ValueTuple;
+            return 1;
         }}
 
-        public bool Equals(ValueTuple other)
+        if (!(other is ValueTuple))
         {{
-            return true;
+            throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
         }}
 
-        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        return 0;
+    }}
+
+    public int CompareTo(ValueTuple other)
+    {{
+        return 0;
+    }}
+
+    int IStructuralComparable.CompareTo(object other, IComparer comparer)
+    {{
+        if (other == null)
         {{
-            return other is ValueTuple;
+            return 1;
         }}
 
-        int IComparable.CompareTo(object other)
+        if (!(other is ValueTuple))
         {{
-            if (other == null)
-            {{
-                return 1;
-            }}
-
-            if (!(other is ValueTuple))
-            {{
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
-            }}
-
-            return 0;
+            throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
         }}
 
-        public int CompareTo(ValueTuple other)
-        {{
-            return 0;
-        }}
+        return 0;
+    }}
 
-        int IStructuralComparable.CompareTo(object other, IComparer comparer)
-        {{
-            if (other == null)
-            {{
-                return 1;
-            }}
+    public override int GetHashCode()
+    {{
+        return 0;
+    }}
 
-            if (!(other is ValueTuple))
-            {{
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
-            }}
+    int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+    {{
+        return 0;
+    }}
 
-            return 0;
-        }}
+    int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+    {{
+        return 0;
+    }}
 
-        public override int GetHashCode()
-        {{
-            return 0;
-        }}
+    public override string ToString()
+    {{
+        return ""()"";
+    }}
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
-        {{
-            return 0;
-        }}
+    string ITupleInternal.ToStringEnd()
+    {{
+        return "")"";
+    }}
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
-        {{
-            return 0;
-        }}
+    public static ValueTuple Create()
+    {{
+        return default(ValueTuple);
+    }}
 
-        public override string ToString()
-        {{
-            return ""()"";
-        }}
+    public static ValueTuple<T1> Create<T1>(T1 item1)
+    {{
+        return new ValueTuple<T1>(item1);
+    }}
 
-        string ITupleInternal.ToStringEnd()
-        {{
-            return "")"";
-        }}
+    public static (T1, T2) Create<T1, T2>(T1 item1, T2 item2)
+    {{
+        return (item1, item2);
+    }}
 
-        public static ValueTuple Create()
-        {{
-            return default(ValueTuple);
-        }}
+    public static (T1, T2, T3) Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+    {{
+        return (item1, item2, item3);
+    }}
 
-        public static ValueTuple<T1> Create<T1>(T1 item1)
-        {{
-            return new ValueTuple<T1>(item1);
-        }}
+    public static (T1, T2, T3, T4) Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
+    {{
+        return (item1, item2, item3, item4);
+    }}
 
-        public static (T1, T2) Create<T1, T2>(T1 item1, T2 item2)
-        {{
-            return (item1, item2);
-        }}
+    public static (T1, T2, T3, T4, T5) Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+    {{
+        return (item1, item2, item3, item4, item5);
+    }}
 
-        public static (T1, T2, T3) Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
-        {{
-            return (item1, item2, item3);
-        }}
+    public static (T1, T2, T3, T4, T5, T6) Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+    {{
+        return (item1, item2, item3, item4, item5, item6);
+    }}
 
-        public static (T1, T2, T3, T4) Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
-        {{
-            return (item1, item2, item3, item4);
-        }}
+    public static (T1, T2, T3, T4, T5, T6, T7) Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+    {{
+        return (item1, item2, item3, item4, item5, item6, item7);
+    }}
 
-        public static (T1, T2, T3, T4, T5) Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
-        {{
-            return (item1, item2, item3, item4, item5);
-        }}
+    public static (T1, T2, T3, T4, T5, T6, T7, T8) Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
+    {{
+        return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, Create(item8));
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6) Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
-        {{
-            return (item1, item2, item3, item4, item5, item6);
-        }}
+    internal static int CombineHashCodes(int h1, int h2)
+    {{
+        return ((h1 << 5) + h1) ^ h2;
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6, T7) Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
-        {{
-            return (item1, item2, item3, item4, item5, item6, item7);
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6, T7, T8) Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
-        {{
-            return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, Create(item8));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2)
-        {{
-            return ((h1 << 5) + h1) ^ h2;
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
     }}
 }}
 #if false // {CSharpEditorResources.Decompilation_log}

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.VisualBasic.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.VisualBasic.cs
@@ -126,101 +126,47 @@ End Namespace",
 
 using System.Runtime.InteropServices;
 
-namespace System
+namespace System;
+
+[Serializable]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false)]
+[ComVisible(true)]
+public sealed class [|ObsoleteAttribute|] : Attribute
 {{
-    //
-    // Summary:
-    //     Marks the program elements that are no longer in use. This class cannot be inherited.
-    [Serializable]
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false)]
-    [ComVisible(true)]
-    [__DynamicallyInvokable]
-    public sealed class [|ObsoleteAttribute|] : Attribute
+    public string Message
     {{
-        private string _message;
-
-        private bool _error;
-
-        //
-        // Summary:
-        //     Gets the workaround message, including a description of the alternative program
-        //     elements.
-        //
-        // Returns:
-        //     The workaround text string.
-        [__DynamicallyInvokable]
-        public string Message
+        get
         {{
-            [__DynamicallyInvokable]
-            get
-            {{
-                return _message;
-            }}
+            /*Error: Empty body found. Decompiled assembly might be a reference assembly.*/
+            ;
         }}
+    }}
 
-        //
-        // Summary:
-        //     Gets a Boolean value indicating whether the compiler will treat usage of the
-        //     obsolete program element as an error.
-        //
-        // Returns:
-        //     true if the obsolete element usage is considered an error; otherwise, false.
-        //     The default is false.
-        [__DynamicallyInvokable]
-        public bool IsError
+    public bool IsError
+    {{
+        get
         {{
-            [__DynamicallyInvokable]
-            get
-            {{
-                return _error;
-            }}
+            /*Error: Empty body found. Decompiled assembly might be a reference assembly.*/
+            ;
         }}
+    }}
 
-        //
-        // Summary:
-        //     Initializes a new instance of the System.ObsoleteAttribute class with default
-        //     properties.
-        [__DynamicallyInvokable]
-        public ObsoleteAttribute()
-        {{
-            _message = null;
-            _error = false;
-        }}
+    public ObsoleteAttribute()
+    {{
+        /*Error: Empty body found. Decompiled assembly might be a reference assembly.*/
+        ;
+    }}
 
-        //
-        // Summary:
-        //     Initializes a new instance of the System.ObsoleteAttribute class with a specified
-        //     workaround message.
-        //
-        // Parameters:
-        //   message:
-        //     The text string that describes alternative workarounds.
-        [__DynamicallyInvokable]
-        public ObsoleteAttribute(string message)
-        {{
-            _message = message;
-            _error = false;
-        }}
+    public ObsoleteAttribute(string message)
+    {{
+        /*Error: Empty body found. Decompiled assembly might be a reference assembly.*/
+        ;
+    }}
 
-        //
-        // Summary:
-        //     Initializes a new instance of the System.ObsoleteAttribute class with a workaround
-        //     message and a Boolean value indicating whether the obsolete element usage is
-        //     considered an error.
-        //
-        // Parameters:
-        //   message:
-        //     The text string that describes alternative workarounds.
-        //
-        //   error:
-        //     true if the obsolete element usage generates a compiler error; false if it generates
-        //     a compiler warning.
-        [__DynamicallyInvokable]
-        public ObsoleteAttribute(string message, bool error)
-        {{
-            _message = message;
-            _error = error;
-        }}
+    public ObsoleteAttribute(string message, bool error)
+    {{
+        /*Error: Empty body found. Decompiled assembly might be a reference assembly.*/
+        ;
     }}
 }}
 #if false // {CSharpEditorResources.Decompilation_log}
@@ -289,167 +235,166 @@ End Namespace",
 using System.Collections;
 using System.Runtime.InteropServices;
 
-namespace System
+namespace System;
+
+[StructLayout(LayoutKind.Sequential, Size = 1)]
+public struct [|ValueTuple|] : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
 {{
-    [StructLayout(LayoutKind.Sequential, Size = 1)]
-    public struct [|ValueTuple|] : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+    int ITupleInternal.Size => 0;
+
+    public override bool Equals(object obj)
     {{
-        int ITupleInternal.Size => 0;
+        return obj is ValueTuple;
+    }}
 
-        public override bool Equals(object obj)
+    public bool Equals(ValueTuple other)
+    {{
+        return true;
+    }}
+
+    bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+    {{
+        return other is ValueTuple;
+    }}
+
+    int IComparable.CompareTo(object other)
+    {{
+        if (other == null)
         {{
-            return obj is ValueTuple;
+            return 1;
         }}
 
-        public bool Equals(ValueTuple other)
+        if (!(other is ValueTuple))
         {{
-            return true;
+            throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
         }}
 
-        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        return 0;
+    }}
+
+    public int CompareTo(ValueTuple other)
+    {{
+        return 0;
+    }}
+
+    int IStructuralComparable.CompareTo(object other, IComparer comparer)
+    {{
+        if (other == null)
         {{
-            return other is ValueTuple;
+            return 1;
         }}
 
-        int IComparable.CompareTo(object other)
+        if (!(other is ValueTuple))
         {{
-            if (other == null)
-            {{
-                return 1;
-            }}
-
-            if (!(other is ValueTuple))
-            {{
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
-            }}
-
-            return 0;
+            throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
         }}
 
-        public int CompareTo(ValueTuple other)
-        {{
-            return 0;
-        }}
+        return 0;
+    }}
 
-        int IStructuralComparable.CompareTo(object other, IComparer comparer)
-        {{
-            if (other == null)
-            {{
-                return 1;
-            }}
+    public override int GetHashCode()
+    {{
+        return 0;
+    }}
 
-            if (!(other is ValueTuple))
-            {{
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, ""other"");
-            }}
+    int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+    {{
+        return 0;
+    }}
 
-            return 0;
-        }}
+    int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+    {{
+        return 0;
+    }}
 
-        public override int GetHashCode()
-        {{
-            return 0;
-        }}
+    public override string ToString()
+    {{
+        return ""()"";
+    }}
 
-        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
-        {{
-            return 0;
-        }}
+    string ITupleInternal.ToStringEnd()
+    {{
+        return "")"";
+    }}
 
-        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
-        {{
-            return 0;
-        }}
+    public static ValueTuple Create()
+    {{
+        return default(ValueTuple);
+    }}
 
-        public override string ToString()
-        {{
-            return ""()"";
-        }}
+    public static ValueTuple<T1> Create<T1>(T1 item1)
+    {{
+        return new ValueTuple<T1>(item1);
+    }}
 
-        string ITupleInternal.ToStringEnd()
-        {{
-            return "")"";
-        }}
+    public static (T1, T2) Create<T1, T2>(T1 item1, T2 item2)
+    {{
+        return (item1, item2);
+    }}
 
-        public static ValueTuple Create()
-        {{
-            return default(ValueTuple);
-        }}
+    public static (T1, T2, T3) Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+    {{
+        return (item1, item2, item3);
+    }}
 
-        public static ValueTuple<T1> Create<T1>(T1 item1)
-        {{
-            return new ValueTuple<T1>(item1);
-        }}
+    public static (T1, T2, T3, T4) Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
+    {{
+        return (item1, item2, item3, item4);
+    }}
 
-        public static (T1, T2) Create<T1, T2>(T1 item1, T2 item2)
-        {{
-            return (item1, item2);
-        }}
+    public static (T1, T2, T3, T4, T5) Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+    {{
+        return (item1, item2, item3, item4, item5);
+    }}
 
-        public static (T1, T2, T3) Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
-        {{
-            return (item1, item2, item3);
-        }}
+    public static (T1, T2, T3, T4, T5, T6) Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+    {{
+        return (item1, item2, item3, item4, item5, item6);
+    }}
 
-        public static (T1, T2, T3, T4) Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
-        {{
-            return (item1, item2, item3, item4);
-        }}
+    public static (T1, T2, T3, T4, T5, T6, T7) Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+    {{
+        return (item1, item2, item3, item4, item5, item6, item7);
+    }}
 
-        public static (T1, T2, T3, T4, T5) Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
-        {{
-            return (item1, item2, item3, item4, item5);
-        }}
+    public static (T1, T2, T3, T4, T5, T6, T7, T8) Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
+    {{
+        return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, Create(item8));
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6) Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
-        {{
-            return (item1, item2, item3, item4, item5, item6);
-        }}
+    internal static int CombineHashCodes(int h1, int h2)
+    {{
+        return ((h1 << 5) + h1) ^ h2;
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6, T7) Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
-        {{
-            return (item1, item2, item3, item4, item5, item6, item7);
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+    }}
 
-        public static (T1, T2, T3, T4, T5, T6, T7, T8) Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
-        {{
-            return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, Create(item8));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2)
-        {{
-            return ((h1 << 5) + h1) ^ h2;
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
+    }}
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
-        }}
-
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
-        {{
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
-        }}
+    internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+    {{
+        return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
     }}
 }}
 #if false // {CSharpEditorResources.Decompilation_log}

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -935,11 +935,10 @@ End Namespace",
 // Decompiled with ICSharpCode.Decompiler {ICSharpCodeDecompilerVersion}
 #endregion
 
-namespace N
+namespace N;
+
+public class [|C|]
 {{
-    public class [|C|]
-    {{
-    }}
 }}
 #if false // {CSharpEditorResources.Decompilation_log}
 {string.Format(CSharpEditorResources._0_items_in_cache, 6)}
@@ -953,11 +952,10 @@ namespace N
 // Decompiled with ICSharpCode.Decompiler {ICSharpCodeDecompilerVersion}
 #endregion
 
-namespace N
+namespace N;
+
+public class [|C|]
 {{
-    public class [|C|]
-    {{
-    }}
 }}
 #if false // {CSharpEditorResources.Decompilation_log}
 {string.Format(CSharpEditorResources._0_items_in_cache, 9)}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
@@ -133,8 +133,8 @@ class C
             var actual = await TestServices.Editor.GetOutliningSpansAsync(HangMitigatingCancellationToken);
 
             // When collapsing, not everything is collapsed (eg, namespace and class aren't), but most things are
-            Assert.Equal(32, actual.Length);
-            Assert.Equal(8, actual.Count(s => !s.Collapsed));
+            Assert.Equal(31, actual.Length);
+            Assert.Equal(7, actual.Count(s => !s.Collapsed));
         }
 
         [IdeFact]

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
@@ -163,7 +163,7 @@ class C
 
             var actual = await TestServices.Editor.GetOutliningSpansAsync(HangMitigatingCancellationToken);
 
-            Assert.Equal(32, actual.Length);
+            Assert.Equal(31, actual.Length);
             Assert.Equal(1, actual.Count(s => s.Collapsed));
         }
 


### PR DESCRIPTION
Fixes OOM when decompiling code with large byte[]s.