### PR TITLE
Enabled .NET remote host by default

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -613,9 +613,9 @@ function Deploy-VsixViaTool() {
   $oop64bitValue = [int]$oop64bit.ToBool()
   &$vsRegEdit set "$vsDir" $hive HKCU "Roslyn\Internal\OnOff\Features" OOP64Bit dword $oop64bitValue
 
-  # Configure RemoteHostOptions.OOPCoreClrFeatureFlag for testing
-  $oopCoreClrFeatureFlagValue = [int]$oopCoreClr.ToBool()
-  &$vsRegEdit set "$vsDir" $hive HKCU "FeatureFlags\Roslyn\ServiceHubCore" Value dword $oopCoreClrFeatureFlagValue
+  # Configure RemoteHostOptions.OOPCoreClr for testing
+  $oopCoreClrValue = [int]$oopCoreClr.ToBool()
+  &$vsRegEdit set "$vsDir" $hive HKCU "Roslyn\Internal\OnOff\Features" OOPCoreClr dword $oopCoreClrValue
 }
 
 # Ensure that procdump is available on the machine.  Returns the path to the directory that contains

--- a/src/EditorFeatures/Core/ExternalAccess/UnitTesting/Api/UnitTestingGlobalOptions.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/UnitTesting/Api/UnitTestingGlobalOptions.cs
@@ -23,6 +23,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
         }
 
         public bool IsServiceHubProcessCoreClr
-            => _globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClrFeatureFlag);
+            => _globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClr);
     }
 }

--- a/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
@@ -14,6 +14,6 @@ namespace Microsoft.CodeAnalysis.Remote
         public static readonly Option2<bool> OOPServerGCFeatureFlag = new("dotnet_enable_server_garbage_collection_in_code_analysis_process", defaultValue: false);
 
         // use coreclr host for OOP
-        public static readonly Option2<bool> OOPCoreClrFeatureFlag = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: false);
+        public static readonly Option2<bool> OOPCoreClrFeatureFlag = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: true);
     }
 }

--- a/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
@@ -10,10 +10,10 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         // use 64bit OOP
         public static readonly Option2<bool> OOP64Bit = new("dotnet_code_analysis_in_separate_process", defaultValue: true);
+        
+        // use coreclr host for OOP
+        public static readonly Option2<bool> OOPCoreClr = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: true);
 
         public static readonly Option2<bool> OOPServerGCFeatureFlag = new("dotnet_enable_server_garbage_collection_in_code_analysis_process", defaultValue: false);
-
-        // use coreclr host for OOP
-        public static readonly Option2<bool> OOPCoreClrFeatureFlag = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: true);
     }
 }

--- a/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Remote/RemoteHostOptionsStorage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         // use 64bit OOP
         public static readonly Option2<bool> OOP64Bit = new("dotnet_code_analysis_in_separate_process", defaultValue: true);
-        
+
         // use coreclr host for OOP
         public static readonly Option2<bool> OOPCoreClr = new("dotnet_enable_core_clr_in_code_analysis_process", defaultValue: true);
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -59,8 +59,14 @@
                               IsThreeState="True"/>
 
                     <CheckBox x:Name="Run_code_analysis_in_separate_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}" />
-
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}"
+                              Checked="Run_code_analysis_in_separate_process_Checked"
+                              Unchecked="Run_code_analysis_in_separate_process_Unchecked"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <CheckBox x:Name="Run_code_analysis_on_dotnet"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_on_dotnet}" />
+                    </StackPanel>
+                    
                     <CheckBox x:Name="Analyze_source_generated_files"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_analyze_source_generated_files}" />
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing;
 using Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral;
 using Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;
 using Microsoft.CodeAnalysis.Editor.Implementation.SplitComment;
-using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.CodeAnalysis.Editor.InlineDiagnostics;
 using Microsoft.CodeAnalysis.Editor.InlineHints;
 using Microsoft.CodeAnalysis.Editor.InlineRename;
@@ -68,6 +67,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.CSharp);
 
             BindToOption(Run_code_analysis_in_separate_process, RemoteHostOptionsStorage.OOP64Bit);
