### PR TITLE
LSP.Range may request beyond length of file

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -757,6 +757,6 @@
     <value>Invalid instrumentation kind: {0}</value>
   </data>
   <data name="LineCannotBeGreaterThanEnd" xml:space="preserve">
-    <value>The requested line number {0} is greater than the number of lines {1}.</value>
+    <value>The requested line number {0} must be less than the number of lines {1}.</value>
   </data>
 </root>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -756,4 +756,7 @@
   <data name="InvalidInstrumentationKind" xml:space="preserve">
     <value>Invalid instrumentation kind: {0}</value>
   </data>
+  <data name="LineCannotBeGreaterThanEnd" xml:space="preserve">
+    <value>The requested line number {0} is greater than the number of lines {1}.</value>
+  </data>
 </root>

--- a/src/Compilers/Core/Portable/Text/TextLineCollection.cs
+++ b/src/Compilers/Core/Portable/Text/TextLineCollection.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Text

--- a/src/Compilers/Core/Portable/Text/TextLineCollection.cs
+++ b/src/Compilers/Core/Portable/Text/TextLineCollection.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -62,6 +63,11 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         public int GetPosition(LinePosition position)
         {
+            if (position.Line >= this.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(position.Line), string.Format(CodeAnalysisResources.LineCannotBeGreaterThanEnd, position.Line, this.Count));
+            }
+
             return this[position.Line].Start + position.Character;
         }
 

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Parametr {0} musí být symbol z této kompilace nebo některé odkazované sestavení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Byl očekáván symbol metody.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Der Parameter "{0}" muss ein Symbol aus dieser Zusammenstellung oder eine referenzierte Assembly sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Methodensymbol erwartet</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -129,6 +129,11 @@
         <target state="translated">El parámetro "{0}" debe ser un símbolo de esta compilación o algún ensamble al que se hace referencia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Se esperaba un símbolo de método</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Le paramètre '{0}' doit être un symbole de cette compilation ou un assembly référencé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Symbole de méthode attendu</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Il parametro '{0}' deve essere un simbolo di questa compilazione oppure un qualsiasi assembly cui viene fatto riferimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">È previsto un simbolo di metodo</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -129,6 +129,11 @@
         <target state="translated">パラメーター '{0}' は、このコンパイルまたはいくつかの参照アセンブリのシンボルにする必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">メソッド シンボルが必要です</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -129,6 +129,11 @@
         <target state="translated">'{0}' 매개 변수는 이 컴파일 또는 일부 참조된 어셈블리의 기호여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">메서드 기호가 필요합니다.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Parametr „{0}” musi być symbolem z tej kompilacji lub przywoływanym zestawem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Oczekiwano symbolu metody</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -129,6 +129,11 @@
         <target state="translated">O parâmetro '{0}' deve ser um símbolo desta compilação ou um assembly referenciado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Símbolo de método esperado</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -129,6 +129,11 @@
         <target state="translated">Параметр "{0}" должен быть символом из этой компиляции или из другой сборки, на которую она ссылается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Ожидается символ метода</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -129,6 +129,11 @@
         <target state="translated">'{0}' parametresi bu derleme veya bazı başvurulan derleme bir sembol olması gerekir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">Yöntem sembolü bekleniyor</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -129,6 +129,11 @@
         <target state="translated">参数“{0}”必须是此编译或某些引用程序集的符号。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">应为方法符号</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -130,8 +130,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LineCannotBeGreaterThanEnd">
