### PR TITLE
Include `ExternalAccess.RazorCompiler` in source build

### DIFF
--- a/src/Tools/ExternalAccess/RazorCompiler/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj
+++ b/src/Tools/ExternalAccess/RazorCompiler/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj
@@ -5,6 +5,9 @@
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
 
+    <!-- Used by Razor source generator which is included in source build. -->
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler</PackageId>


### PR DESCRIPTION
The project will be used by Razor source generator which is source-built, hence this project also needs to be source-built. See https://github.com/dotnet/razor/pull/8242#discussion_r1177578512.