### PR TITLE
Fix number of additional overloads on lambda parameter's member recommendations

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -3746,6 +3746,28 @@ class Program
             await VerifyItemExistsAsync(markup, "Substring");
         }
 
+        [Fact, WorkItem(61343, "https://github.com/dotnet/roslyn/issues/61343")]
+        public async Task LambdaParameterMemberAccessOverloads()
+        {
+            var markup = @"
+using System.Linq;
+
+public class C
+{
+    public void M() { }
+    public void M(int i) { }
+    public int P { get; }
+
+    void Test()
+    {
+        new C[0].Select(x => x.$$)
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "M", expectedDescriptionOrNull: $"void C.M() (+ 1 {FeaturesResources.overload})");
+            await VerifyItemExistsAsync(markup, "P", expectedDescriptionOrNull: "int C.P { get; }");
+        }
+
         [Fact]
         public async Task ValueNotAtRoot_Interactive()
         {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -122,8 +122,11 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
 
             // For each type of b., return all suitable members. Also, ensure we consider the actual type of the
             // parameter the compiler inferred as it may have made a completely suitable inference for it.
+            // (Only add the actual type if it's not already in the set, otherwise the type and all of its members will be considered twice.)
+            if (!parameterTypeSymbols.Contains(parameter.Type, SymbolEqualityComparer.Default))
+                parameterTypeSymbols = parameterTypeSymbols.Concat(parameter.Type);
+
             return parameterTypeSymbols
-                .Concat(parameter.Type)
                 .SelectManyAsArray(parameterTypeSymbol =>
                     GetMemberSymbols(parameterTypeSymbol, position, excludeInstance: false, useBaseReferenceAccessibility: false, unwrapNullable, isForDereference));
         }


### PR DESCRIPTION
Fixes #61343.

The lambda parameter's type was added to the array twice, causing its members to be considered twice too. This resulted in the wrong number of additional overloads being shown in the completion item's tooltip ($2n-1$ instead of $n-1$).
This fix makes the addition of the type symbol conditional so that it doesn't appear more than once in the array of type symbols.