### PR TITLE
Use a weak event handler pattern for GlobalOptionService

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests_EditorFeatures.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests_EditorFeatures.cs
@@ -1453,7 +1453,7 @@ class D { }
             Assert.Equal(FormattingOptions2.IndentStyle.Smart, secondaryWorkspace.Options.GetOption(optionKey));
 
             // Hook up the option changed event handler.
-            primaryWorkspace.GlobalOptions.OptionChanged += OptionService_OptionChanged;
+            primaryWorkspace.GlobalOptions.AddOptionChangedHandler(this, OptionService_OptionChanged);
 
             // Change workspace options through primary workspace
             primaryWorkspace.Options = primaryWorkspace.Options.WithChangedOption(optionKey, FormattingOptions2.IndentStyle.Block);
@@ -1465,7 +1465,7 @@ class D { }
             Assert.Equal(FormattingOptions2.IndentStyle.Block, primaryWorkspace.Options.GetOption(optionKey));
             Assert.Equal(FormattingOptions2.IndentStyle.Block, secondaryWorkspace.Options.GetOption(optionKey));
 
-            primaryWorkspace.GlobalOptions.OptionChanged -= OptionService_OptionChanged;
+            primaryWorkspace.GlobalOptions.RemoveOptionChangedHandler(this, OptionService_OptionChanged);
             return;
 
             void OptionService_OptionChanged(object sender, OptionChangedEventArgs e)

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.OptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.OptionChangedEventSource.cs
@@ -22,12 +22,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
 
             public override void Connect()
             {
-                _globalOptions.OptionChanged += OnGlobalOptionChanged;
+                _globalOptions.AddOptionChangedHandler(this, OnGlobalOptionChanged);
             }
 
             public override void Disconnect()
             {
-                _globalOptions.OptionChanged -= OnGlobalOptionChanged;
+                _globalOptions.RemoveOptionChangedHandler(this, OnGlobalOptionChanged);
             }
 
             private void OnGlobalOptionChanged(object? sender, OptionChangedEventArgs e)

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -77,10 +77,6 @@ public class GlobalOptionsTests
 
         #region Unused
 
-#pragma warning disable CS0067
-        public event EventHandler<OptionChangedEventArgs>? OptionChanged;
-#pragma warning restore
-
         public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey2> optionKeys)
             => throw new NotImplementedException();
 
@@ -97,6 +93,12 @@ public class GlobalOptionsTests
             => throw new NotImplementedException();
 
         public bool SetGlobalOptions(ImmutableArray<KeyValuePair<OptionKey2, object?>> options)
+            => throw new NotImplementedException();
+
+        public void AddOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler)
+            => throw new NotImplementedException();
+
+        public void RemoveOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler)
             => throw new NotImplementedException();
 
         #endregion

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -1827,12 +1827,12 @@ class C
                 this.BlockEvent = new ManualResetEventSlim(initialState: false);
                 this.RunningEvent = new ManualResetEventSlim(initialState: false);
 
