### PR TITLE
Update compiler tool set version in 17.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.4.0-2.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.4.0</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->


### PR DESCRIPTION
This code flow PR https://github.com/dotnet/roslyn/pull/68149 causes a lot of warnings.
https://dev.azure.com/dnceng-public/public/_build/results?buildId=269732&view=results

(Yeah, bot merges the PR with warnings, cool)

I tested locally update the compiler tool set version should address the problem.