### PR TITLE
Hard code segment constants for common type sizes

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
@@ -64,9 +64,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         [MemberData(nameof(ExplicitSizeTypes))]
         public void ExplicitSizesAreCorrect(Type type)
         {
-            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
-            var size = (int)unsafeSizeOfMethod.Invoke(null, null);
-            Assert.Equal(int.Parse(type.Name[4..]), size);
+            Assert.Equal(int.Parse(type.Name[4..]), InvokeUnsafeSizeOf(type));
         }
 
         [Theory]
@@ -74,18 +72,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         public void GetSegmentSize(Type type)
         {
             var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
-            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
-            Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null)), (int)getSegmentSizeMethod.Invoke(null, null));
+            Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateSegmentSize(InvokeUnsafeSizeOf(type)), (int)getSegmentSizeMethod.Invoke(null, null));
         }
 
         [Theory]
         [MemberData(nameof(ExplicitSizeTypes))]
         public void GetSegmentShift(Type type)
         {
-            var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
             var getSegmentShiftMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentShift), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
-            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
-            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null));
+            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize(InvokeUnsafeSizeOf(type));
             Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateSegmentShift(segmentSize), (int)getSegmentShiftMethod.Invoke(null, null));
         }
 
@@ -93,11 +88,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         [MemberData(nameof(ExplicitSizeTypes))]
         public void GetOffsetMask(Type type)
         {
-            var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
             var getOffsetMaskMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetOffsetMask), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
-            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
-            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null));
+            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize(InvokeUnsafeSizeOf(type));
             Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateOffsetMask(segmentSize), (int)getOffsetMaskMethod.Invoke(null, null));
+        }
+
+        private static int InvokeUnsafeSizeOf(Type type)
+        {
+            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
+            return (int)unsafeSizeOfMethod.Invoke(null, null);
         }
 
         [Theory]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedArrayHelperTests.cs
@@ -4,6 +4,11 @@
 
 #nullable disable
 
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Collections.Internal;
 using Roslyn.Utilities;
 using Xunit;
@@ -12,6 +17,89 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {
     public class SegmentedArrayHelperTests
     {
+        [StructLayout(LayoutKind.Sequential, Size = 2)]
+        private struct Size2 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 4)]
+        private struct Size4 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 8)]
+        private struct Size8 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 12)]
+        private struct Size12 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 16)]
+        private struct Size16 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 24)]
+        private struct Size24 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 28)]
+        private struct Size28 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 32)]
+        private struct Size32 { }
+
+        [StructLayout(LayoutKind.Sequential, Size = 40)]
+        private struct Size40 { }
+
+        public static IEnumerable<object[]> ExplicitSizeTypes
+        {
+            get
+            {
+                yield return new object[] { typeof(Size2) };
+                yield return new object[] { typeof(Size4) };
+                yield return new object[] { typeof(Size8) };
+                yield return new object[] { typeof(Size12) };
+                yield return new object[] { typeof(Size16) };
+                yield return new object[] { typeof(Size24) };
+                yield return new object[] { typeof(Size28) };
+                yield return new object[] { typeof(Size32) };
+                yield return new object[] { typeof(Size40) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ExplicitSizeTypes))]
+        public void ExplicitSizesAreCorrect(Type type)
+        {
+            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
+            var size = (int)unsafeSizeOfMethod.Invoke(null, null);
+            Assert.Equal(int.Parse(type.Name[4..]), size);
+        }
+
+        [Theory]
+        [MemberData(nameof(ExplicitSizeTypes))]
+        public void GetSegmentSize(Type type)
+        {
+            var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
+            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
+            Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null)), (int)getSegmentSizeMethod.Invoke(null, null));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExplicitSizeTypes))]
+        public void GetSegmentShift(Type type)
+        {
+            var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
+            var getSegmentShiftMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentShift), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
+            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
+            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null));
+            Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateSegmentShift(segmentSize), (int)getSegmentShiftMethod.Invoke(null, null));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExplicitSizeTypes))]
+        public void GetOffsetMask(Type type)
+        {
+            var getSegmentSizeMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetSegmentSize), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
+            var getOffsetMaskMethod = typeof(SegmentedArrayHelper).GetMethod(nameof(SegmentedArrayHelper.GetOffsetMask), BindingFlags.Static | BindingFlags.NonPublic).MakeGenericMethod(type);
+            var unsafeSizeOfMethod = typeof(Unsafe).GetMethod(nameof(Unsafe.SizeOf)).MakeGenericMethod(type);
+            var segmentSize = SegmentedArrayHelper.TestAccessor.CalculateSegmentSize((int)unsafeSizeOfMethod.Invoke(null, null));
+            Assert.Equal(SegmentedArrayHelper.TestAccessor.CalculateOffsetMask(segmentSize), (int)getOffsetMaskMethod.Invoke(null, null));
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedArrayHelper.cs
@@ -21,8 +21,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         {
             return Unsafe.SizeOf<T>() switch
             {
-                // Hard code common values since not all versions of .NET support constant-folding the calculation.
-                // Values are validated against the reference implementation in CalculateSegmentSize in unit tests.
+                // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
+                // constant value at runtime. Values are validated against the reference implementation in
+                // CalculateSegmentSize in unit tests.
                 4 => 16384,
                 8 => 8192,
                 12 => 4096,
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 #if NETCOREAPP3_0_OR_NEWER
                 _ => InlineCalculateSegmentSize(Unsafe.SizeOf<T>()),
 #else
-                _ => ValueTypeSegmentHelper<T>.SegmentSize,
+                _ => FallbackSegmentHelper<T>.SegmentSize,
 #endif
             };
         }