-                _globalOptions.OptionChanged += GlobalOptionChanged;
+                _globalOptions.AddOptionChangedHandler(this, GlobalOptionChanged);
             }
 
             public void Shutdown()
             {
-                _globalOptions.OptionChanged -= GlobalOptionChanged;
+                _globalOptions.RemoveOptionChangedHandler(this, GlobalOptionChanged);
             }
 
             private void GlobalOptionChanged(object sender, OptionChangedEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(analyzerInfoCache, analyzerService.Listener);
 
-            GlobalOptions.OptionChanged += OnGlobalOptionChanged;
+            GlobalOptions.AddOptionChangedHandler(this, OnGlobalOptionChanged);
         }
 
         private void OnGlobalOptionChanged(object? sender, OptionChangedEventArgs e)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         public void Shutdown()
         {
-            GlobalOptions.OptionChanged -= OnGlobalOptionChanged;
+            GlobalOptions.RemoveOptionChangedHandler(this, OnGlobalOptionChanged);
 
             var stateSets = _stateManager.GetAllStateSets();
 

--- a/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
@@ -51,10 +51,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private sealed class TestGlobalOptionService : IGlobalOptionService
         {
-#pragma warning disable CS0067 // Remove unused event
-            public event EventHandler<OptionChangedEventArgs>? OptionChanged;
-#pragma warning restore
-
             public T GetOption<T>(PerLanguageOption2<T> option, string languageName)
                 => default!;
 
@@ -67,6 +63,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             public void SetGlobalOption<T>(PerLanguageOption2<T> option, string language, T value) => throw new NotImplementedException();
             public void SetGlobalOption(OptionKey2 optionKey, object? value) => throw new NotImplementedException();
             public bool SetGlobalOptions(ImmutableArray<KeyValuePair<OptionKey2, object?>> options) => throw new NotImplementedException();
+            public void AddOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler) => throw new NotImplementedException();
+            public void RemoveOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler) => throw new NotImplementedException();
 
             bool IOptionsReader.TryGetOption<T>(OptionKey2 optionKey, out T value)
             {

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             _tagAggregator.BatchedTagsChanged += OnTagsChanged;
             _textView.LayoutChanged += OnLayoutChanged;
             _textView.ZoomLevelChanged += OnZoomLevelChanged;
-            _globalOptions.OptionChanged += OnGlobalOptionChanged;
+            _globalOptions.AddOptionChangedHandler(this, OnGlobalOptionChanged);
 
             UpdateMarginVisibility();
         }
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 _tagAggregator.BatchedTagsChanged -= OnTagsChanged;
                 _textView.LayoutChanged -= OnLayoutChanged;
                 _textView.ZoomLevelChanged -= OnZoomLevelChanged;
-                _globalOptions.OptionChanged -= OnGlobalOptionChanged;
+                _globalOptions.RemoveOptionChangedHandler(this, OnGlobalOptionChanged);
                 _tagAggregator.Dispose();
                 ((IDisposable)_glyphManager).Dispose();
             }

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 _globalOptions = languageService.Package.ComponentModel.GetService<IGlobalOptionService>();
 
                 _sink = ComEventSink.Advise<IVsCodeWindowEvents>(codeWindow, this);
-                _globalOptions.OptionChanged += GlobalOptionChanged;
+                _globalOptions.AddOptionChangedHandler(this, GlobalOptionChanged);
             }
 
             private void SetupView(IVsTextView view)
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             public int RemoveAdornments()
             {
                 _sink.Unadvise();
-                _globalOptions.OptionChanged -= GlobalOptionChanged;
+                _globalOptions.RemoveOptionChangedHandler(this, GlobalOptionChanged);
 
                 if (_codeWindow is IVsDropdownBarManager dropdownManager)
                 {

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
             _threadingContext = package.ComponentModel.GetService<IThreadingContext>();
             _globalOptions = package.ComponentModel.GetService<IGlobalOptionService>();
 
-            _globalOptions.OptionChanged += GlobalOptionChanged;
+            _globalOptions.AddOptionChangedHandler(this, GlobalOptionChanged);
 
             var enabled = _globalOptions.GetOption(StackTraceExplorerOptionsStorage.OpenOnFocus);
             if (enabled)
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
         {
             UnadviseBroadcastMessages();
 
-            _globalOptions.OptionChanged -= GlobalOptionChanged;
+            _globalOptions.RemoveOptionChangedHandler(this, GlobalOptionChanged);
         }
 
         private void AdviseBroadcastMessages()

--- a/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
                 ProcessOptionChangesAsync,
                 listenerProvider.GetListener(FeatureAttribute.Workspace),
                 this.DisposalToken);
-            _globalOptions.OptionChanged += OnOptionChanged;
+            _globalOptions.AddOptionChangedHandler(this, OnOptionChanged);
         }
 
         protected abstract Task EnableServiceAsync(CancellationToken cancellationToken);
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             // We were enabled for some language.  Kick off the work for this service now. Since we're now enabled, we
             // no longer need to listen for option changes.
             _enabled = true;
-            _globalOptions.OptionChanged -= OnOptionChanged;
+            _globalOptions.RemoveOptionChangedHandler(this, OnOptionChanged);
 
             // Don't both kicking off delay-started services prior to the actual workspace being fully loaded.  We don't
             // want them using CPU/memory in the BG while we're loading things for the user.

