### PR TITLE
[Approach #2] Improve IsDiagnosticAnalyzerSuppressed performance

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.OptionKeys.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.OptionKeys.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    public sealed partial class AnalyzerConfigSet
+    {
+        /// <summary>
+        /// Holds keys for all options in an <see cref="AnalyzerConfigSet"/>.
+        /// </summary>
+        private sealed class OptionKeys
+        {
+            /// <summary>
+            /// Diagnostic Ids whose severities are configured in the corresponding <see cref="AnalyzerConfigSet"/>.
+            /// </summary>
+            private readonly ImmutableHashSet<string> _configuredDiagnosticIds;
+
+            /// <summary>
+            /// Keys for the options in the corresponding <see cref="AnalyzerConfigSet"/> and that
+            /// do not have any special compiler behavior and are passed to analyzers as-is.
+            /// </summary>
+            private readonly ImmutableHashSet<string> _analyzerOptionKeys;
+
+            public OptionKeys(ImmutableHashSet<string> configuredDiagnosticIds, ImmutableHashSet<string> analyzerOptionKeys)
+            {
+                Debug.Assert(configuredDiagnosticIds.KeyComparer == AnalyzerConfig.Section.PropertiesKeyComparer);
+                Debug.Assert(analyzerOptionKeys.KeyComparer == AnalyzerConfig.Section.PropertiesKeyComparer);
+
+                _configuredDiagnosticIds = configuredDiagnosticIds;
+                _analyzerOptionKeys = analyzerOptionKeys;
+            }
+
+            public bool HasSeverityConfigurationKey(DiagnosticDescriptor descriptor)
+                => _configuredDiagnosticIds.Contains(descriptor.Id) ||
+                   AnalyzerOptionsExtensions.HasSeverityBulkConfigurationEntry(_analyzerOptionKeys, descriptor.Category);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -25,7 +24,7 @@ namespace Microsoft.CodeAnalysis
     /// Represents a set of <see cref="AnalyzerConfig"/>, and can compute the effective analyzer options for a given source file. This is used to
     /// collect all the <see cref="AnalyzerConfig"/> files for that would apply to a compilation.
     /// </summary>
-    public sealed class AnalyzerConfigSet
+    public sealed partial class AnalyzerConfigSet
     {
         /// <summary>
         /// The list of <see cref="AnalyzerConfig" />s in this set. This list has been sorted per <see cref="AnalyzerConfig.DirectoryLengthComparer"/>.
@@ -58,6 +57,7 @@ namespace Microsoft.CodeAnalysis
             new ObjectPool<AnalyzerOptions.Builder>(() => ImmutableDictionary.CreateBuilder<string, string>(Section.PropertiesKeyComparer));
 
         private readonly ObjectPool<List<Section>> _sectionKeyPool = new ObjectPool<List<Section>>(() => new List<Section>());
+        private readonly Lazy<OptionKeys> _lazyOptionKeys;
 
         private StrongBox<AnalyzerConfigOptionsResult>? _lazyConfigOptions;
 
@@ -137,6 +137,7 @@ namespace Microsoft.CodeAnalysis
         {
             _analyzerConfigs = analyzerConfigs;
             _globalConfig = globalConfig;
+            _lazyOptionKeys = new Lazy<OptionKeys>(ComputeOptionKeys);
 
             var allMatchers = ArrayBuilder<ImmutableArray<SectionNameMatcher?>>.GetInstance(_analyzerConfigs.Length);
 
@@ -159,8 +160,48 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(allMatchers.Count == _analyzerConfigs.Length);
 
             _analyzerMatchers = allMatchers.ToImmutableAndFree();
-
         }
+
+        private OptionKeys ComputeOptionKeys()
+        {
+            var diagIdsBuilder = ImmutableHashSet.CreateBuilder<string>(Section.PropertiesKeyComparer);
+            var optionKeysBuilder = ImmutableHashSet.CreateBuilder<string>(Section.PropertiesKeyComparer);
+
+            foreach (var config in _analyzerConfigs)
+            {
+                addKeys(config.GlobalSection, diagIdsBuilder, optionKeysBuilder, _diagnosticIdCache);
+                foreach (var section in config.NamedSections)
+                    addKeys(section, diagIdsBuilder, optionKeysBuilder, _diagnosticIdCache);
+            }
+
+            addKeys(_globalConfig.GlobalSection, diagIdsBuilder, optionKeysBuilder, _diagnosticIdCache);
+            foreach (var section in _globalConfig.NamedSections)
+                addKeys(section, diagIdsBuilder, optionKeysBuilder, _diagnosticIdCache);
+
+            return new OptionKeys(diagIdsBuilder.ToImmutable(), optionKeysBuilder.ToImmutable());
+
+            static void addKeys(
+                Section section,
+                ImmutableHashSet<string>.Builder diagIdsBuilder,
+                ImmutableHashSet<string>.Builder optionKeysBuilder,
+                ConcurrentDictionary<ReadOnlyMemory<char>, string> diagnosticIdCache)
+            {
+                foreach (var (key, value) in section.Properties)
+                {
+                    if (TryParseDiagnosticId(key, diagnosticIdCache, out var diagId) && TryParseSeverity(value, out _))
+                    {
+                        diagIdsBuilder.Add(diagId);
+                    }
+                    else
+                    {
+                        optionKeysBuilder.Add(key);
+                    }
+                }
+            }
+        }
+
+        internal bool HasSeverityConfigurationEntry(DiagnosticDescriptor descriptor)
+            => _lazyOptionKeys.Value.HasSeverityConfigurationKey(descriptor);
 
         /// <summary>
         /// Gets an <see cref="AnalyzerConfigOptionsResult"/> that contain the options that apply globally
@@ -404,37 +445,51 @@ namespace Microsoft.CodeAnalysis
             return options;
         }
 
-        private static void ParseSectionOptions(Section section, TreeOptions.Builder treeBuilder, AnalyzerOptions.Builder analyzerBuilder, ArrayBuilder<Diagnostic> diagnosticBuilder, string analyzerConfigPath, ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache)
+        private static bool TryParseDiagnosticId(
+            string key,
+            ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache,
+            [NotNullWhen(true)] out string? diagId)
         {
             const string diagnosticOptionPrefix = "dotnet_diagnostic.";
             const string diagnosticOptionSuffix = ".severity";
 
-            foreach (var (key, value) in section.Properties)
+            // Keys are lowercased in editorconfig parsing
+            int diagIdLength = -1;
+            if (key.StartsWith(diagnosticOptionPrefix, StringComparison.Ordinal) &&
+                key.EndsWith(diagnosticOptionSuffix, StringComparison.Ordinal))
             {
-                // Keys are lowercased in editorconfig parsing
-                int diagIdLength = -1;
-                if (key.StartsWith(diagnosticOptionPrefix, StringComparison.Ordinal) &&
-                    key.EndsWith(diagnosticOptionSuffix, StringComparison.Ordinal))
+                diagIdLength = key.Length - (diagnosticOptionPrefix.Length + diagnosticOptionSuffix.Length);
+            }
+
+            if (diagIdLength >= 0)
+            {
+                ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(diagnosticOptionPrefix.Length, diagIdLength);
+                // PERF: this is similar to a double-checked locking pattern, and trying to fetch the ID first
+                // lets us avoid an allocation if the id has already been added
+                if (!diagIdCache.TryGetValue(idSlice, out diagId))
                 {
-                    diagIdLength = key.Length - (diagnosticOptionPrefix.Length + diagnosticOptionSuffix.Length);
+                    // We use ReadOnlyMemory<char> to allow allocation-free lookups in the
+                    // dictionary, but the actual keys stored in the dictionary are trimmed
+                    // to avoid holding GC references to larger strings than necessary. The
+                    // GetOrAdd APIs do not allow the key to be manipulated between lookup
+                    // and insertion, so we separate the operations here in code.
+                    diagId = idSlice.ToString();
+                    diagId = diagIdCache.GetOrAdd(diagId.AsMemory(), diagId);
                 }
 
-                if (diagIdLength >= 0)
-                {
-                    ReadOnlyMemory<char> idSlice = key.AsMemory().Slice(diagnosticOptionPrefix.Length, diagIdLength);
-                    // PERF: this is similar to a double-checked locking pattern, and trying to fetch the ID first
-                    // lets us avoid an allocation if the id has already been added
-                    if (!diagIdCache.TryGetValue(idSlice, out var diagId))
-                    {
-                        // We use ReadOnlyMemory<char> to allow allocation-free lookups in the
-                        // dictionary, but the actual keys stored in the dictionary are trimmed
-                        // to avoid holding GC references to larger strings than necessary. The
-                        // GetOrAdd APIs do not allow the key to be manipulated between lookup
-                        // and insertion, so we separate the operations here in code.
-                        diagId = idSlice.ToString();
-                        diagId = diagIdCache.GetOrAdd(diagId.AsMemory(), diagId);
-                    }
+                return true;
+            }
 
+            diagId = null;
+            return false;
+        }
+
+        private static void ParseSectionOptions(Section section, TreeOptions.Builder treeBuilder, AnalyzerOptions.Builder analyzerBuilder, ArrayBuilder<Diagnostic> diagnosticBuilder, string analyzerConfigPath, ConcurrentDictionary<ReadOnlyMemory<char>, string> diagIdCache)
+        {
+            foreach (var (key, value) in section.Properties)
+            {
+                if (TryParseDiagnosticId(key, diagIdCache, out var diagId))
+                {
                     if (TryParseSeverity(value, out ReportDiagnostic severity))
                     {
                         treeBuilder[diagId] = severity;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1108,6 +1108,7 @@ namespace Microsoft.CodeAnalysis
                         analyzers,
                         analyzerOptions,
                         new AnalyzerManager(analyzers),
+                        analyzerConfigSet,
                         analyzerExceptionDiagnostics.Add,
                         Arguments.ReportAnalyzer,
                         severityFilter,

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -19,6 +20,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private static string GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(string category)
             => $"{DotnetAnalyzerDiagnosticPrefix}.{CategoryPrefix}-{category}.{SeveritySuffix}";
+
+        public static bool HasSeverityBulkConfigurationEntry(ImmutableHashSet<string> entries, string category)
+        {
+            var categoryBasedEntry = GetCategoryBasedDotnetAnalyzerDiagnosticSeverityKey(category);
+            return entries.Contains(categoryBasedEntry) || entries.Contains(DotnetAnalyzerDiagnosticSeverityKey);
+        }
 
         /// <summary>
         /// Tries to get configured severity for the given <paramref name="descriptor"/>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -1084,7 +1084,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken>? wrappedOnAnalyzerException =
                 onAnalyzerException == null ? null : (ex, analyzer, diagnostic, _) => onAnalyzerException(ex, analyzer, diagnostic);
             var analyzerExecutor = AnalyzerExecutor.CreateForSupportedDiagnostics(wrappedOnAnalyzerException, analyzerManager);
-            return AnalyzerDriver.IsDiagnosticAnalyzerSuppressed(analyzer, options, analyzerManager, analyzerExecutor, analysisScope: null, severityFilter: SeverityFilter.None, CancellationToken.None);
+            return AnalyzerDriver.IsDiagnosticAnalyzerSuppressed(analyzer, options, analyzerManager, analyzerExecutor, analysisScope: null, analyzerConfigSet: null, severityFilter: SeverityFilter.None, CancellationToken.None);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzersOptions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzersOptions.cs
@@ -11,42 +11,40 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     public sealed class CompilationWithAnalyzersOptions
     {
-        private readonly AnalyzerOptions? _options;
-        private readonly Action<Exception, DiagnosticAnalyzer, Diagnostic>? _onAnalyzerException;
-        private readonly Func<Exception, bool>? _analyzerExceptionFilter;
-        private readonly bool _concurrentAnalysis;
-        private readonly bool _logAnalyzerExecutionTime;
-        private readonly bool _reportSuppressedDiagnostics;
-
         /// <summary>
         /// Options passed to <see cref="DiagnosticAnalyzer"/>s.
         /// </summary>
-        public AnalyzerOptions? Options => _options;
+        public AnalyzerOptions? Options { get; }
 
         /// <summary>
         /// An optional delegate to be invoked when an analyzer throws an exception.
         /// </summary>
-        public Action<Exception, DiagnosticAnalyzer, Diagnostic>? OnAnalyzerException => _onAnalyzerException;
+        public Action<Exception, DiagnosticAnalyzer, Diagnostic>? OnAnalyzerException { get; }
 
         /// <summary>
         /// An optional delegate to be invoked when an analyzer throws an exception as an exception filter.
         /// </summary>
-        public Func<Exception, bool>? AnalyzerExceptionFilter => _analyzerExceptionFilter;
+        public Func<Exception, bool>? AnalyzerExceptionFilter { get; }
 
         /// <summary>
         /// Flag indicating whether analysis can be performed concurrently on multiple threads.
         /// </summary>
-        public bool ConcurrentAnalysis => _concurrentAnalysis;
+        public bool ConcurrentAnalysis { get; }
 
         /// <summary>
         /// Flag indicating whether analyzer execution time should be logged.
         /// </summary>
-        public bool LogAnalyzerExecutionTime => _logAnalyzerExecutionTime;
+        public bool LogAnalyzerExecutionTime { get; }
 
         /// <summary>
         /// Flag indicating whether analyzer diagnostics with <see cref="Diagnostic.IsSuppressed"/> should be reported.
         /// </summary>
-        public bool ReportSuppressedDiagnostics => _reportSuppressedDiagnostics;
+        public bool ReportSuppressedDiagnostics { get; }
+
+        /// <summary>
+        /// Optional <see cref="AnalyzerConfigSet"/> from which the analyzer <see cref="Options"/> were computed.
+        /// </summary>
+        public AnalyzerConfigSet? AnalyzerConfigSet { get; }
 
         /// <summary>
         /// Creates a new <see cref="CompilationWithAnalyzersOptions"/>.
@@ -98,13 +96,36 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool logAnalyzerExecutionTime,
             bool reportSuppressedDiagnostics,
             Func<Exception, bool>? analyzerExceptionFilter)
+            : this(options, onAnalyzerException, concurrentAnalysis, logAnalyzerExecutionTime, reportSuppressedDiagnostics, analyzerExceptionFilter, analyzerConfigSet: null)
         {
-            _options = options;
-            _onAnalyzerException = onAnalyzerException;
-            _analyzerExceptionFilter = analyzerExceptionFilter;
-            _concurrentAnalysis = concurrentAnalysis;
-            _logAnalyzerExecutionTime = logAnalyzerExecutionTime;
-            _reportSuppressedDiagnostics = reportSuppressedDiagnostics;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="CompilationWithAnalyzersOptions"/>.
+        /// </summary>
+        /// <param name="options">Options that are passed to analyzers.</param>
+        /// <param name="onAnalyzerException">Action to invoke if an analyzer throws an exception.</param>
+        /// <param name="analyzerExceptionFilter">Action to invoke if an analyzer throws an exception as an exception filter.</param>
+        /// <param name="concurrentAnalysis">Flag indicating whether analysis can be performed concurrently on multiple threads.</param>
+        /// <param name="logAnalyzerExecutionTime">Flag indicating whether analyzer execution time should be logged.</param>
+        /// <param name="reportSuppressedDiagnostics">Flag indicating whether analyzer diagnostics with <see cref="Diagnostic.IsSuppressed"/> should be reported.</param>
+        /// <param name="analyzerConfigSet">Optional <see cref="AnalyzerConfigSet"/> from which the <paramref name="options"/> were computed.</param>
+        public CompilationWithAnalyzersOptions(
+            AnalyzerOptions? options,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic>? onAnalyzerException,
+            bool concurrentAnalysis,
+            bool logAnalyzerExecutionTime,
+            bool reportSuppressedDiagnostics,
+            Func<Exception, bool>? analyzerExceptionFilter,
+            AnalyzerConfigSet? analyzerConfigSet)
+        {
+            Options = options;
+            OnAnalyzerException = onAnalyzerException;
+            AnalyzerExceptionFilter = analyzerExceptionFilter;
+            ConcurrentAnalysis = concurrentAnalysis;
+            LogAnalyzerExecutionTime = logAnalyzerExecutionTime;
+            ReportSuppressedDiagnostics = reportSuppressedDiagnostics;
+            AnalyzerConfigSet = analyzerConfigSet;
         }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 *REMOVED*static Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode>.implicit operator Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode!>(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SeparatedSyntaxList<TNode!>
 *REMOVED*static Microsoft.CodeAnalysis.SyntaxList<TNode>.implicit operator Microsoft.CodeAnalysis.SyntaxList<TNode!>(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.SyntaxNode!> nodes) -> Microsoft.CodeAnalysis.SyntaxList<TNode!>
 Microsoft.CodeAnalysis.Compilation.SupportsRuntimeCapability(Microsoft.CodeAnalysis.RuntimeCapability capability) -> bool
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzersOptions.AnalyzerConfigSet.get -> Microsoft.CodeAnalysis.AnalyzerConfigSet?
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzersOptions.CompilationWithAnalyzersOptions(Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions? options, System.Action<System.Exception!, Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer!, Microsoft.CodeAnalysis.Diagnostic!>? onAnalyzerException, bool concurrentAnalysis, bool logAnalyzerExecutionTime, bool reportSuppressedDiagnostics, System.Func<System.Exception!, bool>? analyzerExceptionFilter, Microsoft.CodeAnalysis.AnalyzerConfigSet? analyzerConfigSet) -> void
 Microsoft.CodeAnalysis.Emit.MethodInstrumentation
 Microsoft.CodeAnalysis.Emit.MethodInstrumentation.Kinds.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind>
 Microsoft.CodeAnalysis.Emit.MethodInstrumentation.Kinds.init -> void

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             var analyzerManager = new AnalyzerManager(analyzersArray);
-            var driver = AnalyzerDriver.CreateAndAttachToCompilation(c, analyzersArray, options, analyzerManager, onAnalyzerException,
+            var driver = AnalyzerDriver.CreateAndAttachToCompilation(c, analyzersArray, options, analyzerManager, analyzerConfigSet: null, onAnalyzerException,
                 analyzerExceptionFilter: null, reportAnalyzer: false, severityFilter: SeverityFilter.None, trackSuppressedDiagnosticIds: false,
                 out var newCompilation, cancellationToken);
             Debug.Assert(newCompilation.SemanticModelProvider != null);

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
@@ -154,6 +154,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Contract.ThrowIfFalse(project.SupportsCompilation);
             AssertCompilation(project, compilation);
 
+            var analyzerConfigSet = await project.State.GetAnalyzerConfigSetAsync(cancellationToken).ConfigureAwait(false);
+
             // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
             // async being used with synchronous blocking concurrency.
             var analyzerOptions = new CompilationWithAnalyzersOptions(
@@ -162,7 +164,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 analyzerExceptionFilter: GetAnalyzerExceptionFilter(),
                 concurrentAnalysis: false,
                 logAnalyzerExecutionTime: true,
-                reportSuppressedDiagnostics: includeSuppressedDiagnostics);
+                reportSuppressedDiagnostics: includeSuppressedDiagnostics,
+                analyzerConfigSet: analyzerConfigSet);
 
             // Create driver that holds onto compilation and associated analyzers
             return compilation.WithAnalyzers(filteredAnalyzers, analyzerOptions);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -249,6 +249,12 @@ namespace Microsoft.CodeAnalysis
                 additionalFiles: AdditionalDocumentStates.SelectAsArray(static documentState => documentState.AdditionalText),
                 optionsProvider: new ProjectAnalyzerConfigOptionsProvider(this));
 
+        public async Task<AnalyzerConfigSet> GetAnalyzerConfigSetAsync(CancellationToken cancellationToken)
+        {
+            var cache = await _lazyAnalyzerConfigOptions.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            return cache.AnalyzerConfigSet;
+        }
+
         public async Task<AnalyzerConfigData> GetAnalyzerOptionsForPathAsync(string path, CancellationToken cancellationToken)
         {
             var cache = await _lazyAnalyzerConfigOptions.GetValueAsync(cancellationToken).ConfigureAwait(false);
@@ -501,9 +507,12 @@ namespace Microsoft.CodeAnalysis
 
             public AnalyzerConfigOptionsCache(AnalyzerConfigSet configSet)
             {
+                AnalyzerConfigSet = configSet;
                 _global = new Lazy<AnalyzerConfigData>(() => new AnalyzerConfigData(configSet.GlobalConfigOptions));
                 _computeFunction = path => new AnalyzerConfigData(configSet.GetOptionsForSourcePath(path));
             }
+
+            public AnalyzerConfigSet AnalyzerConfigSet { get; }
 
             public AnalyzerConfigData GlobalConfigOptions
                 => _global.Value;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -541,6 +541,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             // faster
             compilation = compilation.WithOptions(compilation.Options.WithConcurrentBuild(concurrentAnalysis));
 
+            var analyzerConfigSet = await _project.State.GetAnalyzerConfigSetAsync(cancellationToken).ConfigureAwait(false);
+
             // Run analyzers concurrently, with performance logging and reporting suppressed diagnostics.
             // This allows all client requests with or without performance data and/or suppressed diagnostics to be satisfied.
             // TODO: can we support analyzerExceptionFilter in remote host? 
@@ -551,7 +553,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 analyzerExceptionFilter: null,
                 concurrentAnalysis: concurrentAnalysis,
                 logAnalyzerExecutionTime: true,
-                reportSuppressedDiagnostics: true);
+                reportSuppressedDiagnostics: true,
+                analyzerConfigSet: analyzerConfigSet);
 
             return compilation.WithAnalyzers(analyzers, analyzerOptions);
         }


### PR DESCRIPTION
Fixes [AB#1799782](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1799782). This fixes a long outstanding performance issue for CodeCleanup as well as command line builds.

Related to #67959

`AnalyzerConfigSet` now maintains a set of all unique option keys and configured diagnostic IDs. These keys enable us to do a fast check in `IsDiagnosticAnalyzerSuppressed` to see if a diagnostic ID is never configured in an editorconfig/globalconfig in the entire `AnalyzerConfigSet` for the compilation. The slow path walks all the config files for each tree to determine if there is any entry which enables/unsuppresses the diagnostic ID.

**Public API change:** Add a new ctor overload and property to `CompilationWithAnalyzersOptions` to thread in the `AnalyzerConfigSet` into the analyzer driver