### PR TITLE
Use scouting queue to unblock VS package upgrade

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -56,7 +56,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022preview.scout.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
This needs to be switched back as soon as the non-scouting queue gets the 17.6P3 update.   Yes this can potentially break when the scouting queue upgrades again, but that seems fine as long as we switch back to the main queue as soon as it upgrades.

Unblocks https://github.com/dotnet/roslyn/pull/67071