--- a/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             _buffer = new();
             _taskQueue = new(AsynchronousOperationListenerProvider.NullListener, TaskScheduler.Default);
             _enabled = globalOptions.GetOption(VisualStudioLoggingOptionsStorage.EnableFileLoggingForDiagnostics);
-            globalOptions.OptionChanged += OptionService_OptionChanged;
+            globalOptions.AddOptionChangedHandler(this, OptionService_OptionChanged);
         }
 
         public FileLogger(IGlobalOptionService optionService)

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
@@ -91,7 +91,7 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
                 await vsSettingsPersister.PersistAsync(storage, key, differentValue);
 
                 // make sure we fetch the value from the storage:
-                globalOptions.ClearCachedValues();
+                globalOptions.GetTestAccessor().ClearCachedValues();
 
                 object? updatedValue;
                 try

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/OptionPages/ForceLowMemoryMode.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/OptionPages/ForceLowMemoryMode.cs
@@ -22,7 +22,7 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.OptionsPages
         {
             _globalOptions = globalOptions;
 
-            globalOptions.OptionChanged += Options_OptionChanged;
+            globalOptions.AddOptionChangedHandler(this, Options_OptionChanged);
 
             RefreshFromSettings();
         }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -251,12 +251,26 @@ namespace Microsoft.CodeAnalysis.Options
             }
         }
 
