### PR TITLE
Use client languageId when file path is ambiguous

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -475,13 +475,14 @@ namespace Roslyn.Test.Utilities
             };
         }
 
-        private static LSP.DidOpenTextDocumentParams CreateDidOpenTextDocumentParams(Uri uri, string source)
+        private static LSP.DidOpenTextDocumentParams CreateDidOpenTextDocumentParams(Uri uri, string source, string languageId = "")
             => new LSP.DidOpenTextDocumentParams
             {
                 TextDocument = new LSP.TextDocumentItem
                 {
                     Text = source,
-                    Uri = uri
+                    Uri = uri,
+                    LanguageId = languageId
                 }
             };
 
@@ -610,7 +611,7 @@ namespace Roslyn.Test.Utilities
                 return result;
             }
 
-            public async Task OpenDocumentAsync(Uri documentUri, string? text = null)
+            public async Task OpenDocumentAsync(Uri documentUri, string? text = null, string languageId = "")
             {
                 if (text == null)
                 {
@@ -620,7 +621,7 @@ namespace Roslyn.Test.Utilities
                     text = sourceText.ToString();
                 }
 
-                var didOpenParams = CreateDidOpenTextDocumentParams(documentUri, text.ToString());
+                var didOpenParams = CreateDidOpenTextDocumentParams(documentUri, text.ToString(), languageId);
                 await ExecuteRequestAsync<LSP.DidOpenTextDocumentParams, object>(LSP.Methods.TextDocumentDidOpenName, didOpenParams, CancellationToken.None);
             }
 
@@ -693,7 +694,7 @@ namespace Roslyn.Test.Utilities
 
             internal T GetRequiredLspService<T>() where T : class, ILspService => LanguageServer.GetTestAccessor().GetRequiredLspService<T>();
 
-            internal ImmutableArray<SourceText> GetTrackedTexts() => GetManager().GetTrackedLspText().Values.ToImmutableArray();
+            internal ImmutableArray<SourceText> GetTrackedTexts() => GetManager().GetTrackedLspText().Values.Select(v => v.Text).ToImmutableArray();
 
             public async ValueTask DisposeAsync()
             {

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -73,14 +73,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public static ImmutableArray<DocumentId> GetDocumentIds(this Solution solution, Uri documentUri)
         {
-            // TODO: we need to normalize this. but for now, we check both absolute and local path
-            //       right now, based on who calls this, solution might has "/" or "\\" as directory
-            //       separator
+            // This logic needs to be cleaned up when we support URIs as a first class concept.
+            // For now we do our best to handle as many cases as we can.
+            // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
+
             var documentIds = solution.GetDocumentIdsWithFilePath(documentUri.AbsolutePath);
             if (documentIds.Any())
                 return documentIds;
 
-            return solution.GetDocumentIdsWithFilePath(documentUri.LocalPath);
+            documentIds = solution.GetDocumentIdsWithFilePath(documentUri.LocalPath);
+            if (documentIds.Any())
+                return documentIds;
+
+            documentIds = solution.GetDocumentIdsWithFilePath(documentUri.OriginalString);
+            return documentIds;
         }
 
         public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier)

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Features.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Indentation;

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -13,10 +12,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Features.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.NavigateTo;

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
             // Create SourceText from binary representation of the document, retrieve encoding from the request and checksum algorithm from the project.
             var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8, SourceHashAlgorithms.OpenDocumentChecksumAlgorithm);
 
-            await context.StartTrackingAsync(request.TextDocument.Uri, sourceText, cancellationToken).ConfigureAwait(false);
+            await context.StartTrackingAsync(request.TextDocument.Uri, sourceText, request.TextDocument.LanguageId, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
@@ -5,8 +5,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Features.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
@@ -16,14 +18,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 /// </summary>
 internal interface IDocumentChangeTracker
 {
-    ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, CancellationToken cancellationToken);
+    ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, string languageId, CancellationToken cancellationToken);
     void UpdateTrackedDocument(Uri documentUri, SourceText text);
     ValueTask StopTrackingAsync(Uri documentUri, CancellationToken cancellationToken);
 }
 
 internal class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
 {
-    public ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, CancellationToken cancellationToken)
+    public ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, string languageId, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
@@ -53,20 +53,30 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// Calls to this method and <see cref="TryRemoveMiscellaneousDocument(Uri)"/> are made
         /// from LSP text sync request handling which do not run concurrently.
         /// </summary>