@@ -44,8 +45,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         {
             return Unsafe.SizeOf<T>() switch
             {
-                // Hard code common values since not all versions of .NET support constant-folding the calculation.
-                // Values are validated against the reference implementation in CalculateSegmentShift in unit tests.
+                // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
+                // constant value at runtime. Values are validated against the reference implementation in
+                // CalculateSegmentSize in unit tests.
                 4 => 14,
                 8 => 13,
                 12 => 12,
@@ -57,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 #if NETCOREAPP3_0_OR_NEWER
                 _ => InlineCalculateSegmentShift(Unsafe.SizeOf<T>()),
 #else
-                _ => ValueTypeSegmentHelper<T>.SegmentShift,
+                _ => FallbackSegmentHelper<T>.SegmentShift,
 #endif
             };
         }
@@ -67,8 +69,9 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         {
             return Unsafe.SizeOf<T>() switch
             {
-                // Hard code common values since not all versions of .NET support constant-folding the calculation.
-                // Values are validated against the reference implementation in CalculateOffsetMask in unit tests.
+                // Hard code common values since not all versions of the .NET JIT support reducing this computation to a
+                // constant value at runtime. Values are validated against the reference implementation in
+                // CalculateSegmentSize in unit tests.
                 4 => 16383,
                 8 => 8191,
                 12 => 4095,
@@ -80,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 #if NETCOREAPP3_0_OR_NEWER
                 _ => InlineCalculateOffsetMask(Unsafe.SizeOf<T>()),
 #else
-                _ => ValueTypeSegmentHelper<T>.OffsetMask,
+                _ => FallbackSegmentHelper<T>.OffsetMask,
 #endif
             };
         }
@@ -182,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         }
 
 #if !NETCOREAPP3_0_OR_NEWER
-        private static class ValueTypeSegmentHelper<T>
+        private static class FallbackSegmentHelper<T>
         {
             public static readonly int SegmentSize = CalculateSegmentSize(Unsafe.SizeOf<T>());
             public static readonly int SegmentShift = CalculateSegmentShift(SegmentSize);


### PR DESCRIPTION
* Fix calculation of array sizes
* Allow for inlining for common sizes on .NET Framework
* Reduces inline code size on .NET prior to version 8 (where lzcnt constant folding is first implemented)

Follow-up to #67558