### PR TITLE
Use optimized hash creation methods on .NET 5+

### DIFF
--- a/src/Workspaces/CoreTest/ChecksumTests.cs
+++ b/src/Workspaces/CoreTest/ChecksumTests.cs
@@ -2,35 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class ChecksumTests
     {
-#if NET
         [Fact]
         public void ValidateChecksumFromSpanSameAsChecksumFromBytes1()
         {
             var checksum1 = Checksum.Create("Goo");
             var checksum2 = Checksum.Create("Bar");
 
-            var checksumA = Checksum.TestAccessor.CreateUsingByteArrays(checksum1, checksum2);
-            var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2);
+            var checksumA = Checksum.Create(checksum1, checksum2);
 
-            Assert.Equal(checksumA, checksumB);
+            // Running this test on multiple target frameworks with the same expectation ensures the results match
+            Assert.Equal(Checksum.FromBase64String("N30m5jwVeMZzWpy9cbQbtSYHoXU="), checksumA);
 
             Assert.NotEqual(checksum1, checksum2);
-
             Assert.NotEqual(checksum1, checksumA);
-            Assert.NotEqual(checksum1, checksumB);
             Assert.NotEqual(checksum2, checksumA);
-            Assert.NotEqual(checksum2, checksumB);
         }
 
         [Fact]
@@ -40,22 +31,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var checksum2 = Checksum.Create("Bar");
             var checksum3 = Checksum.Create("Baz");
 
-            var checksumA = Checksum.TestAccessor.CreateUsingByteArrays(checksum1, checksum2, checksum3);
-            var checksumB = Checksum.TestAccessor.CreateUsingSpans(checksum1, checksum2, checksum3);
+            var checksumA = Checksum.Create(checksum1, checksum2, checksum3);
 
-            Assert.Equal(checksumA, checksumB);
+            // Running this test on multiple target frameworks with the same expectation ensures the results match
+            Assert.Equal(Checksum.FromBase64String("NEfIznmqkIqi4VJl12KxycWt7uo="), checksumA);
 
             Assert.NotEqual(checksum1, checksum2);
             Assert.NotEqual(checksum2, checksum3);
             Assert.NotEqual(checksum3, checksum1);
 
             Assert.NotEqual(checksum1, checksumA);
-            Assert.NotEqual(checksum1, checksumB);
             Assert.NotEqual(checksum2, checksumA);
-            Assert.NotEqual(checksum2, checksumB);
             Assert.NotEqual(checksum3, checksumA);
-            Assert.NotEqual(checksum3, checksumB);
         }
-#endif
     }
 }


### PR DESCRIPTION
Implements the changes suggested in https://github.com/dotnet/roslyn/issues/67995#issuecomment-1525781878

Review commit-by-commit highly recommended.

Supersedes #67998
Fixes #67995