### PR TITLE
Move the SyntaxTree and SemanticModel action based analyzers to respect context.FilterSpan

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers
             SyntaxTreeAnalysisContext context,
             CodeStyleOption2<AccessibilityModifiersRequired> option, MemberDeclarationSyntax member)
         {
-            if (!context.IsInAnalysisSpan(member.Span))
+            if (!context.ShouldAnalyzeSpan(member.Span))
                 return;
 
             if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -37,6 +37,9 @@ namespace Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers
             SyntaxTreeAnalysisContext context,
             CodeStyleOption2<AccessibilityModifiersRequired> option, MemberDeclarationSyntax member)
         {
+            if (context.FilterSpan.HasValue && !member.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                return;
+
             if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)
                 ProcessMembers(context, option, namespaceDeclaration.Members);
 

--- a/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddAccessibilityModifiers/CSharpAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers
             SyntaxTreeAnalysisContext context,
             CodeStyleOption2<AccessibilityModifiersRequired> option, MemberDeclarationSyntax member)
         {
-            if (context.FilterSpan.HasValue && !member.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+            if (!context.IsInAnalysisSpan(member.Span))
                 return;
 
             if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.Span))
+                if (!context.ShouldAnalyzeSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
@@ -36,7 +36,10 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
             if (option.Value)
                 return;
 
-            Recurse(context, option.Notification.Severity, context.Tree.GetRoot(context.CancellationToken));
+            var root = context.Tree.GetRoot(context.CancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
+            Recurse(context, option.Notification.Severity, root);
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -48,6 +51,9 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!);
             }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ArrowExpressionClausePlacement/ArrowExpressionClausePlacementDiagnosticAnalyzer.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
             if (option.Value)
                 return;
 
-            var root = context.Tree.GetRoot(context.CancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false));
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -51,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ArrowExpressionClausePlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConditionalExpressionPlacement
             if (option.Value)
                 return;
 
-            var root = context.Tree.GetRoot(context.CancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false));
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -52,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConditionalExpressionPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
@@ -37,7 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConditionalExpressionPlacement
             if (option.Value)
                 return;
 
-            Recurse(context, option.Notification.Severity, context.Tree.GetRoot(context.CancellationToken));
+            var root = context.Tree.GetRoot(context.CancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
+            Recurse(context, option.Notification.Severity, root);
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -49,6 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConditionalExpressionPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!);
             }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConditionalExpressionPlacement/ConditionalExpressionPlacementDiagnosticAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConditionalExpressionPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.Span))
