### PR TITLE
Use correct ref-pack versions

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -11,10 +11,5 @@
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.CSharp.CodeStyle/*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.VisualBasic.CodeStyle/*" />
     <UsagePattern IdentityGlob="Microsoft.Net.Compilers.Toolset/*" />
-
-    <!-- The ref pack versions should be updated to the p3 released versions, along with the SDK. At that
-         point the 8.0 ref pack prebuilts should go away -->
-    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/*8.0.0-preview.3.23164.14*" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*8.0.0-preview.3.23165.3*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/targets/Imports.BeforeArcade.targets
+++ b/eng/targets/Imports.BeforeArcade.targets
@@ -17,11 +17,9 @@
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net8.0'">8.0.0-preview.3.23165.3</TargetingPackVersion>
     </KnownFrameworkReference>
     <KnownFrameworkReference Update="Microsoft.AspNetCore.App">
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net8.0'">8.0.0-preview.3.23164.14</TargetingPackVersion>
     </KnownFrameworkReference>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/67894, https://github.com/dotnet/source-build/issues/3402

https://github.com/dotnet/roslyn/pull/67333 introduced 2 new source-build prebuilts:
```
    <Usage Id="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.3.23164.14" />
    <Usage Id="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23165.3" />
```

Source-build should use ref-packs that match runtime, and consume them from toolset SDK. The idea is to remove these 2 lines:
https://github.com/dotnet/roslyn/blob/32b915695fcc2ab975cd91fdfd294c5451785c26/eng/targets/Imports.BeforeArcade.targets#L20
https://github.com/dotnet/roslyn/blob/32b915695fcc2ab975cd91fdfd294c5451785c26/eng/targets/Imports.BeforeArcade.targets#L24
