### PR TITLE
[Approach #1] Improve IsDiagnosticAnalyzerSuppressed performance

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TouchedFileLogger? touchedFilesLogger,
             ErrorLogger? errorLogger,
             ImmutableArray<AnalyzerConfigOptionsResult> analyzerConfigOptions,
-            AnalyzerConfigOptionsResult globalConfigOptions)
+            AnalyzerConfigOptionsResult globalConfigOptions,
+            AnalyzerConfigSet? analyzerConfigSet)
         {
             var parseOptions = Arguments.ParseOptions;
 
@@ -155,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var loggingFileSystem = new LoggingStrongNameFileSystem(touchedFilesLogger, _tempDirectory);
-            var optionsProvider = new CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalConfigOptions);
+            var optionsProvider = new CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalConfigOptions, analyzerConfigSet);
 
             return CSharpCompilation.Create(
                 Arguments.CompilationName,

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -1527,7 +1527,7 @@ class NonGeneratedCode{0}
             analyzerConfigOptions = new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add("generated_code", "auto"));
             analyzerConfigOptionsPerTreeBuilder.Add(tree, analyzerConfigOptions);
 
-            var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(analyzerConfigOptionsPerTreeBuilder.ToImmutable(), DictionaryAnalyzerConfigOptions.Empty);
+            var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(analyzerConfigOptionsPerTreeBuilder.ToImmutable(), DictionaryAnalyzerConfigOptions.Empty, analyzerConfigSet: null);
             var analyzerOptions = new AnalyzerOptions(additionalFiles: ImmutableArray<AdditionalText>.Empty, analyzerConfigOptionsProvider);
 
             // Verify no compiler diagnostics.

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
@@ -498,7 +498,8 @@ class C
             var analyzerConfigOptions = new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add("dotnet_analyzer_diagnostic.severity", "none"));
             var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(
                 ImmutableDictionary<object, AnalyzerConfigOptions>.Empty.Add(compilation.SyntaxTrees.Single(), analyzerConfigOptions),
-                DictionaryAnalyzerConfigOptions.Empty);
+                DictionaryAnalyzerConfigOptions.Empty,
+                analyzerConfigSet: null);
             var analyzerOptions = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, analyzerConfigOptionsProvider);
             compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, analyzerOptions);
             analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
@@ -544,7 +545,7 @@ class C
                     var analyzerConfigOptions = new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add(options.Value.key, options.Value.value));
                     var analyzerConfigOptionsProvider = new CompilerAnalyzerConfigOptionsProvider(
                         ImmutableDictionary<object, AnalyzerConfigOptions>.Empty.Add(compilation.SyntaxTrees.Single(), analyzerConfigOptions),
-                        DictionaryAnalyzerConfigOptions.Empty);
+                        DictionaryAnalyzerConfigOptions.Empty, analyzerConfigSet: null);
                     analyzerOptions = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, analyzerConfigOptionsProvider);
                 }
                 else

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -846,7 +846,7 @@ class C
             compilation.VerifyDiagnostics();
             Assert.Single(compilation.SyntaxTrees);
 