+            BindToOption(Run_code_analysis_on_dotnet, RemoteHostOptionsStorage.OOPCoreClr);
+
             BindToOption(Analyze_source_generated_files, SolutionCrawlerOptionsStorage.EnableDiagnosticsInSourceGeneratedFiles, () =>
             {
                 // If the option has not been set by the user, check if the option is enabled from experimentation. If so, default to that.
@@ -324,6 +325,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             Collapse_usings_on_file_open.IsEnabled = false;
             Collapse_metadata_signature_files_on_open.IsEnabled = false;
             Collapse_sourcelink_embedded_decompiled_files_on_open.IsEnabled = false;
+        }
+
+        private void Run_code_analysis_in_separate_process_Checked(object sender, RoutedEventArgs e)
+        {
+            Run_code_analysis_on_dotnet.IsEnabled = true;
+        }
+
+        private void Run_code_analysis_in_separate_process_Unchecked(object sender, RoutedEventArgs e)
+        {
+            Run_code_analysis_on_dotnet.IsEnabled = false;
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -84,6 +84,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_run_code_analysis_in_separate_process
             => ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart;
 
+        public static string Option_run_code_analysis_on_dotnet
+            => ServicesVSResources.Run_code_analysis_on_dotnet_requires_restart;
+
         public static string Option_analyze_source_generated_files
             => ServicesVSResources.Analyze_source_generated_files;
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart;
 
         public static string Option_run_code_analysis_on_dotnet
-            => ServicesVSResources.Run_code_analysis_on_dotnet_requires_restart;
+            => ServicesVSResources.Run_code_analysis_on_latest_dotnet_requires_restart;
 
         public static string Option_analyze_source_generated_files
             => ServicesVSResources.Analyze_source_generated_files;

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -363,7 +363,7 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_format_on_save", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "FormatOnSave")},
         {"dotnet_enable_full_solution_analysis_memory_monitor", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Full Solution Analysis Memory Monitor")},
         {"dotnet_code_analysis_in_separate_process", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "OOP64Bit")},
-        {"dotnet_enable_core_clr_in_code_analysis_process", new FeatureFlagStorage(@"Roslyn.ServiceHubCore")},
+        {"dotnet_enable_core_clr_in_code_analysis_process", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "OOPCoreClr")},
         {"dotnet_enable_server_garbage_collection_in_code_analysis_process", new FeatureFlagStorage(@"Roslyn.OOPServerGC")},
         {"dotnet_remove_intellicode_recommendation_limit", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "RemoveRecommendationLimit")},
         {"dotnet_enable_rename_tracking", new LocalUserProfileStorage(@"Roslyn\Internal\OnOff\Features", "Rename Tracking")},

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -25,15 +25,9 @@
 "Title"="C#/VB LSP semantic tokens experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 
-[$RootKey$\FeatureFlags\Roslyn\ServiceHubCore]
-"Description"="Run C#/VB out-of-process code analysis on .Net 6 ServiceHub host."
-"Value"=dword:00000000
-"Title"="Run C#/VB code analysis on .Net 6 (requires restart)"
-"PreviewPaneChannels"="IntPreview,int.main"
-
 [$RootKey$\FeatureFlags\Roslyn\OOPServerGC]
 "Description"="Run C#/VB out-of-process code analysis with ServerGC."
-"Value"=dword:00000001
+"Value"=dword:00000000
 "Title"="Run C#/VB code analysis with ServerGC (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
 

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -33,7 +33,7 @@
 
 [$RootKey$\FeatureFlags\Roslyn\OOPServerGC]
 "Description"="Run C#/VB out-of-process code analysis with ServerGC."
-"Value"=dword:00000000
+"Value"=dword:00000001
 "Title"="Run C#/VB code analysis with ServerGC (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
 

--- a/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var serviceBroker = brokeredServiceContainer.GetFullAccessServiceBroker();
 
                 var configuration =
-                    (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClrFeatureFlag) ? RemoteProcessConfiguration.Core : 0) |
+                    (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPCoreClr) ? RemoteProcessConfiguration.Core : 0) |
                     (_globalOptions.GetOption(RemoteHostOptionsStorage.OOPServerGCFeatureFlag) ? RemoteProcessConfiguration.ServerGC : 0) |
                     (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler) ? RemoteProcessConfiguration.EnableSolutionCrawler : 0);
 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1813,8 +1813,8 @@ Additional information: {1}</value>
   <data name="Run_code_analysis_in_separate_process_requires_restart" xml:space="preserve">
     <value>Run code analysis in separate process (requires restart)</value>
   </data>