+                if (!context.ShouldAnalyzeSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
 
             var root = tree.GetRoot(cancellationToken);
             var text = tree.GetText(cancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
 
             stack.Add(root);
             while (stack.Count > 0)
@@ -63,6 +65,9 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
+                    if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                        continue;
+
                     if (child.IsNode)
                         stack.Add(child.AsNode()!);
                     else if (child.IsToken)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
@@ -46,10 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
             var tree = context.Tree;
             var cancellationToken = context.CancellationToken;
 
-            var root = tree.GetRoot(cancellationToken);
+            var root = context.GetAnalysisRoot(findInTrivia: false);
             var text = tree.GetText(cancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
 
             stack.Add(root);
             while (stack.Count > 0)
@@ -65,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
-                    if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    if (!context.IsInAnalysisSpan(child.FullSpan))
                         continue;
 
                     if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
-                    if (!context.IsInAnalysisSpan(child.FullSpan))
+                    if (!context.ShouldAnalyzeSpan(child.FullSpan))
                         continue;
 
                     if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -38,7 +38,10 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
             if (option.Value)
                 return;
 
-            Recurse(context, option.Notification.Severity, context.Tree.GetRoot(context.CancellationToken));
+            var root = context.Tree.GetRoot(context.CancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
+            Recurse(context, option.Notification.Severity, root);
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -54,6 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!);
             }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
             if (option.Value)
                 return;
 
-            var root = context.Tree.GetRoot(context.CancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false));
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -57,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.Span))
+                if (!context.ShouldAnalyzeSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -37,7 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
             if (option.Value)
                 return;
 
-            Recurse(context, option.Notification.Severity, context.Tree.GetRoot(context.CancellationToken));
+            var root = context.Tree.GetRoot(context.CancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
+            Recurse(context, option.Notification.Severity, root);
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -59,6 +62,9 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!);
             }

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.Span))
+                if (!context.ShouldAnalyzeSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
             if (option.Value)
                 return;
 
-            var root = context.Tree.GetRoot(context.CancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false));
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node)
@@ -62,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.Span))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
         {
             foreach (var child in root.ChildNodesAndTokens())
             {
-                if (child.IsNode && ShouldAnalyze(context, child))
+                if (child.IsNode && context.IsInAnalysisSpan(child.Span))
                 {
                     var node = child.AsNode();
                     if (node is MemberDeclarationSyntax memberDeclaration)

--- a/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
         {
             foreach (var child in root.ChildNodesAndTokens())
             {
-                if (child.IsNode && context.IsInAnalysisSpan(child.Span))
+                if (child.IsNode && context.ShouldAnalyzeSpan(child.Span))
                 {
                     var node = child.AsNode();
                     if (node is MemberDeclarationSyntax memberDeclaration)

--- a/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
         {
             foreach (var child in root.ChildNodesAndTokens())
             {
-                if (child.IsNode)
+                if (child.IsNode && ShouldAnalyze(context, child))
                 {
                     var node = child.AsNode();
                     if (node is MemberDeclarationSyntax memberDeclaration)

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveDiagnosticAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.RemoveUnnecessaryNullableDirec
                 context.RegisterSyntaxTreeAction(context =>
                 {
                     var root = context.GetAnalysisRoot(findInTrivia: true);
-                    
+
                     // Bail out if the root contains no nullable directives.
                     if (!root.ContainsDirective(SyntaxKind.NullableDirectiveTrivia))
                         return;

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveDiagnosticAnalyzer.cs
@@ -47,14 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.RemoveUnnecessaryNullableDirec
                 var defaultNullableContext = ((CSharpCompilation)context.Compilation).Options.NullableContextOptions;
                 context.RegisterSyntaxTreeAction(context =>
                 {
-                    var root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
-                    if (context.FilterSpan.HasValue)
-                    {
-                        // Bail out if the analysis filter span does not have any nullable directives.
-                        var node = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
-                        if (!node.DescendantNodesAndSelf(descendIntoTrivia: true).Any(node => node is NullableDirectiveTriviaSyntax))
-                            return;
-                    }
+                    var root = context.GetAnalysisRoot(findInTrivia: true);
+                    
+                    // Bail out if the root contains no nullable directives.
+                    if (!root.ContainsDirective(SyntaxKind.NullableDirectiveTrivia))
+                        return;
 
                     var initialState = context.Tree.IsGeneratedCode(context.Options, CSharpSyntaxFacts.Instance, context.CancellationToken)
                         ? NullableContextOptions.Disable

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveDiagnosticAnalyzer.cs
@@ -289,14 +289,11 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryNullableDirective
 
             public void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
-                if (context.FilterSpan.HasValue)
-                {
-                    // Bail out if the analysis filter span does not have any nullable directives.
-                    var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
-                    var node = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
-                    if (!node.DescendantNodesAndSelf(descendIntoTrivia: true).Any(node => node is NullableDirectiveTriviaSyntax))
-                        return;
-                }
+                var root = context.GetAnalysisRoot(findInTrivia: true);
+
+                // Bail out if the root contains no nullable directives.
+                if (!root.ContainsDirective(SyntaxKind.NullableDirectiveTrivia))
+                    return;
 
                 // Get the state information for the syntax tree. If the state information is not available, it is
                 // initialized directly to a completed state, ensuring that concurrent (or future) calls to

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode
             // binding diagnostics directly on the SourceMethodSymbol containing this block, and
             // so it can retrieve the diagnostics at practically no cost.
             var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
-            var diagnostics = semanticModel.GetDiagnostics(cancellationToken: cancellationToken);
+            var diagnostics = semanticModel.GetDiagnostics(context.FilterSpan, cancellationToken);
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -56,6 +56,13 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             }
 
             var fileHeader = FileHeaderHelper.ParseFileHeader(root);
+
+            if (context.FilterSpan.HasValue
+                && !fileHeader.GetLocation(tree).SourceSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+            {
+                return;
+            }
+
             if (fileHeader.IsMissing)
             {
                 context.ReportDiagnostic(Diagnostic.Create(s_missingHeaderDescriptor, fileHeader.GetLocation(tree)));

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -57,8 +57,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 
             var fileHeader = FileHeaderHelper.ParseFileHeader(root);
 
-            if (context.FilterSpan.HasValue
-                && !fileHeader.GetLocation(tree).SourceSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+            if (!context.IsInAnalysisSpan(fileHeader.GetLocation(tree).SourceSpan))
             {
                 return;
             }

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 
             var fileHeader = FileHeaderHelper.ParseFileHeader(root);
 
-            if (!context.IsInAnalysisSpan(fileHeader.GetLocation(tree).SourceSpan))
+            if (!context.ShouldAnalyzeSpan(fileHeader.GetLocation(tree).SourceSpan))
             {
                 return;
             }

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -42,11 +42,7 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
             if (option.Value)
                 return;
 
-            var cancellationToken = context.CancellationToken;
-            var root = context.Tree.GetRoot(cancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root, cancellationToken);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false), context.CancellationToken);
         }
 
         private void Recurse(SyntaxTreeAnalysisContext context, ReportDiagnostic severity, SyntaxNode node, CancellationToken cancellationToken)
@@ -59,7 +55,7 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.FullSpan))
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
 
             var cancellationToken = context.CancellationToken;
             var root = context.Tree.GetRoot(cancellationToken);
-
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
             Recurse(context, option.Notification.Severity, root, cancellationToken);
         }
 
@@ -58,6 +59,9 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!, cancellationToken);
             }

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
 
             var cancellationToken = context.CancellationToken;
             var root = context.Tree.GetRoot(cancellationToken);
-
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
             Recurse(context, option.Notification.Severity, root, cancellationToken);
         }
 
@@ -58,6 +59,9 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                     Recurse(context, severity, child.AsNode()!, cancellationToken);
                 else if (child.IsToken)

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -38,11 +38,7 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
             if (option.Value)
                 return;
 
-            var cancellationToken = context.CancellationToken;
-            var root = context.Tree.GetRoot(cancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, option.Notification.Severity, root, cancellationToken);
+            Recurse(context, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false), context.CancellationToken);
         }
 
         private void Recurse(
@@ -59,7 +55,7 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.FullSpan))
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -46,14 +46,8 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
                 return;
             }
 
-            var root = context.Tree.GetRoot(context.CancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
-            Recurse(context, preferredOrder, option.Notification.Severity, root);
+            Recurse(context, preferredOrder, option.Notification.Severity, context.GetAnalysisRoot(findInTrivia: false));
         }
-
-        protected static bool ShouldAnalyze(SyntaxTreeAnalysisContext context, SyntaxNodeOrToken nodeOrToken)
-            => !context.FilterSpan.HasValue || nodeOrToken.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault());
 
         protected abstract void Recurse(
             SyntaxTreeAnalysisContext context,

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -47,8 +47,13 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
             }
 
             var root = context.Tree.GetRoot(context.CancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault());
             Recurse(context, preferredOrder, option.Notification.Severity, root);
         }
