### PR TITLE
EnC: Implements support for generic type/method updates

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
@@ -234,7 +234,7 @@ class C
             var src1 = @"
 class C
 {
-    static void Main(string[] args)
+    static void Main()
     {
         <AS:1>Swap(5,6);</AS:1>
     }
@@ -247,12 +247,9 @@ class C
             var src2 = @"
 class C
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        while (true)
-        {
-            <AS:1>Swap(5,6);</AS:1>
-        }
+        <AS:1>Swap(5,6);</AS:1>
     }
 
     static void Swap<T>(T lhs, T rhs) where T : System.IComparable<T>
@@ -264,8 +261,15 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericMethodUpdate, "static void Swap<T>(T lhs, T rhs)"));
+            edits.VerifySemanticDiagnostics(
+                active,
+                diagnostics: new[] { Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "static void Swap<T>(T lhs, T rhs)", GetResource("method")) },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(
+                active,
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Swap"), preserveLocalVariables: true) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         // Async
@@ -762,52 +766,53 @@ class C
             var src1 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        <AS:1>stringCollection[0] = ""hello"";</AS:1>
-        Console.WriteLine(stringCollection[0]);
+        var c = new C<int>();
+        <AS:1>c[0] = 1;</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { return arr[i]; }
-        set { <AS:0>arr[i] = value;</AS:0> }
+        get => 0;
+        set { <AS:0>value = i;</AS:0> }
     }
 }";
             var src2 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        <AS:1>stringCollection[0] = ""hello"";</AS:1>
-        Console.WriteLine(stringCollection[0]);
+        var c = new C<int>();
+        <AS:1>c[0] = 1;</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { return arr[i]; }
-        set { <AS:0>arr[i+1] = value;</AS:0> }
+        get => 0;
+        set { <AS:0>value = i + 1;</AS:0> }
     }
 }";
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "set"));
+                diagnostics: new[] { Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "set", GetResource("indexer setter")) },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(active,
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.set_Item"), preserveLocalVariables: true) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/750244")]
-        public void Update_Inner_Indexers1()
+        public void Update_Inner_Indexers_Setter()
         {
             var src1 = @"
 using System;
@@ -856,58 +861,58 @@ class SampleCollection<T>
 
             // Rude edits of active statements (AS:1) are not reported if the top-level edits are rude.
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "set"),
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "stringCollection[1] = \"hello\";"));
         }
 
         [Fact]
-        public void Update_Leaf_Indexers2()
+        public void Update_Leaf_Indexers_Getter()
         {
             var src1 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-        <AS:1>Console.WriteLine(stringCollection[0]);</AS:1>
+        var c = new C<int>();
+        <AS:1>Console.WriteLine(c[0]);</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { <AS:0>return arr[i];</AS:0> }
-        set { arr[i] = value; }
+        get { <AS:0>return 0;</AS:0> }
+        set { }
     }
 }";
             var src2 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-        <AS:1>Console.WriteLine(stringCollection[0]);</AS:1>
+        var c = new C<int>();
+        <AS:1>Console.WriteLine(c[0]);</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { <AS:0>return arr[0];</AS:0> }
-        set { arr[i] = value; }
+        get { <AS:0>return 1;</AS:0> }
+        set { }
     }
 }";
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "get"));
+                diagnostics: new[] { Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "get", GetResource("indexer getter")) },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(active,
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.get_Item"), preserveLocalVariables: true) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/750244")]
@@ -958,50 +963,45 @@ class SampleCollection<T>
 
             // Rude edits of active statements (AS:1) are not reported if the top-level edits are rude.
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "get"),
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "Console.WriteLine(stringCollection[1]);"));
         }
 
         [Fact]
-        public void Deleted_Leaf_Indexers1()
+        public void Deleted_Leaf_Indexers_Setter()
         {
             var src1 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        <AS:1>stringCollection[0] = ""hello"";</AS:1>
-        Console.WriteLine(stringCollection[0]);
+        var c = new C<int>();
+        <AS:1>c[0] = 1;</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { return arr[i]; }
-        set { <AS:0>arr[i] = value;</AS:0> }
+        get => 0;
+        set { <AS:0>throw null;</AS:0> }
     }
 }";
             var src2 = @"
 class Test
 {
-    static void Main(string[] args)
+    static void Main()
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        <AS:1>stringCollection[0] = ""hello"";</AS:1>
-        Console.WriteLine(stringCollection[0]);
+        var c = new C<int>();
+        <AS:1>c[0] = 1;</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { return arr[i]; }
+        get => 0;
         set { <AS:0>}</AS:0>
     }
 }";
