### PR TITLE
Allow parsing `ref readonly` modifier

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7409,7 +7409,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_UnscopedScoped" xml:space="preserve">
     <value>UnscopedRefAttribute cannot be applied to parameters that have a 'scoped' modifier.</value>
   </data>
-  <data name="ERR_RefReadOnlyInverted" xml:space="preserve">
+  <data name="ERR_RefReadOnlyWrongOrdering" xml:space="preserve">
     <value>'readonly' modifier must be specified after 'ref'.</value>
   </data>
   <data name="ERR_ScopedDiscard" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7409,8 +7409,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_UnscopedScoped" xml:space="preserve">
     <value>UnscopedRefAttribute cannot be applied to parameters that have a 'scoped' modifier.</value>
   </data>
-  <data name="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn" xml:space="preserve">
-    <value>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</value>
+  <data name="ERR_RefReadOnlyInverted" xml:space="preserve">
+    <value>'readonly' modifier must be specified after 'ref'.</value>
   </data>
   <data name="ERR_ScopedDiscard" xml:space="preserve">
     <value>The 'scoped' modifier cannot be used with discard.</value>
@@ -7510,5 +7510,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny" xml:space="preserve">
     <value>Cannot use primary constructor parameter of type '{0}' inside an instance member</value>
+  </data>
+  <data name="IDS_FeatureRefReadonlyParameters" xml:space="preserve">
+    <value>ref readonly parameters</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2192,7 +2192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ConstantValueOfTypeExpected = 9135,
         ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny = 9136,
 
-        ERR_RefReadOnlyInverted = 9501, // PROTOTYPE: Pack numbers
+        ERR_RefReadOnlyWrongOrdering = 9501, // PROTOTYPE: Pack numbers
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2121,7 +2121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_DuplicateAnalyzerReference = 9067,
         ERR_FileTypeNonUniquePath = 9068,
         ERR_FilePathCannotBeConvertedToUtf8 = 9069,
-        ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn = 9070,
+        //ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn = 9070,
         ERR_FileLocalDuplicateNameInNS = 9071,
         ERR_DeconstructVariableCannotBeByRef = 9072,
         WRN_ScopedMismatchInParameterOfTarget = 9073,
@@ -2191,6 +2191,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadCaseInSwitchArm = 9134,
         ERR_ConstantValueOfTypeExpected = 9135,
         ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny = 9136,
+
+        ERR_RefReadOnlyInverted = 9501, // PROTOTYPE: Pack numbers
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2256,7 +2256,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_UnscopedScoped:
                 case ErrorCode.WRN_DuplicateAnalyzerReference:
                 case ErrorCode.ERR_FilePathCannotBeConvertedToUtf8:
-                case ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn:
                 case ErrorCode.ERR_FileLocalDuplicateNameInNS:
                 case ErrorCode.WRN_ScopedMismatchInParameterOfTarget:
                 case ErrorCode.WRN_ScopedMismatchInParameterOfOverrideOrImplementation:
@@ -2311,6 +2310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_BadCaseInSwitchArm:
                 case ErrorCode.ERR_ConstantValueOfTypeExpected:
                 case ErrorCode.ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny:
+                case ErrorCode.ERR_RefReadOnlyInverted:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2310,7 +2310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_BadCaseInSwitchArm:
                 case ErrorCode.ERR_ConstantValueOfTypeExpected:
                 case ErrorCode.ERR_UnsupportedPrimaryConstructorParameterCapturingRefAny:
-                case ErrorCode.ERR_RefReadOnlyInverted:
+                case ErrorCode.ERR_RefReadOnlyWrongOrdering:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -267,6 +267,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUsingTypeAlias = MessageBase + 12834,
 
         IDS_FeatureInstanceMemberInNameof = MessageBase + 12835,
+
+        IDS_FeatureRefReadonlyParameters = MessageBase + 12900, // PROTOTYPE: Pack numbers
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -452,6 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeaturePrimaryConstructors: // declaration table check
                 case MessageID.IDS_FeatureUsingTypeAlias: // semantic check
                 case MessageID.IDS_FeatureInstanceMemberInNameof: // semantic check
+                case MessageID.IDS_FeatureRefReadonlyParameters: // semantic check
                     return LanguageVersion.Preview;
 
                 // C# 11.0 features.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4433,7 +4433,6 @@ parse_member_name:;
                 case SyntaxKind.OutKeyword:
                 case SyntaxKind.InKeyword:
                 case SyntaxKind.ParamsKeyword:
-                // For error tolerance
                 case SyntaxKind.ReadOnlyKeyword:
                     return true;
             }
@@ -4447,7 +4446,7 @@ parse_member_name:;
 
             while (IsParameterModifierExcludingScoped(this.CurrentToken))
             {
-                if (this.CurrentToken.Kind is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword or SyntaxKind.InKeyword)
+                if (this.CurrentToken.Kind is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword or SyntaxKind.InKeyword or SyntaxKind.ReadOnlyKeyword)
                 {
                     tryScoped = false;
                 }
@@ -4463,8 +4462,8 @@ parse_member_name:;
                 {
                     modifiers.Add(scopedKeyword);
 
-                    // Look if ref/out/in are next
-                    if (this.CurrentToken.Kind is (SyntaxKind.RefKeyword or SyntaxKind.OutKeyword or SyntaxKind.InKeyword))
+                    // Look if ref/out/in/readonly are next
+                    while (this.CurrentToken.Kind is (SyntaxKind.RefKeyword or SyntaxKind.OutKeyword or SyntaxKind.InKeyword or SyntaxKind.ReadOnlyKeyword))
                     {
                         modifiers.Add(this.EatToken());
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -475,8 +475,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.OutKeyword:
-                        Debug.Assert(!seenReadonly);
-
                         if (seenOut)
                         {
                             addERR_DupParamMod(diagnostics, modifier);
@@ -504,8 +502,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ParamsKeyword when !parsingFunctionPointerParams:
-                        Debug.Assert(!seenReadonly);
-
                         if (parsingAnonymousMethodParams)
                         {
                             diagnostics.Add(ErrorCode.ERR_IllegalParams, modifier.GetLocation());
@@ -542,7 +538,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.InKeyword:
-                        Debug.Assert(!seenReadonly);
                         Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureReadOnlyReferences, diagnostics);
 
                         if (seenThis)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -583,11 +583,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ReadOnlyKeyword:
-                        if (!seenReadonly)
-                        {
-                            Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
-                        }
-
                         if (seenReadonly)
                         {
                             addERR_DupParamMod(diagnostics, modifier);
@@ -599,6 +594,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         else
                         {
                             Debug.Assert(seenRef);
+                            Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
                             seenReadonly = true;
                         }
                         break;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -475,6 +475,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.OutKeyword:
+                        Debug.Assert(!seenReadonly);
+
                         if (seenOut)
                         {
                             addERR_DupParamMod(diagnostics, modifier);
@@ -495,10 +497,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.InKeyword);
                         }
-                        else if (seenReadonly)
-                        {
-                            addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.ReadOnlyKeyword);
-                        }
                         else
                         {
                             seenOut = true;
@@ -506,6 +504,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ParamsKeyword when !parsingFunctionPointerParams:
+                        Debug.Assert(!seenReadonly);
+
                         if (parsingAnonymousMethodParams)
                         {
                             diagnostics.Add(ErrorCode.ERR_IllegalParams, modifier.GetLocation());
@@ -530,10 +530,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.OutKeyword);
                         }
-                        else if (seenReadonly)
-                        {
-                            addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.ReadOnlyKeyword);
-                        }
                         else
                         {
                             seenParams = true;
@@ -546,6 +542,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.InKeyword:
+                        Debug.Assert(!seenReadonly);
                         Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureReadOnlyReferences, diagnostics);
 
                         if (seenThis)
@@ -569,10 +566,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             addERR_ParamsCantBeWithModifier(diagnostics, modifier, SyntaxKind.InKeyword);
                         }
-                        else if (seenReadonly)
-                        {
-                            addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.ReadOnlyKeyword);
-                        }
                         else
                         {
                             seenIn = true;
@@ -590,23 +583,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ReadOnlyKeyword:
-                        Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
+                        if (!seenReadonly)
+                        {
+                            Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
+                        }
 
                         if (seenReadonly)
                         {
                             addERR_DupParamMod(diagnostics, modifier);
-                        }
-                        else if (seenOut)
-                        {
-                            addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.OutKeyword);
-                        }
-                        else if (seenIn)
-                        {
-                            addERR_BadParameterModifiers(diagnostics, modifier, SyntaxKind.InKeyword);
-                        }
-                        else if (seenParams)
-                        {
-                            addERR_ParamsCantBeWithModifier(diagnostics, modifier, SyntaxKind.ReadOnlyKeyword);
                         }
                         else if (!seenRef || previousModifier?.Kind() != SyntaxKind.RefKeyword)
                         {
@@ -614,6 +598,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                         else
                         {
+                            Debug.Assert(seenRef);
                             seenReadonly = true;
                         }
                         break;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -411,6 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool seenScoped = false;
             bool seenReadonly = false;
 
+            SyntaxToken? previousModifier = null;
             foreach (var modifier in parameter.Modifiers)
             {
                 switch (modifier.Kind())
@@ -607,7 +608,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             addERR_ParamsCantBeWithModifier(diagnostics, modifier, SyntaxKind.ReadOnlyKeyword);
                         }
-                        else if (!seenRef)
+                        else if (!seenRef || previousModifier?.Kind() != SyntaxKind.RefKeyword)
                         {
                             diagnostics.Add(ErrorCode.ERR_RefReadOnlyInverted, modifier);
                         }
@@ -625,6 +626,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     default:
                         throw ExceptionUtilities.UnexpectedValue(modifier.Kind());
                 }