+
+        protected static bool ShouldAnalyze(SyntaxTreeAnalysisContext context, SyntaxNodeOrToken nodeOrToken)
+            => !context.FilterSpan.HasValue || nodeOrToken.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault());
 
         protected abstract void Recurse(
             SyntaxTreeAnalysisContext context,

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             var tree = context.SemanticModel.SyntaxTree;
             var cancellationToken = context.CancellationToken;
 
-            var unnecessaryImports = UnnecessaryImportsProvider.GetUnnecessaryImports(context.SemanticModel, cancellationToken);
+            var unnecessaryImports = UnnecessaryImportsProvider.GetUnnecessaryImports(context.SemanticModel, context.FilterSpan, cancellationToken);
             if (unnecessaryImports.Any())
             {
                 // The IUnnecessaryImportsService will return individual import pieces that

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -268,8 +268,6 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
 
             public void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
-                var root = context.GetAnalysisRoot(findInTrivia: true);
-
                 // Get the state information for the syntax tree. If the state information is not available, it is
                 // initialized directly to a completed state, ensuring that concurrent (or future) calls to
                 // AnalyzeCodeBlock will always read completed==true, and intervalTree does not need to be initialized
@@ -294,6 +292,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
                     }
                 }
 
+                var root = context.GetAnalysisRoot(findInTrivia: true);
                 var diagnostics = _analyzer.AnalyzeSemanticModel(context, root, intervalTree);
 
                 // After this point, cancellation is not allowed due to possible state alteration

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -268,9 +268,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
 
             public void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
-                var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
-                if (context.FilterSpan.HasValue)
-                    root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
+                var root = context.GetAnalysisRoot(findInTrivia: true);
 
                 // Get the state information for the syntax tree. If the state information is not available, it is
                 // initialized directly to a completed state, ensuring that concurrent (or future) calls to

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
         /// <see cref="AnalyzeSemanticModel"/>.</returns>
         protected abstract bool IsIgnoredCodeBlock(SyntaxNode codeBlock);
         protected abstract ImmutableArray<Diagnostic> AnalyzeCodeBlock(CodeBlockAnalysisContext context);