@@ -1009,11 +1009,16 @@ class SampleCollection<T>
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "set"));
+                diagnostics: new[] { Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "set", GetResource("indexer setter")) },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(active,
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.set_Item"), preserveLocalVariables: true) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
-        public void Deleted_Inner_Indexers1()
+        public void Deleted_Inner_Indexers_Setter()
         {
             var src1 = @"
 class Test
@@ -1062,26 +1067,24 @@ class SampleCollection<T>
         }
 
         [Fact]
-        public void Deleted_Leaf_Indexers2()
+        public void Deleted_Leaf_Indexers_Getter()
         {
             var src1 = @"
 class Test
 {
     static void Main(string[] args)
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-        <AS:1>Console.WriteLine(stringCollection[0]);</AS:1>
+        var c = new C<int>();
+        <AS:1>Console.WriteLine(c[0]);</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
-        get { <AS:0>return arr[i];</AS:0> }
-        set { arr[i] = value; }
+        get { <AS:0>return 1;</AS:0> }
+        set { }
     }
 }";
             var src2 = @"
@@ -1089,30 +1092,33 @@ class Test
 {
     static void Main(string[] args)
     {
-        SampleCollection<string> stringCollection = new SampleCollection<string>();
-        stringCollection[0] = ""hello"";
-        <AS:1>Console.WriteLine(stringCollection[0]);</AS:1>
+        var c = new C<int>();
+        <AS:1>Console.WriteLine(c[0]);</AS:1>
     }
 }
 
-class SampleCollection<T>
+class C<T>
 {
-    private T[] arr = new T[100];
     public T this[int i]
     {
         get { <AS:0>}</AS:0>
-        set { arr[i] = value; }
+        set { }
     }
 }";
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "get"));
+                diagnostics: new[] { Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "get", GetResource("indexer getter")) },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(active,
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.get_Item"), preserveLocalVariables: true) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
-        public void Deleted_Inner_Indexers2()
+        public void Deleted_Inner_Indexers_Getter()
         {
             var src1 = @"
 class Test

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -2144,6 +2144,121 @@ class C
         }
 
         [Fact]
+        public void Lambdas_Insert_First_Static_InGenericContext_Method()
+        {
+            var src1 = @"
+using System;
+class C
+{
+    void F<T>()
+    {
+    }
+}";
+            var src2 = @"
+using System;
+class C
+{
+    void F<T>()
+    {
+        var f = new Func<int, int>(a => a);
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.NewTypeDefinition |
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.AddStaticFieldToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[] { Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "a", GetResource("lambda")) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
+        [Fact]
+        public void Lambdas_Insert_First_Static_InGenericContext_Type()
+        {
+            var src1 = @"
+using System;
+class C<T>
+{
+    void F()
+    {
+    }
+}";
+            var src2 = @"
+using System;
+class C<T>
+{
+    void F()
+    {
+        var f = new Func<int, int>(a => a);
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.NewTypeDefinition |
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.AddStaticFieldToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[] { Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "a", GetResource("lambda")) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
+        [Fact]
+        public void Lambdas_Insert_First_Static_InGenericContext_LocalFunction()
+        {
+            var src1 = @"
+using System;
+class C
+{
+    void F()
+    {
+        void L<T>()
+        {
+        }
+    }
+}";
+            var src2 = @"
+using System;
+class C
+{
+    void F()
+    {
+        void L<T>()
+        {
+            var f = new Func<int, int>(a => a);
+        }
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.NewTypeDefinition |
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[] { Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "a", GetResource("lambda")) },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
+        [Fact]
         public void Lambdas_Insert_Static_Nested()
         {
             var src1 = @"
@@ -5330,6 +5445,141 @@ class C
         }
 
         [Fact]
+        public void LocalFunctions_Insert_Static_InGenericContext_Method()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    void F<T>()
+    {
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    void F<T>()
+    {
+        int f(int a) => a;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "f", GetResource("local function")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F<T>()", GetResource("method"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+        }
+
+        [Fact]
+        public void LocalFunctions_Insert_Static_InGenericContext_Type()
+        {
+            var src1 = @"
+using System;
+
+class C<T>
+{
+    void F()
+    {
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C<T>
+{
+    void F()
+    {
+        int f(int a) => a;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "f", GetResource("local function")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F()", GetResource("method"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+        }
+
+        [Fact]
+        public void LocalFunctions_Insert_Static_InGenericContext_LocalFunction()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    void F()
+    {
+        void L<T>()
+        {
+            void M()
+            {
+            }
+        }
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    void F()
+    {
+        void L<T>()
+        {
+            void M()
+            {
+                int f(int a) => a;
+            }
+        }
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "L", GetResource("local function")),
+                    Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "f", GetResource("local function"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+        }
+
+        [Fact]
         public void LocalFunctions_Insert_Static_Nested_ExpressionBodies()
         {
             var src1 = @"
@@ -7177,6 +7427,45 @@ class C
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.CapturingVariable, "a1", "a1"));
+        }
+
+        [Fact]
+        public void LocalFunctions_Update_Generic()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        int L<T>() => 1;
+        int M<T>() => 1;
+        int N<T>() => 1;
+        int O<T>() => 1;
+    }
+}";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+        int L<T>() => 1;
+        int M<T>() => 2;
+        int N<T>() => 1 ;
+        int O<T>() =>  1;
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "M", GetResource("local function"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21499")]
@@ -9476,7 +9765,10 @@ class C
 ";
             var edits = GetTopEdits(src1, src2);
             edits.VerifySemanticDiagnostics(
-                capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType);
+                capabilities:
+                    EditAndContinueCapabilities.NewTypeDefinition |
+                    EditAndContinueCapabilities.AddStaticFieldToExistingType |
+                    EditAndContinueCapabilities.AddMethodToExistingType);
 
             edits.VerifySemanticDiagnostics(
                 new[]
@@ -9672,6 +9964,129 @@ class C
             edits.VerifySemantics(
                 new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), preserveLocalVariables: true) },
                 capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void Yield_Update_GenericType()
+        {
+            var src1 = @"
+class C<T>
+{
+    static IEnumerable<int> F()
+    {
+        yield return 1;
+    }
+}
+";
+            var src2 = @"
+class C<T>
+{
+    static IEnumerable<int> F()
+    {
+        yield return 2;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "static IEnumerable<int> F()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void Yield_Update_GenericMethod()
+        {
+            var src1 = @"
+class C
+{
+    static IEnumerable<int> F<T>()
+    {
+        yield return 1;
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static IEnumerable<int> F<T>()
+    {
+        yield return 2;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "static IEnumerable<int> F<T>()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void Yield_Update_GenericLocalFunction()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        IEnumerable<int> L<T>()
+        {
+            yield return 1;
+        }
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+        IEnumerable<int> L<T>()
+        {
+            yield return 2;
+        }
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "L", GetResource("local function"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
         }
 
         [Fact]
@@ -10493,7 +10908,136 @@ class C
         }
 
         [Fact]
-        public void MissingAsyncStateMachineAttribute1()
+        public void Await_Update_GenericType()
+        {
+            var src1 = @"
+class C<T>
+{
+    static async Task F()
+    {
+        await Task.FromResult(1);
+    }
+}
+";
+            var src2 = @"
+class C<T>
+{
+    static async Task F()
+    {
+        await Task.FromResult(2);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "static async Task F()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void Await_Update_GenericMethod()
+        {
+            var src1 = @"
+class C
+{
+    static async Task F<T>()
+    {
+        await Task.FromResult(1);
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static async Task F<T>()
+    {
+        await Task.FromResult(2);
+    }
+}
+";
+        var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "static async Task F<T>()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void Await_Update_GenericLocalFunction()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        void M()
+        {
+            async Task L<T>()
+            {
+                await Task.FromResult(1);
+            }
+        }
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+        void M()
+        {
+            async Task L<T>()
+            {
+                await Task.FromResult(2);
+            }
+        }
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "L", GetResource("local function"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void MissingAsyncStateMachineAttribute()
         {
             var src1 = @"
 using System.Threading.Tasks;

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -10967,7 +10967,7 @@ class C
     }
 }
 ";
-        var edits = GetTopEdits(src1, src2);
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
                 capabilities:

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -2009,7 +2009,62 @@ interface I
         }
 
         [Fact]
-        public void Type_Generic_InsertMembers()
+        public void Type_Generic_Insert_StatelessMembers()
+        {
+            var src1 = @"
+using System;
+class C<T>
+{
+    int P1 { get => 1; }
+    int this[string s] { set {} }
+}
+";
+            var src2 = @"
+using System;
+class C<T>
+{
+    C(int x) {}
+
+    void M() {}
+    void G<S>() {}
+    int P1 { get => 1; set {} }
+    int P2 { get => 1; set {} }
+    int this[int i] { set {} get => 1; }
+    int this[string s] { set {} get => 1; }
+    event Action E { add {} remove {} }
+
+    enum E {}
+    interface I {} 
+    interface I<S> {} 
+    class D {}
+    class D<S> {}
+    delegate void Del();
+    delegate void Del<S>();
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            var diagnostics = new[]
+            {
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "C(int x)", FeaturesResources.constructor),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "void M()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "void G<S>()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int P2", FeaturesResources.property_),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int this[int i]", FeaturesResources.indexer_),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "event Action E", FeaturesResources.event_),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "set", CSharpFeaturesResources.property_setter),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "get", CSharpFeaturesResources.indexer_getter),
+            };
+
+            edits.VerifySemanticDiagnostics(diagnostics, capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
+            edits.VerifySemanticDiagnostics(diagnostics, capabilities: EditAndContinueCapabilities.GenericAddMethodToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.GenericAddMethodToExistingType);
+        }
+
+        [Fact]
+        public void Type_Generic_Insert_DataMembers()
         {
             var src1 = @"
 using System;
@@ -2021,29 +2076,85 @@ class C<T>
 using System;
 class C<T>
 {
-    void M() {}
-    int P1 { get; set; }
-    int P2 { get => 1; set {} }
-    int this[int i] { get => 1; set {} }
-    event Action E { add {} remove {} }
+    int P { get; set; }
     event Action EF;
     int F1, F2;
-
-    enum E {}
-    interface I {} 
-    class D {}
+    static int SF;
 }
 ";
             var edits = GetTopEdits(src1, src2);
+
+            var nonGenericCapabilities =
+                EditAndContinueCapabilities.AddInstanceFieldToExistingType |
+                EditAndContinueCapabilities.AddStaticFieldToExistingType |
+                EditAndContinueCapabilities.AddMethodToExistingType;
+
+            edits.VerifySemanticDiagnostics(new[]
+            {
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int P", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "EF", CSharpFeaturesResources.event_field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F1", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F2", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "SF", FeaturesResources.field),
+            }, capabilities: nonGenericCapabilities);
+
+            edits.VerifySemanticDiagnostics(new[]
+            {
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F1", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F2", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "SF", FeaturesResources.field),
+            }, capabilities: nonGenericCapabilities | EditAndContinueCapabilities.GenericAddMethodToExistingType);
+
+            edits.VerifySemanticDiagnostics(new[]
+            {
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int P", FeaturesResources.auto_property),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "EF", CSharpFeaturesResources.event_field)
+            }, capabilities: nonGenericCapabilities | EditAndContinueCapabilities.GenericAddFieldToExistingType);
+
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "void M()", GetResource("method")),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int P1", GetResource("auto-property")),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int P2", GetResource("property")),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "int this[int i]", GetResource("indexer")),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "event Action E", "event"),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "EF", "event field"),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F1", GetResource("field")),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F2", GetResource("field")));
+                capabilities: nonGenericCapabilities | EditAndContinueCapabilities.GenericAddMethodToExistingType | EditAndContinueCapabilities.GenericAddFieldToExistingType);
+        }
+
+        [Fact]
+        public void Type_Generic_Insert_IntoNestedType()
+        {
+            var src1 = @"
+class C<T>
+{
+    class D
+    {
+    }
+}
+";
+            var src2 = @"
+class C<T>
+{
+    class D
+    {
+        void F() {}
+        int X;
+        static int Y;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            var nonGenericCapabilities =
+                EditAndContinueCapabilities.AddMethodToExistingType |
+                EditAndContinueCapabilities.AddInstanceFieldToExistingType |
+                EditAndContinueCapabilities.AddStaticFieldToExistingType;
+
+            edits.VerifySemanticDiagnostics(new[]
+            {
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "void F()", FeaturesResources.method),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "X", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Y", FeaturesResources.field)
+            }, capabilities: nonGenericCapabilities);
+
+            edits.VerifySemanticDiagnostics(capabilities:
+                nonGenericCapabilities |
+                EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                EditAndContinueCapabilities.GenericAddFieldToExistingType);
         }
 
         [Fact]
@@ -2100,11 +2211,28 @@ interface I<T> { void F() {} }
                     DocumentResults(
                         diagnostics: new[]
                         {
-                            Diagnostic(RudeEditKind.GenericTypeUpdate, "void F()"),
-                            Diagnostic(RudeEditKind.GenericTypeUpdate, "void F()"),
-                            Diagnostic(RudeEditKind.GenericTypeUpdate, "void F()"),
+                            Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F()", GetResource("method")),
+                            Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F()", GetResource("method")),
+                            Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F()", GetResource("method"))
                         })
-                });
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
+
+                    DocumentResults(
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember("S.F")),
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember("I.F"))
+                        })
+                },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/54881")]
@@ -5533,7 +5661,7 @@ class D<T>
                     DocumentResults(
                         diagnostics: new[]
                         {
-                            Diagnostic(RudeEditKind.ChangingConstraints, "where T : new()", FeaturesResources.type_parameter)
+                            Diagnostic(RudeEditKind.ChangingConstraints, "where T : new()", GetResource("type parameter"))
                         }),
 
                     DocumentResults(),
@@ -6443,11 +6571,24 @@ partial class C
                 new[]
                 {
                     DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"))
+                    })
+                },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
                     DocumentResults(diagnostics: new[]
                     {
-                        Diagnostic(RudeEditKind.GenericMethodUpdate, "void F<T>()")
+                        Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F<T>()", GetResource("method"))
                     })
-                });
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
         }
 
         [Fact]
