### PR TITLE
Use discarded use site info to avoid unnecessary expensive work

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -828,6 +828,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public CompoundUseSiteInfo<AssemblySymbol> GetNewCompoundUseSiteInfo(BindingDiagnosticBag futureDestination)
         {
+            if (!futureDestination.AccumulatesDiagnostics)
+            {
+                return CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+            }
+
             return new CompoundUseSiteInfo<AssemblySymbol>(futureDestination, Compilation.Assembly);
         }
 


### PR DESCRIPTION
Probably helps with https://github.com/dotnet/roslyn/issues/67926 ?

My analysis is that `GetUseSiteInfo` is showing as expensive

![image](https://user-images.githubusercontent.com/31348972/233832326-3fdd8fd4-e916-40ca-8e83-e5dfc2f1176a.png)

The scenario is IDE completion where the IDE calls `LookupSymbols` here:

https://github.com/dotnet/roslyn/blob/ef625f3b960594fcb3f902af88ad7c90df656516/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs#L393

So this scenario should mostly be using discarded diagnostics. My hypothesis is that we create non-discarded use site info to later add it in a discarded diagnostic bag, so my thought is that when we use non-discarded use site info, we call `GetUseSiteInfo` unnecessarily in some cases. So this PR aims to reduce the `GetUseSiteInfo` calls happening here:

https://github.com/dotnet/roslyn/blob/ef625f3b960594fcb3f902af88ad7c90df656516/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs#L110

by getting into this code path when appropriate:

https://github.com/dotnet/roslyn/blob/ef625f3b960594fcb3f902af88ad7c90df656516/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs#L104-L108

Assuming this change is reasonable and correct, I'd still like someone confirm whether this is the root cause of #67926 or not.
