### PR TITLE
Filter out EnableNullable code actions 

### DIFF
--- a/src/Features/CSharp/Portable/CodeRefactorings/EnableNullable/EnableNullableCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/EnableNullable/EnableNullableCodeRefactoringProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -11,9 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.EnableNullable
@@ -257,6 +256,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.EnableNullable
         private sealed class CustomCodeAction : CodeAction.SolutionChangeAction
         {
             private readonly Func<CodeActionPurpose, CancellationToken, Task<Solution>> _createChangedSolution;
+
+            // This code action might need to check the project file.
+            // Tracked issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1810443
+            public override ImmutableArray<string> Tags => RequiresNonDocumentChangeTags;
 
             public CustomCodeAction(Func<CodeActionPurpose, CancellationToken, Task<Solution>> createChangedSolution)
                 : base(

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                     var currentSetNumber = ++currentHighestSetNumber;
                     foreach (var suggestedAction in set.Actions)
                     {
-                        if (!IsCodeActionNotSupportedByLSP(suggestedAction))
+                        if (!IsCodeActionNotSupportedByVSLsp(suggestedAction))
                         {
                             codeActions.Add(GenerateVSCodeAction(
                                 request, documentText,
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                 {
                     foreach (var suggestedAction in set.Actions)
                     {
-                        if (!IsCodeActionNotSupportedByLSP(suggestedAction))
+                        if (!IsCodeActionNotSupportedByStandardLsp(suggestedAction))
                         {
                             codeActions.AddRange(GenerateCodeActions(
                                 request,
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                 {
                     foreach (var action in actionSet.Actions)
                     {
-                        if (IsCodeActionNotSupportedByLSP(action))
+                        if (!IsCodeActionNotSupportedByStandardLsp(action))
                         {
                             builder.AddRange(GenerateCodeActions(
                                 request,

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
@@ -13,13 +13,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 {
     internal static partial class CodeActionHelpers
     {
-        private static readonly ImmutableArray<string> s_notSupportFixerAndRefactoringProviderNames = ImmutableArray.Create(
-            // Extract method requires inline rename support, not supported by lsp.
-            PredefinedCodeRefactoringProviderNames.ExtractMethod,
-            // There is no good way to modify the project file in lsp server.
-            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1810443
-            PredefinedCodeRefactoringProviderNames.EnableNullable);
-
         /// <summary>
         /// Indicate If code action is supported by standard LSP.
         /// </summary>
@@ -41,8 +34,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
             return originalCodeAction is CodeActionWithOptions
                 // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
                 // https://github.com/dotnet/roslyn/issues/48698
-                || originalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
-                || s_notSupportFixerAndRefactoringProviderNames.Any(originalCodeAction.CustomTags.Contains);
+                || originalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
@@ -16,20 +16,33 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
         private static readonly ImmutableArray<string> s_notSupportFixerAndRefactoringProviderNames = ImmutableArray.Create(
             // Extract method requires inline rename support, not supported by lsp.
             PredefinedCodeRefactoringProviderNames.ExtractMethod,
+            // There is no good way to modify the project file in lsp server.
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1810443
             PredefinedCodeRefactoringProviderNames.EnableNullable);
 
-        private static bool IsCodeActionNotSupportedByLSP(IUnifiedSuggestedAction suggestedAction)
+        /// <summary>
+        /// Indicate If code action is supported by standard LSP.
+        /// </summary>
+        private static bool IsCodeActionNotSupportedByStandardLsp(IUnifiedSuggestedAction suggestedAction)
+        {
+            return IsCodeActionNotSupportedByVSLsp(suggestedAction)
+                // Filter the configure and suppress fixer if it is not VS LSP, because it would generate many nested code actions.
+                // Tracking issue: https://github.com/microsoft/language-server-protocol/issues/994 
+                || suggestedAction.OriginalCodeAction is AbstractConfigurationActionWithNestedActions;
+        }
+
+        /// <summary>
+        /// Indicate If code action is supported by VS LSP, which is a superset of the standard LSP.
+        /// </summary>
+        private static bool IsCodeActionNotSupportedByVSLsp(IUnifiedSuggestedAction suggestedAction)
         {
             var originalCodeAction = suggestedAction.OriginalCodeAction;
             // Filter out code actions with options since they'll show dialogs and we can't remote the UI and the options.
             return originalCodeAction is CodeActionWithOptions
-            // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
-            // https://github.com/dotnet/roslyn/issues/48698
-            || originalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
-            // Filter the configure and suppress fixer if it is not VS LSP, because it would generate many nested code actions.
-            // Tracking issue: https://github.com/microsoft/language-server-protocol/issues/994 
-            || originalCodeAction is AbstractConfigurationActionWithNestedActions
-            || s_notSupportFixerAndRefactoringProviderNames.Any(originalCodeAction.CustomTags.Contains);
+                // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
+                // https://github.com/dotnet/roslyn/issues/48698
+                || originalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
+                || s_notSupportFixerAndRefactoringProviderNames.Any(originalCodeAction.CustomTags.Contains);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
@@ -2,24 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.UnifiedSuggestions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 {
     internal static partial class CodeActionHelpers
     {
+        private static readonly ImmutableArray<string> s_notSupportFixerAndRefactoringProviderNames = ImmutableArray.Create(
+            // Extract method requires inline rename support, not supported by lsp.
+            PredefinedCodeRefactoringProviderNames.ExtractMethod,
+            PredefinedCodeRefactoringProviderNames.EnableNullable);
+
         private static bool IsCodeActionNotSupportedByLSP(IUnifiedSuggestedAction suggestedAction)
         {
+            var originalCodeAction = suggestedAction.OriginalCodeAction;
             // Filter out code actions with options since they'll show dialogs and we can't remote the UI and the options.
-            return suggestedAction.OriginalCodeAction is CodeActionWithOptions
+            return originalCodeAction is CodeActionWithOptions
             // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
             // https://github.com/dotnet/roslyn/issues/48698
-            || suggestedAction.OriginalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
+            || originalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
             // Filter the configure and suppress fixer if it is not VS LSP, because it would generate many nested code actions.
             // Tracking issue: https://github.com/microsoft/language-server-protocol/issues/994 
-            || suggestedAction.OriginalCodeAction is AbstractConfigurationActionWithNestedActions;
+            || originalCodeAction is AbstractConfigurationActionWithNestedActions
+            || s_notSupportFixerAndRefactoringProviderNames.Any(originalCodeAction.CustomTags.Contains);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers_UnsupportedCodeActions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.UnifiedSuggestions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
+{
+    internal static partial class CodeActionHelpers
+    {
+        private static bool IsCodeActionNotSupportedByLSP(IUnifiedSuggestedAction suggestedAction)
+        {
+            // Filter out code actions with options since they'll show dialogs and we can't remote the UI and the options.
+            return suggestedAction.OriginalCodeAction is CodeActionWithOptions
+            // Skip code actions that requires non-document changes.  We can't apply them in LSP currently.
+            // https://github.com/dotnet/roslyn/issues/48698
+            || suggestedAction.OriginalCodeAction.Tags.Contains(CodeAction.RequiresNonDocumentChange)
+            // Filter the configure and suppress fixer if it is not VS LSP, because it would generate many nested code actions.
+            // Tracking issue: https://github.com/microsoft/language-server-protocol/issues/994 
+            || suggestedAction.OriginalCodeAction is AbstractConfigurationActionWithNestedActions;
+        }
+    }
+}


### PR DESCRIPTION
Two changes in the PR.
1. Filter out `EnableNullableCodeRefactoringProvider` (because there is no good way now to modify the csproj file now from the LSP server) ~~and `ExtractMethodCodeRefactoringProvider` (it needs inline renaming by design, something is not supported in LSP)~~
2. I refactor the NotSupported functions and put them in a separate file, it would help when we onboard more fixer/refactoringProvider to the list.

🙂I don't know if we should modify the CodeFixService and CodeRefactoringService internally to support this, it might just be a temporary solution since we might push to enable these in future. 