### PR TITLE
Use net8.0 runtime for InlineArray tests

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,8 @@
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
     <add key="vs-impl-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl-archived/nuget/v3/index.json" />
     <add key="vs-buildservices" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
+    <!-- DO NOT MERGE -->
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,6 +53,7 @@
     <BasicReferenceAssembliesNet50Version>1.2.4</BasicReferenceAssembliesNet50Version>
     <BasicReferenceAssembliesNet60Version>1.2.4</BasicReferenceAssembliesNet60Version>
     <BasicReferenceAssembliesNet70Version>1.3.0</BasicReferenceAssembliesNet70Version>
+    <BasicReferenceAssembliesNet80Version>1.4.2</BasicReferenceAssembliesNet80Version>
     <BasicReferenceAssembliesNet461Version>1.3.0</BasicReferenceAssembliesNet461Version>
     <BasicReferenceAssembliesNetStandard13Version>1.2.4</BasicReferenceAssembliesNetStandard13Version>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>

--- a/src/Compilers/CSharp/Test/Semantic/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests</RootNamespace>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
@@ -20,6 +20,7 @@
     <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
     <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="$(BasicReferenceAssembliesNet50Version)" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="$(BasicReferenceAssembliesNet60Version)" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="$(BasicReferenceAssembliesNet80Version)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -90,7 +90,8 @@ namespace Roslyn.Test.Utilities
 
         Net50,
         Net60,
-        Net70
+        Net70,
+        Net80
     }
 
     /// <summary>
@@ -206,6 +207,7 @@ namespace Roslyn.Test.Utilities
             TargetFramework.Net50 => ImmutableArray.CreateRange<MetadataReference>(LoadDynamicReferences("Net50")),
             TargetFramework.Net60 => ImmutableArray.CreateRange<MetadataReference>(LoadDynamicReferences("Net60")),
             TargetFramework.NetCoreApp or TargetFramework.Net70 => ImmutableArray.CreateRange<MetadataReference>(Net70.All),
+            TargetFramework.Net80 => ImmutableArray.CreateRange<MetadataReference>(LoadDynamicReferences("Net80")),
             TargetFramework.NetFramework => NetFramework.References,
             TargetFramework.NetLatest => NetLatest,
             TargetFramework.Standard => StandardReferences,
@@ -322,6 +324,11 @@ namespace Roslyn.Test.Utilities
 
                 var type = assembly.GetType(assemblyName, throwOnError: true);
                 var prop = type.GetProperty("All", BindingFlags.Public | BindingFlags.Static);
+                if (prop is null)
+                {
+                    type = assembly.GetType(assemblyName + "+References", throwOnError: true);
+                    prop = type.GetProperty("All", BindingFlags.Public | BindingFlags.Static);
+                }
                 var obj = prop.GetGetMethod()!.Invoke(obj: null, parameters: null);
                 references = ((IEnumerable<PortableExecutableReference>)obj).ToImmutableArray();
 


### PR DESCRIPTION
Updates the C# semantic tests to consume the net8.0 reference assemblies and force execution on the .NET 8 runtime. This lets us actually test inline arrays end to end