-        <source>The requested line number {0} is greater than the number of lines {1}.</source>
-        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <source>The requested line number {0} must be less than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} must be less than the number of lines {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MethodSymbolExpected">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -129,6 +129,11 @@
         <target state="translated">參數 '{0}' 必須是此編譯或某些參考組件中的符號。</target>
         <note />
       </trans-unit>
+      <trans-unit id="LineCannotBeGreaterThanEnd">
+        <source>The requested line number {0} is greater than the number of lines {1}.</source>
+        <target state="new">The requested line number {0} is greater than the number of lines {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MethodSymbolExpected">
         <source>Method symbol expected</source>
         <target state="translated">預期的方法符號</target>

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                     // The TextLines will throw a ArgumentException if asked for the line after the last line,
                     // despite the call being valid call per the LSP spec. If the end of the input range is one
                     // beyond the end of the file, edit the end character position of the last line in the file.
-                    if (text.Lines.Count == range.End.Line)
+                    if (text.Lines.Count == range.End.Line && range.End.Character == 0)
                     {
                         var indexOfLastLine = text.Lines.Count - 1;
                         var lastLineOfText = text.Lines[indexOfLastLine];

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -92,4 +92,19 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="LanguageServerResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>LanguageServerResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="LanguageServerResources.resx" GenerateSource="true" Namespace="Microsoft.CodeAnalysis.LanguageServer">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>LanguageServerResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -65,24 +65,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [Fact]
-        public void RangeToTextSpanEndOfDocumentExclusive()
-        {
-            var markup = GetTestMarkup();
-            var sourceText = SourceText.From(markup);
-
-            // LSP documentation on range indicates:
-            // "End position is exclusive.If you want to specify a range that contains a line including the
-            // line ending character(s) then use an end position denoting the start of the next line."
-            //
-            // Specifying one line past the end of the document is an allowed range. 
-            var range = new Range() { Start = new Position(0, 0), End = new Position(sourceText.Lines.Count, 0) };
-            var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
-
-            Assert.Equal(0, textSpan.Start);
-            Assert.Equal(30, textSpan.End);
-        }
-
-        [Fact]
         public void RangeToTextSpanLineEndOfDocumentWithEndOfLineChars()
         {
             var markup =
@@ -103,24 +85,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         }
 
         [Fact]
-        public void RangeToTextSpanEndOfDocumentCharacterError()
+        public void RangeToTextSpanLineOutOfRangeError()
         {
             var markup = GetTestMarkup();
             var sourceText = SourceText.From(markup);
 
-            // Ensure that requesting a character on the line that doesn't exist throws an error
-            var range = new Range() { Start = new Position(0, 0), End = new Position(4, 1) };
+            var range = new Range() { Start = new Position(0, 0), End = new Position(sourceText.Lines.Count, 0) };
             Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
         }
 
         [Fact]
-        public void RangeToTextSpanEndOfDocumentStartError()
+        public void RangeToTextSpanEndAfterStartError()
         {
             var markup = GetTestMarkup();
             var sourceText = SourceText.From(markup);
 
-            // Start position beyond the end of the document is not valid
-            var range = new Range() { Start = new Position(sourceText.Lines.Count, 0), End = new Position(sourceText.Lines.Count, 0) };
+            // This start position will be beyond the end position
+            var range = new Range() { Start = new Position(2, 20), End = new Position(3, 0) };
             Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
         }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
@@ -18,6 +21,94 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var containsFunction = map.Values.Any(c => c.Contains(CompletionItemKind.Function));
 
             Assert.False(containsFunction && containsMethod, "Don't use Method and Function completion item kinds as it causes user confusion.");
+        }
+
+        [Fact]
+        public void RangeToTextSpanStartWithNextLine()
+        {
+            var markup = GetTestMarkup();
+
+            var sourceText = SourceText.From(markup);
+            var range = new Range() { Start = new Position(0, 0), End = new Position(1, 0) };
+            var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+            // End should be start of the second line
+            Assert.Equal(0, textSpan.Start);
+            Assert.Equal(10, textSpan.End);
+        }
+
+        [Fact]
+        public void RangeToTextSpanWithNextLine()
+        {
+            var markup = GetTestMarkup();
+            var sourceText = SourceText.From(markup);
+            var range = new Range() { Start = new Position(2, 0), End = new Position(3, 0) };
+            var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+            // End should be start of fourth line
+            Assert.Equal(13, textSpan.Start);
+            Assert.Equal(29, textSpan.End);
+        }
+
+        [Fact]
+        public void RangeToTextSpanMidLine()
+        {
+            var markup = GetTestMarkup();
+            var sourceText = SourceText.From(markup);
+
+            // Take just "x = 5"
+            var range = new Range() { Start = new Position(2, 8), End = new Position(2, 12) };
+            var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+            Assert.Equal(21, textSpan.Start);
+            Assert.Equal(25, textSpan.End);
+        }
+
+        [Fact]
+        public void RangeToTextSpanLineAfterEndOfDocument()
+        {
+            var markup = GetTestMarkup();
+            var sourceText = SourceText.From(markup);
+
+            // LSP documentation on range indicates:
+            // "End position is exclusive.If you want to specify a range that contains a line including the
+            // line ending character(s) then use an end position denoting the start of the next line."
+            //
+            // Specifying one line past the end of the document is an allowed range. 
+            var range = new Range() { Start = new Position(0, 0), End = new Position(sourceText.Lines.Count, 0) };
+            var textSpan = ProtocolConversions.RangeToTextSpan(range, sourceText);
+
+            Assert.Equal(0, textSpan.Start);
+            Assert.Equal(30, textSpan.End);
+        }
+
+        [Fact]
+        public void RangeToTextSpanStartFailure()
+        {
+            var markup = GetTestMarkup();
+            var sourceText = SourceText.From(markup);
+
+            // Start position beyond the end of the document is not valid
+            var range = new Range() { Start = new Position(sourceText.Lines.Count, 0), End = new Position(sourceText.Lines.Count, 0) };
+            Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
+        }
+
+        private static string GetTestMarkup()
+        {
+            // Markup is 31 characters long. Line break (\n) is 2 characters 
+            /*
+            void M()        [Line = 0; Start = 0; End = 8; End including line break = 10]
+            {               [Line = 1; Start = 10; End = 11; End including line break = 13]
+                var x = 5;  [Line = 2; Start = 13; End = 27; End including line break = 29]
+            }               [Line = 3; Start = 29; End = 30; End including line break = 30]
+             */
+
+            var markup =
+@"void M()
+{
+    var x = 5;
+}";
+            return markup;
         }
     }
 }


### PR DESCRIPTION
There has been a persistent issue with ArgumentException at `ProtocolConversions.RangeToTextSpan`. [Issue 66258](https://github.com/dotnet/roslyn/issues/66258).  

Cyrus added more logging and it seems the problem is triggered when a line beyond the end of the document is requested. Here is an example error logged: `System.ArgumentException: Range={ Start={ Line=0, Character=0 }, End={ Line=31, Character=0 } }. text.Length=811. text.Lines.Count=31`

Per the [LSP Range](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range) spec 

> A range in a text document expressed as (zero-based) start and end positions. A range is comparable to a selection in an editor. Therefore, the end position is exclusive. **If you want to specify a range that contains a line including the line ending character(s) then use an end position denoting the start of the next line.**

**Edit: End range outside of the length of the file should throw an error.** 
~~Using this definition, it seems that for a document with n lines, requesting line n +1 is a valid way to specify you'd like the line ending characters included.~~