### PR TITLE
Handle null compilation options in IsCandidateForFullSolutionAnalysis

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -432,6 +432,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return true;
             }
 
+            if (project.CompilationOptions is null)
+            {
+                // Skip compilation options based checks for non-C#/VB projects.
+                return true;
+            }
+
             // For most of analyzers, the number of diagnostic descriptors is small, so this should be cheap.
             var descriptors = DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer);
             var analyzerConfigOptions = project.GetAnalyzerConfigOptions();


### PR DESCRIPTION
Fixes [AB#1816199](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1816199)

Compilation options can be null for non-C#/VB projects. I attempted to add a solution crawler test for non-C#/VB project, but that seems to have lot of missing pieces. Given that the fix is just a null check, IMO it is fine to not require a test for this fix.