-            var options = new CompilerAnalyzerConfigOptionsProvider(ImmutableDictionary<object, AnalyzerConfigOptions>.Empty, new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add("a", "abc").Add("b", "def")));
+            var options = new CompilerAnalyzerConfigOptionsProvider(ImmutableDictionary<object, AnalyzerConfigOptions>.Empty, new DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty.Add("a", "abc").Add("b", "def")), analyzerConfigSet: null);
 
             AnalyzerConfigOptionsProvider? passedIn = null;
             var testGenerator = new CallbackGenerator(
@@ -2378,7 +2378,7 @@ class C { }
 
             var builder = ImmutableDictionary<string, string>.Empty.ToBuilder();
             builder.Add("test", "value1");
-            var optionsProvider = new CompilerAnalyzerConfigOptionsProvider(ImmutableDictionary<object, AnalyzerConfigOptions>.Empty, new DictionaryAnalyzerConfigOptions(builder.ToImmutable()));
+            var optionsProvider = new CompilerAnalyzerConfigOptionsProvider(ImmutableDictionary<object, AnalyzerConfigOptions>.Empty, new DictionaryAnalyzerConfigOptions(builder.ToImmutable()), analyzerConfigSet: null);
 
             // run the generator once, and check it was passed the configs
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions, optionsProvider: optionsProvider, driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
@@ -2415,7 +2415,7 @@ class C { }
             // now update the config
             builder.Clear();
             builder.Add("test", "value2");
-            var newOptionsProvider = optionsProvider.WithGlobalOptions(new DictionaryAnalyzerConfigOptions(builder.ToImmutable()));
+            var newOptionsProvider = optionsProvider.WithGlobalOptions(new DictionaryAnalyzerConfigOptions(builder.ToImmutable()), builder.Keys);
             driver = driver.WithUpdatedAnalyzerConfigOptions(newOptionsProvider);
 
             // check we ran

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigOptionKeys.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigOptionKeys.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Holds keys for all options in an <see cref="AnalyzerConfigSet"/>.
+    /// </summary>
+    public readonly struct AnalyzerConfigOptionKeys
+    {
+        /// <summary>
+        /// Diagnostic Ids whose severities are configured in the corresponding <see cref="AnalyzerConfigSet"/>.
+        /// </summary>
+        public ImmutableHashSet<string> ConfiguredDiagnosticIds { get; }
+
+        /// <summary>
+        /// Keys for the options in the corresponding <see cref="AnalyzerConfigSet"/> and that
+        /// do not have any special compiler behavior and are passed to analyzers as-is.
+        /// </summary>
+        public ImmutableHashSet<string> AnalyzerOptionKeys { get; }
+
+        internal AnalyzerConfigOptionKeys(ImmutableHashSet<string> configuredDiagnosticIds, ImmutableHashSet<string> analyzerOptionKeys)
+        {
+            ConfiguredDiagnosticIds = UpdateComparerIfNeeded(configuredDiagnosticIds);
+            AnalyzerOptionKeys = UpdateComparerIfNeeded(analyzerOptionKeys);
+        }
+
+        private static ImmutableHashSet<string> UpdateComparerIfNeeded(ImmutableHashSet<string> keys)
+            => keys.KeyComparer == AnalyzerConfig.Section.PropertiesKeyComparer
+                ? keys
+                : keys.WithComparer(AnalyzerConfig.Section.PropertiesKeyComparer);
+
+        internal AnalyzerConfigOptionKeys WithAdditionalAnalyzerConfigOptionKeys(IEnumerable<string> optionKeys)
+        {
+            if (optionKeys.IsEmpty())
+                return this;
+
+            var newOptionKeys = ImmutableHashSet.CreateBuilder(AnalyzerOptionKeys.KeyComparer);
+            newOptionKeys.AddAll(AnalyzerOptionKeys);
+            newOptionKeys.AddAll(optionKeys);
+
+            if (newOptionKeys.Count == AnalyzerOptionKeys.Count)
+                return this;
+
+            return new AnalyzerConfigOptionKeys(ConfiguredDiagnosticIds, newOptionKeys.ToImmutable());
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerConfigOptionsProvider.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerConfigOptionsProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>
@@ -23,5 +25,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Get options for a given <see cref="AdditionalText"/>
         /// </summary>
         public abstract AnalyzerConfigOptions GetOptions(AdditionalText textFile);
+
+        public virtual bool TryGetAnalyzerConfigOptionKeys(CancellationToken cancellationToken, out AnalyzerConfigOptionKeys? optionKeys)
+        {
+            optionKeys = null;
+            return false;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -19,6 +20,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static string GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(string category)
             => $"{DotnetAnalyzerDiagnosticPrefix}.{CategoryPrefix}-{category}.{SeveritySuffix}";
+
+        public static bool HasSeverityBulkConfigurationEntry(ImmutableHashSet<string> entries, string category)
+        {
+            var categoryBasedEntry = GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(category);
+            return entries.Contains(categoryBasedEntry) || entries.Contains(DotnetAnalyzerDiagnosticSeverityKey);
+        }
 
         /// <summary>
         /// Tries to get configured severity for the given <paramref name="descriptor"/>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerAnalyzerConfigOptionsProvider.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerAnalyzerConfigOptionsProvider.cs
@@ -2,25 +2,39 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal sealed class CompilerAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
     {
         private readonly ImmutableDictionary<object, AnalyzerConfigOptions> _treeDict;
+        private readonly AnalyzerConfigOptionKeys? _optionKeys;
 
         public static CompilerAnalyzerConfigOptionsProvider Empty { get; }
             = new CompilerAnalyzerConfigOptionsProvider(
                 ImmutableDictionary<object, AnalyzerConfigOptions>.Empty,
-                DictionaryAnalyzerConfigOptions.Empty);
+                DictionaryAnalyzerConfigOptions.Empty,
+                analyzerConfigSet: null);
 
-        internal CompilerAnalyzerConfigOptionsProvider(
+        private CompilerAnalyzerConfigOptionsProvider(
             ImmutableDictionary<object, AnalyzerConfigOptions> treeDict,
-            AnalyzerConfigOptions globalOptions)
+            AnalyzerConfigOptions globalOptions,
+            AnalyzerConfigOptionKeys? optionKeys)
         {
             _treeDict = treeDict;
             GlobalOptions = globalOptions;
+            _optionKeys = optionKeys;
+        }
+
+        internal CompilerAnalyzerConfigOptionsProvider(
+            ImmutableDictionary<object, AnalyzerConfigOptions> treeDict,
+            AnalyzerConfigOptions globalOptions,
+            AnalyzerConfigSet? analyzerConfigSet)
+            : this(treeDict, globalOptions, analyzerConfigSet?.OptionKeys)
+        {
         }
 
         public override AnalyzerConfigOptions GlobalOptions { get; }
@@ -31,10 +45,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
             => _treeDict.TryGetValue(textFile, out var options) ? options : DictionaryAnalyzerConfigOptions.Empty;
 
-        internal CompilerAnalyzerConfigOptionsProvider WithAdditionalTreeOptions(ImmutableDictionary<object, AnalyzerConfigOptions> treeDict)
-            => new CompilerAnalyzerConfigOptionsProvider(_treeDict.AddRange(treeDict), GlobalOptions);
+        public override bool TryGetAnalyzerConfigOptionKeys(CancellationToken cancellationToken, out AnalyzerConfigOptionKeys? optionKeys)
+        {
+            optionKeys = _optionKeys;
+            return optionKeys != null;
+        }
 
-        internal CompilerAnalyzerConfigOptionsProvider WithGlobalOptions(AnalyzerConfigOptions globalOptions)
-            => new CompilerAnalyzerConfigOptionsProvider(_treeDict, globalOptions);
+        internal CompilerAnalyzerConfigOptionsProvider WithAdditionalTreeOptions(ImmutableDictionary<object, AnalyzerConfigOptions> treeDict, IEnumerable<string> optionKeys)
+            => new CompilerAnalyzerConfigOptionsProvider(_treeDict.AddRange(treeDict), GlobalOptions, WithAdditionalOptionKeys(_optionKeys, optionKeys));
+
+        internal CompilerAnalyzerConfigOptionsProvider WithGlobalOptions(AnalyzerConfigOptions globalOptions, IEnumerable<string> optionKeys)
+            => new CompilerAnalyzerConfigOptionsProvider(_treeDict, globalOptions, WithAdditionalOptionKeys(_optionKeys, optionKeys));
+
+        private static AnalyzerConfigOptionKeys WithAdditionalOptionKeys(AnalyzerConfigOptionKeys? existingOptionKeys, IEnumerable<string> optionKeys)
+            => existingOptionKeys?.WithAdditionalAnalyzerConfigOptionKeys(optionKeys)
+                ?? new AnalyzerConfigOptionKeys(configuredDiagnosticIds: ImmutableHashSet<string>.Empty, optionKeys.ToImmutableHashSet());
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,10 @@
 *REMOVED*static Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode>.implicit operator Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode!>(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode!>
 *REMOVED*static Microsoft.CodeAnalysis.SyntaxList<TNode>.implicit operator Microsoft.CodeAnalysis.SyntaxList<TNode!>(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SyntaxList<TNode!>
+Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys
+Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys.AnalyzerConfigOptionKeys() -> void
+Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys.AnalyzerOptionKeys.get -> System.Collections.Immutable.ImmutableHashSet<string!>!
+Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys.ConfiguredDiagnosticIds.get -> System.Collections.Immutable.ImmutableHashSet<string!>!
+Microsoft.CodeAnalysis.AnalyzerConfigSet.OptionKeys.get -> Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys
 Microsoft.CodeAnalysis.Compilation.SupportsRuntimeCapability(Microsoft.CodeAnalysis.RuntimeCapability capability) -> bool
 Microsoft.CodeAnalysis.Emit.MethodInstrumentation
 Microsoft.CodeAnalysis.Emit.MethodInstrumentation.Kinds.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind>
@@ -29,5 +34,7 @@ static Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode>.explicit operator Micro
 static Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode>.op_Implicit(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode!>
 static Microsoft.CodeAnalysis.SyntaxList<TNode>.explicit operator Microsoft.CodeAnalysis.SyntaxList<TNode!>(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SyntaxList<TNode!>
 static Microsoft.CodeAnalysis.SyntaxList<TNode>.op_Implicit(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SyntaxList<TNode!>
+virtual Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider.TryGetAnalyzerConfigOptionKeys(System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys? optionKeys) -> bool
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitAttribute(Microsoft.CodeAnalysis.Operations.IAttributeOperation! operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitAttribute(Microsoft.CodeAnalysis.Operations.IAttributeOperation! operation, TArgument argument) -> TResult?
+virtual Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetAnalyzerConfigOptionKeys(System.Threading.CancellationToken cancellationToken, out Microsoft.CodeAnalysis.AnalyzerConfigOptionKeys? optionKeys) -> bool

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
@@ -92,7 +92,8 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 touchedFilesLogger: null,
                 errorLoggerOpt: null,
                 analyzerConfigOptions: default,
-                globalConfigOptions: default);
+                globalConfigOptions: default,
+                analyzerConfigSet: null);
             AssertEx.NotNull(compilation);
             Assert.Empty(writer.GetStringBuilder().ToString());
             var obj = GetSyntaxTreeValues(compilation, compiler.Arguments.PathMap);

--- a/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
+++ b/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
@@ -106,7 +106,8 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 touchedFilesLogger: null,
                 errorLoggerOpt: null,
                 analyzerConfigOptions: default,
-                globalConfigOptions: default);
+                globalConfigOptions: default,
+                analyzerConfigSet: null);
             AssertEx.NotNull(compilation);
             RoundTripUtil.VerifyCompilationOptions(commonCompiler.Arguments.CompilationOptions, compilation.Options);
 

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -68,16 +68,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLogger)
-            => CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt: default, globalDiagnosticOptionsOpt: default);
+            => CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt: default, globalDiagnosticOptionsOpt: default, analyzerConfigSet: null);
 
         public override Compilation CreateCompilation(
             TextWriter consoleOutput,
             TouchedFileLogger touchedFilesLogger,
             ErrorLogger errorLogger,
             ImmutableArray<AnalyzerConfigOptionsResult> syntaxDiagOptionsOpt,
-            AnalyzerConfigOptionsResult globalDiagnosticOptionsOpt)
+            AnalyzerConfigOptionsResult globalDiagnosticOptionsOpt,
+            AnalyzerConfigSet analyzerConfigSet)
         {
-            Compilation = base.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt, globalDiagnosticOptionsOpt);
+            Compilation = base.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxDiagOptionsOpt, globalDiagnosticOptionsOpt, analyzerConfigSet);
             return Compilation;
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -62,11 +62,11 @@ Friend Class MockVisualBasicCompiler
     End Sub
 
     Public Overloads Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult)) As Compilation
