### PR TITLE
Limit amount of tokens used to calculate LCS distance

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxComparerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxComparerTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -94,31 +95,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public void ComputeDistance2()
-        {
-            var distance = SyntaxComparer.ComputeDistance(
-                ImmutableArray.Create(MakeLiteral(0), MakeLiteral(1), MakeLiteral(2)),
-                ImmutableArray.Create(MakeLiteral(1), MakeLiteral(3)));
-
-            Assert.Equal(0.67, Math.Round(distance, 2));
-        }
-
-        [Fact]
         public void ComputeDistance3()
         {
             var distance = SyntaxComparer.ComputeDistance(
                 new[] { SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword), SyntaxFactory.Token(SyntaxKind.AsyncKeyword) },
                 new[] { SyntaxFactory.Token(SyntaxKind.StaticKeyword), SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.AsyncKeyword) });
-
-            Assert.Equal(0.33, Math.Round(distance, 2));
-        }
-
-        [Fact]
-        public void ComputeDistance4()
-        {
-            var distance = SyntaxComparer.ComputeDistance(
-                ImmutableArray.Create(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword), SyntaxFactory.Token(SyntaxKind.AsyncKeyword)),
-                ImmutableArray.Create(SyntaxFactory.Token(SyntaxKind.StaticKeyword), SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.AsyncKeyword)));
 
             Assert.Equal(0.33, Math.Round(distance, 2));
         }
@@ -141,18 +122,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         public void ComputeDistance_Null()
         {
             var distance = SyntaxComparer.ComputeDistance(
-                default,
-                ImmutableArray.Create(SyntaxFactory.Token(SyntaxKind.StaticKeyword)));
-
-            Assert.Equal(1, Math.Round(distance, 2));
-
-            distance = SyntaxComparer.ComputeDistance(
-                default,
-                ImmutableArray.Create(MakeLiteral(0)));
-
-            Assert.Equal(1, Math.Round(distance, 2));
-
-            distance = SyntaxComparer.ComputeDistance(
                 null,
                 Array.Empty<SyntaxNode>());
 
@@ -175,6 +144,21 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 null);
 
             Assert.Equal(0, Math.Round(distance, 2));