-        protected abstract ImmutableArray<Diagnostic> AnalyzeSemanticModel(SemanticModelAnalysisContext context, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree);
+        protected abstract ImmutableArray<Diagnostic> AnalyzeSemanticModel(SemanticModelAnalysisContext context, SyntaxNode root, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree);
 
         public bool TrySimplify(SemanticModel model, SyntaxNode node, [NotNullWhen(true)] out Diagnostic? diagnostic, TSimplifierOptions options, CancellationToken cancellationToken)
         {
@@ -268,6 +268,10 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
 
             public void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
+                var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
+                if (context.FilterSpan.HasValue)
+                    root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
+
                 // Get the state information for the syntax tree. If the state information is not available, it is
                 // initialized directly to a completed state, ensuring that concurrent (or future) calls to
                 // AnalyzeCodeBlock will always read completed==true, and intervalTree does not need to be initialized
@@ -281,7 +285,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
                 //   true: the state was initialized on the previous line, and either intervalTree will be null, or
                 //         a previous call to AnalyzeSemanticModel was cancelled and the new one will operate on the
                 //         same interval tree presented during the previous call.
-                if (!completed.Value)
+                if (!completed.Value && !context.FilterSpan.HasValue)
                 {
                     // This lock ensures we do not use intervalTree while it is being updated by a concurrent call to
                     // AnalyzeCodeBlock.
@@ -292,7 +296,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
                     }
                 }
 
-                var diagnostics = _analyzer.AnalyzeSemanticModel(context, intervalTree);
+                var diagnostics = _analyzer.AnalyzeSemanticModel(context, root, intervalTree);
 
                 // After this point, cancellation is not allowed due to possible state alteration
                 foreach (var diagnostic in diagnostics)

--- a/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
@@ -37,6 +37,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddAccessibilityModifiers
                 [option] As CodeStyleOption2(Of AccessibilityModifiersRequired),
                 member As StatementSyntax)
 
+            If context.FilterSpan.HasValue AndAlso Not member.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault) Then
+                Return
+            End If
+
             If member.Kind() = SyntaxKind.NamespaceBlock Then
                 Dim namespaceBlock = DirectCast(member, NamespaceBlockSyntax)
                 ProcessMembers(context, [option], namespaceBlock.Members)

--- a/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddAccessibilityModifiers
                 [option] As CodeStyleOption2(Of AccessibilityModifiersRequired),
                 member As StatementSyntax)
 
-            If context.FilterSpan.HasValue AndAlso Not member.Span.IntersectsWith(context.FilterSpan.GetValueOrDefault) Then
+            If Not context.IsInAnalysisSpan(member.Span) Then
                 Return
             End If
 

--- a/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/AddAccessibilityModifiers/VisualBasicAddAccessibilityModifiersDiagnosticAnalyzer.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddAccessibilityModifiers
                 [option] As CodeStyleOption2(Of AccessibilityModifiersRequired),
                 member As StatementSyntax)
 
-            If Not context.IsInAnalysisSpan(member.Span) Then
+            If Not context.ShouldAnalyzeSpan(member.Span) Then
                 Return
             End If
 

--- a/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
             root As SyntaxNode)
 
             For Each child In root.ChildNodesAndTokens()
-                If child.IsNode Then
+                If child.IsNode And ShouldAnalyze(context, child) Then
                     Dim declarationStatement = TryCast(child.AsNode(), DeclarationStatementSyntax)
                     If declarationStatement IsNot Nothing Then
                         If ShouldCheck(declarationStatement) Then

--- a/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
             root As SyntaxNode)
 
             For Each child In root.ChildNodesAndTokens()
-                If child.IsNode And context.IsInAnalysisSpan(child.Span) Then
+                If child.IsNode And context.ShouldAnalyzeSpan(child.Span) Then
                     Dim declarationStatement = TryCast(child.AsNode(), DeclarationStatementSyntax)
                     If declarationStatement IsNot Nothing Then
                         If ShouldCheck(declarationStatement) Then

--- a/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
             root As SyntaxNode)
 
             For Each child In root.ChildNodesAndTokens()
-                If child.IsNode And ShouldAnalyze(context, child) Then
+                If child.IsNode And context.IsInAnalysisSpan(child.Span) Then
                     Dim declarationStatement = TryCast(child.AsNode(), DeclarationStatementSyntax)
                     If declarationStatement IsNot Nothing Then
                         If ShouldCheck(declarationStatement) Then

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
             {
                 var semanticModel = _compilation.GetSemanticModel(context.Tree);
-                var diagnostics = semanticModel.GetSyntaxDiagnostics(cancellationToken: context.CancellationToken);
+                var diagnostics = semanticModel.GetSyntaxDiagnostics(context.FilterSpan, context.CancellationToken);
                 ReportDiagnostics(diagnostics, context.ReportDiagnostic, IsSourceLocation, s_syntactic);
             }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -58,15 +58,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             return simplifier.Diagnostics;
         }
 