-        Return Me.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, Nothing)
+        Return Me.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, Nothing, Nothing)
     End Function
 
-    Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult), globalConfigOptions As AnalyzerConfigOptionsResult) As Compilation
-        Compilation = MyBase.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, globalConfigOptions)
+    Public Overrides Function CreateCompilation(consoleOutput As TextWriter, touchedFilesLogger As TouchedFileLogger, errorLogger As ErrorLogger, syntaxTreeDiagnosticOptionsOpt As ImmutableArray(Of AnalyzerConfigOptionsResult), globalConfigOptions As AnalyzerConfigOptionsResult, analyzerConfigSet As AnalyzerConfigSet) As Compilation
+        Compilation = MyBase.CreateCompilation(consoleOutput, touchedFilesLogger, errorLogger, syntaxTreeDiagnosticOptionsOpt, globalConfigOptions, analyzerConfigSet)
         Return Compilation
     End Function
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -87,7 +87,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     touchedFilesLogger As TouchedFileLogger,
                                                     errorLogger As ErrorLogger,
                                                     analyzerConfigOptions As ImmutableArray(Of AnalyzerConfigOptionsResult),
-                                                    globalAnalyzerConfigOptions As AnalyzerConfigOptionsResult) As Compilation
+                                                    globalAnalyzerConfigOptions As AnalyzerConfigOptionsResult,
+                                                    analyzerConfigSet As AnalyzerConfigSet) As Compilation
             Dim parseOptions = Arguments.ParseOptions
 
             ' We compute script parse options once so we don't have to do it repeatedly in
