### PR TITLE
Implement code folding for anonymous object creation

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/AnonymousObjectCreationExpressionStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/AnonymousObjectCreationExpressionStructureTests.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Structure;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
+{
+    [Trait(Traits.Feature, Traits.Features.Outlining)]
+    public class AnonymousObjectCreationExpressionStructureTests : AbstractCSharpSyntaxNodeStructureTests<AnonymousObjectCreationExpressionSyntax>
+    {
+        internal override AbstractSyntaxStructureProvider CreateProvider()
+            => new AnonymousObjectCreationExpressionStructureProvider();
+
+        [Fact]
+        public async Task TestAnonymousObjectCreation()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    void M()
+    {
+        var v = {|hint:new{|textspan: $${
+            Name = ""John"",
+            Age = 19
+        }|}|};
+    }
+}
+",
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             builder.Add<FileScopedNamespaceDeclarationSyntax, FileScopedNamespaceDeclarationStructureProvider>();
             builder.Add<IndexerDeclarationSyntax, IndexerDeclarationStructureProvider>();
             builder.Add<InitializerExpressionSyntax, InitializerExpressionStructureProvider>();
+            builder.Add<AnonymousObjectCreationExpressionSyntax, AnonymousObjectCreationExpressionStructureProvider>();
             builder.Add<InterfaceDeclarationSyntax, TypeDeclarationStructureProvider>();
             builder.Add<MethodDeclarationSyntax, MethodDeclarationStructureProvider>();
             builder.Add<NamespaceDeclarationSyntax, NamespaceDeclarationStructureProvider>();

--- a/src/Features/CSharp/Portable/Structure/Providers/AnonymousObjectCreationExpressionStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/AnonymousObjectCreationExpressionStructureProvider.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Structure
+{
+    internal class AnonymousObjectCreationExpressionStructureProvider : AbstractSyntaxNodeStructureProvider<AnonymousObjectCreationExpressionSyntax>
+    {
+        protected override void CollectBlockSpans(
+            SyntaxToken previousToken,
+            AnonymousObjectCreationExpressionSyntax node,
+            ref TemporaryArray<BlockSpan> spans,
+            BlockStructureOptions options,
+            CancellationToken cancellationToken)
+        {
+            // Node is something like:
+            //
+            //      new
+            //      {
+            //          Field1 = ...,
+            //          Field2 = ...,
+            //          ...
+            //      }
+            //
+            // The collapsed textspan should be from the end of new keyword to the end of the whole node
+            // And the hint span should be the entire node
+
+            spans.Add(new BlockSpan(
+                isCollapsible: true,
+                textSpan: TextSpan.FromBounds(node.NewKeyword.Span.End, node.Span.End),
+                hintSpan: node.Span,
+                type: BlockTypes.Expression));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #64679

Works as expected for all kinds of formatting or nesting:
![code_fold](https://user-images.githubusercontent.com/46457277/235555195-5a2034c7-6ebf-45cd-a26d-873a7ffcd01b.png)