+
+                previousModifier = modifier;
             }
 
             static void addERR_DupParamMod(BindingDiagnosticBag diagnostics, SyntaxToken modifier)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -582,13 +582,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             addERR_DupParamMod(diagnostics, modifier);
                         }
-                        else if (!seenRef || previousModifier?.Kind() != SyntaxKind.RefKeyword)
+                        else if (previousModifier?.Kind() != SyntaxKind.RefKeyword)
                         {
                             diagnostics.Add(ErrorCode.ERR_RefReadOnlyWrongOrdering, modifier);
                         }
-                        else
+                        else if (seenRef)
                         {
-                            Debug.Assert(seenRef);
                             Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
                             seenReadonly = true;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -610,7 +610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                         else if (!seenRef || previousModifier?.Kind() != SyntaxKind.RefKeyword)
                         {
-                            diagnostics.Add(ErrorCode.ERR_RefReadOnlyInverted, modifier);
+                            diagnostics.Add(ErrorCode.ERR_RefReadOnlyWrongOrdering, modifier);
                         }
                         else
                         {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">{0}: U přístupových objektů se modifikátor readonly může použít jenom v případě, že vlastnost nebo indexer má přístupový objekt get i set.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">Readonly není podporován jako modifikátor parametru. Měli jste na mysli in?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Primární konstruktor je v konfliktu se syntetizovaně zkopírovaným konstruktorem.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Levá strana přiřazení odkazu musí být parametr Ref.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">pole ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">Levá strana přiřazení odkazu musí být parametr Ref.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">Die linke Seite einer Ref-Zuweisung muss eine Ref-Variable sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">{0}: "readonly" kann für Accessoren nur verwendet werden, wenn die Eigenschaft oder der Indexer sowohl einen get- als auch einen set-Accessor aufweist.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">"readonly" wird als Parametermodifizierer nicht unterstützt. Meinten Sie "in"?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Der primäre Konstruktor verursacht einen Konflikt mit dem synthetisierten Kopierkonstruktor.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Die linke Seite einer Ref-Zuweisung muss eine Ref-Variable sein.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">Referenzfelder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">La parte izquierda de una asignación de referencias debe ser una variable local.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">"{0}": "readonly" solo se puede usar en los descriptores de acceso si la propiedad o el indexador tienen un descriptor de acceso get y set</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">"readonly" no se admite como modificador de parámetro. ¿Quizás quiera decir "in"?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">El constructor principal está en conflicto con el constructor de copia sintetizado.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">La parte izquierda de una asignación de referencias debe ser una variable local.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">campos de referencia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}' : 'readonly' peut uniquement être utilisé sur des accesseurs si la propriété ou l'indexeur a un accesseur get et un accesseur set</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly' n’est pas pris en charge en tant que modificateur de paramètre. Vouliez-vous dire « in » ?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Le constructeur principal est en conflit avec le constructeur de copie synthétisée.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Le côté gauche d’une affectation ref doit être une variable ref.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">champs ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">Le côté gauche d’une affectation ref doit être une variable ref.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 'readonly' può essere usato su funzioni di accesso solo se la proprietà o l'indicizzatore include entrambi le funzioni di accesso get e set</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly' non è supportato come modificatore di parametro. Si intendeva 'in'?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Il costruttore primario è in conflitto con il costruttore di copia sintetizzato.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">La parte sinistra di un'assegnazione ref deve essere una variabile ref.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">campi ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">La parte sinistra di un'assegnazione ref deve essere una variabile ref.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 'readonly' は、プロパティまたはインデクサーが get および set の両方のアクセサーを含む場合にのみ、アクセサーで使用できます</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly' はパラメーター修飾子としてサポートされていません。'in' のことですか?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">プライマリ コンストラクターが、合成されたコピー コンストラクターと競合しています。</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 代入の左辺は ref 変数である必要があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">ref フィールド</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">ref 代入の左辺は ref 変数である必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 속성 또는 인덱서에 get 접근자와 set 접근자가 둘 다 있는 경우에만 접근자에 'readonly'를 사용할 수 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly'는 매개 변수 한정자로 지원되지 않습니다. 'in'을 의미했나요?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">기본 생성자가 합성된 복사 생성자와 충돌합니다.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 할당의 왼쪽은 ref 변수여야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">참조 필드</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">ref 할당의 왼쪽은 ref 변수여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">Lewa strona przypisania referencyjnego musi być zmienną referencyjną.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">„{0}”: modyfikatora „readonly” można użyć dla metod dostępu tylko wtedy, gdy właściwość lub indeksator mają metody dostępu get i set</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">Element „readonly” nie jest obsługiwany jako modyfikator parametrów. Czy chodziło Ci o „in”?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Konstruktor podstawowy powoduje konflikt z konstruktorem syntetyzowanej kopii.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Lewa strona przypisania referencyjnego musi być zmienną referencyjną.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">pola referencyjne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">O lado esquerdo de uma atribuição ref deve ser uma variável ref.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 'readonly' somente pode ser usado em acessadores quando a propriedade ou o indexador tem um acessador get e um set</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly' não é suportado como modificador de parâmetro. Você quis dizer 'in'?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">O construtor primário entra em conflito com o construtor de cópia sintetizado.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">O lado esquerdo de uma atribuição ref deve ser uma variável ref.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">campos ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">Левая сторона назначения ref должна быть переменной ref.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">"{0}": readonly можно использовать для методов доступа, только если свойство или индексатор имеет оба метода доступа, get и set.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">"readonly" не поддерживается в качестве модификатора параметров. Вы подразумевали "in"?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Первичный конструктор конфликтует с синтезированным конструктором копий.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">Левая сторона назначения ref должна быть переменной ref.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">поля ref</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">ref atamasının sol tarafı, ref değişkeni olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 'readonly' erişimcilerde yalnızca özellik veya dizin oluşturucusu hem alma hem ayarlama erişimcisine sahipse kullanılabilir</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">'readonly' parametre değiştirici olarak desteklenmez. "in" mi demek istedin?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">Birincil oluşturucu, sentezlenmiş kopya oluşturucusuyla çakışıyor.</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref atamasının sol tarafı, ref değişkeni olmalıdır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">başvuru alanları</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">“{0}”: 仅当属性或索引器同时具有 get 访问器和 set 访问器时，才能对访问器使用 "readonly"</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">不支持将 “readonly” 作为参数修饰符。你的意思是否为 “in”?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">主构造函数与合成的复制构造函数冲突。</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">ref 赋值的左侧必须为 ref 变量。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">ref 字段</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">ref 赋值的左侧必须为 ref 变量。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1387,7 +1387,7 @@
         <target state="translated">參考指派的左側必須為 ref 變數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_RefReadOnlyInverted">
+      <trans-unit id="ERR_RefReadOnlyWrongOrdering">
         <source>'readonly' modifier must be specified after 'ref'.</source>
         <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1347,11 +1347,6 @@
         <target state="translated">'{0}': 只有在屬性或索引子同時具有 get 和 set 存取子時，才能在存取子上使用 'readonly'</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn">
-        <source>'readonly' is not supported as a parameter modifier. Did you mean 'in'?</source>
-        <target state="translated">不支援使用 'readonly' 做為參數修飾元。您的意思是 'in' 嗎?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_RecordAmbigCtor">
         <source>The primary constructor conflicts with the synthesized copy constructor.</source>
         <target state="translated">主要建構函式與合成的複製建構函式相衝突。</target>
@@ -1390,6 +1385,11 @@
       <trans-unit id="ERR_RefLocalOrParamExpected">
         <source>The left-hand side of a ref assignment must be a ref variable.</source>
         <target state="translated">參考指派的左側必須為 ref 變數。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_RefReadOnlyInverted">
+        <source>'readonly' modifier must be specified after 'ref'.</source>
+        <target state="new">'readonly' modifier must be specified after 'ref'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefReadonlyPrimaryConstructorParameter">
@@ -1970,6 +1970,11 @@
       <trans-unit id="IDS_FeatureRefFields">
         <source>ref fields</source>
         <target state="translated">ref 欄位</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefReadonlyParameters">
+        <source>ref readonly parameters</source>
+        <target state="new">ref readonly parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureRelaxedShiftOperator">

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -64,20 +64,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(readonly readonly int p) { }
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
-                // (3,21): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 21),
-                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21));
-
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -88,6 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -102,9 +89,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 }
                 """;
             CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly ref readonly int p) { }
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
@@ -132,20 +116,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(readonly readonly ref int p) { }
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
-                // (3,21): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 21),
-                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21));
-
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -156,6 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -203,14 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(readonly int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
-
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -218,6 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -231,14 +195,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(readonly params int[] p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
-
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -246,6 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -259,17 +216,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(params ref readonly int[] p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,19): error CS1611: The params parameter cannot be declared as ref
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
-                // (3,23): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 23),
-                // (3,23): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 23));
-
             var expectedDiagnostics = new[]
             {
                 // (3,19): error CS1611: The params parameter cannot be declared as ref
@@ -280,6 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 23)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -293,14 +240,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(in readonly int[] p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,15): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 15),
-                // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15));
-
             var expectedDiagnostics = new[]
             {
                 // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -308,6 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -321,14 +261,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     void M(out readonly int[] p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16));
-
             var expectedDiagnostics = new[]
             {
                 // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -336,6 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -349,14 +282,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     public static void M(this readonly int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,31): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 31),
-                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31));
-
             var expectedDiagnostics = new[]
             {
                 // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -364,6 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -395,14 +321,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     public static void M(ref this readonly int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35),
-                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35));
-
             var expectedDiagnostics = new[]
             {
                 // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -410,6 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -459,23 +378,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     public static void M(ref scoped readonly int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
-                // (3,37): error CS1001: Identifier expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
-                // (3,37): error CS1003: Syntax error, ',' expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
-                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37),
-                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37));
-
             var expectedDiagnostics = new[]
             {
                 // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
@@ -492,6 +394,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -505,23 +408,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     public static void M(readonly scoped ref int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 26),
-                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
-                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
-                // (3,42): error CS1001: Identifier expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
-                // (3,42): error CS1003: Syntax error, ',' expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42));
-
             var expectedDiagnostics = new[]
             {
                 // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -538,6 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -551,23 +438,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                     public static void M(scoped readonly int p) => throw null;
                 }
                 """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
