### PR TITLE
Avoid rooting document instances in NavigateToSearchResult

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
                 _sourceSpan = sourceSpan;
             }
 
-            public Document Document => _workspace.CurrentSolution.Projects.Single().Documents.Single();
+            public INavigableItem.NavigableDocument Document => INavigableItem.NavigableDocument.FromDocument(_workspace.CurrentSolution.Projects.Single().Documents.Single());
             public TextSpan SourceSpan => _sourceSpan;
 
             public string AdditionalInformation => throw new NotImplementedException();

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/DefaultNavigateToPreviewService.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/DefaultNavigateToPreviewService.cs
@@ -4,14 +4,16 @@
 
 #nullable disable
 
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 {
     internal sealed class DefaultNavigateToPreviewService : INavigateToPreviewService
     {
-        public int GetProvisionalViewingStatus(Document document)
-            => 0;
+        public __VSPROVISIONALVIEWINGSTATUS GetProvisionalViewingStatus(INavigableItem.NavigableDocument document)
+            => __VSPROVISIONALVIEWINGSTATUS.PVS_Disabled;
 
         public bool CanPreview(Document document)
             => true;

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/INavigateToPreviewService.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/INavigateToPreviewService.cs
@@ -5,13 +5,15 @@
 #nullable disable
 
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 {
     internal interface INavigateToPreviewService : IWorkspaceService
     {
-        int GetProvisionalViewingStatus(Document document);
+        __VSPROVISIONALVIEWINGSTATUS GetProvisionalViewingStatus(INavigableItem.NavigableDocument document);
         bool CanPreview(Document document);
         void PreviewItem(INavigateToItemDisplay itemDisplay);
     }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
@@ -63,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 return new List<DescriptionItem>().AsReadOnly();
             }
 
-            var sourceText = document.GetTextSynchronously(CancellationToken.None);
+            var sourceText = document.GetTextSynchronously(document.Workspace.CurrentSolution, CancellationToken.None);
             var span = NavigateToUtilities.GetBoundedSpan(_searchResult.NavigableItem, sourceText);
 
             var items = new List<DescriptionItem>
@@ -111,13 +112,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             var document = _searchResult.NavigableItem.Document;
             if (document == null)
             {
-                return 0;
+                return (int)__VSPROVISIONALVIEWINGSTATUS.PVS_Disabled;
             }
 
-            var workspace = document.Project.Solution.Workspace;
+            var workspace = document.Workspace;
             var previewService = workspace.Services.GetService<INavigateToPreviewService>();
 
-            return previewService.GetProvisionalViewingStatus(document);
+            return (int)previewService.GetProvisionalViewingStatus(document);
         }
 
         public void PreviewItem()
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 return;
             }
 
-            var workspace = document.Project.Solution.Workspace;
+            var workspace = document.Workspace;
             var previewService = workspace.Services.GetService<INavigateToPreviewService>();
 
             previewService.PreviewItem(this);

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -64,9 +64,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 return new List<DescriptionItem>().AsReadOnly();
             }
 
-            var sourceText = document.GetTextSynchronously(document.Workspace.CurrentSolution, CancellationToken.None);
-            var span = NavigateToUtilities.GetBoundedSpan(_searchResult.NavigableItem, sourceText);
-
             var items = new List<DescriptionItem>
                     {
                         new DescriptionItem(
@@ -79,12 +76,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                                 new[] { new DescriptionRun("File:", bold: true) }),
                             new ReadOnlyCollection<DescriptionRun>(
                                 new[] { new DescriptionRun(document.FilePath ?? document.Name) })),
-                        new DescriptionItem(
-                            new ReadOnlyCollection<DescriptionRun>(
-                                new[] { new DescriptionRun("Line:", bold: true) }),
-                            new ReadOnlyCollection<DescriptionRun>(
-                                new[] { new DescriptionRun((sourceText.Lines.IndexOf(span.Start) + 1).ToString()) }))
                     };
