### PR TITLE
Avoid rooting documents for languages that support syntax trees

### DIFF
--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -301,8 +301,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
                 lock (_gate)
                 {
-                    // 📝 Explicit casts added only to work around https://github.com/dotnet/roslyn/issues/67975
-                    _lastProcessedData = (currentSnapshot, currentRoot is not null ? (SumType<SyntaxNode, Document>)currentRoot : (SumType<SyntaxNode, Document>)currentDocument);
+                    _lastProcessedData = (currentSnapshot, (SumType<SyntaxNode, Document>?)currentRoot ?? currentDocument);
                 }
 
                 // Notify the editor now that there were changes.  Note: we do not need to go the

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -301,7 +301,8 @@ namespace Microsoft.CodeAnalysis.Classification
 
                 lock (_gate)
                 {
-                    _lastProcessedData = (currentSnapshot, currentRoot is not null ? currentRoot : currentDocument);
+                    // 📝 Explicit casts added only to work around https://github.com/dotnet/roslyn/issues/67975
+                    _lastProcessedData = (currentSnapshot, currentRoot is not null ? (SumType<SyntaxNode, Document>)currentRoot : (SumType<SyntaxNode, Document>)currentDocument);
                 }
 
                 // Notify the editor now that there were changes.  Note: we do not need to go the


### PR DESCRIPTION
Addresses 17GB memory overhead observed in a local heap dump where 50+ documents were open.