@@ -6463,11 +6604,24 @@ partial class C
                 new[]
                 {
                     DocumentResults(),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"))
+                    })
+                },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2), GetTopEdits(srcB1, srcB2) },
+                new[]
+                {
+                    DocumentResults(),
                     DocumentResults(diagnostics: new[]
                     {
-                        Diagnostic(RudeEditKind.GenericTypeUpdate, "void F()")
+                        Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F()", GetResource("method"))
                     })
-                });
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
         }
 
         [Fact]
@@ -6762,17 +6916,18 @@ partial class C
                 new[]
                 {
                     DocumentResults(
-                        diagnostics: new[]
+                        semanticEdits: new[]
                         {
-                            Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "void F<T>()", GetResource("method"))
+                            SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("S.F").FirstOrDefault(m => m.GetArity() == 1)?.ISymbol)
                         }),
 
                     DocumentResults(
                         semanticEdits: new[]
                         {
-                            SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("S.F").FirstOrDefault(m => m.GetMemberTypeParameters().Length == 0)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("S"))
+                            SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("S.F").FirstOrDefault(m => m.GetArity() == 0)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("S"))
                         }),
-                });
+                },
+                capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.GenericAddMethodToExistingType);
         }
 
         #endregion
@@ -8080,6 +8235,102 @@ class C
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
+        [Fact]
+        public void Method_Rename_GenericType()
+        {
+            var src1 = @"
+class C<T>
+{
+    static void F()
+    {
+    }
+}";
+            var src2 = @"
+class C<T>
+{
+    static void G()
+    {
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void G()", FeaturesResources.method)
+                },
+                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void G()", FeaturesResources.method)
+                },
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.F"), deletedSymbolContainerProvider: c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.G"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
+        [Fact]
+        public void Method_Rename_GenericMethod()
+        {
+            var src1 = @"
+class C
+{
+    static void F<T>()
+    {
+    }
+}";
+            var src2 = @"
+class C
+{
+    static void G<T>()
+    {
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void G<T>()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "static void G<T>()", GetResource("method"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMember("C.F"), deletedSymbolContainerProvider: c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMember("C.G"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.AddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
         [Theory]
         [InlineData("virtual")]
         [InlineData("abstract")]
@@ -8199,6 +8450,43 @@ class Test
 
             edits.VerifySemanticDiagnostics(
                 capabilities: EditAndContinueCapabilities.AddInstanceFieldToExistingType);
+        }
+
+        [Fact]
+        public void MethodUpdate_AsyncMethod_Generic()
+        {
+            var src1 = @"
+class C
+{
+    public async Task F<T>()
+    {
+        await Task.FromResult(1);
+    }
+}";
+            var src2 = @"
+class C
+{
+    public async Task F<T>()
+    {
+        await Task.FromResult(2);
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                capabilities:
+                    EditAndContinueCapabilities.AddInstanceFieldToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod |
+                    EditAndContinueCapabilities.GenericAddFieldToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, "public async Task F<T>()"),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "public async Task F<T>()", GetResource("method")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "public async Task F<T>()", GetResource("method"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
         }
 
         [Fact]
@@ -9872,7 +10160,18 @@ class C<T>
                 "Update [public C(int a) : base(a) { }]@21 -> [public C(int a) { }]@21");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "public C(int a)"));
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "public C(int a)", GetResource("constructor"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                },
+                capabilities: EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -9915,7 +10214,18 @@ class C<T>
                 "Update [public C(int a) : base(a) { }]@21 -> [public C(int a) : base(a + 1) { }]@21");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "public C(int a)"));
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "public C(int a)", GetResource("constructor"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                },
+                capabilities: EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/743552")]
@@ -11894,8 +12204,19 @@ public class C
                 "Update [a = 1]@17 -> [a = 2]@17");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "a = 2"),
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "class C<T>"));
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "a = 2", GetResource("field")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "class C<T>", GetResource("constructor", "C()"))
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                },
+                capabilities: EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -11907,8 +12228,19 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "int a"),
-                Diagnostic(RudeEditKind.GenericTypeUpdate, "class C<T>"));
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int a", GetResource("property")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "class C<T>", GetResource("constructor", "C()")),
+                },
+                capabilities: EditAndContinueCapabilities.Baseline);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
+                },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -15918,28 +16250,6 @@ class C
         }
 
         [Fact]
-        public void Indexer_AddSetAccessor_GenericType()
-        {
-            var src1 = @"
-class C<T>
-{
-    public T this[int i] { get { return default; } }
-}";
-            var src2 = @"
-class C<T>
-{
-    public T this[int i] { get { return default; } set { } }
-}";
-            var edits = GetTopEdits(src1, src2);
-
-            edits.VerifyEdits("Insert [set { }]@68");
-
-            edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "set", GetResource("indexer setter")) },
-                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
-        }
-
-        [Fact]
         public void Indexer_Delete()
         {
             var src1 = @"
@@ -17048,6 +17358,42 @@ class C
         }
 
         [Fact]
+        public void Parameter_Reorder_Rename_Generic()
+        {
+            var src1 = @"class C<T> { public void M(int a, int b) {} }";
+            var src2 = @"class C<T> { public void M(int b, int c) {} } ";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemantics(
+                new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.M"))
+                },
+                capabilities:
+                    EditAndContinueCapabilities.UpdateParameters |
+                    EditAndContinueCapabilities.GenericAddMethodToExistingType |
+                    EditAndContinueCapabilities.GenericUpdateMethod);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int b", GetResource("method")),
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", GetResource("parameter")),
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int c", GetResource("parameter"))
+                },
+                capabilities: EditAndContinueCapabilities.GenericAddMethodToExistingType);
+
+            edits.VerifySemanticDiagnostics(
+                new[]
+                {
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", FeaturesResources.parameter),
+                    Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int c", FeaturesResources.parameter)
+                },
+                capabilities: EditAndContinueCapabilities.GenericUpdateMethod);
+        }
+
+        [Fact]
         public void Parameter_Type_Update()
         {
             var src1 = "class C { static void M(int a) {} }";
@@ -17460,11 +17806,8 @@ class C { static void M(string a) { } }
                 "Update [T]@75 -> [[A]T]@72");
 
             edits.VerifySemanticDiagnostics(
-                new[]
-                {
-                    Diagnostic(RudeEditKind.GenericMethodUpdate, "T"),
-                },
-                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
+                new[] { Diagnostic(RudeEditKind.GenericMethodUpdate, "T") },
+                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -17482,11 +17825,8 @@ class C { static void M(string a) { } }
                 "Update [[A   ]T]@120 -> [[A, B]T]@120");
 
             edits.VerifySemanticDiagnostics(
-                new[]
-                {
-                    Diagnostic(RudeEditKind.GenericMethodUpdate, "T")
-                },
-                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
+                new[] { Diagnostic(RudeEditKind.GenericMethodUpdate, "T") },
+                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -17507,7 +17847,7 @@ class C { static void M(string a) { } }
                 {
                     Diagnostic(RudeEditKind.GenericMethodUpdate, "T")
                 },
-                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
+                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -17529,7 +17869,7 @@ class C { static void M(string a) { } }
                 {
                     Diagnostic(RudeEditKind.GenericMethodUpdate, "T")
                 },
-                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
+                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes | EditAndContinueCapabilities.GenericUpdateMethod);
         }
 
         [Fact]