-  <data name="Run_code_analysis_on_dotnet_requires_restart" xml:space="preserve">
-    <value>Run code analysis on .NET (requires restart)</value>
+  <data name="Run_code_analysis_on_latest_dotnet_requires_restart" xml:space="preserve">
+    <value>Run code analysis on latest .NET (requires restart)</value>
   </data>
   <data name="Quick_Actions" xml:space="preserve">
     <value>Quick Actions</value>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1813,6 +1813,9 @@ Additional information: {1}</value>
   <data name="Run_code_analysis_in_separate_process_requires_restart" xml:space="preserve">
     <value>Run code analysis in separate process (requires restart)</value>
   </data>
+  <data name="Run_code_analysis_on_dotnet_requires_restart" xml:space="preserve">
+    <value>Run code analysis on .NET (requires restart)</value>
+  </data>
   <data name="Quick_Actions" xml:space="preserve">
     <value>Quick Actions</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Spustit analýzu kódu v samostatném procesu (vyžaduje restartování)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Spustit analýzu kódu v samostatném procesu (vyžaduje restartování)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Spouští se analýza kódu pro {0}...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Codeanalyse in separatem Prozess ausführen (Neustart erforderlich)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Die Codeanalyse für "{0}" wird ausgeführt...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Codeanalyse in separatem Prozess ausführen (Neustart erforderlich)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Ejecutar el análisis de código en un proceso independiente (requiere reiniciar)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Ejecutando el análisis de código para "{0}"...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Ejecutar el análisis de código en un proceso independiente (requiere reiniciar)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Exécuter l’analyse du code dans un processus séparé (requiert un redémarrage)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Exécuter l’analyse du code dans un processus séparé (requiert un redémarrage)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Exécution de l'analyse du code pour '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Esegui analisi codice in un processo separato (richiede il riavvio)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Esegui analisi codice in un processo separato (richiede il riavvio)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Esecuzione di Code Analysis per '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">別のプロセスでコード分析を実行する (再起動が必要)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}' のコード分析を実行しています...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">別のプロセスでコード分析を実行する (再起動が必要)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">별도의 프로세스에서 코드 분석 실행(다시 시작해야 함)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}'에 대한 코드 분석을 실행하는 중...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">별도의 프로세스에서 코드 분석 실행(다시 시작해야 함)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Uruchom analizę kodu w oddzielnym procesie (wymaga ponownego uruchomienia)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Uruchom analizę kodu w oddzielnym procesie (wymaga ponownego uruchomienia)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Trwa analizowanie kodu dla elementu „{0}”...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Execute a análise de código em um processo separado (requer reinicialização)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Execute a análise de código em um processo separado (requer reinicialização)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Executando a análise de código para '{0}'...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Запуск анализа кода в отдельном процессе (требуется перезапуск)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Запуск анализа кода в отдельном процессе (требуется перезапуск)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">Выполняется анализ кода для "{0}"…</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">Kod analizini ayrı bir işlemde çalıştır (yeniden başlatma gerektirir)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">Kod analizini ayrı bir işlemde çalıştır (yeniden başlatma gerektirir)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">'{0}' için kod analizi çalıştırılıyor...</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">在单独的进程中运行代码分析(需要重启)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">正在为“{0}”运行代码分析…</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">在单独的进程中运行代码分析(需要重启)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1307,9 +1307,9 @@
         <target state="translated">在獨立的流程中執行程式碼分析 (需要重新開機)</target>
         <note />
       </trans-unit>
-      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
-        <source>Run code analysis on .NET (requires restart)</source>
-        <target state="new">Run code analysis on .NET (requires restart)</target>
+      <trans-unit id="Run_code_analysis_on_latest_dotnet_requires_restart">
+        <source>Run code analysis on latest .NET (requires restart)</source>
+        <target state="new">Run code analysis on latest .NET (requires restart)</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1307,6 +1307,11 @@
         <target state="translated">在獨立的流程中執行程式碼分析 (需要重新開機)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_code_analysis_on_dotnet_requires_restart">