+        }
+
+        [Fact]
+        public void ComputeDistance_LongSequences()
+        {
+            var t1 = SyntaxFactory.Token(SyntaxKind.PublicKeyword);
+            var t2 = SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
+            var t3 = SyntaxFactory.Token(SyntaxKind.ProtectedKeyword);
+
+            var distance = SyntaxComparer.ComputeDistance(
+                Enumerable.Range(0, 10000).Select(i => i < 2000 ? t1 : t2),
+                Enumerable.Range(0, 10000).Select(i => i < 2000 ? t1 : t3));
+
+            // long sequences are indistinguishable if they have common prefix shorter then threshold:
+            Assert.Equal(0, distance);
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxComparer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxComparer.vb
@@ -1389,7 +1389,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' Distance is a number within [0, 1], the smaller the more similar the tokens are. 
         ''' </remarks>
         Public Overloads Shared Function ComputeDistance(oldToken As SyntaxToken, newToken As SyntaxToken) As Double
-            Return LongestCommonSubstring.ComputeDistance(oldToken.ValueText, newToken.ValueText)
+            Return LongestCommonSubstring.ComputePrefixDistance(
+                oldToken.Text, Math.Min(oldToken.Text.Length, LongestCommonSubsequence.MaxSequenceLengthForDistanceCalculation),
+                newToken.Text, Math.Min(newToken.Text.Length, LongestCommonSubsequence.MaxSequenceLengthForDistanceCalculation))
+        End Function
+
+        Private Shared Function CreateArrayForDistanceCalculation(Of T)(enumerable As IEnumerable(Of T)) As ImmutableArray(Of T)
+            Return If(enumerable Is Nothing, ImmutableArray(Of T).Empty, enumerable.Take(LongestCommonSubsequence.MaxSequenceLengthForDistanceCalculation).ToImmutableArray())
         End Function
 
         ''' <summary>
@@ -1399,17 +1405,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         ''' </remarks>
         Public Overloads Shared Function ComputeDistance(oldTokens As IEnumerable(Of SyntaxToken), newTokens As IEnumerable(Of SyntaxToken)) As Double
-            Return ComputeDistance(oldTokens.AsImmutableOrNull(), newTokens.AsImmutableOrNull())
-        End Function
-
-        ''' <summary>
-        ''' Calculates the distance between two sequences of syntax tokens, disregarding trivia. 
-        ''' </summary>
-        ''' <remarks>
-        ''' Distance is a number within [0, 1], the smaller the more similar the sequences are. 
-        ''' </remarks>
-        Public Overloads Shared Function ComputeDistance(oldTokens As ImmutableArray(Of SyntaxToken), newTokens As ImmutableArray(Of SyntaxToken)) As Double
-            Return LcsTokens.Instance.ComputeDistance(oldTokens.NullToEmpty(), newTokens.NullToEmpty())
+            Return ComputeDistance(CreateArrayForDistanceCalculation(oldTokens), CreateArrayForDistanceCalculation(newTokens))
         End Function
 
         ''' <summary>
@@ -1419,17 +1415,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' Distance is a number within [0, 1], the smaller the more similar the sequences are. 
         ''' </remarks>
         Public Overloads Shared Function ComputeDistance(oldTokens As IEnumerable(Of SyntaxNode), newTokens As IEnumerable(Of SyntaxNode)) As Double
-            Return ComputeDistance(oldTokens.AsImmutableOrNull(), newTokens.AsImmutableOrNull())
-        End Function
-
-        ''' <summary>
-        ''' Calculates the distance between two sequences of syntax nodes, disregarding trivia. 
-        ''' </summary>
-        ''' <remarks>
-        ''' Distance is a number within [0, 1], the smaller the more similar the sequences are. 
-        ''' </remarks>
-        Public Overloads Shared Function ComputeDistance(oldTokens As ImmutableArray(Of SyntaxNode), newTokens As ImmutableArray(Of SyntaxNode)) As Double
-            Return LcsNodes.Instance.ComputeDistance(oldTokens.NullToEmpty(), newTokens.NullToEmpty())
+            Return ComputeDistance(CreateArrayForDistanceCalculation(oldTokens), CreateArrayForDistanceCalculation(newTokens))
         End Function
 
         ''' <summary>

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -8,12 +8,18 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Differencing
 {
     internal abstract class LongestCommonSubsequence
     {
+        /// <summary>
+        /// Limit the number of tokens used to compute distance between sequences of tokens so that 
+        /// we always use the pooled buffers. The combined length of the two sequences being compared
+        /// must be less than <see cref="VBuffer.PooledSegmentMaxDepthThreshold"/>.
+        /// </summary>
+        public const int MaxSequenceLengthForDistanceCalculation = VBuffer.PooledSegmentMaxDepthThreshold / 2;
+
         // Define the pool in a non-generic base class to allow sharing among instantiations.
         private static readonly ObjectPool<VBuffer> s_pool = new(() => new VBuffer());
 
@@ -40,17 +46,31 @@ namespace Microsoft.CodeAnalysis.Differencing
             /// For 150 it'd be 91KB, which would be allocated on LOH.
             /// The buffers grow by factor of <see cref="GrowFactor"/>, so the next buffer will be allocated on LOH.
             /// </summary>
-            private const int FirstBufferMaxDepth = 100;
+            public const int FirstSegmentMaxDepth = 100;
 
             // 3 + Sum { d = 1..maxDepth : 2*d+1 } = (maxDepth + 1)^2 + 2
-            private const int FirstBufferLength = (FirstBufferMaxDepth + 1) * (FirstBufferMaxDepth + 1) + 2;
+            private const int FirstSegmentLength = (FirstSegmentMaxDepth + 1) * (FirstSegmentMaxDepth + 1) + 2;
 
-            internal const int GrowFactor = 2;
+            // Segment     Segment        Total buffer
+            // MaxDepth    length            length
+            // ---------------------------------------
+            // 100           10,204           10,204
+            // 150           12,600           22,804
+            // 225           28,275           51,079
+            // 338           63,845          114,924
+            // 507          143,143          258,067
+            // 761          322,580          580,647
+            // 1142         725,805        1,306,452
+            // 1713       1,631,347        2,937,799  <-- last pooled segment
+            // 2570       3,672,245        6,610,044
+            // 3855       8,258,695       14,868,739
+            internal const double GrowFactor = 1.5;
 
             /// <summary>
-            /// Do not pool segments that are too large.
+            /// Do not expand pooled buffers to more than ~12 MB total size (sum of all linked segment sizes).
+            /// This threshold is achieved when <see cref="MaxDepth"/> is greater than <see cref="PooledSegmentMaxDepthThreshold"/> = sqrt(size_limit / sizeof(int)).
             /// </summary>
-            internal const int MaxPooledBufferSize = 1024 * 1024;
+            internal const int PooledSegmentMaxDepthThreshold = 1800;
 
             public VBuffer Previous { get; private set; }
             public VBuffer Next { get; private set; }
@@ -62,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Differencing
 
             public VBuffer()
             {
-                _array = new int[FirstBufferLength];
-                MaxDepth = FirstBufferMaxDepth;
+                _array = new int[FirstSegmentLength];
+                MaxDepth = FirstSegmentMaxDepth;
             }
 
             public VBuffer(VBuffer previous)
@@ -71,13 +91,13 @@ namespace Microsoft.CodeAnalysis.Differencing
                 Debug.Assert(previous != null);
 
                 var minDepth = previous.MaxDepth + 1;
-                var maxDepth = previous.MaxDepth * GrowFactor;
+                var maxDepth = (int)(previous.MaxDepth * GrowFactor);
 
                 Debug.Assert(minDepth > 0);
                 Debug.Assert(minDepth <= maxDepth);
 
                 Previous = previous;
-                _array = new int[GetNextBufferLength(minDepth - 1, maxDepth)];
+                _array = new int[GetNextSegmentLength(minDepth - 1, maxDepth)];
                 MinDepth = minDepth;
                 MaxDepth = maxDepth;
 
@@ -95,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             }
 
             public bool IsTooLargeToPool
-                => _array.Length > MaxPooledBufferSize;
+                => MaxDepth > PooledSegmentMaxDepthThreshold;
 
             private static int GetVArrayLength(int depth)
                 => 2 * Math.Max(depth, 1) + 1;
@@ -105,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Differencing
                 => (depth == 0) ? 0 : depth * depth + 2;
 
             // Sum { d = previousChunkDepth..maxDepth : 2*d+1 } = (maxDepth + 1)^2 - precedingBufferMaxDepth^2
-            private static int GetNextBufferLength(int precedingBufferMaxDepth, int maxDepth)
+            private static int GetNextSegmentLength(int precedingBufferMaxDepth, int maxDepth)
                 => (maxDepth + 1) * (maxDepth + 1) - precedingBufferMaxDepth * precedingBufferMaxDepth;
 
             public void Unlink()

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubstring.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubstring.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.Differencing
         protected override bool ItemsEqual(string oldSequence, int oldIndex, string newSequence, int newIndex)
             => oldSequence[oldIndex] == newSequence[newIndex];
 
-        public static double ComputeDistance(string oldValue, string newValue)
-            => s_instance.ComputeDistance(oldValue, oldValue.Length, newValue, newValue.Length);
+        public static double ComputePrefixDistance(string oldValue, int oldLength, string newValue, int newLength)
+            => s_instance.ComputeDistance(oldValue, oldLength, newValue, newLength);
 
         public static IEnumerable<SequenceEdit> GetEdits(string oldValue, string newValue)
             => s_instance.GetEdits(oldValue, oldValue.Length, newValue, newValue.Length);


### PR DESCRIPTION
Reduces the amount of buffers allocated on LOH during calculation of EnC/Hot Reload delta.