### PR TITLE
Pool `BindingDiagnosticBag`s

### DIFF
--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis
 
         internal bool AccumulatesDependencies => DependenciesBag is object;
 
-        internal void Free()
+        internal virtual void Free()
         {
             DiagnosticBag?.Free();
             ((PooledHashSet<TAssemblySymbol>?)DependenciesBag)?.Free();


### PR DESCRIPTION
Resolves #67785. Haven't yet figured out how to configure <samp>PerfView.exe</samp> to show me numbers like in that issue to compare effect of this PR.

@CyrusNajmabadi FYI