-        public Document? AddMiscellaneousDocument(Uri uri, SourceText documentText, ILspLogger logger)
+        public Document? AddMiscellaneousDocument(Uri uri, SourceText documentText, string languageId, ILspLogger logger)
         {
-            var uriAbsolutePath = uri.AbsolutePath;
-            if (!s_extensionToLanguageInformation.TryGetValue(Path.GetExtension(uriAbsolutePath), out var languageInformation))
+            // If we have a file:///xyz URI, we'll store the actual file path string in the document file path.
+            // Otherwise we have a URI that doesn't point to an actual file.  In such a scenario, we'll store the full URI string (including schema).
+            // This will allow correct round-tripping of the URI for features that need it until we support URI as a first class document concept.
+            // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
+            var documentFilePath = uri.OriginalString;
+            if (uri.IsFile)
+            {
+                documentFilePath = uri.LocalPath;
+            }
+
+            var languageInformation = GetLanguageInformation(documentFilePath, languageId);
+            if (languageInformation == null)
             {
                 // Only log here since throwing here could take down the LSP server.
-                logger.LogError($"Could not find language information for {uri} with absolute path {uriAbsolutePath}");
+                logger.LogError($"Could not find language information for {uri} with absolute path {documentFilePath}");
                 return null;
             }
 
-            var sourceTextLoader = new SourceTextLoader(documentText, uriAbsolutePath);
+            var sourceTextLoader = new SourceTextLoader(documentText, documentFilePath);
 
             var projectInfo = MiscellaneousFileUtilities.CreateMiscellaneousProjectInfoForDocument(
-                this, uri.AbsolutePath, sourceTextLoader, languageInformation, documentText.ChecksumAlgorithm, Services.SolutionServices, ImmutableArray<MetadataReference>.Empty);
+                this, documentFilePath, sourceTextLoader, languageInformation, documentText.ChecksumAlgorithm, Services.SolutionServices, ImmutableArray<MetadataReference>.Empty);
             OnProjectAdded(projectInfo);
 
             var id = projectInfo.Documents.Single().Id;
@@ -76,15 +86,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// <summary>
         /// Removes a document with the matching file path from this workspace.
         /// 
