### PR TITLE
Interceptors: address duplicate interceptions feedback, handle nameof, add test coverage

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7592,4 +7592,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullabilityMismatchInReturnTypeOnInterceptor_Title" xml:space="preserve">
     <value>Nullability of reference types in return type doesn't match interceptable method.</value>
   </data>
+  <data name="ERR_InterceptorCannotInterceptNameof" xml:space="preserve">
+    <value>A nameof operator cannot be intercepted.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2288,7 +2288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 factoryArgument: (AttributeLocation: attributeLocation, Interceptor: interceptor));
         }
 
-        internal (Location AttributeLocation, MethodSymbol Interceptor)? TryGetInterceptor(Location? callLocation, BindingDiagnosticBag diagnostics)
+        internal (Location AttributeLocation, MethodSymbol Interceptor)? TryGetInterceptor(Location? callLocation)
         {
             if (_interceptions is null || callLocation is null)
             {
@@ -2306,6 +2306,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return oneInterception;
                 }
 
+                // Duplicate interceptors is an error in the declaration phase.
+                // This method is only expected to be called if no such errors are present.
                 throw ExceptionUtilities.Unreachable();
             }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2306,10 +2306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return oneInterception;
                 }
 
-                // We don't normally reach this branch in batch compilation, because we would have already reported an error after the declaration phase.
-                // One scenario where we may reach this is when validating used assemblies, which performs lowering of method bodies even if declaration errors would be reported.
-                // See 'CSharpCompilation.GetCompleteSetOfUsedAssemblies'.
-                diagnostics.Add(ErrorCode.ERR_ModuleEmitFailure, callLocation, this.SourceModule.Name, new LocalizableResourceString(nameof(CSharpResources.ERR_DuplicateInterceptor), CodeAnalysisResources.ResourceManager, typeof(CodeAnalysisResources)));
+                throw ExceptionUtilities.Unreachable();
             }
 
             return null;
@@ -3274,8 +3271,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasDeclarationErrors = !FilterAndAppendDiagnostics(diagnostics, GetDiagnostics(CompilationStage.Declare, true, cancellationToken), excludeDiagnostics, cancellationToken);
             excludeDiagnostics?.Free();
 
-            hasDeclarationErrors |= CheckDuplicateInterceptions(diagnostics);
-
             // TODO (tomat): NoPIA:
             // EmbeddedSymbolManager.MarkAllDeferredSymbolsAsReferenced(this)
 
@@ -3417,7 +3412,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <returns><see langword="true"/> if duplicate interceptors are present in the compilation. Otherwise, <see langword="false" />.</returns>
-        private bool CheckDuplicateInterceptions(DiagnosticBag diagnostics)
+        internal bool CheckDuplicateInterceptions(BindingDiagnosticBag diagnostics)
         {
             if (_interceptions is null)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3413,7 +3413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.CheckDuplicateFilePathsAndFree(SyntaxTrees, GlobalNamespace);
         }
 
