### PR TITLE
.editorconfig only shows as dirty with changes

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorControl.xaml.cs
@@ -94,10 +94,15 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 var updatedText = originalText;
                 foreach (var view in _views)
                 {
+                    // Get any changes for the editors. This will return the source text if there are no changes.
                     updatedText = await view.UpdateEditorConfigAsync(updatedText).ConfigureAwait(false);
                 }
 
-                _textUpdater.UpdateText(updatedText.GetTextChanges(originalText));
+                // Save the updates if they are different from what is currently saved
+                if (updatedText != originalText)
+                {
+                    _textUpdater.UpdateText(updatedText.GetTextChanges(originalText));
+                }
             });
         }
 


### PR DESCRIPTION
Current implementation shows the file as dirty on open. This is because in SynchronizeSettings the updateText ran every time the method executed. This PR updates SynchronizeSettings to only run the text updated when the underlying .editorconfig text has changed.

![editorconfig](https://user-images.githubusercontent.com/9122518/234998663-01f03ca0-2083-40e7-b1a2-2ae6ccb5bddb.gif)