@@ -17567,7 +17907,7 @@ class C { static void M(string a) { } }
             edits.VerifySemanticDiagnostics(
                 new[]
                 {
-                    Diagnostic(RudeEditKind.GenericMethodUpdate, "void F<[A(1)]T>(T a)"),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "void F<[A(1)]T>(T a)", GetResource("method")),
                     Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "T", GetResource("type parameter"))
                 },
                 capabilities: EditAndContinueCapabilities.Baseline);

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -1617,7 +1617,7 @@ class C { int Y => 2; }
             diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
             AssertEx.Equal(new[]
                 {
-                    "ENC0036: " + FeaturesResources.Modifying_a_generic_method_requires_restarting_the_application,
+                    "ENC0113: " + string.Format(FeaturesResources.Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime, FeaturesResources.method),
                     "ENC0021: " + string.Format(FeaturesResources.Adding_0_requires_restarting_the_application, FeaturesResources.type_parameter)
                 },
                 diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}"));
@@ -1645,7 +1645,7 @@ class C { int Y => 2; }
                 {
                     "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=1|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=2",
                     "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=2|EmitDeltaErrorIdCount=0|InBreakState=True|Capabilities=31|ProjectIdsWithAppliedChanges=",
-                    "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=36|RudeEditSyntaxKind=8875|RudeEditBlocking=True",
+                    "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=113|RudeEditSyntaxKind=8875|RudeEditBlocking=True",
                     "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=21|RudeEditSyntaxKind=8910|RudeEditBlocking=True"
                 }, _telemetryLog);
             }
@@ -1655,7 +1655,7 @@ class C { int Y => 2; }
                 {
                     "Debugging_EncSession: SolutionSessionId={00000000-AAAA-AAAA-AAAA-000000000000}|SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=1|EmptyHotReloadSessionCount=0",
                     "Debugging_EncSession_EditSession: SessionId=1|EditSessionId=2|HadCompilationErrors=False|HadRudeEdits=True|HadValidChanges=False|HadValidInsignificantChanges=False|RudeEditsCount=2|EmitDeltaErrorIdCount=0|InBreakState=False|Capabilities=31|ProjectIdsWithAppliedChanges=",
-                    "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=36|RudeEditSyntaxKind=8875|RudeEditBlocking=True",
+                    "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=113|RudeEditSyntaxKind=8875|RudeEditBlocking=True",
                     "Debugging_EncSession_EditSession_RudeEdit: SessionId=1|EditSessionId=2|RudeEditKind=21|RudeEditSyntaxKind=8910|RudeEditBlocking=True"
                 }, _telemetryLog);
             }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -39,7 +39,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             EditAndContinueCapabilities.UpdateParameters;
 
         public const EditAndContinueCapabilities AllRuntimeCapabilities =
-            Net6RuntimeCapabilities;
+            Net6RuntimeCapabilities |
+            EditAndContinueCapabilities.GenericAddMethodToExistingType |
+            EditAndContinueCapabilities.GenericUpdateMethod |
+            EditAndContinueCapabilities.GenericAddFieldToExistingType;
 
         public abstract AbstractEditAndContinueAnalyzer Analyzer { get; }
 

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
@@ -366,9 +366,17 @@ Class C(Of T)
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
+
             edits.VerifyLineEdits(
                 Array.Empty(Of SequencePointUpdates),
-                diagnostics:={Diagnostic(RudeEditKind.GenericTypeTriviaUpdate, vbCrLf & "            ", FeaturesResources.method)})
+                diagnostics:={Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, vbCrLf & "            ", FeaturesResources.method)},
+                capabilities:=EditAndContinueCapabilities.Baseline)
+
+            edits.VerifyLineEdits(
+                Array.Empty(Of SequencePointUpdates),
+                semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Bar"))},
+                capabilities:=EditAndContinueCapabilities.GenericUpdateMethod)
+
         End Sub
 
         <Fact>
@@ -392,7 +400,13 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyLineEdits(
                 Array.Empty(Of SequencePointUpdates),
-                diagnostics:={Diagnostic(RudeEditKind.GenericMethodTriviaUpdate, vbCrLf & "        ", FeaturesResources.method)})
+                diagnostics:={Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, vbCrLf & "        ", FeaturesResources.method)},
+                capabilities:=EditAndContinueCapabilities.Baseline)
+
+            edits.VerifyLineEdits(
+                Array.Empty(Of SequencePointUpdates),
+                semanticEdits:={SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Bar"))},
+                capabilities:=EditAndContinueCapabilities.GenericUpdateMethod)
         End Sub
 
         <Fact>
@@ -957,9 +971,22 @@ End Class
 "
 
             Dim edits = GetTopEdits(src1, src2)
+
             edits.VerifyLineEdits(
                 Array.Empty(Of SequencePointUpdates),
-                diagnostics:={Diagnostic(RudeEditKind.GenericTypeUpdate, "Class C(Of T)")})
+                diagnostics:=
+                {
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
+                },
+                capabilities:=EditAndContinueCapabilities.Baseline)
+
+            edits.VerifyLineEdits(
+                Array.Empty(Of SequencePointUpdates),
+                semanticEdits:=
+                {
+                    SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)
+                },
+                capabilities:=EditAndContinueCapabilities.GenericUpdateMethod)
         End Sub
 
         <Fact>
@@ -1433,7 +1460,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyLineEdits(
                  Array.Empty(Of SequencePointUpdates)(),
-                 diagnostics:={Diagnostic(RudeEditKind.GenericMethodTriviaUpdate, "Sub Bar(Of T)()", FeaturesResources.method)})
+                 diagnostics:={Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Sub Bar(Of T)()", FeaturesResources.method)},
+                 capabilities:=EditAndContinueCapabilities.Baseline)
         End Sub
 
 #End Region

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -3267,10 +3267,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         }
 
                         // updating generic methods and types
-                        if (InGenericContext(oldSymbol, out var oldIsGenericMethod))
+                        if (InGenericContext(oldSymbol) && !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
                         {
-                            var rudeEdit = oldIsGenericMethod ? RudeEditKind.GenericMethodTriviaUpdate : RudeEditKind.GenericTypeTriviaUpdate;
-                            diagnostics.Add(new RudeEditDiagnostic(rudeEdit, diagnosticSpan, newEditNode, new[] { GetDisplayName(newEditNode) }));
+                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, diagnosticSpan, newEditNode, new[] { GetDisplayName(newEditNode) }));
                             continue;
                         }
 
@@ -3707,16 +3706,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, GetDiagnosticSpan(newDeclaration, EditKind.Update)));
                 }
 