+
+            if (document.TryGetTextSynchronously(document.Workspace.CurrentSolution, CancellationToken.None) is { } sourceText)
+            {
+                var span = NavigateToUtilities.GetBoundedSpan(_searchResult.NavigableItem, sourceText);
+                items.Add(
+                    new DescriptionItem(
+                        new ReadOnlyCollection<DescriptionRun>(
+                            new[] { new DescriptionRun("Line:", bold: true) }),
+                        new ReadOnlyCollection<DescriptionRun>(
+                            new[] { new DescriptionRun((sourceText.Lines.IndexOf(span.Start) + 1).ToString()) })));
+            }
 
             var summary = _searchResult.Summary;
             if (!string.IsNullOrWhiteSpace(summary))

--- a/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                     if (await navigationService.CanNavigateToPositionAsync(
                             workspace, document.Id, item.SourceSpan.Start, cancellationToken).ConfigureAwait(false))
                     {
-                        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                        var text = await document.GetTextAsync(project.Solution, cancellationToken).ConfigureAwait(false);
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);
                         if (document.FilePath != null)
                         {

--- a/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
+++ b/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CodeDefinitionWindow
                 {
                     if (await navigationService.CanNavigateToSpanAsync(workspace, item.Document.Id, item.SourceSpan, cancellationToken).ConfigureAwait(false))
                     {
-                        var text = await item.Document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                        var text = await item.Document.GetTextAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);
 
                         if (item.Document.FilePath != null)

--- a/src/EditorFeatures/Core/NavigateTo/NavigateToHelpers.cs
+++ b/src/EditorFeatures/Core/NavigateTo/NavigateToHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigateTo
             if (document == null)
                 return;
 
-            var workspace = document.Project.Solution.Workspace;
+            var workspace = document.Workspace;
             var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
 
             // Document tabs opened by NavigateTo are carefully created as preview or regular tabs

--- a/src/EditorFeatures/Test2/CodeDefinitionWindow/CrossLanguageCodeDefinitionWindowTests.vb
+++ b/src/EditorFeatures/Test2/CodeDefinitionWindow/CrossLanguageCodeDefinitionWindowTests.vb
@@ -22,10 +22,10 @@ Namespace Microsoft.CodeAnalysis.Editor.CodeDefinitionWindow.UnitTests
         Private Class FakeNavigableItem
             Implements INavigableItem
 
-            Private ReadOnly _document As Document
+            Private ReadOnly _document As INavigableItem.NavigableDocument
 
             Public Sub New(document As Document)
-                _document = document
+                _document = INavigableItem.NavigableDocument.FromDocument(document)
             End Sub
 
             Public ReadOnly Property ChildItems As ImmutableArray(Of INavigableItem) Implements INavigableItem.ChildItems
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.CodeDefinitionWindow.UnitTests
                 End Get
             End Property
 
-            Public ReadOnly Property Document As Document Implements INavigableItem.Document
+            Public ReadOnly Property Document As INavigableItem.NavigableDocument Implements INavigableItem.Document
                 Get
                     Return _document
                 End Get

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigableItemWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigableItemWrapper.cs
@@ -12,10 +12,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
     internal sealed class VSTypeScriptNavigableItemWrapper : INavigableItem
     {
         private readonly IVSTypeScriptNavigableItem _navigableItem;
+        private readonly INavigableItem.NavigableDocument _navigableDocument;
 
         public VSTypeScriptNavigableItemWrapper(IVSTypeScriptNavigableItem navigableItem)
         {
             _navigableItem = navigableItem;
+            _navigableDocument = INavigableItem.NavigableDocument.FromDocument(navigableItem.Document);
         }
 
         public Glyph Glyph => _navigableItem.Glyph;
@@ -26,7 +28,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 
         public bool IsImplicitlyDeclared => _navigableItem.IsImplicitlyDeclared;
 
-        public Document Document => _navigableItem.Document;
+        public INavigableItem.NavigableDocument Document => _navigableDocument;
 
         public TextSpan SourceSpan => _navigableItem.SourceSpan;
 

--- a/src/Features/Core/Portable/Navigation/INavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/INavigableItem.cs
@@ -61,18 +61,13 @@ namespace Microsoft.CodeAnalysis.Navigation
                     Workspace = document.Project.Solution.Workspace,
                 };
 
-            internal async ValueTask<Document> GetDocumentAsync(Solution solution, CancellationToken cancellationToken)
-            {
-                if (solution.GetDocument(Id) is { } document)
-                    return document;
+            internal ValueTask<Document> GetDocumentAsync(Solution solution, CancellationToken cancellationToken)
+                => solution.GetRequiredDocumentAsync(Id, includeSourceGenerated: IsSourceGeneratedDocument, cancellationToken);
 
-                return await solution.GetRequiredDocumentAsync(Id, includeSourceGenerated: IsSourceGeneratedDocument, cancellationToken).ConfigureAwait(false);
-            }
-
-            internal async Task<SourceText> GetTextAsync(Solution solution, CancellationToken cancellationToken)
+            internal async ValueTask<SourceText> GetTextAsync(Solution solution, CancellationToken cancellationToken)
             {
                 var document = await GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
-                return await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                return await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             }
 
             internal SourceText GetTextSynchronously(Solution solution, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Navigation/INavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/INavigableItem.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -49,24 +48,35 @@ namespace Microsoft.CodeAnalysis.Navigation
 
         ImmutableArray<INavigableItem> ChildItems { get; }
 
-        public record NavigableDocument(NavigableProject Project, string Name, string? FilePath, IReadOnlyList<string> Folders, DocumentId Id)
+        public record NavigableDocument(NavigableProject Project, string Name, string? FilePath, IReadOnlyList<string> Folders, DocumentId Id, bool IsSourceGeneratedDocument, Workspace Workspace)
         {
-            public required bool IsSourceGeneratedDocument { get; init; }
-            public required Workspace Workspace { get; init; }
-
             public static NavigableDocument FromDocument(Document document)
-                => new(NavigableProject.FromProject(document.Project), document.Name, document.FilePath, document.Folders, document.Id)
-                {
-                    IsSourceGeneratedDocument = document is SourceGeneratedDocument,
-                    Workspace = document.Project.Solution.Workspace,
-                };
+                => new(
+                    NavigableProject.FromProject(document.Project),
+                    document.Name,
+                    document.FilePath,
+                    document.Folders,
+                    document.Id,
+                    IsSourceGeneratedDocument: document is SourceGeneratedDocument,
+                    document.Project.Solution.Workspace);
 
-            internal ValueTask<Document> GetDocumentAsync(Solution solution, CancellationToken cancellationToken)
+            /// <summary>
+            /// Get the <see cref="CodeAnalysis.Document"/> within <paramref name="solution"/> which is referenced by
+            /// this navigable item. The document is required to exist within the solution, e.g. a case where the
+            /// navigable item was constructed during a Find Symbols operation on the same solution instance.
+            /// </summary>
+            internal ValueTask<Document> GetRequiredDocumentAsync(Solution solution, CancellationToken cancellationToken)
                 => solution.GetRequiredDocumentAsync(Id, includeSourceGenerated: IsSourceGeneratedDocument, cancellationToken);
 
+            /// <summary>
+            /// Get the <see cref="SourceText"/> of the <see cref="CodeAnalysis.Document"/> within
+            /// <paramref name="solution"/> which is referenced by this navigable item. The document is required to
+            /// exist within the solution, e.g. a case where the navigable item was constructed during a Find Symbols
+            /// operation on the same solution instance.
+            /// </summary>
             internal async ValueTask<SourceText> GetTextAsync(Solution solution, CancellationToken cancellationToken)
             {
-                var document = await GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
+                var document = await GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
                 return await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Features/Core/Portable/Navigation/INavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/INavigableItem.cs
@@ -70,10 +70,10 @@ namespace Microsoft.CodeAnalysis.Navigation
                 return await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            internal SourceText GetTextSynchronously(Solution solution, CancellationToken cancellationToken)
+            internal SourceText? TryGetTextSynchronously(Solution solution, CancellationToken cancellationToken)
             {
-                var document = solution.GetRequiredDocument(Id);
-                return document.GetTextSynchronously(cancellationToken);
+                var document = solution.GetDocument(Id);
+                return document?.GetTextSynchronously(cancellationToken);
             }
         }
 

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -5,8 +5,10 @@
 #nullable disable
 
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Navigation
 {
@@ -17,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Navigation
             private readonly Solution _solution;
             private readonly ISymbol _symbol;
             private readonly Location _location;
+            private StrongBox<INavigableItem.NavigableDocument> _lazyDocument;
 
             public SymbolLocationNavigableItem(
                 Solution solution,
@@ -38,8 +41,21 @@ namespace Microsoft.CodeAnalysis.Navigation
 
             public bool IsImplicitlyDeclared => _symbol.IsImplicitlyDeclared;
 
-            public Document Document
-                => _location.IsInSource ? _solution.GetDocument(_location.SourceTree) : null;
+            public INavigableItem.NavigableDocument Document
+            {
+                get
+                {
+                    return LazyInitialization.EnsureInitialized(
+                        ref _lazyDocument,
+                        static self =>
+                        {
+                            return (self._location.IsInSource && self._solution.GetDocument(self._location.SourceTree) is { } document)
+                                ? INavigableItem.NavigableDocument.FromDocument(document)
+                                : null;
+                        },
+                        this);
+                }
+            }
 
             public TextSpan SourceSpan => _location.SourceSpan;
 

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -19,6 +20,11 @@ namespace Microsoft.CodeAnalysis.Navigation
             private readonly Solution _solution;
             private readonly ISymbol _symbol;
             private readonly Location _location;
+
+            /// <summary>
+            /// Lazily-initialized backing field for <see cref="Document"/>.
+            /// </summary>
+            /// <seealso cref="LazyInitialization.EnsureInitialized{T, U}(ref StrongBox{T}, Func{U, T}, U)"/>
             private StrongBox<INavigableItem.NavigableDocument> _lazyDocument;
 
             public SymbolLocationNavigableItem(

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     }
 
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
-                        await definition.Document.GetDocumentAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false),
+                        await definition.Document.GetRequiredDocumentAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false),
                         definition.SourceSpan,
                         definition.IsStale,
                         cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -59,7 +59,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     }
 
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
-                        definition.Document, definition.SourceSpan, definition.IsStale, cancellationToken).ConfigureAwait(false);
+                        await definition.Document.GetDocumentAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false),
+                        definition.SourceSpan,
+                        definition.IsStale,
+                        cancellationToken).ConfigureAwait(false);
                     locations.AddIfNotNull(location);
                 }
             }

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
-                var document = await result.NavigableItem.Document.GetDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+                var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
 
                 var location = await ProtocolConversions.TextSpanToLocationAsync(
                     document, result.NavigableItem.SourceSpan, result.NavigableItem.IsStale, _context, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -85,8 +85,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
+                var document = await result.NavigableItem.Document.GetDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+
                 var location = await ProtocolConversions.TextSpanToLocationAsync(
-                    result.NavigableItem.Document, result.NavigableItem.SourceSpan, result.NavigableItem.IsStale, _context, cancellationToken).ConfigureAwait(false);
+                    document, result.NavigableItem.SourceSpan, result.NavigableItem.IsStale, _context, cancellationToken).ConfigureAwait(false);
                 if (location == null)
                     return;
 

