### PR TITLE
Eliminate enumerator boxing in basic block analysis

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -237,7 +237,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 #if NET
                         values.EnsureCapacity(values.Count + operations.Count);
 #endif
-                        values.AddRange(operations);
+
+                        // Enumerate explicitly, instead of calling AddRange, to avoid unnecessary expensive IEnumerator allocation.
+                        foreach (var operation in operations)
+                            values.Add(operation);
                     }
                 }
             }


### PR DESCRIPTION
Addresses 1.1% of all allocs while typing in IDE:

![image](https://github.com/dotnet/roslyn/assets/4564579/a08b01e1-b845-4fb7-afa6-948be94b92c6)