-        /// Calls to this method and <see cref="AddMiscellaneousDocument(Uri, SourceText, ILspLogger)"/> are made
+        /// Calls to this method and <see cref="AddMiscellaneousDocument(Uri, SourceText, string, ILspLogger)"/> are made
         /// from LSP text sync request handling which do not run concurrently.
         /// </summary>
         public void TryRemoveMiscellaneousDocument(Uri uri)
         {
-            var uriAbsolutePath = uri.AbsolutePath;
-
-            // We only add misc files to this workspace using the absolute file path.
-            var matchingDocument = CurrentSolution.GetDocumentIdsWithFilePath(uriAbsolutePath).SingleOrDefault();
+            // We'll only ever have a single document matching this URI in the misc solution.
+            var matchingDocument = CurrentSolution.GetDocumentIds(uri).SingleOrDefault();
             if (matchingDocument != null)
             {
                 OnDocumentRemoved(matchingDocument);
@@ -100,6 +108,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         {
             this.OnDocumentTextChanged(documentId, sourceText, PreservationMode.PreserveIdentity, requireDocumentPresent: false);
             return ValueTaskFactory.CompletedTask;
+        }
+
+        private static LanguageInformation? GetLanguageInformation(string documentPath, string languageId)
+        {
+            if (s_extensionToLanguageInformation.TryGetValue(Path.GetExtension(documentPath), out var languageInformation))
+            {
+                return languageInformation;
+            }
+
+            // It is totally possible to not find language based on the file path (e.g. a newly created file that hasn't been saved to disk).
+            // In that case, we use the languageId that the client gave us.
+            return languageId switch
+            {
+                "csharp" => s_csharpLanguageInformation,
+                "vb" => s_vbLanguageInformation,
+                _ => null,
+            };
         }
 
         private sealed class SourceTextLoader : TextLoader

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspMiscellaneousFilesWorkspace.cs
@@ -59,11 +59,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // Otherwise we have a URI that doesn't point to an actual file.  In such a scenario, we'll store the full URI string (including schema).
             // This will allow correct round-tripping of the URI for features that need it until we support URI as a first class document concept.
             // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
-            var documentFilePath = uri.OriginalString;
-            if (uri.IsFile)
-            {
-                documentFilePath = uri.LocalPath;
-            }
+            var documentFilePath = uri.IsFile ? uri.LocalPath : uri.OriginalString;
 
             var languageInformation = GetLanguageInformation(documentFilePath, languageId);
             if (languageInformation == null)

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Features.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -61,7 +62,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// the URI.
     /// <para/> Access to this is guaranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    private ImmutableDictionary<Uri, SourceText> _trackedDocuments = ImmutableDictionary<Uri, SourceText>.Empty;
+    private ImmutableDictionary<Uri, (SourceText Text, string LanguageId)> _trackedDocuments = ImmutableDictionary<Uri, (SourceText, string)>.Empty;
 
     private readonly ILspLogger _logger;
     private readonly LspMiscellaneousFilesWorkspace? _lspMiscellaneousFilesWorkspace;
@@ -99,11 +100,11 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// 
     /// <see cref="DidOpenHandler.MutatesSolutionState"/> is true which means this runs serially in the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    public async ValueTask StartTrackingAsync(Uri uri, SourceText documentText, CancellationToken cancellationToken)
+    public async ValueTask StartTrackingAsync(Uri uri, SourceText documentText, string languageId, CancellationToken cancellationToken)
     {
         // First, store the LSP view of the text as the uri is now owned by the LSP client.
         Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(uri), $"didOpen received for {uri} which is already open.");
-        _trackedDocuments = _trackedDocuments.Add(uri, documentText);
+        _trackedDocuments = _trackedDocuments.Add(uri, (documentText, languageId));
 
         // If LSP changed, we need to compare against the workspace again to get the updated solution.
         _cachedLspSolutions.Clear();
@@ -172,7 +173,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     {
         // Store the updated LSP view of the source text.
         Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didChange received for {uri} which is not open.");
-        _trackedDocuments = _trackedDocuments.SetItem(uri, newSourceText);
+        var (_, language) = _trackedDocuments[uri];
+        _trackedDocuments = _trackedDocuments.SetItem(uri, (newSourceText, language));
 
         // If LSP changed, we need to compare against the workspace again to get the updated solution.
         _cachedLspSolutions.Clear();
@@ -180,7 +182,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         LspTextChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    public ImmutableDictionary<Uri, SourceText> GetTrackedLspText() => _trackedDocuments;
+    public ImmutableDictionary<Uri, (SourceText Text, string LanguageId)> GetTrackedLspText() => _trackedDocuments;
 
     #endregion
 
@@ -247,9 +249,9 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
         // Add the document to our loose files workspace (if we have one) if it iss open.
-        if (_trackedDocuments.TryGetValue(uri, out var trackedText))
+        if (_trackedDocuments.TryGetValue(uri, out var trackedDocument))
         {
-            var miscDocument = _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, trackedText, _logger);
+            var miscDocument = _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, trackedDocument.Text, trackedDocument.LanguageId, _logger);
             if (miscDocument is not null)
                 return (_lspMiscellaneousFilesWorkspace, miscDocument.Project.Solution, miscDocument);
         }
@@ -340,7 +342,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             // Step 5: Fork a new solution from the workspace with the LSP text applied.
             var lspSolution = workspaceCurrentSolution;
             foreach (var (uri, workspaceDocuments) in documentsInWorkspace)
-                lspSolution = lspSolution.WithDocumentText(workspaceDocuments.Select(d => d.Id), _trackedDocuments[uri]);
+                lspSolution = lspSolution.WithDocumentText(workspaceDocuments.Select(d => d.Id), _trackedDocuments[uri].Text);
 
             // Remember this forked solution and the workspace version it was forked from.
             _cachedLspSolutions[workspace] = (workspaceCurrentSolution.WorkspaceVersion, lspSolution);
@@ -349,7 +351,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 
         async ValueTask TryOpenAndEditDocumentsInMutatingWorkspaceAsync(Workspace workspace)
         {
-            foreach (var (uri, sourceText) in _trackedDocuments)
+            foreach (var (uri, (sourceText, _)) in _trackedDocuments)
             {
                 await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, async (mutatingWorkspace, documentId) =>
                 {
@@ -382,7 +384,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         {
             // We're comparing text, so we can take any of the linked documents.
             var firstDocument = documentsForUri.First();
-            var isTextEquivalent = await AreChecksumsEqualAsync(firstDocument, _trackedDocuments[uriInWorkspace], cancellationToken).ConfigureAwait(false);
+            var isTextEquivalent = await AreChecksumsEqualAsync(firstDocument, _trackedDocuments[uriInWorkspace].Text, cancellationToken).ConfigureAwait(false);
 
             if (!isTextEquivalent)
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+public class UriTests : AbstractLanguageServerProtocolTests
+{
+    public UriTests(ITestOutputHelper? testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestMiscDocument_WithFileScheme(bool mutatingLspWorkspace)
+    {
+        var source =
+@"class A
+{
+    void M()
+    {
+    }
+}";
+
+        // Create a server that supports LSP misc files and verify no misc files present.
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Open an empty loose file with a file URI.
+        var filePath = @"C:\Users\user\someFile.txt";
+        var looseFileUri = new Uri(filePath, UriKind.Absolute);
+        await testLspServer.OpenDocumentAsync(looseFileUri, source, languageId: "csharp").ConfigureAwait(false);
+
+        // Verify file is added to the misc file workspace.
+        var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = looseFileUri }, CancellationToken.None);
+        Assert.True(workspace is LspMiscellaneousFilesWorkspace);
+        AssertEx.NotNull(document);
+        Assert.Equal(looseFileUri, document.GetURI());
+        Assert.Equal(filePath, document.FilePath);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestMiscDocument_WithOtherScheme(bool mutatingLspWorkspace)
+    {
+        var source =
+@"class A
+{
+    void M()
+    {
+    }
+}";
+
+        // Create a server that supports LSP misc files and verify no misc files present.
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        // Open an empty loose file that hasn't been saved with a name.
+        var looseFileUri = new Uri(@"untitled:untitledFile", UriKind.Absolute);
+        await testLspServer.OpenDocumentAsync(looseFileUri, source, languageId: "csharp").ConfigureAwait(false);
+
+        // Verify file is added to the misc file workspace.
+        var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = looseFileUri }, CancellationToken.None);
+        Assert.True(workspace is LspMiscellaneousFilesWorkspace);
+        AssertEx.NotNull(document);
+        Assert.Equal(looseFileUri, document.GetURI());
+        Assert.Equal(looseFileUri.OriginalString, document.FilePath);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestWorkspaceDocument_WithFileScheme(bool mutatingLspWorkspace)
+    {
+        var documentFilePath = @"C:\A.cs";
+        var markup =
+@$"<Workspace>
+    <Project Language=""C#"" Name=""CSProj1"" CommonReferences=""true"" FilePath=""C:\CSProj1.csproj"">
+        <Document FilePath=""{documentFilePath}"">
+            public class A
+            {{
+            }}
+        </Document>
+    </Project>
+</Workspace>";
+        await using var testLspServer = await CreateXmlTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var workspaceDocument = testLspServer.TestWorkspace.CurrentSolution.Projects.Single().Documents.Single();
+        var expectedDocumentUri = new Uri(documentFilePath, UriKind.Absolute);
+
+        await testLspServer.OpenDocumentAsync(expectedDocumentUri).ConfigureAwait(false);
+
+        // Verify file is added to the misc file workspace.
+        var (workspace, _, document) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { Uri = expectedDocumentUri }, CancellationToken.None);
+        Assert.False(workspace is LspMiscellaneousFilesWorkspace);
+        AssertEx.NotNull(document);
+        Assert.Equal(expectedDocumentUri, document.GetURI());
+        Assert.Equal(documentFilePath, document.FilePath);
+    }
+}


### PR DESCRIPTION
When we can't find the language info from the file, we can use the client provided language information.  This only applies to misc files as normally we just lookup the document from the workspace directly

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1760512/
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1808885