-                // (3,33): error CS1001: Identifier expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
-                // (3,33): error CS1003: Syntax error, ',' expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
-                // (3,33): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 33),
-                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33));
-
             var expectedDiagnostics = new[]
             {
                 // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
@@ -584,6 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
             };
 
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -5,631 +5,630 @@
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public class RefReadonlyParameterTests : CSharpTestBase
 {
-    public class RefReadonlyParameterTests : CSharpTestBase
+    [Fact]
+    public void Modifier()
     {
-        [Fact]
-        public void Modifier()
-        {
-            var source = """
-                class C
-                {
-                    void M(ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly int p);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void DuplicateModifier_01()
-        {
-            var source = """
-                class C
-                {
-                    void M(ref readonly readonly int p) { }
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
-                //     void M(ref readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25));
-
-            var expectedDiagnostics = new[]
+        var source = """
+            class C
             {
-                // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
-                //     void M(ref readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25)
-            };
+                void M(ref readonly int p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly int p);
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16));
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics();
+    }
 
-        [Fact]
-        public void DuplicateModifier_02()
-        {
-            var source = """
-                class C
-                {
-                    void M(readonly readonly int p) { }
-                }
-                """;
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void DuplicateModifier_01()
+    {
+        var source = """
+            class C
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
-                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
-            };
+                void M(ref readonly readonly int p) { }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly readonly int p) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+            // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
+            //     void M(ref readonly readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void DuplicateModifier_03()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(readonly ref readonly int p) { }
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
-                // (3,25): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 25));
+            // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
+            //     void M(ref readonly readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25)
+        };
 
-            var expectedDiagnostics = new[]
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void DuplicateModifier_02()
+    {
+        var source = """
+            class C
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void DuplicateModifier_04()
+                void M(readonly readonly int p) { }
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(readonly readonly ref int p) { }
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly readonly int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+            // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly readonly int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void DuplicateModifier_03()
+    {
+        var source = """
+            class C
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
-                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly readonly ref int p) { }
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
-            };
+                void M(readonly ref readonly int p) { }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+            // (3,25): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 25));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void DuplicateModifier_05()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(ref readonly ref readonly int p) { }
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,25): error CS1107: A parameter can only have one 'ref' modifier
-                //     void M(ref readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
-                // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
-                //     void M(ref readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29));
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+        };
 
