### PR TITLE
Move to non-segmented dictionary

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// <summary>
             /// Cached mapping of localizable strings in this descriptor to any exceptions thrown while obtaining them.
             /// </summary>
-            private static ImmutableSegmentedDictionary<LocalizableString, Exception?> s_localizableStringToException = ImmutableSegmentedDictionary<LocalizableString, Exception?>.Empty.WithComparer(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+            private static ImmutableDictionary<LocalizableString, Exception?> s_localizableStringToException = ImmutableDictionary<LocalizableString, Exception?>.Empty.WithComparers(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
             private readonly DiagnosticAnalyzer _analyzer;
             private readonly object _gate;
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (!localizableString.CanThrowExceptions)
                         return null;
 
-                    return RoslynImmutableInterlocked.GetOrAdd(ref s_localizableStringToException, localizableString, computeException);
+                    return ImmutableInterlocked.GetOrAdd(ref s_localizableStringToException, localizableString, computeException);
 
                     static Exception? computeException(LocalizableString localizableString)
                     {


### PR DESCRIPTION
Fixes [AB#1806580](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1806580)

ImmutableSegmentedDictionary can exhibit n^2 memory performance on linear mutation (e.g. each mutation is O(n)). Moving to ImmutableDictionary as that has n-log(n) performance. 

This was found in tests that measure startup cost.  Original testing was around scenarios where startup had completed and we'd landed in a steady state.  