### PR TITLE
Improve parsing of switch expressions whith missing `}` or `]`

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -85,10 +85,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             IsEndOfFunctionPointerParameterListErrored = 1 << 24,
             IsEndOfFunctionPointerCallingConvention = 1 << 25,
             IsEndOfRecordOrClassOrStructOrInterfaceSignature = 1 << 26,
-            IsExpressionOrPatternInCaseLabelOfSwitchStatement = 1 << 27,
+            IsExpressionOrPatternInLabelOfSwitchStatementOrExpression = 1 << 27,
         }
 
-        private const int LastTerminatorState = (int)TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement;
+        private const int LastTerminatorState = (int)TerminatorState.IsExpressionOrPatternInLabelOfSwitchStatementOrExpression;
 
         private bool IsTerminator()
         {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -85,10 +85,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             IsEndOfFunctionPointerParameterListErrored = 1 << 24,
             IsEndOfFunctionPointerCallingConvention = 1 << 25,
             IsEndOfRecordOrClassOrStructOrInterfaceSignature = 1 << 26,
-            IsExpressionOrPatternInLabelOfSwitchStatementOrExpression = 1 << 27,
+            IsExpressionOrPatternInCaseLabelOfSwitchStatement = 1 << 27,
+            IsPatternInSwitchExpressionArm = 1 << 28,
         }
 
-        private const int LastTerminatorState = (int)TerminatorState.IsExpressionOrPatternInLabelOfSwitchStatementOrExpression;
+        private const int LastTerminatorState = (int)TerminatorState.IsPatternInSwitchExpressionArm;
 
         private bool IsTerminator()
         {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -546,11 +546,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (@this._termState.HasFlag(TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement) && @this.CurrentToken.Kind is SyntaxKind.ColonToken)
                 return PostSkipAction.Abort;
 
-            // This is pretty much the same as above, but for switch expressions and `=>` token.
-            // The reason why we cannot use single flag for both cases is because we only want `:` to be "exit" token for switch statements and `=>` for switch expressions.
+            // This is pretty much the same as above, but for switch expressions and `=>` and `:` tokens.
+            // The reason why we cannot use single flag for both cases is because we want `=>` to be the "exit" token only for switch expressions.
             // Consider the following example: `case (() => 0):`. Normally `=>` is treated as bad separator, so we parse this basically the same as `case ((), 1):`, which is syntactically valid.
             // However, if we treated `=>` as "exit" token, parsing wouldn't consume full case label properly and would produce a lot of noise errors.
-            if (@this._termState.HasFlag(TerminatorState.IsPatternInSwitchExpressionArm) && @this.CurrentToken.Kind is SyntaxKind.EqualsGreaterThanToken)
+            // We can afford `:` to be the exit token for switch expressions because error recovery is already good enough and treats `:` as bad `=>`,
+            // meaning that switch expression arm `{ : 1` can be recovered to `{ } => 1` where the closing `}` is missing and instead of `=>` we have `:`.
+            if (@this._termState.HasFlag(TerminatorState.IsPatternInSwitchExpressionArm) && @this.CurrentToken.Kind is SyntaxKind.EqualsGreaterThanToken or SyntaxKind.ColonToken)
                 return PostSkipAction.Abort;
 
             return @this.SkipBadSeparatedListTokensWithExpectedKind(ref open, list,

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
@@ -124,8 +124,7 @@ class C
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "M2").WithLocation(18, 18));
         }
 
-        [Fact]
-        [WorkItem(34980, "https://github.com/dotnet/roslyn/issues/34980")]
+        [Fact, WorkItem(34980, "https://github.com/dotnet/roslyn/issues/34980")]
         public void PatternMatchGenericParameterToNonConstantExprs()
         {
             var comp = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -5371,6 +5371,93 @@ System.Console.WriteLine(true)";
             EOF();
         }
 
