### PR TITLE
Sync C# required members implementation with VB changes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5267,7 +5267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        private static void CheckRequiredMembersInObjectInitializer(
+        internal static void CheckRequiredMembersInObjectInitializer(
             MethodSymbol constructor,
             ImmutableArray<BoundExpression> initializers,
             SyntaxNode creationSyntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -66,6 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MethodSymbol smallestConstructor = smallestCtor.AsMember(smallestType);
                 BoundObjectCreationExpression currentCreation = new BoundObjectCreationExpression(syntax, smallestConstructor, smallestCtorArguments);
 
+                Binder.CheckRequiredMembersInObjectInitializer(smallestConstructor, initializers: ImmutableArray<BoundExpression>.Empty, syntax, _diagnostics);
+
                 if (underlyingTupleTypeChain.Count > 0)
                 {
                     NamedTypeSymbol tuple8Type = underlyingTupleTypeChain.Peek();
@@ -77,6 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         return _factory.BadExpression(type);
                     }
+
+                    Binder.CheckRequiredMembersInObjectInitializer(tuple8Ctor, initializers: ImmutableArray<BoundExpression>.Empty, syntax, _diagnostics);
 
                     // make successively larger creation expressions containing the previous one
                     do

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -599,6 +599,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 foreach (var member in GetMembersUnordered())
                 {
+                    if (member is PropertySymbol { ParameterCount: > 0 } prop)
+                    {
+                        if (prop.IsRequired)
+                        {
+                            // Bad metadata. Indexed properties cannot be required.
+                            return false;
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+
                     if (baseAllRequiredMembers.TryGetValue(member.Name, out var existingMember))
                     {
                         // This is only permitted if the member is an override of a required member from a base type, and is required itself.

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                CalculateRequiredMembersIfRequired();
+                EnsureRequiredMembersCalculated();
                 Debug.Assert(!_lazyRequiredMembers.IsDefault);
                 return _lazyRequiredMembers == RequiredMembersErrorSentinel;
             }
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                CalculateRequiredMembersIfRequired();
+                EnsureRequiredMembersCalculated();
                 Debug.Assert(!_lazyRequiredMembers.IsDefault);
                 if (_lazyRequiredMembers == RequiredMembersErrorSentinel)
                 {
@@ -571,60 +571,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private void CalculateRequiredMembersIfRequired()
+        private void EnsureRequiredMembersCalculated()
         {
             if (!_lazyRequiredMembers.IsDefault)
             {
                 return;
             }
 
-            ImmutableSegmentedDictionary<string, Symbol>.Builder? builder = null;
-            bool success = TryCalculateRequiredMembers(ref builder);
+            bool success = tryCalculateRequiredMembers(out ImmutableSegmentedDictionary<string, Symbol>.Builder? builder);
 
             var requiredMembers = success
-                ? builder?.ToImmutable() ?? ImmutableSegmentedDictionary<string, Symbol>.Empty
+                ? builder?.ToImmutable() ?? BaseTypeNoUseSiteDiagnostics?.AllRequiredMembers ?? ImmutableSegmentedDictionary<string, Symbol>.Empty
                 : RequiredMembersErrorSentinel;
 
             RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyRequiredMembers, requiredMembers);
-        }
 
-        /// <summary>
-        /// Attempts to calculate the required members for this type. Returns false if there were errors.
-        /// </summary>
-        private bool TryCalculateRequiredMembers(ref ImmutableSegmentedDictionary<string, Symbol>.Builder? requiredMembersBuilder)
-        {
-            var lazyRequiredMembers = _lazyRequiredMembers;
-            if (lazyRequiredMembers == RequiredMembersErrorSentinel)
+            bool tryCalculateRequiredMembers(out ImmutableSegmentedDictionary<string, Symbol>.Builder? requiredMembersBuilder)
             {
-                return false;
-            }
+                requiredMembersBuilder = null;
+                if (BaseTypeNoUseSiteDiagnostics?.HasRequiredMembersError == true)
+                {
+                    return false;
+                }
 
-            if (BaseTypeNoUseSiteDiagnostics?.TryCalculateRequiredMembers(ref requiredMembersBuilder) == false)
-            {
-                return false;
-            }
-
-            // We need to make sure that members from a base type weren't hidden by members from the current type.
-            if (!HasDeclaredRequiredMembers && requiredMembersBuilder == null)
-            {
-                return true;
-            }
-
-            return addCurrentTypeMembers(ref requiredMembersBuilder);
-
-            bool addCurrentTypeMembers(ref ImmutableSegmentedDictionary<string, Symbol>.Builder? requiredMembersBuilder)
-            {
-                requiredMembersBuilder ??= ImmutableSegmentedDictionary.CreateBuilder<string, Symbol>();
+                var baseAllRequiredMembers = BaseTypeNoUseSiteDiagnostics?.AllRequiredMembers ?? ImmutableSegmentedDictionary<string, Symbol>.Empty;
+                var hasDeclaredRequiredMembers = HasDeclaredRequiredMembers;
 
                 foreach (var member in GetMembersUnordered())
                 {
-                    if (requiredMembersBuilder.ContainsKey(member.Name))
+                    if (baseAllRequiredMembers.TryGetValue(member.Name, out var existingMember))
                     {
                         // This is only permitted if the member is an override of a required member from a base type, and is required itself.
                         if (!member.IsRequired()
-                            || member.Kind == SymbolKind.Field
                             || member.GetOverriddenMember() is not { } overriddenMember
-                            || !overriddenMember.Equals(requiredMembersBuilder[member.Name], TypeCompareKind.ConsiderEverything))
+                            || !overriddenMember.Equals(existingMember, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.AllNullableIgnoreOptions))
                         {
                             return false;
                         }
@@ -634,6 +614,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         continue;
                     }
+
+                    if (!hasDeclaredRequiredMembers)
+                    {
+                        // Bad metadata. Type claimed it didn't declare any required members, but we found one.
+                        return false;
+                    }
+
+                    requiredMembersBuilder ??= baseAllRequiredMembers.ToBuilder();
 
                     requiredMembersBuilder[member.Name] = member;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return OriginalDefinition.GetTypeMembers(name, arity).SelectAsArray((t, self) => t.AsMember(self), this);
         }
 
-        internal sealed override bool HasDeclaredRequiredMembers => OriginalDefinition.HasDeclaredRequiredMembers;
+        internal sealed override bool HasDeclaredRequiredMembers => !_unbound && OriginalDefinition.HasDeclaredRequiredMembers;
 
         public sealed override ImmutableArray<Symbol> GetMembers()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -6214,6 +6214,9 @@ public class Derived : Base
             // (8,25): error CS0102: The type 'C' already contains a definition for 'Test'
             //     public required int Test;
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(8, 25),
+            // (12,19): error CS9035: Required member 'C.Test' must be set in the object initializer or attribute constructor.
+            //         C c = new C { T = 42 };
+            Diagnostic(ErrorCode.ERR_RequiredMemberMustBeSet, "C").WithArguments("C.Test").WithLocation(12, 19),
             // (12,23): error CS0117: 'C' does not contain a definition for 'T'
             //         C c = new C { T = 42 };
             Diagnostic(ErrorCode.ERR_NoSuchMember, "T").WithArguments("C", "T").WithLocation(12, 23)
@@ -6242,20 +6245,23 @@ public class Derived : Base
 
         comp.VerifyDiagnostics(
             // (4,25): error CS0102: The type 'C' already contains a definition for 'Test'
-            //     public required int Test;
+            //     public required int Test { get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(4, 25),
             // (5,25): error CS0102: The type 'C' already contains a definition for 'Test'
-            //     public required int Test;
+            //     public required int Test { get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(5, 25),
             // (6,25): error CS0102: The type 'C' already contains a definition for 'Test'
-            //     public required int Test;
+            //     public required int Test { get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(6, 25),
             // (7,25): error CS0102: The type 'C' already contains a definition for 'Test'
-            //     public required int Test;
+            //     public required int Test { get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(7, 25),
             // (8,25): error CS0102: The type 'C' already contains a definition for 'Test'
-            //     public required int Test;
+            //     public required int Test { get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "Test").WithArguments("C", "Test").WithLocation(8, 25),
+            // (12,19): error CS9035: Required member 'C.Test' must be set in the object initializer or attribute constructor.
+            //         C c = new C { T = 42 };
+            Diagnostic(ErrorCode.ERR_RequiredMemberMustBeSet, "C").WithArguments("C.Test").WithLocation(12, 19),
             // (12,23): error CS0117: 'C' does not contain a definition for 'T'
             //         C c = new C { T = 42 };
             Diagnostic(ErrorCode.ERR_NoSuchMember, "T").WithArguments("C", "T").WithLocation(12, 23)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/RequiredMembersTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/RequiredMembersTests.vb
@@ -87,7 +87,7 @@ BC37324: 'VbDerivedDerived' cannot satisfy the 'New' constraint on parameter 'T'
             ' {
             '     public required int P { get; set; }
             ' }
-            ' public class Derived
+            ' public class Derived : Base
             ' {
             '     public new required int P { get; set; }
             '     public Derived() {}


### PR DESCRIPTION
Update the C# required members implementation with changes from the VB implementation, handling a few edge cases that were caught during implementation. The changes are not complex, but I would still recommend commit-by-commit review for ease of understanding what test was affected by what change.