@@ -159,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sourceFileResolver = New LoggingSourceFileResolver(ImmutableArray(Of String).Empty, Arguments.BaseDirectory, Arguments.PathMap, touchedFilesLogger)
 
             Dim loggingFileSystem = New LoggingStrongNameFileSystem(touchedFilesLogger, _tempDirectory)
-            Dim syntaxTreeOptions = New CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalAnalyzerConfigOptions)
+            Dim syntaxTreeOptions = New CompilerSyntaxTreeOptionsProvider(trees, analyzerConfigOptions, globalAnalyzerConfigOptions, analyzerConfigSet)
 
             Return VisualBasicCompilation.Create(
                  Arguments.CompilationName,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -317,6 +317,12 @@ namespace Microsoft.CodeAnalysis
                 return GetOptionsForSourcePath(cache, tree.FilePath);
             }
 
+            public override bool TryGetAnalyzerConfigOptionKeys(CancellationToken cancellationToken, out AnalyzerConfigOptionKeys? optionKeys)
+            {
+                optionKeys = _projectState._lazyAnalyzerConfigOptions.GetValue(cancellationToken).AnalyzerConfigSet.OptionKeys;
+                return true;
+            }
+
             internal async ValueTask<StructuredAnalyzerConfigOptions> GetOptionsAsync(DocumentState documentState, CancellationToken cancellationToken)
             {
                 var cache = await _projectState._lazyAnalyzerConfigOptions.GetValueAsync(cancellationToken).ConfigureAwait(false);
@@ -465,6 +471,12 @@ namespace Microsoft.CodeAnalysis
                 return options.TreeOptions.TryGetValue(diagnosticId, out severity);
             }
 
