### PR TITLE
Cleanup ArgumentOutOfRange exception for LSP.Range

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -206,6 +206,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 }
                 catch (ArgumentException ex)
                 {
+                    // Remove after ArgumentException investigation - https://github.com/dotnet/roslyn/issues/66258
                     // Create a custom error for this so we can examine the data we're getting.
                     throw new ArgumentException($"Range={RangeToString(range)}. text.Length={text.Length}. text.Lines.Count={text.Lines.Count}", ex);
                 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -105,6 +105,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
         }
 
+        [Fact]
+        public void RangeToTextSpanNegativeValueError()
+        {
+            var markup = GetTestMarkup();
+            var sourceText = SourceText.From(markup);
+
+            var range = new Range() { Start = new Position(-1, 0), End = new Position(0, 0) };
+            Assert.Throws<ArgumentOutOfRangeException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
+        }
+
         private static string GetTestMarkup()
         {
             // Markup is 31 characters long. Line break (\n) is 2 characters 


### PR DESCRIPTION
This is a correction to [PR 68081](https://github.com/dotnet/roslyn/pull/68081), which went in without appropriate approval. PR 68081 added an error message when requesting a line beyond the length of the file. 

> The requested line number {0} must be less than the number of lines {1}.

Two things here...
- Added the issue for removing the ProtocolConversions exception handling code that was added by Cyrus for this investigation
- Added a test case for a negative line number