--- a/src/Tools/ExternalAccess/FSharp/Internal/Navigation/InternalFSharpNavigableItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Navigation/InternalFSharpNavigableItem.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
 using Microsoft.CodeAnalysis.Navigation;
@@ -13,11 +14,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation
 {
     internal class InternalFSharpNavigableItem : INavigableItem
     {
+        private readonly INavigableItem.NavigableDocument _navigableDocument;
+
         public InternalFSharpNavigableItem(FSharpNavigableItem item)
         {
             Glyph = FSharpGlyphHelpers.ConvertTo(item.Glyph);
             DisplayTaggedParts = item.DisplayTaggedParts;
             Document = item.Document;
+            _navigableDocument = INavigableItem.NavigableDocument.FromDocument(item.Document);
             SourceSpan = item.SourceSpan;
         }
 
@@ -30,6 +34,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation
         public bool IsImplicitlyDeclared => false;
 
         public Document Document { get; }
+
+        INavigableItem.NavigableDocument INavigableItem.Document => _navigableDocument;
 
         public TextSpan SourceSpan { get; }
 

--- a/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.GoToDefinition
             var service = document.GetRequiredLanguageService<IFindDefinitionService>();
             var result = await service.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
             return await result.NullToEmpty().SelectAsArrayAsync(
-                async (original, solution, cancellationToken) => new OmniSharpNavigableItem(original.DisplayTaggedParts, await original.Document.GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false), original.SourceSpan),
+                async (original, solution, cancellationToken) => new OmniSharpNavigableItem(original.DisplayTaggedParts, await original.Document.GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false), original.SourceSpan),
                 document.Project.Solution,
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/GoToDefinition/OmniSharpFindDefinitionService.cs
@@ -17,7 +17,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.GoToDefinition
         {
             var service = document.GetRequiredLanguageService<IFindDefinitionService>();
             var result = await service.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return result.NullToEmpty().SelectAsArray(original => new OmniSharpNavigableItem(original.DisplayTaggedParts, original.Document, original.SourceSpan));
+            return await result.NullToEmpty().SelectAsArrayAsync(
+                async (original, solution, cancellationToken) => new OmniSharpNavigableItem(original.DisplayTaggedParts, await original.Document.GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false), original.SourceSpan),
+                document.Project.Solution,
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation;
@@ -45,8 +42,9 @@ internal static class OmniSharpNavigateToSearcher
             _callback = callback;
         }
 
-        public Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
+        public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
+            var document = await result.NavigableItem.Document.GetDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
             var omniSharpResult = new OmniSharpNavigateToSearchResult(
                 result.AdditionalInformation,
                 result.Kind,
@@ -56,9 +54,9 @@ internal static class OmniSharpNavigateToSearcher
                 result.NameMatchSpans,
                 result.SecondarySort,
                 result.Summary!,
-                new(result.NavigableItem.DisplayTaggedParts, result.NavigableItem.Document, result.NavigableItem.SourceSpan));
+                new OmniSharpNavigableItem(result.NavigableItem.DisplayTaggedParts, document, result.NavigableItem.SourceSpan));
 