-        /// <returns><see langword="true"/> if duplicate interceptors are present in the compilation. Otherwise, <see langword="false" />.</returns>
+        /// <returns><see langword="true"/> if duplicate interceptions are present in the compilation. Otherwise, <see langword="false" />.</returns>
         internal bool CheckDuplicateInterceptions(BindingDiagnosticBag diagnostics)
         {
             if (_interceptions is null)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -120,10 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(diagnostics != null);
             Debug.Assert(diagnostics.DiagnosticBag != null);
 
-            // PROTOTYPE(ic):
-            // - Move check for duplicate interceptions in here.
-            // - Change lowering to throw on duplicates.
-            // - Test no duplicate error given when emitting a ref assembly.
+            hasDeclarationErrors |= compilation.CheckDuplicateInterceptions(diagnostics);
 
             if (compilation.PreviousSubmission != null)
             {

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2216,6 +2216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InterceptorLineCharacterMustBePositive = 27020,
         WRN_NullabilityMismatchInReturnTypeOnInterceptor = 27021,
         WRN_NullabilityMismatchInParameterTypeOnInterceptor = 27022,
+        ERR_InterceptorCannotInterceptNameof = 27023,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -595,6 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_InterceptorScopedMismatch:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnInterceptor:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor:
+                case ErrorCode.ERR_InterceptorCannotInterceptNameof:
                     // Update src\EditorFeatures\CSharp\LanguageServer\CSharpLspBuildOnlyDiagnostics.cs
                     // whenever new values are added here.
                     return true;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -222,10 +222,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression? VisitExpressionImpl(BoundExpression node)
         {
-            if (node is BoundNameOfOperator { WasCompilerGenerated: false, Syntax: InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Location: var nameofPseudoCallLocation } } }
-                && this._compilation.TryGetInterceptor(nameofPseudoCallLocation) is not null)
+            if (node is BoundNameOfOperator nameofOperator)
             {
-                this._diagnostics.Add(ErrorCode.ERR_InterceptorCannotInterceptNameof, nameofPseudoCallLocation);
+                Debug.Assert(!nameofOperator.WasCompilerGenerated);
+                var nameofIdentiferSyntax = (IdentifierNameSyntax)((InvocationExpressionSyntax)nameofOperator.Syntax).Expression;
+                if (this._compilation.TryGetInterceptor(nameofIdentiferSyntax.Location) is not null)
+                {
+                    this._diagnostics.Add(ErrorCode.ERR_InterceptorCannotInterceptNameof, nameofIdentiferSyntax.Location);
+                }
             }
 
             ConstantValue? constantValue = node.ConstantValueOpt;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -222,6 +222,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression? VisitExpressionImpl(BoundExpression node)
         {
+            if (node is BoundNameOfOperator { WasCompilerGenerated: false, Syntax: InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Location: var nameofPseudoCallLocation } } }
+                && this._compilation.TryGetInterceptor(nameofPseudoCallLocation) is not null)
+            {
+                this._diagnostics.Add(ErrorCode.ERR_InterceptorCannotInterceptNameof, nameofPseudoCallLocation);
+            }
+
             ConstantValue? constantValue = node.ConstantValueOpt;
             if (constantValue != null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Add assertions for the possible shapes of calls which could come through this method.
             // When the BoundCall shape changes in the future, force developer to decide what to do here.
 
-            if (this._compilation.TryGetInterceptor(interceptableLocation, _diagnostics) is not var (attributeLocation, interceptor))
+            if (this._compilation.TryGetInterceptor(interceptableLocation) is not var (attributeLocation, interceptor))
             {
                 // The call was not intercepted.
                 return;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -989,7 +989,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var syntaxTrees = DeclaringCompilation.SyntaxTrees;
-            SyntaxTree matchingTree = null;
+            SyntaxTree? matchingTree = null;
             foreach (var tree in syntaxTrees)
             {
                 if (tree.FilePath == filePath)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -988,9 +989,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var syntaxTrees = DeclaringCompilation.SyntaxTrees;
-            // PROTOTYPE(ic): consider avoiding an array allocation here, on the assumption that 1 matching tree is the success (common) case, 0 is the most common error case, and 2 or more is much more rare.
-            var matchingTrees = syntaxTrees.WhereAsArray(static (tree, filePath) => tree.FilePath == filePath, filePath);
-            if (matchingTrees is [])
+            SyntaxTree matchingTree = null;
+            foreach (var tree in syntaxTrees)
+            {
+                if (tree.FilePath == filePath)
+                {
+                    if (matchingTree == null)
+                    {
+                        matchingTree = tree;
+                        // need to keep searching in case we find another tree with the same path
+                    }
+                    else
+                    {
+                        diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath);
+                        return;
+                    }
+                }
+            }
+
+            if (matchingTree == null)
             {
                 var suffixMatch = syntaxTrees.FirstOrDefault(static (tree, filePath) => tree.FilePath.EndsWith(filePath), filePath);
                 if (suffixMatch != null)
@@ -1002,12 +1019,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath);
                 }
 
-                return;
-            }
-
-            if (matchingTrees is not [var matchingTree])
-            {
-                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath);
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -990,6 +990,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var syntaxTrees = DeclaringCompilation.SyntaxTrees;
             SyntaxTree? matchingTree = null;