-        // for testing
-        public void ClearCachedValues()
+        internal TestAccessor GetTestAccessor()
         {
-            lock (_gate)
+            return new TestAccessor(this);
+        }
+
+        internal readonly struct TestAccessor
+        {
+            private readonly GlobalOptionService _instance;
+
+            internal TestAccessor(GlobalOptionService instance)
             {
-                _currentValues = ImmutableDictionary.Create<OptionKey2, object?>();
+                _instance = instance;
+            }
+
+            public void ClearCachedValues()
+            {
+                lock (_instance._gate)
+                {
+                    _instance._currentValues = ImmutableDictionary.Create<OptionKey2, object?>();
+                }
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -29,9 +30,15 @@ namespace Microsoft.CodeAnalysis.Options
         private ImmutableArray<IOptionPersister> _lazyOptionPersisters;
         private ImmutableDictionary<OptionKey2, object?> _currentValues;
 
+        /// <summary>
+        /// Each registered event handler has the lifetime of an associated owning object. This table ensures the weak
+        /// references to the event handlers are not cleaned up while the owning object is still alive.
+        /// </summary>
+        private readonly ConditionalWeakTable<object, EventHandler<OptionChangedEventArgs>> _keepAliveTable = new();
+
         #endregion
 
-        public event EventHandler<OptionChangedEventArgs>? OptionChanged;
+        private ImmutableList<WeakReference<EventHandler<OptionChangedEventArgs>>> _weakHandlers = ImmutableList<WeakReference<EventHandler<OptionChangedEventArgs>>>.Empty;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -236,17 +243,79 @@ namespace Microsoft.CodeAnalysis.Options
             return true;
         }
 
+        public void AddOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler)
+        {
+            lock (_gate)
+            {
+                if (_keepAliveTable.TryGetValue(target, out var existingHandler))
+                {
+                    var newHandler = existingHandler + handler;
+#if NET6_0_OR_GREATER
+                    _keepAliveTable.AddOrUpdate(target, newHandler);
+#else
+                    _keepAliveTable.Remove(target);
+                    _keepAliveTable.Add(target, newHandler);
+#endif
+                }
+            }
+
+            ImmutableInterlocked.Update(
+                ref _weakHandlers,
+                static (weakHandlers, handler) =>
+                {
+                    return weakHandlers
+                        .RemoveAll(WeakReferenceExtensions.IsNull)
+                        .Add(new WeakReference<EventHandler<OptionChangedEventArgs>>(handler));
+                },
+                handler);
+        }
+
+        public void RemoveOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler)
+        {
+            lock (_gate)
+            {
+                if (_keepAliveTable.TryGetValue(target, out var existingHandler))
+                {
+                    var newHandler = existingHandler - handler;
+                    if (newHandler is null)
+                    {
+                        _keepAliveTable.Remove(target);
+                    }
+                    else
+                    {
+#if NET6_0_OR_GREATER
+                        _keepAliveTable.AddOrUpdate(target, newHandler);
+#else
+                        _keepAliveTable.Remove(target);
+                        _keepAliveTable.Add(target, newHandler);
+#endif
+                    }
+                }
+            }
+
+            ImmutableInterlocked.Update(
+                ref _weakHandlers,
+                static (weakHandlers, handler) =>
+                {
+                    return weakHandlers
+                        .RemoveAll(weakHandler => !weakHandler.TryGetTarget(out var target) || (target - handler) is null);
+                },
+                handler);
+        }
+
         private void RaiseOptionChangedEvent(List<OptionChangedEventArgs> changedOptions)
         {
             Debug.Assert(changedOptions.Count > 0);
 
             // Raise option changed events.
-            var optionChanged = OptionChanged;
-            if (optionChanged != null)
+            foreach (var weakHandler in _weakHandlers)
             {
+                if (!weakHandler.TryGetTarget(out var handler))
+                    continue;
+
                 foreach (var changedOption in changedOptions)
                 {
-                    optionChanged(this, changedOption);
+                    handler(this, changedOption);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -43,20 +43,18 @@ namespace Microsoft.CodeAnalysis.Options
         /// Sets and persists the value of a global option.
         /// Sets the value of a global option.
         /// Invokes registered option persisters.
-        /// Triggers <see cref="OptionChanged"/>.
+        /// Triggers option changed event for handlers registered with <see cref="AddOptionChangedHandler"/>.
         /// </summary>
         void SetGlobalOption(OptionKey2 optionKey, object? value);
 
         /// <summary>
         /// Atomically sets the values of specified global options. The option values are persisted.
-        /// Triggers <see cref="OptionChanged"/>.
+        /// Triggers option changed event for handlers registered with <see cref="AddOptionChangedHandler"/>.
         /// </summary>
         /// <remarks>
         /// Returns true if any option changed its value stored in the global options.
         /// </remarks>
         bool SetGlobalOptions(ImmutableArray<KeyValuePair<OptionKey2, object?>> options);
-
-        event EventHandler<OptionChangedEventArgs>? OptionChanged;
 
         /// <summary>
         /// Refreshes the stored value of an option. This should only be called from persisters.
@@ -66,5 +64,9 @@ namespace Microsoft.CodeAnalysis.Options
         /// Returns true if the option changed its value stored in the global options.
         /// </remarks>
         bool RefreshOption(OptionKey2 optionKey, object? newValue);
+
+        void AddOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler);
+
+        void RemoveOptionChangedHandler(object target, EventHandler<OptionChangedEventArgs> handler);
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/GlobalOptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/GlobalOptionServiceTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var changedOptions = new List<OptionChangedEventArgs>();
 
             var handler = new EventHandler<OptionChangedEventArgs>((_, e) => changedOptions.Add(e));
-            globalOptions.OptionChanged += handler;
+            globalOptions.AddOptionChangedHandler(this, handler);
 
             var values = globalOptions.GetOptions(ImmutableArray.Create(new OptionKey2(option1), new OptionKey2(option2)));
             Assert.Equal(1, values[0]);
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             Assert.Equal(6, globalOptions.GetOption(option2));
             Assert.Equal(3, globalOptions.GetOption(option3));
 
-            globalOptions.OptionChanged -= handler;
+            globalOptions.RemoveOptionChangedHandler(this, handler);
         }
 
         [Fact]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -538,6 +538,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SpecializedTasks.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\StringBreaker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ValueTaskExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\WeakEvent`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\WordSimilarityChecker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\StringEscapeEncoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SyntaxPath.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/WeakEvent`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/WeakEvent`1.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
+namespace Roslyn.Utilities;
+
+internal sealed class WeakEvent<TEventArgs>
+{
+    /// <summary>
+    /// Each registered event handler has the lifetime of an associated owning object. This table ensures the weak
+    /// references to the event handlers are not cleaned up while the owning object is still alive.
+    /// </summary>
+    /// <remarks>
+    /// Access to this table is guarded by itself. For example:
+    /// <code>
+    /// <see langword="lock"/> (<see cref="_keepAliveTable"/>)
+    /// {
+    ///   // Read or write to <see cref="_keepAliveTable"/>.
+    /// }
+    /// </code>
+    /// </remarks>
+    private readonly ConditionalWeakTable<object, EventHandler<TEventArgs>> _keepAliveTable = new();
+
+    private ImmutableList<WeakReference<EventHandler<TEventArgs>>> _weakHandlers = ImmutableList<WeakReference<EventHandler<TEventArgs>>>.Empty;
+
+    public void AddHandler(object target, EventHandler<TEventArgs> handler)
+    {
+        lock (_keepAliveTable)
+        {
+            if (_keepAliveTable.TryGetValue(target, out var existingHandler))
+            {
+                // Combine the delegates and store the combination in the keep-alive table
+                var newHandler = existingHandler + handler;
+#if NET6_0_OR_GREATER
+                _keepAliveTable.AddOrUpdate(target, newHandler);
+#else
+                _keepAliveTable.Remove(target);
+                _keepAliveTable.Add(target, newHandler);
+#endif
+            }
+            else
+            {
+                // This is the first handler for this target, so just store it in the table directly
+                _keepAliveTable.Add(target, handler);
+            }
+        }
+
+        ImmutableInterlocked.Update(
+            ref _weakHandlers,
+            static (weakHandlers, handler) =>
+            {
+                // Add a weak reference to the handler to the list of delegates to invoke for this event. During the
+                // mutation, also remove any handlers that were collected without being removed (and are now null).
+                return weakHandlers
+                    .RemoveAll(WeakReferenceExtensions.IsNull)
+                    .Add(new WeakReference<EventHandler<TEventArgs>>(handler));
+            },
+            handler);
+    }
+
+    public void RemoveHandler(object target, EventHandler<TEventArgs> handler)
+    {
+        lock (_keepAliveTable)
+        {
+            if (_keepAliveTable.TryGetValue(target, out var existingHandler))
+            {
+                var newHandler = existingHandler - handler;
+                if (newHandler is null)
+                {
+                    _keepAliveTable.Remove(target);
+                }
+                else
+                {
+#if NET6_0_OR_GREATER
+                    _keepAliveTable.AddOrUpdate(target, newHandler);
+#else
+                    _keepAliveTable.Remove(target);
+                    _keepAliveTable.Add(target, newHandler);
+#endif
+                }
+            }
+        }
+
+        ImmutableInterlocked.Update(
+            ref _weakHandlers,
+            static (weakHandlers, handler) =>
+            {
+                // Remove any references to the handler from the list of delegates to invoke for this event. During the
+                // mutation, also remove any handlers that were collected without being removed (and are now null).
+                var builder = weakHandlers.ToBuilder();
+                for (var i = weakHandlers.Count - 1; i >= 0; i--)
+                {
+                    var weakHandler = weakHandlers[i];
+                    if (!weakHandler.TryGetTarget(out var target))
+                    {
+                        // This handler was collected
+                        builder.RemoveAt(i);
+                        continue;
+                    }
+
+                    var updatedHandler = target - handler;
+                    if (updatedHandler is null)
+                    {
+                        builder.RemoveAt(i);
+                    }
+                    else if (updatedHandler != target)
+                    {
+                        builder[i].SetTarget(updatedHandler);
+                    }
+                }
+
+                return builder.ToImmutable();
+            },
+            handler);
+    }
+
+    public void RaiseEvent(object? sender, TEventArgs e)
+    {
+        foreach (var weakHandler in _weakHandlers)
+        {
+            if (!weakHandler.TryGetTarget(out var handler))
+                continue;
+
+            handler(sender, e);
+        }
+    }
+}


### PR DESCRIPTION
Force the use of a weak event handler pattern for GlobalOptionService. In the event a PreviewWorkspace fails to be released, it will no longer be GC rooted through this event.

Extracted from #68054 