+        [Fact]
+        public void ParseSwitchStatementWithUnclosedPatternAndArrow()
+        {
+            // No good error recovery strategy yet
+            UsingStatement("""
+                switch (obj)
+                {
+                    case { =>
+                        break;
+                    case { =>
+                        break;
+                }
+                """,
+                // (3,12): error CS1001: Identifier expected
+                //     case { =>
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(3, 12),
+                // (4,14): error CS1513: } expected
+                //         break;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ";").WithLocation(4, 14),
+                // (4,14): error CS1003: Syntax error, ':' expected
+                //         break;
+                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(":").WithLocation(4, 14),
+                // (5,12): error CS1001: Identifier expected
+                //     case { =>
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(5, 12),
+                // (6,14): error CS1513: } expected
+                //         break;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ";").WithLocation(6, 14),
+                // (6,14): error CS1003: Syntax error, ':' expected
+                //         break;
+                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(":").WithLocation(6, 14));
+
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "obj");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        M(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.EmptyStatement);
+                    {
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.PropertyPatternClause);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                M(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        M(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.EmptyStatement);
+                    {
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
+
         private sealed class TokenAndTriviaWalker : CSharpSyntaxWalker
         {
             public int Tokens;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
@@ -1260,6 +1260,129 @@ public class SwitchExpressionParsingTests : ParsingTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern1_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: Type { } : 1,
+                Type { Prop: Type { } : 2
+            }
+            """,
+            // (3,27): error CS1513: } expected
+            //     Type { Prop: Type { } : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 27),
+            // (3,27): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: Type { } : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 27),
+            // (4,27): error CS1513: } expected
+            //     Type { Prop: Type { } : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 27),
+            // (4,27): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: Type { } : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 27));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
     public void TestUnclosedRecursivePattern2()
     {
         UsingExpression("""
@@ -1372,6 +1495,135 @@ public class SwitchExpressionParsingTests : ParsingTests
                     }
                 }
                 N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern2_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: Type { : 1,
+                Type { Prop: Type { : 2
+            }
+            """,
+            // (3,25): error CS1513: } expected
+            //     Type { Prop: Type { : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 25),
+            // (3,25): error CS1513: } expected
+            //     Type { Prop: Type { : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 25),
+            // (3,25): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: Type { : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 25),
+            // (4,25): error CS1513: } expected
+            //     Type { Prop: Type { : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 25),
+            // (4,25): error CS1513: } expected
+            //     Type { Prop: Type { : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 25),
+            // (4,25): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: Type { : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 25));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
                 N(SyntaxKind.NumericLiteralExpression);
                 {
                     N(SyntaxKind.NumericLiteralToken, "2");
@@ -1542,6 +1794,171 @@ public class SwitchExpressionParsingTests : ParsingTests
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern3_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: { Prop: { : 1,
+                Type { Prop: { Prop: { : 2
+            }
+            """,
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 28),
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 28),
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(3, 28),
+            // (3,28): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: { Prop: { : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { : 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(4, 28),
+            // (4,28): error CS1003: Syntax error, '=>' expected
+            //     Type { Prop: { Prop: { : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 28));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.Subpattern);
+                                    {
+                                        N(SyntaxKind.NameColon);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Prop");
+                                            }
+                                            N(SyntaxKind.ColonToken);
+                                        }
+                                        N(SyntaxKind.RecursivePattern);
+                                        {
+                                            N(SyntaxKind.PropertyPatternClause);
+                                            {
+                                                N(SyntaxKind.OpenBraceToken);
+                                                M(SyntaxKind.CloseBraceToken);
+                                            }
+                                        }
+                                    }
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.Subpattern);
+                                    {
+                                        N(SyntaxKind.NameColon);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Prop");
+                                            }
+                                            N(SyntaxKind.ColonToken);
+                                        }
+                                        N(SyntaxKind.RecursivePattern);
+                                        {
+                                            N(SyntaxKind.PropertyPatternClause);
+                                            {
+                                                N(SyntaxKind.OpenBraceToken);
+                                                M(SyntaxKind.CloseBraceToken);
+                                            }
+                                        }
+                                    }
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
     public void TestUnclosedListPattern1()
     {
         UsingExpression("""
@@ -1588,6 +2005,69 @@ public class SwitchExpressionParsingTests : ParsingTests
                     M(SyntaxKind.CloseBracketToken);
                 }
                 N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern1_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [ : 1,
+                [ : 2
+            }
+            """,
+            // (3,7): error CS1003: Syntax error, ']' expected
+            //     [ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 7),
+            // (3,7): error CS1003: Syntax error, '=>' expected
+            //     [ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 7),
+            // (4,7): error CS1003: Syntax error, ']' expected
+            //     [ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 7),
+            // (4,7): error CS1003: Syntax error, '=>' expected
+            //     [ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 7));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
                 N(SyntaxKind.NumericLiteralExpression);
                 {
                     N(SyntaxKind.NumericLiteralToken, "2");
@@ -1661,6 +2141,85 @@ public class SwitchExpressionParsingTests : ParsingTests
                     M(SyntaxKind.CloseBracketToken);
                 }
                 N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern2_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [[ : 1,
+                [[ : 2
+            }
+            """,
+            // (3,8): error CS1003: Syntax error, ']' expected
+            //     [[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 8),
+            // (3,8): error CS1003: Syntax error, ']' expected
+            //     [[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 8),
+            // (3,8): error CS1003: Syntax error, '=>' expected
+            //     [[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 8),
+            // (4,8): error CS1003: Syntax error, ']' expected
+            //     [[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 8),
+            // (4,8): error CS1003: Syntax error, ']' expected
+            //     [[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 8),
+            // (4,8): error CS1003: Syntax error, '=>' expected
+            //     [[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 8));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
                 N(SyntaxKind.NumericLiteralExpression);
                 {
                     N(SyntaxKind.NumericLiteralToken, "2");
@@ -1750,6 +2309,101 @@ public class SwitchExpressionParsingTests : ParsingTests
                     M(SyntaxKind.CloseBracketToken);
                 }
                 N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern3_Colon()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [[[ : 1,
+                [[[ : 2
+            }
+            """,
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 9),
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 9),
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(3, 9),
+            // (3,9): error CS1003: Syntax error, '=>' expected
+            //     [[ : 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(3, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("]").WithLocation(4, 9),
+            // (4,9): error CS1003: Syntax error, '=>' expected
+            //     [[ : 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments("=>").WithLocation(4, 9));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
                 N(SyntaxKind.NumericLiteralExpression);
                 {
                     N(SyntaxKind.NumericLiteralToken, "2");

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1076,9 +1077,6 @@ public class SwitchExpressionParsingTests : ParsingTests
     [Fact]
     public void TestNormalDefaultInSwitchExpression2_Semicolons()
     {
-        var v = typeof((int, int));
-        var v1 = typeof(int[]);
-
         UsingExpression("""
             x switch
             {
@@ -1092,6 +1090,7 @@ public class SwitchExpressionParsingTests : ParsingTests
             // (4,22): error CS1003: Syntax error, ',' expected
             //     default(int) => 2;
             Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(",").WithLocation(4, 22));
+
         N(SyntaxKind.SwitchExpression);
         {
             N(SyntaxKind.IdentifierName);
@@ -1138,6 +1137,624 @@ public class SwitchExpressionParsingTests : ParsingTests
                 }
             }
             M(SyntaxKind.CommaToken);
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern1()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: Type { } => 1,
+                Type { Prop: Type { } => 2
+            }
+            """,
+            // (3,27): error CS1513: } expected
+            //     Type { Prop: Type { } => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 27),
+            // (4,27): error CS1513: } expected
+            //     Type { Prop: Type { } => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 27));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern2()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: Type { => 1,
+                Type { Prop: Type { => 2
+            }
+            """,
+            // (3,25): error CS1513: } expected
+            //     Type { Prop: Type { => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 25),
+            // (3,25): error CS1513: } expected
+            //     Type { Prop: Type { => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 25),
+            // (4,25): error CS1513: } expected
+            //     Type { Prop: Type { => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 25),
+            // (4,25): error CS1513: } expected
+            //     Type { Prop: Type { => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 25));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Type");
+                                }
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedRecursivePattern3()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                Type { Prop: { Prop: { => 1,
+                Type { Prop: { Prop: { => 2
+            }
+            """,
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 28),
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 28),
+            // (3,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 1,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(3, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 28),
+            // (4,28): error CS1513: } expected
+            //     Type { Prop: { Prop: { => 2
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(4, 28));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.Subpattern);
+                                    {
+                                        N(SyntaxKind.NameColon);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Prop");
+                                            }
+                                            N(SyntaxKind.ColonToken);
+                                        }
+                                        N(SyntaxKind.RecursivePattern);
+                                        {
+                                            N(SyntaxKind.PropertyPatternClause);
+                                            {
+                                                N(SyntaxKind.OpenBraceToken);
+                                                M(SyntaxKind.CloseBraceToken);
+                                            }
+                                        }
+                                    }
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Type");
+                    }
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.Subpattern);
+                                    {
+                                        N(SyntaxKind.NameColon);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Prop");
+                                            }
+                                            N(SyntaxKind.ColonToken);
+                                        }
+                                        N(SyntaxKind.RecursivePattern);
+                                        {
+                                            N(SyntaxKind.PropertyPatternClause);
+                                            {
+                                                N(SyntaxKind.OpenBraceToken);
+                                                M(SyntaxKind.CloseBraceToken);
+                                            }
+                                        }
+                                    }
+                                    M(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern1()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [ => 1,
+                [ => 2
+            }
+            """,
+            // (3,7): error CS1003: Syntax error, ']' expected
+            //     [ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 7),
+            // (4,7): error CS1003: Syntax error, ']' expected
+            //     [ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 7));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern2()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [[ => 1,
+                [[ => 2
+            }
+            """,
+            // (3,8): error CS1003: Syntax error, ']' expected
+            //     [[ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 8),
+            // (3,8): error CS1003: Syntax error, ']' expected
+            //     [[ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 8),
+            // (4,8): error CS1003: Syntax error, ']' expected
+            //     [[ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 8),
+            // (4,8): error CS1003: Syntax error, ']' expected
+            //     [[ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 8));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67876")]
+    public void TestUnclosedListPattern3()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                [[[ => 1,
+                [[[ => 2
+            }
+            """,
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 9),
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 9),
+            // (3,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 1,
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(3, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 9),
+            // (4,9): error CS1003: Syntax error, ']' expected
+            //     [[[ => 2
+            Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments("]").WithLocation(4, 9));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+            }
+            N(SyntaxKind.CommaToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.ListPattern);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.ListPattern);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ListPattern);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        M(SyntaxKind.CloseBracketToken);
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                }
+            }
             N(SyntaxKind.CloseBraceToken);
         }
         EOF();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
@@ -2413,4 +2413,106 @@ public class SwitchExpressionParsingTests : ParsingTests
         }
         EOF();
     }
+
+    [Fact]
+    public void TestIncompleteSwitchExpression()
+    {
+        UsingExpression("""
+            obj switch
+            {
+                { Prop: 1, { Prop: 2 }
+            """,
+            // (3,27): error CS1513: } expected
+            //     { Prop: 1, { Prop: 2 }
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(3, 27),
+            // (3,27): error CS1003: Syntax error, '=>' expected
+            //     { Prop: 1, { Prop: 2 }
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("=>").WithLocation(3, 27),
+            // (3,27): error CS1733: Expected expression
+            //     { Prop: 1, { Prop: 2 }
+            Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(3, 27),
+            // (3,27): error CS1003: Syntax error, ',' expected
+            //     { Prop: 1, { Prop: 2 }
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(",").WithLocation(3, 27),
+            // (3,27): error CS1513: } expected
+            //     { Prop: 1, { Prop: 2 }
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(3, 27));
+
+        N(SyntaxKind.SwitchExpression);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "obj");
+            }
+            N(SyntaxKind.SwitchKeyword);
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.SwitchExpressionArm);
+            {
+                N(SyntaxKind.RecursivePattern);
+                {
+                    N(SyntaxKind.PropertyPatternClause);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.NameColon);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Prop");
+                                }
+                                N(SyntaxKind.ColonToken);
+                            }
+                            N(SyntaxKind.ConstantPattern);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                }
+                            }
+                        }
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Subpattern);
+                        {
+                            N(SyntaxKind.RecursivePattern);
+                            {
+                                N(SyntaxKind.PropertyPatternClause);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.Subpattern);
+                                    {
+                                        N(SyntaxKind.NameColon);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Prop");
+                                            }
+                                            N(SyntaxKind.ColonToken);
+                                        }
+                                        N(SyntaxKind.ConstantPattern);
+                                        {
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "2");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            M(SyntaxKind.CommaToken);
+            M(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/67876