### PR TITLE
Clear out data from pooled object before returning to pool

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -547,6 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public void Free()
             {
+                this.Args = default;
                 s_checkConstraintsArgsBoxedPool.Free(this);
             }
         }


### PR DESCRIPTION
Otherwise stale information from prior object usage could be held onto for longer than desired.

Fixes 1500MB of storage overhead observed in a local heap dump for @sharwell 