### PR TITLE
Fix a wrong text span usage in MergeIfStatementsCodeRefactoringProvider

### DIFF
--- a/src/EditorFeatures/CSharpTest/SplitOrMergeIfStatements/MergeConsecutiveIfStatementsTests_ElseIf_Middle.cs
+++ b/src/EditorFeatures/CSharpTest/SplitOrMergeIfStatements/MergeConsecutiveIfStatementsTests_ElseIf_Middle.cs
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitOrMergeIfStatement
                     {
                         if (a)
                             System.Console.WriteLine(null);
-                        [||]else if (b)
+                        [||]else {|applicableSpan:if (b)
                             System.Console.WriteLine();
                         else if (c)
-                            System.Console.WriteLine();
+                            System.Console.WriteLine();|}
                     }
                 }
                 """;
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitOrMergeIfStatement
 
             await TestActionCountAsync(Initial, 1);
             await TestInRegularAndScriptAsync(Initial, Expected);
+            await TestCodeRefactoringApplicableTextSpan(Initial, "applicableSpan");
         }
 
         [Fact]

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         protected override Task<ImmutableArray<Diagnostic>> GetDiagnosticsWorkerAsync(TestWorkspace workspace, TestParameters parameters)
             => SpecializedTasks.EmptyImmutableArray<Diagnostic>();
 
-        internal async Task<CodeRefactoring> GetCodeRefactoringAsync(
+        internal override async Task<CodeRefactoring> GetCodeRefactoringAsync(
             TestWorkspace workspace, TestParameters parameters)
         {
             GetDocumentAndSelectSpanOrAnnotatedSpan(workspace, out var document, out var span, out _);

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -25,6 +25,11 @@ using Microsoft.CodeAnalysis.Remote.Testing;
 using Xunit.Abstractions;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using System;
+using FixAllState = Microsoft.CodeAnalysis.CodeFixes.FixAllState;
+using FixAllProvider = Microsoft.CodeAnalysis.CodeFixes.FixAllProvider;
+using FixAllContext = Microsoft.CodeAnalysis.CodeFixes.FixAllContext;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 {
@@ -84,6 +89,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var (dxs, _, _) = await GetDiagnosticAndFixesAsync(workspace, parameters);
             return dxs;
         }
+
+        internal override Task<CodeRefactoring> GetCodeRefactoringAsync(TestWorkspace workspace, TestParameters parameters)
+            => throw new NotImplementedException("No refactoring provided in diagnostic test");
 
         protected static void AddAnalyzerToWorkspace(Workspace workspace, DiagnosticAnalyzer analyzer, TestParameters parameters)
         {

--- a/src/Features/Core/Portable/SplitOrMergeIfStatements/AbstractMergeIfStatementsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/SplitOrMergeIfStatements/AbstractMergeIfStatementsCodeRefactoringProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.SplitOrMergeIfStatements
                             c => RefactorAsync(document, upperIfOrElseIfSpan, lowerIfOrElseIfSpan, c),
                             direction,
                             syntaxFacts.GetText(syntaxKinds.IfKeyword)),
-                        new TextSpan(upperIfOrElseIfSpan.Start, lowerIfOrElseIfSpan.End));
+                        TextSpan.FromBounds(upperIfOrElseIfSpan.Start, lowerIfOrElseIfSpan.End));
                 }
             }
         }


### PR DESCRIPTION
One-line fix.
The second parameter of `new TextSpan()` is length, not end.