-        protected override ImmutableArray<Diagnostic> AnalyzeSemanticModel(SemanticModelAnalysisContext context, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree)
+        protected override ImmutableArray<Diagnostic> AnalyzeSemanticModel(SemanticModelAnalysisContext context, SyntaxNode root, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree)
         {
-            var semanticModel = context.SemanticModel;
-            var cancellationToken = context.CancellationToken;
-
             var options = context.GetCSharpAnalyzerOptions().GetSimplifierOptions();
-            var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
-
-            var simplifier = new TypeSyntaxSimplifierWalker(this, semanticModel, options, ignoredSpans: codeBlockIntervalTree, cancellationToken);
+            var simplifier = new TypeSyntaxSimplifierWalker(this, context.SemanticModel, options, ignoredSpans: codeBlockIntervalTree, context.CancellationToken);
             simplifier.Visit(root);
             return simplifier.Diagnostics;
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
@@ -46,18 +46,11 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
         public void Analyze(SemanticModelAnalysisContext context)
         {
-            var semanticModel = context.SemanticModel;
-            var syntaxTree = semanticModel.SyntaxTree;
-            var cancellationToken = context.CancellationToken;
-
             if (!context.GetIdeAnalyzerOptions().DetectAndOfferEditorFeaturesForProbableJsonStrings)
                 return;
 
-            var detector = JsonLanguageDetector.GetOrCreate(semanticModel.Compilation, _info);
-            var root = syntaxTree.GetRoot(cancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
-            Analyze(context, detector, root, cancellationToken);
+            var detector = JsonLanguageDetector.GetOrCreate(context.SemanticModel.Compilation, _info);
+            Analyze(context, detector, context.GetAnalysisRoot(findInTrivia: true), context.CancellationToken);
         }
 
         private void Analyze(
@@ -70,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                if (!context.IsInAnalysisSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.FullSpan))
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDetectionAnalyzer.cs
@@ -55,6 +55,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             var detector = JsonLanguageDetector.GetOrCreate(semanticModel.Compilation, _info);
             var root = syntaxTree.GetRoot(cancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
             Analyze(context, detector, root, cancellationToken);
         }
 
@@ -68,6 +70,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                 {
                     Analyze(context, detector, child.AsNode()!, cancellationToken);

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             var detector = JsonLanguageDetector.GetOrCreate(semanticModel.Compilation, _info);
             var root = syntaxTree.GetRoot(cancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
             Analyze(context, detector, root, cancellationToken);
         }
 
@@ -63,6 +65,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             foreach (var child in node.ChildNodesAndTokens())
             {
+                if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    continue;
+
                 if (child.IsNode)
                 {
                     Analyze(context, detector, child.AsNode()!, cancellationToken);

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonDiagnosticAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
             foreach (var child in node.ChildNodesAndTokens())
             {
-                if (!context.IsInAnalysisSpan(child.FullSpan))
+                if (!context.ShouldAnalyzeSpan(child.FullSpan))
                     continue;
 
                 if (child.IsNode)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
@@ -51,6 +51,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 
             // Use an actual stack object so that we don't blow the actual stack through recursion.
             var root = syntaxTree.GetRoot(cancellationToken);
+            if (context.FilterSpan.HasValue)
+                root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
             var stack = new Stack<SyntaxNode>();
             stack.Push(root);
 
@@ -61,6 +63,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
+                    if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                        continue;
+
                     if (child.IsNode)
                     {
                         stack.Push(child.AsNode());

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
         public void Analyze(SemanticModelAnalysisContext context)
         {
             var semanticModel = context.SemanticModel;
-            var syntaxTree = semanticModel.SyntaxTree;
             var cancellationToken = context.CancellationToken;
 
             var option = context.GetIdeAnalyzerOptions().ReportInvalidRegexPatterns;
@@ -50,9 +49,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
             var detector = RegexLanguageDetector.GetOrCreate(semanticModel.Compilation, _info);
 
             // Use an actual stack object so that we don't blow the actual stack through recursion.
-            var root = syntaxTree.GetRoot(cancellationToken);
-            if (context.FilterSpan.HasValue)
-                root = root.FindNode(context.FilterSpan.GetValueOrDefault(), findInsideTrivia: true, getInnermostNodeForTie: true);
+            var root = context.GetAnalysisRoot(findInTrivia: true);
             var stack = new Stack<SyntaxNode>();
             stack.Push(root);
 
@@ -63,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
-                    if (context.FilterSpan.HasValue && !child.FullSpan.IntersectsWith(context.FilterSpan.GetValueOrDefault()))
+                    if (!context.IsInAnalysisSpan(child.FullSpan))
                         continue;
 
                     if (child.IsNode)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {
-                    if (!context.IsInAnalysisSpan(child.FullSpan))
+                    if (!context.ShouldAnalyzeSpan(child.FullSpan))
                         continue;
 
                     if (child.IsNode)

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -46,16 +46,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             Return simplifier.Diagnostics
         End Function
 
-        Protected Overrides Function AnalyzeSemanticModel(context As SemanticModelAnalysisContext, codeBlockIntervalTree As SimpleIntervalTree(Of TextSpan, TextSpanIntervalIntrospector)) As ImmutableArray(Of Diagnostic)
-            Dim semanticModel = context.SemanticModel
-            Dim cancellationToken = context.CancellationToken
-
-            Dim syntaxTree = semanticModel.SyntaxTree
-            Dim configOptions = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree)
+        Protected Overrides Function AnalyzeSemanticModel(context As SemanticModelAnalysisContext, root As SyntaxNode, codeBlockIntervalTree As SimpleIntervalTree(Of TextSpan, TextSpanIntervalIntrospector)) As ImmutableArray(Of Diagnostic)
+            Dim configOptions = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.SemanticModel.SyntaxTree)
             Dim simplifierOptions = context.GetVisualBasicAnalyzerOptions().GetSimplifierOptions()
-            Dim root = syntaxTree.GetRoot(cancellationToken)
-
-            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, simplifierOptions, ignoredSpans:=codeBlockIntervalTree, cancellationToken)
+            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, context.SemanticModel, simplifierOptions, ignoredSpans:=codeBlockIntervalTree, context.CancellationToken)
             simplifier.Visit(root)
             Return simplifier.Diagnostics
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -240,6 +240,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\VirtualCharSequence.Chunks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\VirtualCharSequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\VirtualCharSequence.Enumerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\AnalysisContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticAnalyzerExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticDescriptorExtensions.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis
     internal static class AnalysisContextExtensions
     {
         /// <summary>
-        /// Returns true if the given <paramref name="span"/> is in the analysis span of the given <paramref name="context"/>,
+        /// Returns true if the given <paramref name="span"/> should be analyzed for the given <paramref name="context"/>,
         /// i.e. either of the following is true:
         ///  - <see cref="SyntaxTreeAnalysisContext.FilterSpan"/> is <code>null</code> (we are analyzing the entire tree)
         ///  OR
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis
             => !context.FilterSpan.HasValue || span.IntersectsWith(context.FilterSpan.Value);
 
         /// <summary>
-        /// Returns true if the given <paramref name="span"/> is in the analysis span of the given <paramref name="context"/>,
+        /// Returns true if the given <paramref name="span"/> should be analyzed for the given <paramref name="context"/>,
         /// i.e. either of the following is true:
         ///  - <see cref="SemanticModelAnalysisContext.FilterSpan"/> is <code>null</code> (we are analyzing the entire tree)
         ///  OR

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class AnalysisContextExtensions
+    {
+        /// <summary>
+        /// Returns true if the given <paramref name="span"/> is in the analysis span of the given <paramref name="context"/>,
+        /// i.e. either of the following is true:
+        ///  - <see cref="SyntaxTreeAnalysisContext.FilterSpan"/> is <code>null</code> (we are analyzing the entire tree)
+        ///  OR
+        ///  - <paramref name="span"/> intersects with <see cref="SyntaxTreeAnalysisContext.FilterSpan"/>.
+        /// </summary>
+        public static bool IsInAnalysisSpan(this SyntaxTreeAnalysisContext context, TextSpan span)
+            => !context.FilterSpan.HasValue || span.IntersectsWith(context.FilterSpan.Value);
+
+        /// <summary>
+        /// Returns true if the given <paramref name="span"/> is in the analysis span of the given <paramref name="context"/>,
+        /// i.e. either of the following is true:
+        ///  - <see cref="SemanticModelAnalysisContext.FilterSpan"/> is <code>null</code> (we are analyzing the entire tree)
+        ///  OR
+        ///  - <paramref name="span"/> intersects with <see cref="SemanticModelAnalysisContext.FilterSpan"/>.
+        /// </summary>
+        public static bool IsInAnalysisSpan(this SemanticModelAnalysisContext context, TextSpan span)
+            => !context.FilterSpan.HasValue || span.IntersectsWith(context.FilterSpan.Value);
+
+        /// <summary>
+        /// Gets the root node in the analysis span for the given <paramref name="context"/>.
+        /// </summary>
+        public static SyntaxNode GetAnalysisRoot(this SyntaxTreeAnalysisContext context, bool findInTrivia)
+            => context.Tree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie: false, context.CancellationToken);
+
+        /// <summary>
+        /// Gets the root node in the analysis span for the given <paramref name="context"/>.
+        /// </summary>
+        public static SyntaxNode GetAnalysisRoot(this SemanticModelAnalysisContext context, bool findInTrivia)
+            => context.SemanticModel.SyntaxTree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie: false, context.CancellationToken);
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/AnalysisContextExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
         ///  OR
         ///  - <paramref name="span"/> intersects with <see cref="SyntaxTreeAnalysisContext.FilterSpan"/>.
         /// </summary>
-        public static bool IsInAnalysisSpan(this SyntaxTreeAnalysisContext context, TextSpan span)
+        public static bool ShouldAnalyzeSpan(this SyntaxTreeAnalysisContext context, TextSpan span)
             => !context.FilterSpan.HasValue || span.IntersectsWith(context.FilterSpan.Value);
 
         /// <summary>
@@ -27,19 +27,19 @@ namespace Microsoft.CodeAnalysis
         ///  OR
         ///  - <paramref name="span"/> intersects with <see cref="SemanticModelAnalysisContext.FilterSpan"/>.
         /// </summary>
-        public static bool IsInAnalysisSpan(this SemanticModelAnalysisContext context, TextSpan span)
+        public static bool ShouldAnalyzeSpan(this SemanticModelAnalysisContext context, TextSpan span)
             => !context.FilterSpan.HasValue || span.IntersectsWith(context.FilterSpan.Value);
 
         /// <summary>
         /// Gets the root node in the analysis span for the given <paramref name="context"/>.
         /// </summary>
-        public static SyntaxNode GetAnalysisRoot(this SyntaxTreeAnalysisContext context, bool findInTrivia)
-            => context.Tree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie: false, context.CancellationToken);
+        public static SyntaxNode GetAnalysisRoot(this SyntaxTreeAnalysisContext context, bool findInTrivia, bool getInnermostNodeForTie = false)
+            => context.Tree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie, context.CancellationToken);
 
         /// <summary>
         /// Gets the root node in the analysis span for the given <paramref name="context"/>.
         /// </summary>
-        public static SyntaxNode GetAnalysisRoot(this SemanticModelAnalysisContext context, bool findInTrivia)
-            => context.SemanticModel.SyntaxTree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie: false, context.CancellationToken);
+        public static SyntaxNode GetAnalysisRoot(this SemanticModelAnalysisContext context, bool findInTrivia, bool getInnermostNodeForTie = false)
+            => context.SemanticModel.SyntaxTree.GetNodeForSpan(context.FilterSpan, findInTrivia, getInnermostNodeForTie, context.CancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxTreeExtensions.cs
@@ -241,5 +241,17 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return GeneratedCodeUtilities.IsGeneratedCode(
                 syntaxTree, t => syntaxFacts.IsRegularComment(t) || syntaxFacts.IsDocumentationComment(t), cancellationToken);
         }
+
+        /// <summary>
+        /// Gets the node in the given <paramref name="syntaxTree"/> corresponding to the given <paramref name="span"/>.
+        /// If the <paramref name="span"/> is <code>null</code>, then returns the root node of the tree.
+        /// </summary>
+        public static SyntaxNode GetNodeForSpan(this SyntaxTree syntaxTree, TextSpan? span, bool findInTrivia, bool getInnermostNodeForTie, CancellationToken cancellationToken)
+        {
+            var root = syntaxTree.GetRoot(cancellationToken);
+            return span.HasValue
+                ? root.FindNode(span.Value, findInTrivia, getInnermostNodeForTie)
+                : root;
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             if (span.HasValue)
             {
                 // Bail out if there are no usings/imports in the filter span.
-                var node = model.SyntaxTree.GetNodeForSpan(span, findInTrivia: false, getInnermostNodeForTie: true, cancellationToken);
+                var node = model.SyntaxTree.GetNodeForSpan(span, findInTrivia: false, getInnermostNodeForTie: false, cancellationToken);
                 if (node.FirstAncestorOrSelf<TSyntaxNode>() is null)
                     return ImmutableArray<TSyntaxNode>.Empty;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 {
@@ -18,8 +19,23 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
         public abstract ImmutableArray<TSyntaxNode> GetUnnecessaryImports(
             SemanticModel model, Func<SyntaxNode, bool>? predicate, CancellationToken cancellationToken);
 
-        public ImmutableArray<TSyntaxNode> GetUnnecessaryImports(SemanticModel model, CancellationToken cancellationToken)
-            => GetUnnecessaryImports(model, predicate: null, cancellationToken: cancellationToken);
+        public ImmutableArray<TSyntaxNode> GetUnnecessaryImports(SemanticModel model, TextSpan? span, CancellationToken cancellationToken)
+            => GetUnnecessaryImports(model, span, predicate: null, cancellationToken: cancellationToken);
+
+        public ImmutableArray<TSyntaxNode> GetUnnecessaryImports(
+            SemanticModel model, TextSpan? span, Func<SyntaxNode, bool>? predicate, CancellationToken cancellationToken)
+        {
+            if (span.HasValue)
+            {
+                // Bail out if there are no usings/imports in the filter span.
+                var root = model.SyntaxTree.GetRoot(cancellationToken);
+                var node = root.FindNode(span.GetValueOrDefault(), getInnermostNodeForTie: true);
+                if (node.FirstAncestorOrSelf<TSyntaxNode>() is null)
+                    return ImmutableArray<TSyntaxNode>.Empty;
+            }
+
+            return GetUnnecessaryImports(model, predicate, cancellationToken);
+        }
 
         bool IEqualityComparer<TSyntaxNode>.Equals([AllowNull] TSyntaxNode x, [AllowNull] TSyntaxNode y)
             => x?.Span == y?.Span;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/AbstractUnnecessaryImportsProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
@@ -28,8 +29,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             if (span.HasValue)
             {
                 // Bail out if there are no usings/imports in the filter span.
-                var root = model.SyntaxTree.GetRoot(cancellationToken);
-                var node = root.FindNode(span.GetValueOrDefault(), getInnermostNodeForTie: true);
+                var node = model.SyntaxTree.GetNodeForSpan(span, findInTrivia: false, getInnermostNodeForTie: true, cancellationToken);
                 if (node.FirstAncestorOrSelf<TSyntaxNode>() is null)
                     return ImmutableArray<TSyntaxNode>.Empty;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/IUnnecessaryImportsProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Helpers/RemoveUnnecessaryImports/IUnnecessaryImportsProvider.cs
@@ -5,16 +5,18 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 {
     internal interface IUnnecessaryImportsProvider<TSyntaxNode>
         where TSyntaxNode : SyntaxNode
     {
-        ImmutableArray<TSyntaxNode> GetUnnecessaryImports(SemanticModel model, CancellationToken cancellationToken);
+        ImmutableArray<TSyntaxNode> GetUnnecessaryImports(SemanticModel model, TextSpan? span, CancellationToken cancellationToken);
 
         ImmutableArray<TSyntaxNode> GetUnnecessaryImports(
             SemanticModel model,
+            TextSpan? span,
             Func<SyntaxNode, bool>? predicate,
             CancellationToken cancellationToken);
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsService.cs
@@ -32,13 +32,13 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 
             var unnecessaryImports = new HashSet<T>(this);
             unnecessaryImports.AddRange(UnnecessaryImportsProvider.GetUnnecessaryImports(
-                model, predicate, cancellationToken));
+                model, span: null, predicate, cancellationToken));
             foreach (var current in document.GetLinkedDocuments())
             {
                 var currentModel = await current.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                 unnecessaryImports.IntersectWith(UnnecessaryImportsProvider.GetUnnecessaryImports(
-                    currentModel, predicate, cancellationToken));
+                    currentModel, span: null, predicate, cancellationToken));
             }
 
             return unnecessaryImports;


### PR DESCRIPTION
Closes #67888
Follow-up to #67818

## Performance measurements

### Summary

- **SyntaxTree analyzers**: _Decent_ performance improvements seen in this PR for the syntax analyzers. Note that majority of performance benefit was already fetched from #67818, which moved our slowest syntax analyzer (IDE0055 - formatting analyzer) to respect `context.FilterSpan`

- **SemanticModel analyzers**: Pretty _significant_ performance improvements seen in this PR for the semantic model action analyzers. See screenshots below

Performance screenshots info:
- Left image: Using CodeStyle analyzer package built from main branch
- Right image: Using CodeStyle analyzer package built from this PR branch

### SyntaxTree action analyzers

![image](https://user-images.githubusercontent.com/10605811/235129053-f391baa5-669b-46fe-8c07-2948e06dc646.png)

### SemanticModel action analyzers

![image](https://user-images.githubusercontent.com/10605811/235131397-84e03230-6735-43a3-9911-75baae2101be.png)

### All analyzers (excluding SymbolStart analyzers)

![image](https://user-images.githubusercontent.com/10605811/235134886-ae804ab4-1189-4373-8298-5c0a416d5196.png)