-                var newIsGenericMethod = false;
-                var oldInGenericLocalContext = false;
-                var newInGenericLocalContext = false;
-                if (InGenericContext(oldMember, out var oldIsGenericMethod) ||
-                    InGenericContext(newMember, out newIsGenericMethod) ||
-                    (oldInGenericLocalContext = InGenericLocalContext(oldBody, memberBodyMatch.OldRoot)) ||
-                    (newInGenericLocalContext = InGenericLocalContext(newBody, memberBodyMatch.NewRoot)))
+                if ((InGenericContext(oldMember) ||
+                     InGenericContext(newMember) ||
+                     InGenericLocalContext(oldBody, memberBodyMatch.OldRoot) ||
+                     InGenericLocalContext(newBody, memberBodyMatch.NewRoot)) &&
+                    !capabilities.Grant(EditAndContinueCapabilities.GenericAddFieldToExistingType))
                 {
-                    var rudeEdit = oldIsGenericMethod || newIsGenericMethod || oldInGenericLocalContext || newInGenericLocalContext ? RudeEditKind.GenericMethodUpdate : RudeEditKind.GenericTypeUpdate;
-                    diagnostics.Add(new RudeEditDiagnostic(rudeEdit, GetDiagnosticSpan(newDeclaration, EditKind.Update), newDeclaration));
+                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, GetDiagnosticSpan(newDeclaration, EditKind.Update), newDeclaration, new[] { GetDisplayName(newDeclaration) }));
                 }
             }
         }
@@ -4016,13 +4012,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // updating within generic context
-            var oldIsGenericMethod = false;
-            var newIsGenericMethod = false;
             if (rudeEdit == RudeEditKind.None &&
                 oldSymbol is not INamedTypeSymbol and not ITypeParameterSymbol and not IParameterSymbol &&
-                (InGenericContext(oldSymbol, out oldIsGenericMethod) || InGenericContext(newSymbol, out newIsGenericMethod)))
+                (InGenericContext(oldSymbol) || InGenericContext(newSymbol)) &&
+                !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
             {
-                rudeEdit = oldIsGenericMethod || newIsGenericMethod ? RudeEditKind.GenericMethodUpdate : RudeEditKind.GenericTypeUpdate;
+                rudeEdit = RudeEditKind.UpdatingGenericNotSupportedByRuntime;
             }
 
             if (rudeEdit != RudeEditKind.None)
@@ -4558,7 +4553,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         private bool CanRenameOrChangeSignature(ISymbol oldSymbol, ISymbol newSymbol, EditAndContinueCapabilitiesGrantor capabilities, CancellationToken cancellationToken)
             => CanAddNewMemberToExistingType(newSymbol, capabilities, cancellationToken) &&
-               CanUpdateMemberBody(oldSymbol, newSymbol);
+               CanUpdateMemberBody(oldSymbol, newSymbol, capabilities);
 
         private bool CanAddNewMemberToExistingType(ISymbol newSymbol, EditAndContinueCapabilitiesGrantor capabilities, CancellationToken cancellationToken)
         {
@@ -4575,19 +4570,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // Inserting a member into an existing generic type, or a generic method into a type is only allowed if the runtime supports it
-            if (newSymbol is not INamedTypeSymbol && InGenericContext(newSymbol, out _))
+            if (newSymbol is not INamedTypeSymbol && InGenericContext(newSymbol))
             {
-                return false;
+                requiredCapabilities |= newSymbol is IFieldSymbol ? EditAndContinueCapabilities.GenericAddFieldToExistingType : EditAndContinueCapabilities.GenericAddMethodToExistingType;
             }
 
             return capabilities.Grant(requiredCapabilities);
         }
 
-        private static bool CanUpdateMemberBody(ISymbol oldSymbol, ISymbol newSymbol)
+        private static bool CanUpdateMemberBody(ISymbol oldSymbol, ISymbol newSymbol, EditAndContinueCapabilitiesGrantor capabilities)
         {
-            if (InGenericContext(oldSymbol, out _) || InGenericContext(newSymbol, out _))
+            if (InGenericContext(oldSymbol) || InGenericContext(newSymbol))
             {
-                return false;
+                return capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod);
             }
 
             return true;
@@ -5247,9 +5242,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             oldStateMachineInfo,
                             newStateMachineInfo);
 
-                        if (IsGenericLocalFunction(oldLambda) || IsGenericLocalFunction(newLambda))
+                        if ((IsGenericLocalFunction(oldLambda) || IsGenericLocalFunction(newLambda)) &&
+                            !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
                         {
-                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.GenericMethodUpdate, GetDiagnosticSpan(newLambda, EditKind.Update), newLambda, new[] { GetDisplayName(newLambda) }));
+                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime,  GetDiagnosticSpan(newLambda, EditKind.Update), newLambda, new[] { GetDisplayName(newLambda) }));
                         }
                     }
                 }
@@ -5466,7 +5462,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             var containingTypeDeclaration = TryGetContainingTypeDeclaration(newMemberBody);
             var isInInterfaceDeclaration = containingTypeDeclaration != null && IsInterfaceDeclaration(containingTypeDeclaration);
-            var isNewMemberInGenericContext = InGenericContext(newMember, out _);
+            var isNewMemberInGenericContext = InGenericContext(newMember);
 
             var newHasLambdaBodies = newHasLambdasOrLocalFunctions;
             while (newHasLambdaBodies)
@@ -5526,7 +5522,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (isNewMemberInGenericContext || inGenericLocalContext)
                 {
-                    return false;
+                    requiredCapabilities |= EditAndContinueCapabilities.GenericAddMethodToExistingType;
                 }
 
                 // Static lambdas are cached in static fields, unless in generic local functions.
@@ -5540,6 +5536,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 if (isLambdaCachedInField)
                 {
                     requiredCapabilities |= EditAndContinueCapabilities.AddStaticFieldToExistingType;
+
+                    // If we are in a generic type or a member then the closure type is generic and we are adding a static field to a generic type.
+                    if (isNewMemberInGenericContext)
+                    {
+                        requiredCapabilities |= EditAndContinueCapabilities.GenericAddFieldToExistingType;
+                    }
                 }
 
                 // If the old verison of the method had any lambdas the nwe know a closure type exists and a new one isn't needed.
@@ -6207,7 +6209,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static bool IsGlobalMain(ISymbol symbol)
             => symbol is IMethodSymbol { Name: WellKnownMemberNames.TopLevelStatementsEntryPointMethodName };
 
-        private static bool InGenericContext(ISymbol symbol, out bool isGenericMethod)
+        private static bool InGenericContext(ISymbol symbol)
         {
             var current = symbol;
 
@@ -6215,20 +6217,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 if (current is IMethodSymbol { Arity: > 0 })
                 {
-                    isGenericMethod = true;
                     return true;
                 }
 
                 if (current is INamedTypeSymbol { Arity: > 0 })
                 {
-                    isGenericMethod = false;
                     return true;
                 }
 
                 current = current.ContainingSymbol;
                 if (current == null)
                 {
-                    isGenericMethod = false;
                     return false;
                 }
             }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -5245,7 +5245,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         if ((IsGenericLocalFunction(oldLambda) || IsGenericLocalFunction(newLambda)) &&
                             !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
                         {
-                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime,  GetDiagnosticSpan(newLambda, EditKind.Update), newLambda, new[] { GetDisplayName(newLambda) }));
+                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, GetDiagnosticSpan(newLambda, EditKind.Update), newLambda, new[] { GetDisplayName(newLambda) }));
                         }
                     }
                 }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
@@ -50,6 +50,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Whether the runtime supports updating the Param table, and hence related edits (eg parameter renames)
         /// </summary>
         UpdateParameters = 1 << 6,
+
+        /// <summary>
+        /// Adding a static or instance method, property or event to an existing type (without backing fields), such that the method and/or the type are generic.
+        /// </summary>
+        GenericAddMethodToExistingType = 1 << 7,
+
+        /// <summary>
+        /// Updating an existing static or instance method, property or event (without backing fields) that is generic and/or contained in a generic type. 
+        /// </summary>
+        GenericUpdateMethod = 1 << 8,
+
+        /// <summary>
+        /// Adding a static or instance field to an existing generic type.
+        /// </summary>
+        GenericAddFieldToExistingType = 1 << 9,
     }
 
     internal static class EditAndContinueCapabilitiesParser
@@ -69,6 +84,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     nameof(EditAndContinueCapabilities.NewTypeDefinition) => EditAndContinueCapabilities.NewTypeDefinition,
                     nameof(EditAndContinueCapabilities.ChangeCustomAttributes) => EditAndContinueCapabilities.ChangeCustomAttributes,
                     nameof(EditAndContinueCapabilities.UpdateParameters) => EditAndContinueCapabilities.UpdateParameters,
