### PR TITLE
Avoid waiting on the thread pool when there is no work to do

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
@@ -1031,10 +1032,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         foreach (var suppressor in suppressors)
                         {
-                            var task = Task.Run(
-                                () => AnalyzerExecutor.ExecuteSuppressionAction(suppressor, getSuppressableDiagnostics(suppressor), cancellationToken),
-                                cancellationToken);
-                            tasks.Add(task);
+                            var suppressableDiagnostics = getSuppressableDiagnostics(suppressor);
+                            if (!suppressableDiagnostics.IsEmpty)
+                            {
+                                var task = Task.Run(
+                                    () => AnalyzerExecutor.ExecuteSuppressionAction(suppressor, suppressableDiagnostics, cancellationToken),
+                                    cancellationToken);
+                                tasks.Add(task);
+                            }
                         }
 
                         Task.WaitAll(tasks.ToArray(), cancellationToken);
@@ -1062,7 +1067,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         return ImmutableArray<Diagnostic>.Empty;
                     }
 
-                    var builder = ArrayBuilder<Diagnostic>.GetInstance();
+                    using var builder = TemporaryArray<Diagnostic>.Empty;
                     foreach (var diagnostic in reportedDiagnostics)
                     {
                         if (supportedSuppressions.Contains(s => s.SuppressedDiagnosticId == diagnostic.Id))
@@ -1071,7 +1076,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         }
                     }
 
-                    return builder.ToImmutableAndFree();
+                    return builder.ToImmutableAndClear();
                 }
             }
 


### PR DESCRIPTION
This change avoids creating a background task to invoke ExecuteSuppressionAction when there are no suppressable diagnostics.