+            // PROTOTYPE(ic): we need to resolve the paths before comparing (i.e. respect /pathmap).
+            // At that time, we should look at caching the resolved paths for the trees in a set (or maybe a Map<string, OneOrMany<SyntaxTree>>).
+            // so we can reduce the cost of these checks.
             foreach (var tree in syntaxTrees)
             {
                 if (tree.FilePath == filePath)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -857,6 +857,11 @@
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptNameof">
+        <source>A nameof operator cannot be intercepted.</source>
+        <target state="new">A nameof operator cannot be intercepted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCharacterOutOfRange">
         <source>The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</source>
         <target state="new">The given line is '{0}' characters long, which is fewer than the provided character number '{1}'.</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -14,20 +14,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 
 public class InterceptorsTests : CSharpTestBase
 {
-    // PROTOTYPE(ic): Ensure that all `MethodSymbol.IsInterceptable` implementations have test coverage.
-
-    // PROTOTYPE(ic): Possible test cases:
-    //
-    // * Intercept instance method with instance method in same class, base class, derived class
-    // * Intercept with extern method
-    // * Intercept an abstract or interface method
-    // * Intercept a virtual or overridden method
-    // * Intercept a non-extension call to a static method with a static method when one or both are extension methods
-    // * Intercept a struct instance method with an extension method with by-value / by-ref this parameter
-    // * An explicit interface implementation marked as interceptable
-
-    // PROTOTYPE(ic): test intercepting an extension method with a non-extension method. Perhaps should be an error for simplicity even if calling in non-reduced form.
-
     private static readonly (string, string) s_attributesSource = ("""
         namespace System.Runtime.CompilerServices;
 
@@ -323,6 +309,38 @@ public class InterceptorsTests : CSharpTestBase
     }
 
     [Fact]
+    public void InterceptableExtensionMethod_InterceptorExtensionMethod_NormalForm()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            interface I1 { }
+            class C : I1 { }
+
+            static class Program
+            {
+                [Interceptable]
+                public static I1 InterceptableMethod(this I1 i1, string param) { Console.Write("interceptable " + param); return i1; }
+
+                public static void Main()
+                {
+                    var c = new C();
+                    InterceptableMethod(c, "call site");
+                }
+            }
+
+            static class D
+            {
+                [InterceptsLocation("Program.cs", 15, 9)]
+                public static I1 Interceptor1(this I1 i1, string param) { Console.Write("interceptor " + param); return i1; }
+            }
+            """;
+        var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, expectedOutput: "interceptor call site");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
     public void InterceptableInstanceMethod_InterceptorExtensionMethod()
     {
         var source = """
@@ -594,6 +612,192 @@ public class InterceptorsTests : CSharpTestBase
             // Program.cs(14,6): error CS27016: The indicated call is intercepted multiple times.
             //     [InterceptsLocation("Program.cs", 3, 3)]
             Diagnostic(ErrorCode.ERR_DuplicateInterceptor, @"InterceptsLocation(""Program.cs"", 3, 3)").WithLocation(14, 6));
+    }
+
+    [Fact]
+    public void InterceptorVirtual_01()
+    {
+        // Intercept a method call with a call to a virtual method on the same type.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            c = new D();
+            c.M();
+
+            class C
+            {
+                [Interceptable]
+                public void M() => throw null!;
+
+                [InterceptsLocation("Program.cs", 5, 3)]
+                [InterceptsLocation("Program.cs", 8, 3)]
+                public virtual void Interceptor() => Console.Write("C");
+            }
+
+            class D : C
+            {
+                public override void Interceptor() => Console.Write("D");
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Method)]
+                public sealed class InterceptableAttribute : Attribute { }
+
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                public sealed class InterceptsLocationAttribute : Attribute
+                {
+                    public InterceptsLocationAttribute(string filePath, int line, int character)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify((source, "Program.cs"), expectedOutput: "CD");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void InterceptorVirtual_02()
+    {
+        // Intercept a call with a virtual method call on the base type.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            D d = new D();
+            d.M();
+
+            class C
+            {
+                [InterceptsLocation("Program.cs", 5, 3)]
+                public virtual void Interceptor() => throw null!;
+            }
+
+            class D : C
+            {
+                [Interceptable]
+                public void M() => throw null!;
+
+                public override void Interceptor() => throw null!;
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Method)]
+                public sealed class InterceptableAttribute : Attribute { }
+
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                public sealed class InterceptsLocationAttribute : Attribute
+                {
+                    public InterceptsLocationAttribute(string filePath, int line, int character)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation((source, "Program.cs"));
+        comp.VerifyEmitDiagnostics(
+            // Program.cs(9,6): error CS27011: Interceptor must have a 'this' parameter matching parameter 'D this' on 'D.M()'.
+            //     [InterceptsLocation("Program.cs", 5, 3)]
+            Diagnostic(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, @"InterceptsLocation(""Program.cs"", 5, 3)").WithArguments("D this", "D.M()").WithLocation(9, 6));
+    }
+
+    [Fact]
+    public void InterceptorOverride_01()
+    {
+        // Intercept a call with a call to an override method on a derived type.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            D d = new D();
+            d.M();
+
+            class C
+            {
+                [Interceptable]
+                public void M() => throw null!;
+
+                public virtual void Interceptor() => throw null!;
+            }
+
+            class D : C
+            {
+                [InterceptsLocation("Program.cs", 5, 3)] // 1
+                public override void Interceptor() => throw null!;
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Method)]
+                public sealed class InterceptableAttribute : Attribute { }
+
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                public sealed class InterceptsLocationAttribute : Attribute
+                {
+                    public InterceptsLocationAttribute(string filePath, int line, int character)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var comp = CreateCompilation((source, "Program.cs"));
+        comp.VerifyEmitDiagnostics(
+            // Program.cs(17,6): error CS27011: Interceptor must have a 'this' parameter matching parameter 'C this' on 'C.M()'.
+            //     [InterceptsLocation("Program.cs", 5, 3)] // 1
+            Diagnostic(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, @"InterceptsLocation(""Program.cs"", 5, 3)").WithArguments("C this", "C.M()").WithLocation(17, 6));
+    }
+
+    [Fact]
+    public void InterceptorOverride_02()
+    {
+        // Intercept a call with an override method on the same type.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            D d = new D();
+            d.M();
+
+            class C
+            {
+                public virtual void Interceptor() => throw null!;
+            }
+
+            class D : C
+            {
+                [Interceptable]
+                public void M() => throw null!;
+
+                [InterceptsLocation("Program.cs", 5, 3)]
+                public override void Interceptor() => Console.Write(1);
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [AttributeUsage(AttributeTargets.Method)]
+                public sealed class InterceptableAttribute : Attribute { }
+
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                public sealed class InterceptsLocationAttribute : Attribute
+                {
+                    public InterceptsLocationAttribute(string filePath, int line, int character)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify((source, "Program.cs"), expectedOutput: "1");
+        verifier.VerifyDiagnostics();
     }
 
     [Fact]
@@ -938,6 +1142,31 @@ public class InterceptorsTests : CSharpTestBase
             // Program.cs(14,6): error CS27011: Interceptor must have a 'this' parameter matching parameter 'C c' on 'D.InterceptableMethod(C)'.
             //     [InterceptsLocation("Program.cs", 5, 3)]
             Diagnostic(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, @"InterceptsLocation(""Program.cs"", 5, 3)").WithArguments("C c", "D.InterceptableMethod(C)").WithLocation(14, 6));
+    }
+
+    [Fact]
+    public void InterceptableExtensionMethod_InterceptorStaticMethod_NormalForm()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            var c = new C();
+            D.InterceptableMethod(c);
+
+            class C { }
+
+            static class D
+            {
+                [Interceptable]
+                public static void InterceptableMethod(this C c) => throw null!;
+
+                [InterceptsLocation("Program.cs", 5, 3)]
+                public static void Interceptor1(C c) => Console.Write(1);
+            }
+            """;
+        var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, expectedOutput: "1");
+        verifier.VerifyDiagnostics();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -1090,9 +1090,7 @@ public class InterceptorsTests : CSharpTestBase
             }
             """;
         var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, expectedOutput: "12");
-        // PROTOTYPE(ic): perhaps give a more specific error here.
-        // If/when we change "missing InterceptableAttribute" to an error, we might not need any specific error, because user cannot attribute the Invoke method.
-        // I don't think we intend for delegate Invoke to be interceptable, but it doesn't seem harmful to allow it.
+        // PROTOTYPE(ic): drop warning when InterceptableAttribute is removed from the design.
         verifier.VerifyDiagnostics(
             // Program.cs(16,6): warning CS27000: Call to 'Action.Invoke()' is intercepted, but the method is not marked with 'System.Runtime.CompilerServices.InterceptableAttribute'.
             //     [InterceptsLocation("Program.cs", 10, 9)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -1073,7 +1073,7 @@ public class InterceptorsTests : CSharpTestBase
             using System.Runtime.CompilerServices;
             using System;
 
-            C.M(() => Console.Write(0));
+            C.M(() => Console.Write(1));
 
             static class C
             {
@@ -1086,10 +1086,10 @@ public class InterceptorsTests : CSharpTestBase
             static class D
             {
                 [InterceptsLocation("Program.cs", 10, 9)]
-                public static void Interceptor1(this Action action) { Console.Write(1); }
+                public static void Interceptor1(this Action action) { action(); Console.Write(2); }
             }
             """;
-        var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, expectedOutput: "1");
+        var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, expectedOutput: "12");
         // PROTOTYPE(ic): perhaps give a more specific error here.
         // If/when we change "missing InterceptableAttribute" to an error, we might not need any specific error, because user cannot attribute the Invoke method.
         // I don't think we intend for delegate Invoke to be interceptable, but it doesn't seem harmful to allow it.

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2951,6 +2951,7 @@ class Program
                     case ErrorCode.ERR_InterceptorScopedMismatch:
                     case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnInterceptor:
                     case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor:
