### PR TITLE
Compare reference names up front

### DIFF
--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -935,7 +935,7 @@ namespace Microsoft.CodeAnalysis
             {
                 AssemblyIdentity definition = definitions[i].Identity;
 
-                if (reference.Name != definition.Name)
+                if (!AssemblyIdentityComparer.SimpleNameComparer.Equals(reference.Name, definition.Name))
                 {
                     continue;
                 }

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -935,6 +935,11 @@ namespace Microsoft.CodeAnalysis
             {
                 AssemblyIdentity definition = definitions[i].Identity;
 
+                if (reference.Name != definition.Name)
+                {
+                    continue;
+                }
+
                 switch (assemblyIdentityComparer.Compare(reference, definition))
                 {
                     case AssemblyIdentityComparer.ComparisonResult.NotEquivalent:


### PR DESCRIPTION
Somewhat mitigates https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1815503 by prioritizing the name comparison when determining whether two assemblies are the same. This will not restore the same perf that https://github.com/dotnet/roslyn/pull/66430 gave, but is faster than the current implementation in RPS (https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/470691 is the test insertion, showing a 9-13% total elapsed time improvement in orchardcore speedometer runs.