+            public override bool TryGetAnalyzerConfigOptionKeys(CancellationToken cancellationToken, out AnalyzerConfigOptionKeys? optionKeys)
+            {
+                optionKeys = _lazyAnalyzerConfigSet.GetValue(cancellationToken).AnalyzerConfigSet.OptionKeys;
+                return true;
+            }
+
             public override bool Equals(object? obj)
             {
                 return obj is ProjectSyntaxTreeOptionsProvider other
@@ -501,9 +513,12 @@ namespace Microsoft.CodeAnalysis
 
             public AnalyzerConfigOptionsCache(AnalyzerConfigSet configSet)
             {
+                AnalyzerConfigSet = configSet;
                 _global = new Lazy<AnalyzerConfigData>(() => new AnalyzerConfigData(configSet.GlobalConfigOptions));
                 _computeFunction = path => new AnalyzerConfigData(configSet.GetOptionsForSourcePath(path));
             }
+
+            public AnalyzerConfigSet AnalyzerConfigSet { get; }
 
             public AnalyzerConfigData GlobalConfigOptions
                 => _global.Value;


### PR DESCRIPTION
Fixes [AB#1799782](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1799782). This fixes a long outstanding performance issue for CodeCleanup as well as command line builds.

`AnalyzerConfigSet` now exposes a set of all unique option keys and configured diagnostic IDs, which are in turn exposed by `SyntaxTreeOptionsProvider` and `AnalyzerConfigOptionsProvider`. These keys enable us to do a fast check in `IsDiagnosticAnalyzerSuppressed` to see if a diagnostic ID is never configured in an editorconfig/globalconfig in the entire `AnalyzerConfigSet` for the compilation. The slow path walks all the config files for each tree to determine if there is any entry which enables/unsuppresses the diagnostic ID.