-            var expectedDiagnostics = new[]
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void DuplicateModifier_04()
+    {
+        var source = """
+            class C
             {
-                // (3,25): error CS1107: A parameter can only have one 'ref' modifier
-                //     void M(ref readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
-                // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
-                //     void M(ref readonly ref readonly int p) { }
-                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithoutRef()
+                void M(readonly readonly ref int p) { }
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(readonly int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly readonly ref int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+            // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly readonly ref int p) { }
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void DuplicateModifier_05()
+    {
+        var source = """
+            class C
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
-            };
+                void M(ref readonly ref readonly int p) { }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+            // (3,25): error CS1107: A parameter can only have one 'ref' modifier
+            //     void M(ref readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
+            // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
+            //     void M(ref readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithParams()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(readonly params int[] p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,25): error CS1107: A parameter can only have one 'ref' modifier
+            //     void M(ref readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
+            // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
+            //     void M(ref readonly ref readonly int p) { }
+            Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void ReadonlyWithoutRef()
+    {
+        var source = """
+            class C
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithParams_01()
+                void M(readonly int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(params ref readonly int[] p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void ReadonlyWithParams()
+    {
+        var source = """
+            class C
             {
-                // (3,19): error CS1611: The params parameter cannot be declared as ref
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithParams_02()
+                void M(readonly params int[] p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(ref readonly params int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
-                //     void M(ref readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25));
+            // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(readonly params int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+        };
 
-            var expectedDiagnostics = new[]
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonlyWithParams_01()
+    {
+        var source = """
+            class C
             {
-                // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
-                //     void M(ref readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithIn()
+                void M(params ref readonly int[] p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(in readonly int[] p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,19): error CS1611: The params parameter cannot be declared as ref
+            //     void M(params ref readonly int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonlyWithParams_02()
+    {
+        var source = """
+            class C
             {
-                // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15)
-            };
+                void M(ref readonly params int[] p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly params int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+            // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
+            //     void M(ref readonly params int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithIn()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(ref readonly in int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly in int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
-                //     void M(ref readonly in int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25));
+            // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
+            //     void M(ref readonly params int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25)
+        };
 
-            var expectedDiagnostics = new[]
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void ReadonlyWithIn()
+    {
+        var source = """
+            class C
             {
-                // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
-                //     void M(ref readonly in int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithOut()
+                void M(in readonly int[] p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(out readonly int[] p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(in readonly int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonlyWithIn()
+    {
+        var source = """
+            class C
             {
-                // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16)
-            };
+                void M(ref readonly in int[] p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly in int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+            // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
+            //     void M(ref readonly in int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithOut()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                class C
-                {
-                    void M(ref readonly out int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly out int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
-                //     void M(ref readonly out int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25));
+            // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
+            //     void M(ref readonly in int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25)
+        };
 
-            var expectedDiagnostics = new[]
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void ReadonlyWithOut()
+    {
+        var source = """
+            class C
             {
-                // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
-                //     void M(ref readonly out int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithThis()
+                void M(out readonly int[] p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                static class C
-                {
-                    public static void M(this readonly int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     void M(out readonly int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonlyWithOut()
+    {
+        var source = """
+            class C
             {
-                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
-            };
+                void M(ref readonly out int[] p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     void M(ref readonly out int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+            // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
+            //     void M(ref readonly out int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithThis_01()
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                static class C
-                {
-                    public static void M(this ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(this ref readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
+            // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
+            //     void M(ref readonly out int[] p) => throw null;
+            Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25)
+        };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
 
-        [Fact]
-        public void RefReadonlyWithThis_02()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(ref this readonly int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void ReadonlyWithThis()
+    {
+        var source = """
+            static class C
             {
-                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithThis_03()
+                public static void M(this readonly int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                static class C
-                {
-                    public static void M(ref readonly this int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly this int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+            // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     public static void M(this readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
+        };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
 
-        [Fact]
-        public void RefReadonlyWithScoped_01()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(scoped ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(scoped ref readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonlyWithScoped_02()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(ref scoped readonly int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void RefReadonlyWithThis_01()
+    {
+        var source = """
+            static class C
             {
-                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
-                // (3,37): error CS1001: Identifier expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
-                // (3,37): error CS1003: Syntax error, ',' expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
-                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
-            };
+                public static void M(this ref readonly int p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(this ref readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics();
+    }
 
-        [Fact]
-        public void RefReadonlyWithScoped_03()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(readonly scoped ref int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void RefReadonlyWithThis_02()
+    {
+        var source = """
+            static class C
             {
-                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
-                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
-                // (3,42): error CS1001: Identifier expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
-                // (3,42): error CS1003: Syntax error, ',' expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithScoped()
+                public static void M(ref this readonly int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
         {
-            var source = """
-                static class C
-                {
-                    public static void M(scoped readonly int p) => throw null;
-                }
-                """;
-            var expectedDiagnostics = new[]
+            // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     public static void M(ref this readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonlyWithThis_03()
+    {
+        var source = """
+            static class C
             {
-                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
-                // (3,33): error CS1001: Identifier expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
-                // (3,33): error CS1003: Syntax error, ',' expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
-                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
-            };
+                public static void M(ref readonly this int p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly this int p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics();
+    }
 
-        [Fact]
-        public void RefReadonly_ScopedParameterName()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(ref readonly int scoped) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly int scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonly_ScopedTypeName()
-        {
-            var source = """
-                struct scoped { }
-                static class C
-                {
-                    public static void M(ref readonly scoped p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void RefReadonlyWithScoped_01()
+    {
+        var source = """
+            static class C
             {
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-            };
+                public static void M(scoped ref readonly int p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(scoped ref readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37));
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics();
+    }
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
-                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
-                // struct scoped { }
-                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-        }
-
-        [Fact]
-        public void RefReadonly_ScopedBothNames()
-        {
-            var source = """
-                struct scoped { }
-                static class C
-                {
-                    public static void M(ref readonly scoped scoped) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-
-            var expectedDiagnostics = new[]
+    [Fact]
+    public void RefReadonlyWithScoped_02()
+    {
+        var source = """
+            static class C
             {
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-            };
+                public static void M(ref scoped readonly int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
+        {
+            // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+            //     public static void M(ref scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
+            // (3,37): error CS1001: Identifier expected
+            //     public static void M(ref scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
+            // (3,37): error CS1003: Syntax error, ',' expected
+            //     public static void M(ref scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
+            // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     public static void M(ref scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
+        };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
 
-            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
-                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
-                // struct scoped { }
-                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-        }
+    [Fact]
+    public void RefReadonlyWithScoped_03()
+    {
+        var source = """
+            static class C
+            {
+                public static void M(readonly scoped ref int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
+        {
+            // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     public static void M(readonly scoped ref int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
+            // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+            //     public static void M(readonly scoped ref int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
+            // (3,42): error CS1001: Identifier expected
+            //     public static void M(readonly scoped ref int p) => throw null;
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
+            // (3,42): error CS1003: Syntax error, ',' expected
+            //     public static void M(readonly scoped ref int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void ReadonlyWithScoped()
+    {
+        var source = """
+            static class C
+            {
+                public static void M(scoped readonly int p) => throw null;
+            }
+            """;
+        var expectedDiagnostics = new[]
+        {
+            // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+            //     public static void M(scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
+            // (3,33): error CS1001: Identifier expected
+            //     public static void M(scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
+            // (3,33): error CS1003: Syntax error, ',' expected
+            //     public static void M(scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
+            // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
+            //     public static void M(scoped readonly int p) => throw null;
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+    }
+
+    [Fact]
+    public void RefReadonly_ScopedParameterName()
+    {
+        var source = """
+            static class C
+            {
+                public static void M(ref readonly int scoped) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly int scoped) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void RefReadonly_ScopedTypeName()
+    {
+        var source = """
+            struct scoped { }
+            static class C
+            {
+                public static void M(ref readonly scoped p) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+            // struct scoped { }
+            Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly scoped p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+            // struct scoped { }
+            Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+            // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+            // struct scoped { }
+            Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+            // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly scoped p) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+    }
+
+    [Fact]
+    public void RefReadonly_ScopedBothNames()
+    {
+        var source = """
+            struct scoped { }
+            static class C
+            {
+                public static void M(ref readonly scoped scoped) => throw null;
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+            // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+            // struct scoped { }
+            Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly scoped scoped) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+            // struct scoped { }
+            Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+        };
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+            // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+            // struct scoped { }
+            Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+            // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public static void M(ref readonly scoped scoped) => throw null;
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         }
 
         [Fact]
-        public void RefReadonlyWithParams()
+        public void RefReadonlyWithParams_01()
         {
             var source = """
                 class C
@@ -227,6 +227,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             };
 
             CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithParams_02()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly params int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
+                //     void M(ref readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,25): error CS8328:  The parameter modifier 'params' cannot be used with 'ref'
+                //     void M(ref readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "params").WithArguments("params", "ref").WithLocation(3, 25)
+            };
+
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
@@ -253,6 +281,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         }
 
         [Fact]
+        public void RefReadonlyWithIn()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly in int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly in int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
+                //     void M(ref readonly in int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,25): error CS8328:  The parameter modifier 'in' cannot be used with 'ref'
+                //     void M(ref readonly in int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(3, 25)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
         public void ReadonlyWithOut()
         {
             var source = """
@@ -269,6 +325,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             };
 
             CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithOut()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly out int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly out int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
+                //     void M(ref readonly out int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,25): error CS8328:  The parameter modifier 'out' cannot be used with 'ref'
+                //     void M(ref readonly out int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "ref").WithLocation(3, 25)
+            };
+
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -220,10 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             {
                 // (3,19): error CS1611: The params parameter cannot be declared as ref
                 //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
-                // (3,23): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 23)
+                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -1,0 +1,683 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class RefReadonlyParameterTests : CSharpTestBase
+    {
+        [Fact]
+        public void Modifier()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly int p);
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DuplicateModifier_01()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly readonly int p) { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
+                //     void M(ref readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,25): error CS1107: A parameter can only have one 'readonly' modifier
+                //     void M(ref readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 25)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void DuplicateModifier_02()
+        {
+            var source = """
+                class C
+                {
+                    void M(readonly readonly int p) { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (3,21): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 21),
+                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void DuplicateModifier_03()
+        {
+            var source = """
+                class C
+                {
+                    void M(readonly ref readonly int p) { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (3,25): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 25));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void DuplicateModifier_04()
+        {
+            var source = """
+                class C
+                {
+                    void M(readonly readonly ref int p) { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (3,21): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 21),
+                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (3,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly readonly ref int p) { }
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 21)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void DuplicateModifier_05()
+        {
+            var source = """
+                class C
+                {
+                    void M(ref readonly ref readonly int p) { }
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,25): error CS1107: A parameter can only have one 'ref' modifier
+                //     void M(ref readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
+                // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
+                //     void M(ref readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,25): error CS1107: A parameter can only have one 'ref' modifier
+                //     void M(ref readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "ref").WithArguments("ref").WithLocation(3, 25),
+                // (3,29): error CS1107: A parameter can only have one 'readonly' modifier
+                //     void M(ref readonly ref readonly int p) { }
+                Diagnostic(ErrorCode.ERR_DupParamMod, "readonly").WithArguments("readonly").WithLocation(3, 29)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithoutRef()
+        {
+            var source = """
+                class C
+                {
+                    void M(readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithParams()
+        {
+            var source = """
+                class C
+                {
+                    void M(readonly params int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly params int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithParams()
+        {
+            var source = """
+                class C
+                {
+                    void M(params ref readonly int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,19): error CS1611: The params parameter cannot be declared as ref
+                //     void M(params ref readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
+                // (3,23): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(params ref readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 23),
+                // (3,23): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(params ref readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 23));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,19): error CS1611: The params parameter cannot be declared as ref
+                //     void M(params ref readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
+                // (3,23): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(params ref readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 23)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithIn()
+        {
+            var source = """
+                class C
+                {
+                    void M(in readonly int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,15): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(in readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 15),
+                // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(in readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,15): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(in readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 15)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithOut()
+        {
+            var source = """
+                class C
+                {
+                    void M(out readonly int[] p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(out readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(out readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,16): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(out readonly int[] p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 16)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithThis()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(this readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,31): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 31),
+                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_01()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(this ref readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(this ref readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_02()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref this readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35),
+                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_03()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref readonly this int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly this int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_01()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(scoped ref readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(scoped ref readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_02()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref scoped readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
+                // (3,37): error CS1001: Identifier expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
+                // (3,37): error CS1003: Syntax error, ',' expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
+                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37),
+                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
+                // (3,37): error CS1001: Identifier expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
+                // (3,37): error CS1003: Syntax error, ',' expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
+                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_03()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(readonly scoped ref int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 26),
+                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
+                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
+                // (3,42): error CS1001: Identifier expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
+                // (3,42): error CS1003: Syntax error, ',' expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
+                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
+                // (3,42): error CS1001: Identifier expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
+                // (3,42): error CS1003: Syntax error, ',' expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithScoped()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(scoped readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
+                // (3,33): error CS1001: Identifier expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
+                // (3,33): error CS1003: Syntax error, ',' expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
+                // (3,33): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 33),
+                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
+                // (3,33): error CS1001: Identifier expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
+                // (3,33): error CS1003: Syntax error, ',' expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
+                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedParameterName()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref readonly int scoped) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly int scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedTypeName()
+        {
+            var source = """
+                struct scoped { }
+                static class C
+                {
+                    public static void M(ref readonly scoped p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+            var expectedDiagnostics = new[]
+            {
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct scoped { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedBothNames()
+        {
+            var source = """
+                struct scoped { }
+                static class C
+                {
+                    public static void M(ref readonly scoped scoped) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+            var expectedDiagnostics = new[]
+            {
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct scoped { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -544,9 +544,6 @@ class C
                 // (6,19): error CS0027: Keyword 'this' is not available in the current context
                 //         delegate*<this string, void> p2,
                 Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(6, 19),
-                // (7,19): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //         delegate*<readonly ref string, void> p3,
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(7, 19),
                 // (7,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         delegate*<readonly ref string, void> p3,
                 Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(7, 19),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -549,7 +549,7 @@ class C
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(7, 19),
                 // (7,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         delegate*<readonly ref string, void> p3,
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(7, 19),
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(7, 19),
                 // (8,22): error CS8328:  The parameter modifier 'out' cannot be used with 'in'
                 //         delegate*<in out string, void> p4,
                 Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "in").WithLocation(8, 22),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -544,9 +544,12 @@ class C
                 // (6,19): error CS0027: Keyword 'this' is not available in the current context
                 //         delegate*<this string, void> p2,
                 Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(6, 19),
-                // (7,19): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+                // (7,19): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         delegate*<readonly ref string, void> p3,
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(7, 19),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(7, 19),
+                // (7,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //         delegate*<readonly ref string, void> p3,
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(7, 19),
                 // (8,22): error CS8328:  The parameter modifier 'out' cannot be used with 'in'
                 //         delegate*<in out string, void> p4,
                 Diagnostic(ErrorCode.ERR_BadParameterModifiers, "out").WithArguments("out", "in").WithLocation(8, 22),
@@ -1913,9 +1916,9 @@ unsafe class C
                 // (8,19): error CS8808: 'in' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.
                 //         delegate*<in int> ptr2;
                 Diagnostic(ErrorCode.ERR_InvalidFuncPointerReturnTypeModifier, "in").WithArguments("in").WithLocation(8, 19),
-                // (9,23): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+                // (9,23): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         delegate*<ref readonly int, void> ptr3;
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(9, 23),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(9, 23),
                 // (10,19): error CS1536: Invalid parameter type 'void'
                 //         delegate*<void, void> ptr4;
                 Diagnostic(ErrorCode.ERR_NoVoidParameter, "void").WithLocation(10, 19),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
@@ -192,7 +192,7 @@ public class Base {
 }").VerifyDiagnostics(
             // (3,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
             //     public void M(readonly ref int X) {
-            Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 19));
+            Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 19));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -205,7 +205,7 @@ public class Base {
 }").VerifyDiagnostics(
                 // (3,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public void M(readonly int X) {
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 19));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 19));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -220,7 +220,7 @@ public class Base {
 }").VerifyDiagnostics(
                 // (5,18): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         var v = (readonly int i) => { };
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(5, 18));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(5, 18));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -247,7 +247,7 @@ public class Base {
 }").VerifyDiagnostics(
                 // (5,18): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         var v = (readonly ref int i) => { };
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(5, 18));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(5, 18));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ModifierTests.cs
@@ -179,10 +179,7 @@ struct S<T> where T : struct
 public class Base {
     public void M(ref readonly int X) {
     }
-}").VerifyDiagnostics(
-                // (3,23): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
-                //     public void M(ref readonly int X) {
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(3, 23));
+}").VerifyDiagnostics();
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -193,9 +190,9 @@ public class Base {
     public void M(readonly ref int X) {
     }
 }").VerifyDiagnostics(
-            // (3,19): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+            // (3,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
             //     public void M(readonly ref int X) {
-            Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(3, 19));
+            Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 19));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -206,9 +203,9 @@ public class Base {
     public void M(readonly int X) {
     }
 }").VerifyDiagnostics(
-                // (3,19): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+                // (3,19): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public void M(readonly int X) {
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(3, 19));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 19));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -221,9 +218,9 @@ public class Base {
         var v = (readonly int i) => { };
     }
 }").VerifyDiagnostics(
-                // (5,18): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+                // (5,18): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         var v = (readonly int i) => { };
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(5, 18));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(5, 18));
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -235,10 +232,7 @@ public class Base {
     {
         var v = (ref readonly int i) => { };
     }
-}").VerifyDiagnostics(
-                // (5,22): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
-                //         var v = (ref readonly int i) => { };
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(5, 22));
+}").VerifyDiagnostics();
         }
 
         [Fact, WorkItem(63758, "https://github.com/dotnet/roslyn/issues/63758")]
@@ -251,9 +245,9 @@ public class Base {
         var v = (readonly ref int i) => { };
     }
 }").VerifyDiagnostics(
-                // (5,18): error CS9068: 'readonly' is not supported as a parameter modifier. Did you mean 'in'?
+                // (5,18): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //         var v = (readonly ref int i) => { };
-                Diagnostic(ErrorCode.ERR_ReadOnlyNotSuppAsParamModDidYouMeanIn, "readonly").WithLocation(5, 18));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(5, 18));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationScopeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationScopeParsingTests.cs
@@ -797,17 +797,7 @@ ref @scoped F4() { }";
         public void Method_12(LanguageVersion langVersion)
         {
             string source = "void F(scoped ref readonly int a) { }";
-            UsingDeclaration(source, TestOptions.Regular.WithLanguageVersion(langVersion),
-                // (1,19): error CS1031: Type expected
-                // void F(scoped ref readonly int a) { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "readonly").WithLocation(1, 19),
-                // (1,19): error CS1001: Identifier expected
-                // void F(scoped ref readonly int a) { }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(1, 19),
-                // (1,19): error CS1003: Syntax error, ',' expected
-                // void F(scoped ref readonly int a) { }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(1, 19)
-                );
+            UsingDeclaration(source, TestOptions.Regular.WithLanguageVersion(langVersion));
 
             N(SyntaxKind.MethodDeclaration);
             {
@@ -823,15 +813,6 @@ ref @scoped F4() { }";
                     {
                         N(SyntaxKind.ScopedKeyword);
                         N(SyntaxKind.RefKeyword);
-                        M(SyntaxKind.IdentifierName);
-                        {
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        M(SyntaxKind.IdentifierToken);
-                    }
-                    M(SyntaxKind.CommaToken);
-                    N(SyntaxKind.Parameter);
-                    {
                         N(SyntaxKind.ReadOnlyKeyword);
                         N(SyntaxKind.PredefinedType);
                         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -498,7 +498,7 @@ class Test
         }
 
         [Fact]
-        public void RefReadonly_Declaration()
+        public void RefReadonlyParameter()
         {
             var source = "void M(ref readonly int p);";
             UsingDeclaration(source, TestOptions.Regular11);
@@ -541,217 +541,227 @@ class Test
         }
 
         [Fact]
-        public void RefReadonly_Compilation()
+        public void Readonly_Duplicate_01()
         {
-            var source = """
-                class C
-                {
-                    void M(ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(ref readonly int p);
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16));
+            var source = "void M(ref readonly readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
-        public void ReadonlyWithoutRef()
+        public void Readonly_Duplicate_02()
         {
-            var source = """
-                class C
-                {
-                    void M(readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
+            var source = "void M(readonly readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
 
-            var expectedDiagnostics = new[]
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
-        public void ReadonlyWithParams()
+        public void Readonly_Duplicate_03()
         {
-            var source = """
-                class C
-                {
-                    void M(readonly params int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,12): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
+            var source = "void M(readonly ref readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
 
-            var expectedDiagnostics = new[]
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
             {
-                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
-        public void RefReadonlyWithParams()
+        public void Readonly_Duplicate_04()
         {
-            var source = """
-                class C
-                {
-                    void M(params ref readonly int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,19): error CS1611: The params parameter cannot be declared as ref
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
-                // (3,23): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 23),
-                // (3,23): error CS1611: The params parameter cannot be declared as readonly
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "readonly").WithArguments("readonly").WithLocation(3, 23));
+            var source = "void M(readonly readonly ref int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
 
-            var expectedDiagnostics = new[]
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
             {
-                // (3,19): error CS1611: The params parameter cannot be declared as ref
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "ref").WithArguments("ref").WithLocation(3, 19),
-                // (3,23): error CS1611: The params parameter cannot be declared as readonly
-                //     void M(params ref readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_ParamsCantBeWithModifier, "readonly").WithArguments("readonly").WithLocation(3, 23)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
-        public void ReadonlyWithIn()
+        public void Readonly_Duplicate_05()
         {
-            var source = """
-                class C
-                {
-                    void M(in readonly int[] p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,15): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 15),
-                // (3,15): error CS8328:  The parameter modifier 'readonly' cannot be used with 'in'
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "readonly").WithArguments("readonly", "in").WithLocation(3, 15));
+            var source = "void M(ref readonly ref readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
 
-            var expectedDiagnostics = new[]
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
             {
-                // (3,15): error CS8328:  The parameter modifier 'readonly' cannot be used with 'in'
-                //     void M(in readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "readonly").WithArguments("readonly", "in").WithLocation(3, 15)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithOut()
-        {
-            var source = """
-                class C
+                N(SyntaxKind.MethodDeclaration);
                 {
-                    void M(out readonly int[] p) => throw null;
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
                 }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (3,16): error CS8328:  The parameter modifier 'readonly' cannot be used with 'out'
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "readonly").WithArguments("readonly", "out").WithLocation(3, 16));
-
-            var expectedDiagnostics = new[]
-            {
-                // (3,16): error CS8328:  The parameter modifier 'readonly' cannot be used with 'out'
-                //     void M(out readonly int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "readonly").WithArguments("readonly", "out").WithLocation(3, 16)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void ReadonlyWithThis()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(this readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,31): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 31),
-                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31));
-
-            var expectedDiagnostics = new[]
-            {
-                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+                EOF();
+            }
         }
 
         [Fact]
         public void RefReadonlyWithThis()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(this ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(this ref readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonlyWithThis_Nodes()
         {
             var source = "void M(this ref readonly int p);";
             UsingDeclaration(source, TestOptions.Regular11);
@@ -797,34 +807,6 @@ class Test
         [Fact]
         public void RefReadonlyWithThis_02()
         {
-            var source = """
-                static class C
-                {
-                    public static void M(ref this readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35),
-                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35));
-
-            var expectedDiagnostics = new[]
-            {
-                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-        }
-
-        [Fact]
-        public void RefReadonlyWithThis_02_Nodes()
-        {
             var source = "void M(ref this readonly int p);";
             UsingDeclaration(source, TestOptions.Regular11);
             verifyNodes();
@@ -868,24 +850,6 @@ class Test
 
         [Fact]
         public void RefReadonlyWithThis_03()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(ref readonly this int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly this int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonlyWithThis_03_Nodes()
         {
             var source = "void M(ref readonly this int p);";
             UsingDeclaration(source, TestOptions.Regular11);
@@ -931,24 +895,6 @@ class Test
         [Fact]
         public void RefReadonlyWithScoped_01()
         {
-            var source = """
-                static class C
-                {
-                    public static void M(scoped ref readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(scoped ref readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonlyWithScoped_01_Nodes()
-        {
             var source = "void M(scoped ref readonly int p);";
             UsingDeclaration(source, TestOptions.Regular11);
             verifyNodes();
@@ -993,161 +939,252 @@ class Test
         [Fact]
         public void RefReadonlyWithScoped_02()
         {
-            var source = """
-                static class C
-                {
-                    public static void M(ref scoped readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
-                // (3,37): error CS1001: Identifier expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
-                // (3,37): error CS1003: Syntax error, ',' expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
-                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37),
-                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37));
-
+            var source = "void M(ref scoped readonly int p);";
             var expectedDiagnostics = new[]
             {
-                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
-                // (3,37): error CS1001: Identifier expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
-                // (3,37): error CS1003: Syntax error, ',' expected
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
-                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
+                // (1,19): error CS1001: Identifier expected
+                // void M(ref scoped readonly int p);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(1, 19),
+                // (1,19): error CS1003: Syntax error, ',' expected
+                // void M(ref scoped readonly int p);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(1, 19)
             };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+            UsingDeclaration(source, TestOptions.Regular11, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularPreview, expectedDiagnostics);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
         public void RefReadonlyWithScoped_03()
         {
-            var source = """
-                static class C
-                {
-                    public static void M(readonly scoped ref int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 26),
-                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
-                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
-                // (3,42): error CS1001: Identifier expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
-                // (3,42): error CS1003: Syntax error, ',' expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42));
-
+            var source = "void M(readonly scoped ref int p);";
             var expectedDiagnostics = new[]
             {
-                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
-                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
-                // (3,42): error CS1001: Identifier expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
-                // (3,42): error CS1003: Syntax error, ',' expected
-                //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
+                // (1,24): error CS1001: Identifier expected
+                // void M(readonly scoped ref int p);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(1, 24),
+                // (1,24): error CS1003: Syntax error, ',' expected
+                // void M(readonly scoped ref int p);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(1, 24)
             };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+            UsingDeclaration(source, TestOptions.Regular11, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularPreview, expectedDiagnostics);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
         public void ReadonlyWithScoped()
         {
-            var source = """
-                static class C
-                {
-                    public static void M(scoped readonly int p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
-                // (3,33): error CS1001: Identifier expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
-                // (3,33): error CS1003: Syntax error, ',' expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
-                // (3,33): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 33),
-                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33));
-
+            var source = "void M(scoped readonly int p);";
             var expectedDiagnostics = new[]
             {
-                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
-                // (3,33): error CS1001: Identifier expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
-                // (3,33): error CS1003: Syntax error, ',' expected
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
-                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
-                //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
+                // (1,15): error CS1001: Identifier expected
+                // void M(scoped readonly int p);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(1, 15),
+                // (1,15): error CS1003: Syntax error, ',' expected
+                // void M(scoped readonly int p);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(1, 15)
             };
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+            UsingDeclaration(source, TestOptions.Regular11, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularPreview, expectedDiagnostics);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void ReadonlyWithScoped_02()
+        {
+            var source = "void M(scoped readonly ref int p);";
+            var expectedDiagnostics = new[]
+            {
+                // (1,15): error CS1001: Identifier expected
+                // void M(scoped readonly ref int p);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(1, 15),
+                // (1,15): error CS1003: Syntax error, ',' expected
+                // void M(scoped readonly ref int p);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(1, 15)
+            };
+
+            UsingDeclaration(source, TestOptions.Regular11, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext, expectedDiagnostics);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularPreview, expectedDiagnostics);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
         }
 
         [Fact]
         public void RefReadonly_ScopedParameterName()
-        {
-            var source = """
-                static class C
-                {
-                    public static void M(ref readonly int scoped) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly int scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void RefReadonly_ScopedParameterName_Nodes()
         {
             var source = "void M(ref readonly int scoped);";
             UsingDeclaration(source, TestOptions.Regular11);
@@ -1192,43 +1229,6 @@ class Test
         [Fact]
         public void RefReadonly_ScopedTypeName()
         {
-            var source = """
-                struct scoped { }
-                static class C
-                {
-                    public static void M(ref readonly scoped p) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-
-            var expectedDiagnostics = new[]
-            {
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
-                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
-                // struct scoped { }
-                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-        }
-
-        [Fact]
-        public void RefReadonly_ScopedTypeName_Nodes()
-        {
             var source = "void M(ref readonly scoped p);";
             UsingDeclaration(source, TestOptions.Regular11);
             verifyNodes();
@@ -1271,43 +1271,6 @@ class Test
 
         [Fact]
         public void RefReadonly_ScopedBothNames()
-        {
-            var source = """
-                struct scoped { }
-                static class C
-                {
-                    public static void M(ref readonly scoped scoped) => throw null;
-                }
-                """;
-            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-
-            var expectedDiagnostics = new[]
-            {
-                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
-                // struct scoped { }
-                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
-            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
-                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
-                // struct scoped { }
-                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
-                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     public static void M(ref readonly scoped scoped) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
-        }
-
-        [Fact]
-        public void RefReadonly_ScopedBothNames_Nodes()
         {
             var source = "void M(ref readonly scoped scoped);";
             UsingDeclaration(source, TestOptions.Regular11);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -917,5 +917,429 @@ class Test
                 EOF();
             }
         }
+
+        [Fact]
+        public void RefReadonlyWithScoped_01()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(scoped ref readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(scoped ref readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_01_Nodes()
+        {
+            var source = "void M(scoped ref readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ScopedKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_02()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref scoped readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
+                // (3,37): error CS1001: Identifier expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
+                // (3,37): error CS1003: Syntax error, ',' expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
+                // (3,37): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37),
+                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 37));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,30): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 30),
+                // (3,37): error CS1001: Identifier expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 37),
+                // (3,37): error CS1003: Syntax error, ',' expected
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
+                // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 37)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonlyWithScoped_03()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(readonly scoped ref int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 26),
+                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 26),
+                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
+                // (3,42): error CS1001: Identifier expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
+                // (3,42): error CS1003: Syntax error, ',' expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 26),
+                // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
+                // (3,42): error CS1001: Identifier expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "ref").WithLocation(3, 42),
+                // (3,42): error CS1003: Syntax error, ',' expected
+                //     public static void M(readonly scoped ref int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",").WithLocation(3, 42)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ReadonlyWithScoped()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(scoped readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
+                // (3,33): error CS1001: Identifier expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
+                // (3,33): error CS1003: Syntax error, ',' expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
+                // (3,33): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 33),
+                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 33));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,26): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 26),
+                // (3,33): error CS1001: Identifier expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "readonly").WithLocation(3, 33),
+                // (3,33): error CS1003: Syntax error, ',' expected
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
+                // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(scoped readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 33)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedParameterName()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref readonly int scoped) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly int scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedParameterName_Nodes()
+        {
+            var source = "void M(ref readonly int scoped);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedTypeName()
+        {
+            var source = """
+                struct scoped { }
+                static class C
+                {
+                    public static void M(ref readonly scoped p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+            var expectedDiagnostics = new[]
+            {
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct scoped { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedTypeName_Nodes()
+        {
+            var source = "void M(ref readonly scoped p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedBothNames()
+        {
+            var source = """
+                struct scoped { }
+                static class C
+                {
+                    public static void M(ref readonly scoped scoped) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+
+            var expectedDiagnostics = new[]
+            {
+                // (1,8): error CS9062: Types and aliases cannot be named 'scoped'.
+                // struct scoped { }
+                Diagnostic(ErrorCode.ERR_ScopedTypeNameDisallowed, "scoped").WithLocation(1, 8),
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'scoped' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct scoped { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "scoped").WithArguments("scoped").WithLocation(1, 8),
+                // (4,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly scoped scoped) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(4, 30));
+        }
+
+        [Fact]
+        public void RefReadonly_ScopedBothNames_Nodes()
+        {
+            var source = "void M(ref readonly scoped scoped);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.Regular9);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -415,7 +415,7 @@ class Test
 }").VerifyDiagnostics(
                 // (4,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly ref int p)
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(4, 12));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(4, 12));
         }
 
         [Fact]
@@ -573,13 +573,13 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 12));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
 
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 12)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
@@ -601,13 +601,13 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 12),
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 12));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12));
 
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     void M(readonly params int[] p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 12)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
@@ -719,13 +719,13 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 31),
                 // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 31));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31));
 
             var expectedDiagnostics = new[]
             {
                 // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 31)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 31)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
@@ -809,13 +809,13 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35),
                 // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 35));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35));
 
             var expectedDiagnostics = new[]
             {
                 // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 35)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 35)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
@@ -1014,7 +1014,7 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 37),
                 // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 37));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37));
 
             var expectedDiagnostics = new[]
             {
@@ -1029,7 +1029,7 @@ class Test
                 Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 37),
                 // (3,37): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(ref scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 37)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 37)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
@@ -1051,7 +1051,7 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 26),
                 // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 26),
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
                 // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
                 //     public static void M(readonly scoped ref int p) => throw null;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
@@ -1066,7 +1066,7 @@ class Test
             {
                 // (3,26): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(readonly scoped ref int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 26),
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 26),
                 // (3,35): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
                 //     public static void M(readonly scoped ref int p) => throw null;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 35),
@@ -1106,7 +1106,7 @@ class Test
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 33),
                 // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 33));
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33));
 
             var expectedDiagnostics = new[]
             {
@@ -1121,7 +1121,7 @@ class Test
                 Diagnostic(ErrorCode.ERR_SyntaxError, "readonly").WithArguments(",").WithLocation(3, 33),
                 // (3,33): error CS9501: 'readonly' modifier must be specified after 'ref'.
                 //     public static void M(scoped readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 33)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 33)
             };
 
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -703,5 +703,33 @@ class Test
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
+
+        [Fact]
+        public void ReadonlyWithThis()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(this readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,31): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 31),
+                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 31));
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,31): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 31)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -806,10 +806,20 @@ class Test
             CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
                 // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     public static void M(ref this readonly int p) => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35),
+                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 35));
 
-            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-            CreateCompilation(source).VerifyDiagnostics();
+            var expectedDiagnostics = new[]
+            {
+                // (3,35): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_RefReadOnlyInverted, "readonly").WithLocation(3, 35)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
+            CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyTests.cs
@@ -731,5 +731,191 @@ class Test
             CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(expectedDiagnostics);
             CreateCompilation(source).VerifyDiagnostics(expectedDiagnostics);
         }
+
+        [Fact]
+        public void RefReadonlyWithThis()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(this ref readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(this ref readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_Nodes()
+        {
+            var source = "void M(this ref readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.ThisKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_02()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref this readonly int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,35): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref this readonly int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 35));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_02_Nodes()
+        {
+            var source = "void M(ref this readonly int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ThisKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_03()
+        {
+            var source = """
+                static class C
+                {
+                    public static void M(ref readonly this int p) => throw null;
+                }
+                """;
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (3,30): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     public static void M(ref readonly this int p) => throw null;
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 30));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReadonlyWithThis_03_Nodes()
+        {
+            var source = "void M(ref readonly this int p);";
+            UsingDeclaration(source, TestOptions.Regular11);
+            verifyNodes();
+
+            UsingDeclaration(source, TestOptions.RegularNext);
+            verifyNodes();
+
+            UsingDeclaration(source);
+            verifyNodes();
+
+            void verifyNodes()
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.ThisKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "p");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
     }
 }


### PR DESCRIPTION
Speclet: https://github.com/dotnet/csharplang/blob/0c269d235e0687419c1ec69743fb51cea8b4d466/proposals/ref-readonly-parameters.md
Test plan: https://github.com/dotnet/roslyn/issues/68056