### PR TITLE
Make diagnostic bag argument non-nullable

### DIFF
--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -113,14 +113,11 @@ namespace Microsoft.CodeAnalysis
             AddDependencies(other.Dependencies);
         }
 
-        internal void AddRange(BindingDiagnosticBag<TAssemblySymbol>? other, bool allowMismatchInDependencyAccumulation = false)
+        internal void AddRange(BindingDiagnosticBag<TAssemblySymbol> other, bool allowMismatchInDependencyAccumulation = false)
         {
-            if (other is object)
-            {
-                AddRange(other.DiagnosticBag);
-                Debug.Assert(allowMismatchInDependencyAccumulation || !other.AccumulatesDependencies || this.AccumulatesDependencies);
-                AddDependencies(other.DependenciesBag);
-            }
+            AddRange(other.DiagnosticBag);
+            Debug.Assert(allowMismatchInDependencyAccumulation || !other.AccumulatesDependencies || this.AccumulatesDependencies);
+            AddDependencies(other.DependenciesBag);
         }
 
         internal void AddRange(DiagnosticBag? bag)

--- a/src/Compilers/Core/Portable/Binding/UseSiteInfo.cs
+++ b/src/Compilers/Core/Portable/Binding/UseSiteInfo.cs
@@ -132,18 +132,14 @@ namespace Microsoft.CodeAnalysis
             _assemblyBeingBuilt = assemblyBeingBuilt;
         }
 
-        public CompoundUseSiteInfo(BindingDiagnosticBag<TAssemblySymbol>? futureDestination, TAssemblySymbol assemblyBeingBuilt)
+        public CompoundUseSiteInfo(BindingDiagnosticBag<TAssemblySymbol> futureDestination, TAssemblySymbol assemblyBeingBuilt)
         {
             Debug.Assert(assemblyBeingBuilt is object);
             Debug.Assert(assemblyBeingBuilt is ISourceAssemblySymbolInternal);
 
             this = default;
 
-            if (futureDestination is null)
-            {
-                _discardLevel = DiscardLevel.DiagnosticsAndDependencies;
-            }
-            else if (!futureDestination.AccumulatesDependencies)
+            if (!futureDestination.AccumulatesDependencies)
             {
                 _discardLevel = DiscardLevel.Dependencies;
             }


### PR DESCRIPTION
Found during exploratory work to reduce allocations of BindingDiagnosticBags.