### PR TITLE
Add RequiresNonDocumentChangesTag to ProjectOptionsChangeAction  

### DIFF
--- a/src/Analyzers/Core/CodeFixes/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
@@ -122,6 +122,8 @@ namespace Microsoft.CodeAnalysis.UpgradeProject
 
     internal class ProjectOptionsChangeAction : SolutionChangeAction
     {
+        public override ImmutableArray<string> Tags => RequiresNonDocumentChangeTags;
+
         private ProjectOptionsChangeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution)
             : base(title, createChangedSolution, equivalenceKey: null, priority: CodeActionPriority.Default, createdFromFactoryMethod: true)
         {


### PR DESCRIPTION
`ProjectOptionsChangeAction` is used by `UpdateProjectToAllowUnsafeCodeFixProvider` and `UpgradeProjectCodeFixProvider`
I think they add `AllowUnsafe` or change the LanguageVersion in the project file.
Both are not allow in LSP now