-            return _callback(project, omniSharpResult, cancellationToken);
+            await _callback(project, omniSharpResult, cancellationToken).ConfigureAwait(false);
         }
 
         public void Done(bool isFullyLoaded)

--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
@@ -44,7 +44,7 @@ internal static class OmniSharpNavigateToSearcher
 
         public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
-            var document = await result.NavigableItem.Document.GetDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+            var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
             var omniSharpResult = new OmniSharpNavigateToSearchResult(
                 result.AdditionalInformation,
                 result.Kind,

--- a/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewService.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/VisualStudioNavigateToPreviewService.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo;
+using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -16,14 +17,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigateTo
 {
     internal sealed class VisualStudioNavigateToPreviewService : INavigateToPreviewService
     {
-        public int GetProvisionalViewingStatus(Document document)
+        public __VSPROVISIONALVIEWINGSTATUS GetProvisionalViewingStatus(INavigableItem.NavigableDocument document)
         {
             if (document.FilePath == null)
             {
-                return (int)__VSPROVISIONALVIEWINGSTATUS.PVS_Disabled;
+                return __VSPROVISIONALVIEWINGSTATUS.PVS_Disabled;
             }
 
-            return (int)VsShellUtilities.GetProvisionalViewingStatus(document.FilePath);
+            return (__VSPROVISIONALVIEWINGSTATUS)VsShellUtilities.GetProvisionalViewingStatus(document.FilePath);
         }
 
         public bool CanPreview(Document document)

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -756,7 +756,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             symbolNode.AddCategory(category);
             symbolNode[DgmlNodeProperties.Icon] = GetIconString(result.NavigableItem.Glyph);
             symbolNode[RoslynGraphProperties.ContextDocumentId] = document.Id;
-            symbolNode[RoslynGraphProperties.ContextProjectId] = document.Id.ProjectId;
+            symbolNode[RoslynGraphProperties.ContextProjectId] = document.Project.Id;
 
             symbolNode[CodeNodeProperties.SourceLocation] = sourceLocation.Value;
 

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -699,7 +699,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         public async Task<GraphNode?> CreateNodeAsync(Solution solution, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
-            var document = await result.NavigableItem.Document.GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
+            var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
             var project = document.Project;
 
             // If it doesn't belong to a document or project we can navigate to, then ignore entirely.

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -697,9 +697,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
         }
 
-        public async Task<GraphNode?> CreateNodeAsync(INavigateToSearchResult result, CancellationToken cancellationToken)
+        public async Task<GraphNode?> CreateNodeAsync(Solution solution, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
-            var document = result.NavigableItem.Document;
+            var document = await result.NavigableItem.Document.GetDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
             var project = document.Project;
 
             // If it doesn't belong to a document or project we can navigate to, then ignore entirely.
@@ -756,7 +756,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             symbolNode.AddCategory(category);
             symbolNode[DgmlNodeProperties.Icon] = GetIconString(result.NavigableItem.Glyph);
             symbolNode[RoslynGraphProperties.ContextDocumentId] = document.Id;
-            symbolNode[RoslynGraphProperties.ContextProjectId] = project.Id;
+            symbolNode[RoslynGraphProperties.ContextProjectId] = document.Id.ProjectId;
 
             symbolNode[CodeNodeProperties.SourceLocation] = sourceLocation.Value;
 

--- a/src/VisualStudio/Core/Def/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueries/ProgressionNavigateToSearchCallback.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
-                var node = await _graphBuilder.CreateNodeAsync(result, cancellationToken).ConfigureAwait(false);
+                var node = await _graphBuilder.CreateNodeAsync(project.Solution, result, cancellationToken).ConfigureAwait(false);
                 if (node != null)
                 {
                     // _context.OutputNodes is not threadsafe.  So ensure only one navto callback can mutate it at a time.

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -159,10 +159,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
             var items = NavigableItemFactory.GetItemsFromPreferredSourceLocations(context.Solution, symbol, displayTaggedParts: null, cancellationToken);
             if (items.Any())
             {
+                RoslynDebug.AssertNotNull(context.Solution);
                 foreach (var item in items)
                 {
+                    var document = await item.Document.GetDocumentAsync(context.Solution, cancellationToken).ConfigureAwait(false);
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
-                        item.Document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
+                        document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
                     locations.AddIfNotNull(location);
                 }
             }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 RoslynDebug.AssertNotNull(context.Solution);
                 foreach (var item in items)
                 {
-                    var document = await item.Document.GetDocumentAsync(context.Solution, cancellationToken).ConfigureAwait(false);
+                    var document = await item.Document.GetRequiredDocumentAsync(context.Solution, cancellationToken).ConfigureAwait(false);
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
                         document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
                     locations.AddIfNotNull(location);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
@@ -48,10 +48,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => solution.GetDocument(documentId) ?? throw CreateDocumentNotFoundException();
 
 #if !CODE_STYLE
-        public static async Task<Document> GetRequiredDocumentAsync(this Solution solution, DocumentId documentId, bool includeSourceGenerated = false, CancellationToken cancellationToken = default)
+        public static async ValueTask<Document> GetRequiredDocumentAsync(this Solution solution, DocumentId documentId, bool includeSourceGenerated = false, CancellationToken cancellationToken = default)
             => (await solution.GetDocumentAsync(documentId, includeSourceGenerated, cancellationToken).ConfigureAwait(false)) ?? throw CreateDocumentNotFoundException();
 
-        public static async Task<TextDocument> GetRequiredTextDocumentAsync(this Solution solution, DocumentId documentId, CancellationToken cancellationToken = default)
+        public static async ValueTask<TextDocument> GetRequiredTextDocumentAsync(this Solution solution, DocumentId documentId, CancellationToken cancellationToken = default)
             => (await solution.GetTextDocumentAsync(documentId, cancellationToken).ConfigureAwait(false)) ?? throw CreateDocumentNotFoundException();
 #endif
 


### PR DESCRIPTION
Addresses 11.1GB retained set observed in a local heap dump.

Submitted as draft for PR validation.

Follow-up to #68071