+                    case ErrorCode.ERR_InterceptorCannotInterceptNameof:
                         Assert.True(isBuildOnly, $"Check failed for ErrorCode.{errorCode}");
                         break;
 

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<ResourceDescription> manifestResources = null)
             where TCompilation : Compilation
         {
-            var pdbStream = MonoHelpers.IsRunningOnMono() ? null : new MemoryStream();
+            var pdbStream = MonoHelpers.IsRunningOnMono() || options.EmitMetadataOnly ? null : new MemoryStream();
             return c.Emit(new MemoryStream(), pdbStream: pdbStream, options: options, manifestResources: manifestResources).Diagnostics;
         }
 

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<ResourceDescription> manifestResources = null)
             where TCompilation : Compilation
         {
-            var pdbStream = MonoHelpers.IsRunningOnMono() || options.EmitMetadataOnly ? null : new MemoryStream();
+            var pdbStream = MonoHelpers.IsRunningOnMono() || options?.EmitMetadataOnly == true ? null : new MemoryStream();
             return c.Emit(new MemoryStream(), pdbStream: pdbStream, options: options, manifestResources: manifestResources).Diagnostics;
         }
 

--- a/src/EditorFeatures/CSharp/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
+++ b/src/EditorFeatures/CSharp/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServer
         "CS27018", // ErrorCode.ERR_InterceptorNotAccessible
         "CS27019", // ErrorCode.ERR_InterceptorScopedMismatch
         "CS27021", // ErrorCode.WRN_NullabilityMismatchInReturnTypeOnInterceptor
-        "CS27022" // ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor
+        "CS27022", // ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor
+        "CS27023" // ErrorCode.ERR_InterceptorCannotInterceptNameof
         )]
     internal sealed class CSharpLspBuildOnlyDiagnostics : ILspBuildOnlyDiagnostics
     {


### PR DESCRIPTION
Test plan: #67421

- Addresses https://github.com/dotnet/roslyn/pull/67786#pullrequestreview-1398851643
- Fixes missing error for intercepting a `nameof()` operator
- Removes an unnecessary array allocation when checking `[InterceptsLocation]` file path
- Adds more test coverage and moves more test prototype comments to the test plan