+        <source>Run code analysis on .NET (requires restart)</source>
+        <target state="new">Run code analysis on .NET (requires restart)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="translated">正在執行 '{0}' 的程式碼分析...</target>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -364,11 +364,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 // Configure RemoteHostOptions.OOPCoreClrFeatureFlag for testing
                 if (string.Equals(Environment.GetEnvironmentVariable("ROSLYN_OOPCORECLR"), "true", StringComparison.OrdinalIgnoreCase))
                 {
-                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Roslyn\\ServiceHubCore\" Value dword 1")).WaitForExit();
+                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"Roslyn\\Internal\\OnOff\\Feature\" OOPCoreClr dword 1")).WaitForExit();
                 }
                 else
                 {
-                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Roslyn\\ServiceHubCore\" Value dword 0")).WaitForExit();
+                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"Roslyn\\Internal\\OnOff\\Feature\" OOPCoreClr dword 0")).WaitForExit();
                 }
 
                 _firstLaunch = false;

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -51,8 +51,16 @@
                                      Content="{x:Static local:AdvancedOptionPageStrings.Option_on_the_right_edge_of_the_editor_window}"/>
                         </StackPanel>
                     </StackPanel>
+
                     <CheckBox x:Name="Run_code_analysis_in_separate_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}" />
+                              Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_in_separate_process}"
+                              Checked="Run_code_analysis_in_separate_process_Checked"
+                              Unchecked="Run_code_analysis_in_separate_process_Unchecked"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <CheckBox x:Name="Run_code_analysis_on_dotnet"
+                                  Content="{x:Static local:AdvancedOptionPageStrings.Option_run_code_analysis_on_dotnet}" />
+                    </StackPanel>
+
                     <CheckBox x:Name="Analyze_source_generated_files"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_analyze_source_generated_files}" />
                     <CheckBox x:Name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -71,6 +71,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(at_the_end_of_the_line_of_code, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfCode, LanguageNames.VisualBasic)
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptionsStorage.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.VisualBasic)
             BindToOption(Run_code_analysis_in_separate_process, RemoteHostOptionsStorage.OOP64Bit)
+            BindToOption(Run_code_analysis_on_dotnet, RemoteHostOptionsStorage.OOPCoreClr)
+
             BindToOption(Enable_file_logging_for_diagnostics, VisualStudioLoggingOptionsStorage.EnableFileLoggingForDiagnostics)
             BindToOption(Skip_analyzers_for_implicitly_triggered_builds, FeatureOnOffOptions.SkipAnalyzersForImplicitlyTriggeredBuilds)
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences,
@@ -236,6 +238,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             Collapse_imports_on_file_open.IsEnabled = False
             Collapse_sourcelink_embedded_decompiled_files_on_open.IsEnabled = False
             Collapse_metadata_signature_files_on_open.IsEnabled = False
+        End Sub
+
+        Private Sub Run_code_analysis_in_separate_process_Checked(sender As Object, e As RoutedEventArgs)
+            Run_code_analysis_on_dotnet.IsEnabled = True
+        End Sub
+
+        Private Sub Run_code_analysis_in_separate_process_Unchecked(sender As Object, e As RoutedEventArgs)
+            Run_code_analysis_on_dotnet.IsEnabled = False
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -76,6 +76,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_run_code_analysis_in_separate_process As String =
             ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart
 
+        Public ReadOnly Property Option_run_code_analysis_on_dotnet As String =
+            ServicesVSResources.Run_code_analysis_on_dotnet_requires_restart
+
         Public ReadOnly Property Option_DisplayLineSeparators As String =
             BasicVSResources.Show_procedure_line_separators
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart
 
         Public ReadOnly Property Option_run_code_analysis_on_dotnet As String =
-            ServicesVSResources.Run_code_analysis_on_dotnet_requires_restart
+            ServicesVSResources.Run_code_analysis_on_latest_dotnet_requires_restart
 
         Public ReadOnly Property Option_DisplayLineSeparators As String =
             BasicVSResources.Show_procedure_line_separators


### PR DESCRIPTION
Finally able to do this, now that we have an arm64 vsix for remote bits. Also changed the option from a feature flag to a regular VS option. We might want run on .NET exclusively at some point in the future, but for now I'm keeping the option.


Validation:
~~https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/471195~~
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/471960

UI change in options panel:

![image](https://github.com/dotnet/roslyn/assets/788783/a885be51-5bf1-4bdb-92be-04512342aa03)


RPS exception tracking bugs:
[AB#1820959](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1820959)
[AB#1820967](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1820967)


