### PR TITLE
System.UriFormatException in ProtocolConversions

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
             if (!context.IsTracking(document.GetURI()))
             {
-                context.TraceWarning($"Ignoring diagnostics request for untracked document: {document.GetURI()}");
+                context.TraceWarning($"Ignoring diagnostics request for untracked document");
                 return ImmutableArray<IDiagnosticSource>.Empty;
             }
 


### PR DESCRIPTION
Remove call to document.GetUri() in the logging so it can fail gracefully.