### PR TITLE
Only do LOC for 17.6

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -82,11 +82,11 @@ stages:
     demands: ImageOverride -equals windows.vs2022.amd64
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.4') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.6-vs-deps') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: roslyn
-        MirrorBranch: release/dev17.4
+        MirrorBranch: release/dev17.6-vs-deps
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-ROSLYN'
 


### PR DESCRIPTION
Bot is keeping creating PRs like
https://github.com/dotnet/roslyn/pull/68169
https://github.com/dotnet/roslyn/pull/68148

Right now our registered branch for LOC is `release/dev17.6-vs-deps` (Only one active LOC branch is allowed)
So change this in 17.4 so we don't get wrong LOC PR anymore in future.
Also this would fix 17.5 when code flows 