+                    nameof(EditAndContinueCapabilities.GenericAddMethodToExistingType) => EditAndContinueCapabilities.GenericAddMethodToExistingType,
+                    nameof(EditAndContinueCapabilities.GenericUpdateMethod) => EditAndContinueCapabilities.GenericUpdateMethod,
+                    nameof(EditAndContinueCapabilities.GenericAddFieldToExistingType) => EditAndContinueCapabilities.GenericAddFieldToExistingType,
 
                     // To make it eaiser for  runtimes to specify more broad capabilities
                     "AddDefinitionToExistingType" => EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticDescriptors.cs
@@ -93,14 +93,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.InsertOperator, nameof(FeaturesResources.Adding_a_user_defined_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.InsertIntoStruct, nameof(FeaturesResources.Adding_0_into_a_1_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.InsertIntoClassWithLayout, nameof(FeaturesResources.Adding_0_into_a_class_with_explicit_or_sequential_layout_requires_restarting_the_application));
-            AddRudeEdit(RudeEditKind.InsertGenericMethod, nameof(FeaturesResources.Adding_a_generic_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.Move, nameof(FeaturesResources.Moving_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.Delete, nameof(FeaturesResources.Deleting_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.GenericMethodUpdate, nameof(FeaturesResources.Modifying_a_generic_method_requires_restarting_the_application));
-            AddRudeEdit(RudeEditKind.GenericMethodTriviaUpdate, nameof(FeaturesResources.Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.GenericTypeUpdate, nameof(FeaturesResources.Modifying_a_method_inside_the_context_of_a_generic_type_requires_restarting_the_application));
-            AddRudeEdit(RudeEditKind.GenericTypeTriviaUpdate, nameof(FeaturesResources.Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application));
-            AddRudeEdit(RudeEditKind.GenericTypeInitializerUpdate, nameof(FeaturesResources.Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas, nameof(FeaturesResources.Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.RenamingCapturedVariable, nameof(FeaturesResources.Renaming_a_captured_variable_from_0_to_1_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.StackAllocUpdate, nameof(FeaturesResources.Modifying_0_which_contains_the_stackalloc_operator_requires_restarting_the_application));
@@ -137,7 +133,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.MemberBodyInternalError, nameof(FeaturesResources.Modifying_body_of_0_requires_restarting_the_application_due_to_internal_error_1));
             AddRudeEdit(RudeEditKind.MemberBodyTooBig, nameof(FeaturesResources.Modifying_body_of_0_requires_restarting_the_application_because_the_body_has_too_many_statements));
             AddRudeEdit(RudeEditKind.SourceFileTooBig, nameof(FeaturesResources.Modifying_source_file_0_requires_restarting_the_application_because_the_file_is_too_big));
-            AddRudeEdit(RudeEditKind.InsertIntoGenericType, nameof(FeaturesResources.Adding_0_into_a_generic_type_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.ImplementRecordParameterAsReadOnly, nameof(FeaturesResources.Implementing_a_record_positional_parameter_0_as_read_only_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.ImplementRecordParameterWithSet, nameof(FeaturesResources.Implementing_a_record_positional_parameter_0_with_a_set_accessor_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.ExplicitRecordMethodParameterNamesMustMatch, nameof(FeaturesResources.Explicitly_implemented_methods_of_records_must_have_parameter_names_that_match_the_compiler_generated_equivalent_0));
@@ -157,6 +152,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             AddRudeEdit(RudeEditKind.ChangingTypeNotSupportedByRuntime, nameof(FeaturesResources.Changing_the_type_of_0_requires_restarting_the_application));
             AddRudeEdit(RudeEditKind.DeleteNotSupportedByRuntime, nameof(FeaturesResources.Deleting_0_requires_restarting_the_application_because_is_not_supported_by_the_runtime));
             AddRudeEdit(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, nameof(FeaturesResources.Updating_async_or_iterator_requires_restarting_the_application_because_is_not_supported_by_the_runtime));
+            AddRudeEdit(RudeEditKind.UpdatingGenericNotSupportedByRuntime, nameof(FeaturesResources.Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime));
 
             // VB specific
             AddRudeEdit(RudeEditKind.HandlesClauseUpdate, nameof(FeaturesResources.Updating_the_Handles_clause_of_0_requires_restarting_the_application));

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertExtern = 25,
         InsertOperator = 26,
         // InsertNonPublicConstructor = 27,
-        InsertGenericMethod = 28,
+        // InsertGenericMethod = 28,
         InsertDllImport = 29,
         InsertIntoStruct = 30,
         InsertIntoClassWithLayout = 31,
@@ -50,10 +50,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         // MethodBodyAdd = 34,
         // MethodBodyDelete = 35,
         GenericMethodUpdate = 36,
-        GenericMethodTriviaUpdate = 37,
+        // GenericMethodTriviaUpdate = 37,
         GenericTypeUpdate = 38,
-        GenericTypeTriviaUpdate = 39,
-        GenericTypeInitializerUpdate = 40,
+        // GenericTypeTriviaUpdate = 39,
+        // GenericTypeInitializerUpdate = 40,
         // PartialTypeInitializerUpdate = 41,
         // AsyncMethodUpdate = 42,
         // AsyncMethodTriviaUpdate = 43,
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         MemberBodyInternalError = 88,
         SourceFileTooBig = 89,
         MemberBodyTooBig = 90,
-        InsertIntoGenericType = 91,
+        // InsertIntoGenericType = 91,
 
         ImplementRecordParameterAsReadOnly = 92,
         ImplementRecordParameterWithSet = 93,
@@ -139,5 +139,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         ChangingTypeNotSupportedByRuntime = 110,
         DeleteNotSupportedByRuntime = 111,
         UpdatingStateMachineMethodNotSupportedByRuntime = 112,
+        UpdatingGenericNotSupportedByRuntime = 113,
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -414,9 +414,6 @@
   <data name="Adding_0_into_an_interface_requires_restarting_the_application" xml:space="preserve">
     <value>Adding {0} into an interface requires restarting the application.</value>
   </data>
-  <data name="Adding_0_into_a_generic_type_requires_restarting_the_application" xml:space="preserve">
-    <value>Adding {0} into a generic type requires restarting the application.</value>
-  </data>
   <data name="Adding_0_into_an_interface_method_requires_restarting_the_application" xml:space="preserve">
     <value>Adding {0} into an interface method requires restarting the application.</value>
   </data>
@@ -496,9 +493,6 @@
   <data name="Adding_a_user_defined_0_requires_restarting_the_application" xml:space="preserve">
     <value>Adding a user defined {0} requires restarting the application.</value>
   </data>
-  <data name="Adding_a_generic_0_requires_restarting_the_application" xml:space="preserve">
-    <value>Adding a generic {0} requires restarting the application.</value>
-  </data>
   <data name="Adding_0_around_an_active_statement_requires_restarting_the_application" xml:space="preserve">
     <value>Adding {0} around an active statement requires restarting the application.</value>
   </data>
@@ -524,17 +518,8 @@
   <data name="Modifying_a_generic_method_requires_restarting_the_application" xml:space="preserve">
     <value>Modifying a generic method requires restarting the application.</value>
   </data>
-  <data name="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application" xml:space="preserve">
-    <value>Modifying whitespace or comments in a generic {0} requires restarting the application.</value>
-  </data>
   <data name="Modifying_a_method_inside_the_context_of_a_generic_type_requires_restarting_the_application" xml:space="preserve">
     <value>Modifying a method inside the context of a generic type requires restarting the application.</value>
-  </data>
-  <data name="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application" xml:space="preserve">
-    <value>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</value>
-  </data>
-  <data name="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application" xml:space="preserve">
-    <value>Modifying the initializer of {0} in a generic type requires restarting the application.</value>
   </data>
   <data name="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application" xml:space="preserve">
     <value>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</value>
@@ -3120,6 +3105,9 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   </data>
   <data name="Deleting_0_requires_restarting_the_application_because_is_not_supported_by_the_runtime" xml:space="preserve">
     <value>Deleting {0} requires restarting the application because is not supported by the runtime.</value>
+  </data>
+  <data name="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime" xml:space="preserve">
+    <value>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</value>
   </data>
   <data name="Updating_async_or_iterator_requires_restarting_the_application_because_is_not_supported_by_the_runtime" xml:space="preserve">
     <value>Updating async or iterator requires restarting the application because is not supported by the runtime.</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -100,11 +100,6 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Přidání {0} do třídy s explicitním nebo sekvenčním rozložením vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Přidání {0} do obecného typu vyžaduje restartování aplikace.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Přidání {0} do metody rozhraní vyžaduje restartování aplikace.</target>
@@ -138,11 +133,6 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Přidání konstruktoru k typu s inicializátorem pole nebo vlastnosti, který obsahuje anonymní funkci, vyžaduje restartování aplikace.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Přidání obecného {0} vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Úprava zdroje s povolenými experimentálními jazykovými funkcemi vyžaduje restartování aplikace.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Úprava inicializátoru {0} v obecném typu vyžaduje restartování aplikace.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Úprava prázdných znaků nebo komentářů v {0} uvnitř kontextu obecného typu vyžaduje restartování aplikace.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Úprava prázdných znaků nebo komentářů v obecném {0} vyžaduje restartování aplikace.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Pozitivní kontrolní výrazy zpětného vyhledávání s nulovou délkou se obv
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Aktualizace {0} vyžaduje restartování aplikace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -100,11 +100,6 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Das Hinzufügen von {0} zu einer Klasse mit explizitem oder sequenziellem Layout erfordert einen Neustart der Anwendung.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Das Hinzufügen von {0} zu einem generischen Typ erfordert einen Neustart der Anwendung.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Das Hinzufügen von {0} zu einer Schnittstellenmethode erfordert einen Neustart der Anwendung.</target>
@@ -138,11 +133,6 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Das Hinzufügen eines Konstruktors zu einem Typ mit einem Feld- oder Eigenschafteninitialisierer, der eine anonyme Funktion enthält, erfordert einen Neustart der Anwendung.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Das Hinzufügen einer generischen {0}erfordert einen Neustart der Anwendung.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Das Ändern der Quelle mit aktivierten experimentellen Sprachfeatures erfordert einen Neustart der Anwendung.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Das Aktualisieren des Initialisierers von {0} in einen generischen Typ erfordert einen Neustart der Anwendung.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Das Ändern von Leerzeichen oder Kommentaren in {0} im Kontext eines generischen Typs erfordert einen Neustart der Anwendung.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Das Ändern von Leerzeichen oder Kommentaren in einer generischen {0} erfordert einen Neustart der Anwendung.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Positive Lookbehindassertionen mit Nullbreite werden normalerweise am Anfang reg
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Das Aktualisieren von „{0}“ erfordert einen Neustart der Anwendung.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -100,11 +100,6 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Para agregar {0} en una clase con un diseño secuencial o explícito es necesario reiniciar la aplicación.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Para agregar {0} a un tipo genérico, es necesario reiniciar la aplicación.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Para agregar {0} en un método de interfaz es necesario reiniciar la aplicación.</target>
@@ -138,11 +133,6 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Para agregar un constructor a un tipo con un inicializador de campo o propiedad que contiene una función anónima, es necesario reiniciar la aplicación.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Para agregar un {0} genérico, es necesario reiniciar la aplicación.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Para modificar el origen con las características de lenguaje experimental habilitadas se requiere reiniciar la aplicación.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Para modificar el inicializador de {0} en un tipo genérico se requiere reiniciar la aplicación.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Para modificar espacios en blanco o comentarios en {0} dentro del contexto de un tipo genérico se requiere reiniciar la aplicación.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Para modificar espacios en blanco o comentarios en un {0}genérico es necesario reiniciar la aplicación.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Las aserciones de búsqueda retrasada (lookbehind) positivas de ancho cero se us
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Para actualizar "{0}" es necesario reiniciar la aplicación.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -100,11 +100,6 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">L’ajout de {0} dans une classe avec une disposition explicite ou séquentielle requiert le redémarrage de l’application.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">L’ajout de {0} dans un type générique requiert le redémarrage de l’application.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">L’ajout de {0} dans une méthode d’interface requiert le redémarrage de l’application.</target>
@@ -138,11 +133,6 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">L'ajout d'un constructeur à un type avec un initialiseur de champ ou de propriété contenant une fonction anonyme requiert le redémarrage de l’application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">L’ajout d’un {0} générique requiert le redémarrage de l’application.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">La modification de la source avec les fonctionnalités de langage expérimentales activées requiert le redémarrage de l’application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">La modification de l’initialiseur de {0} dans un type générique requiert le redémarrage de l’application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">La modification d’espaces blancs ou de commentaires dans {0} dans le contexte d’un type générique requiert le redémarrage de l’application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">La modification des espaces blancs ou des commentaires dans une {0} générique requiert le redémarrage de l’application.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Les assertions arrière positives de largeur nulle sont généralement utilisée
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">La mise à jour de « {0} » requiert le redémarrage de l’application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -100,11 +100,6 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Se si aggiunge {0} in una classe con layout esplicito o sequenziale, è necessario riavviare l'applicazione.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Se si aggiunge {0} in un tipo generico, è necessario riavviare l'applicazione.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Se si aggiunge {0} in un metodo di interfaccia, è necessario riavviare l'applicazione.</target>
@@ -138,11 +133,6 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Se aggiunge un costruttore a un tipo con un inizializzatore di campo o proprietà che contiene una funzione anonima, è necessario riavviare l'applicazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Se si aggiunge un elemento {0} generico, è necessario riavviare l'applicazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Se si modifica l'origine con le funzionalità del linguaggio sperimentali abilitate, è necessario riavviare l'applicazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Se si modifica l'inizializzatore di {0} in un tipo generico, è necessario riavviare l'applicazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Se si modificano spazi vuoti o commenti in {0} all'interno del contesto di un tipo generico, è necessario riavviare l'applicazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Se si modificano spazi vuoti o commenti in un elemento {0} generico, è necessario riavviare l'applicazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Le asserzioni lookbehind positive di larghezza zero vengono usate in genere all'
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Se si elimina '{0}', è necessario riavviare l'applicazione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -100,11 +100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">明示的またはシーケンシャルなレイアウトのクラスに {0} を追加するには、アプリケーションを再起動する必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">ジェネリック型に {0} を追加するには、アプリケーションを再起動する必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">インターフェイス メソッドに {0} を追加するには、アプリケーションを再起動する必要があります。</target>
@@ -138,11 +133,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">匿名関数を含むフィールドまたはプロパティの初期化子を持つ型にコンストラクターを追加するには、アプリケーションを再起動する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">汎用 {0} を追加するには、アプリケーションを再起動する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">試験的な言語機能を有効にしてソースを変更するには、アプリケーションを再起動する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">ジェネリック型の {0} の初期化子を変更するには、アプリケーションを再起動する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">ジェネリック型のコンテキスト内で {0} の空白またはコメントを変更するには、アプリケーションを再起動する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">ジェネリックの {0} 内の空白またはコメントを変更するには、アプリケーションを再起動する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">'{0}' を更新するには、アプリケーションを再起動する必要があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -100,11 +100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">명시적 또는 순차 레이아웃이 있는 클래스에 {0}을(를) 추가하려면 응용 프로그램을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">제네릭 형식에 {0}을(를) 추가하려면 애플리케이션을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">인터페이스 메소드에 {0}을(를) 추가하려면 응용 프로그램을 다시 시작해야 합니다.</target>
@@ -138,11 +133,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">익명 함수가 포함된 필드 또는 속성 이니셜라이저가 있는 형식에 생성자를 추가하려면 응용 프로그램을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">제네릭 {0}을(를) 추가하려면 애플리케이션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">실험 언어 기능이 활성화된 원본를 수정하려면 응용 프로그램을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">제네릭 형식의 {0}의 이니셜라이저를 수정하려면 애플리케이션을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">제네릭 형식의 컨텍스트 내에서 {0}의 공백 또는 주석을 수정하려면 애플리케이션을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">제네릭 {0}에서 공백 또는 주석을 수정하려면 애플리케이션을 다시 시작해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">'{0}'을(를) 업데이트하려면 애플리케이션을 다시 시작해야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -100,11 +100,6 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Dodawanie elementu {0} do klasy za pomocą jawnego lub sekwencyjnego układu wymaga ponownego uruchomienia aplikacji.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Dodanie elementu {0} do typu ogólnego wymaga ponownego uruchomienia aplikacji.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Dodanie elementu {0} do metody interfejsu wymaga ponownego uruchomienia aplikacji.</target>
@@ -138,11 +133,6 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Dodanie konstruktora do typu z inicjatorem pola lub właściwości zawierającego funkcję anonimową wymaga ponownego uruchomienia aplikacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Dodanie ogólnego elementu {0} wymaga ponownego uruchomienia aplikacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Modyfikowanie źródła z włączonymi funkcjami eksperymentalnymi języka wymaga ponownego uruchomienia aplikacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Modyfikacja inicjatora elementu {0} w typie ogólnym wymaga ponownego uruchomienia aplikacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Modyfikacja odstępów lub komentarzy w elemencie {0} w kontekście typu ogólnego wymaga ponownego uruchomienia aplikacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Modyfikacja odstępów lub komentarzy w ogólnym elemencie {0} wymaga ponownego uruchomienia aplikacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Pozytywne asercje wsteczne o zerowej szerokości są zwykle używane na początk
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Aktualizacja elementu „{0}” wymaga ponownego uruchomienia aplikacji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -100,11 +100,6 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Adicionar {0} a uma classe com layout explícito ou sequencial requer a reinicialização do aplicativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Adicionar {0} a um tipo genérico requer o reinício do aplicativo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Adicionar {0} a um método de interface requer a reinicialização do aplicativo.</target>
@@ -138,11 +133,6 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Adicionar um construtor a um tipo com um inicializador de campo ou propriedade que contém uma função anônima requer a reinicialização do aplicativo.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Adicionar um {0} genérico requer o reinício do aplicativo.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Modificar a origem com recursos de linguagem experimental habilitados requer a reinicialização do aplicativo.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Modificar o inicializador de {0} em um tipo genérico requer a reinicialização do aplicativo.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">A modificação de espaços em branco ou comentários em {0} dentro do contexto de um tipo genérico requer o reinício do aplicativo.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">A modificação de espaços em branco ou comentários em um {0} genérico requer a reinicialização do aplicativo.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ As declarações de lookbehind positivas de largura zero normalmente são usadas
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Atualizar '{0}' requer reiniciar o aplicativo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -100,11 +100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Для добавления {0} в класс с явным или последовательным макетом требуется перезапустить приложение.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Для добавления {0} в универсальный тип требуется перезапустить приложение.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Для добавления {0} в метод интерфейса требуется перезапустить приложение.</target>
@@ -138,11 +133,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Для добавления конструктора к типу с инициализатором поля или свойства, содержащим анонимную функцию, требуется перезапустить приложение.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Для добавления универсального {0} требуется перезапустить приложение.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Для изменения исходного кода с включенными экспериментальными функциями языка требуется перезапустить приложение..</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">Для изменения инициализатора {0} универсального типа требуется перезапустить приложение.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Для изменения пустого пространства или комментариев в {0} в контексте универсального типа требуется перезапустить приложение.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Для изменения пустого пространства или комментариев в универсальном {0} требуется перезапустить приложение.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">Для обновления "{0}" требуется перезапустить приложение.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -100,11 +100,6 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">Açık veya sıralı düzene sahip bir sınıfa {0} eklemek, uygulamanın yeniden başlatılmasını gerektirir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">Genel bir türe {0} eklenmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">Bir arabirim yöntemine {0} eklemek, uygulamanın yeniden başlatılmasını gerektirir.</target>
@@ -138,11 +133,6 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">Anonim bir tür içeren alan veya özellik başlatıcısının bulunduğu bir türe oluşturucu eklenmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">Genel bir {0} eklemek için uygulamanın yeniden başlatılması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">Deneysel dil özellikleri etkinken kaynağı değiştirme, uygulamanın yeniden başlatılmasını gerektirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">{0} öğesinin başlatıcısının genel bir türde değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">Genel bir tür bağlamında {0} öğesindeki boşlukların veya yorumların değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">Genel bir {0} öğesindeki boşlukların veya yorumları değiştirilmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Sıfır genişlikli pozitif geri yönlü onaylamalar genellikle normal ifadeleri
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">{0} öğesinin güncelleştirilmesi, uygulamanın yeniden başlatılmasını gerektirir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -100,11 +100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">将 {0} 添加到具有显式或顺序布局的类中需要重新启动应用程序。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">向泛型类型添加 {0} 需要重启应用程序。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">将 {0} 添加到接口方法中需要重新启动应用程序。</target>
@@ -138,11 +133,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">使用包含匿名类型的字段或属性初始值设定项向类型添加构造函数需要重新启动应用程序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">添加泛型 {0} 要求重启应用程序。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">在启用实验语言功能的情况下修改源需要重新启动应用程序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">在泛型类型中修改 {0} 的初始化表达式需要重启应用程序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">修改泛型类型上下文内 {0} 中空格或注释需要重启应用程序。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">修改泛型 {0} 中的空格或注释需要重启应用程序。</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">更新“{0}”需要重启应用程序。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -100,11 +100,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">在具有明確或循序配置的類別中新增 {0} 需要重新啟動應用程式。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Adding_0_into_a_generic_type_requires_restarting_the_application">
-        <source>Adding {0} into a generic type requires restarting the application.</source>
-        <target state="translated">在泛型型別中新增 {0} 需要重新啟動應用程式。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Adding_0_into_an_interface_method_requires_restarting_the_application">
         <source>Adding {0} into an interface method requires restarting the application.</source>
         <target state="translated">在介面方法中新增 {0} 需要重新啟動應用程式。</target>
@@ -138,11 +133,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Adding_a_constructor_to_a_type_with_a_field_or_property_initializer_that_contains_an_anonymous_function_requires_restarting_the_application">
         <source>Adding a constructor to a type with a field or property initializer that contains an anonymous function requires restarting the application.</source>
         <target state="translated">使用包含匿名函式的欄位或屬性初始設定式，將建構函式新增至類型需要重新啟動應用程式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Adding_a_generic_0_requires_restarting_the_application">
-        <source>Adding a generic {0} requires restarting the application.</source>
-        <target state="translated">新增一般 {0} 需要重新啟動應用程式。</target>
         <note />
       </trans-unit>
       <trans-unit id="Adding_a_method_with_an_explicit_interface_specifier_requires_restarting_the_application">
@@ -1198,21 +1188,6 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Modifying_source_with_experimental_language_features_enabled_requires_restarting_the_application">
         <source>Modifying source with experimental language features enabled requires restarting the application.</source>
         <target state="translated">以啟用的實驗語言功能修改原始檔，需要重新啟動應用程式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_the_initializer_of_0_in_a_generic_type_requires_restarting_the_application">
-        <source>Modifying the initializer of {0} in a generic type requires restarting the application.</source>
-        <target state="translated">修改泛型型別中 {0} 的初始設定式需要重新啟動應用程式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_0_inside_the_context_of_a_generic_type_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in {0} inside the context of a generic type requires restarting the application.</source>
-        <target state="translated">修改泛型型別内容 {0} 中的空白或註解需要重新啟動應用程式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Modifying_whitespace_or_comments_in_a_generic_0_requires_restarting_the_application">
-        <source>Modifying whitespace or comments in a generic {0} requires restarting the application.</source>
-        <target state="translated">修改泛型 {0} 中的空白或註解需要重新啟動應用程式。</target>
         <note />
       </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
@@ -2828,6 +2803,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Updating_0_requires_restarting_the_application">
         <source>Updating '{0}' requires restarting the application.</source>
         <target state="translated">更新 '{0}' 需要重新啟動應用程式。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Updating_0_within_generic_type_or_method_requires_restarting_the_application_because_is_not_supported_by_the_runtime">
+        <source>Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</source>
+        <target state="new">Updating {0} within generic type or method requires restarting the application because is not supported by the runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_a_0_around_an_active_statement_requires_restarting_the_application">


### PR DESCRIPTION
Introduces the following capabilities that runtimes can now implement:

```C#
/// <summary>
/// Adding a static or instance method, property or event to an existing type (without backing fields), such that the method and/or the type are generic.
/// </summary>
GenericAddMethodToExistingType = 1 << 7,

/// <summary>
/// Updating an existing static or instance method, property or event (without backing fields) that is generic and/or contained in a generic type. 
/// </summary>
GenericUpdateMethod = 1 << 8,

/// <summary>
/// Adding a static or instance field to an existing generic type.
/// </summary>
GenericAddFieldToExistingType = 1 << 9,
```

Updates rude edit reporting accordingly.

Related: https://github.com/dotnet/runtime/pull/85177