### PR TITLE
Lazily calculate preview operations

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/PreviewExceptionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PreviewExceptionTests.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -51,20 +50,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             Assert.True(errorReported);
         }
 
-        [WpfFact]
-        public async Task TestExceptionInActionSets()
-        {
-            using var workspace = CreateWorkspaceFromOptions("class D {}", new TestParameters());
-
-            var errorReportingService = (TestErrorReportingService)workspace.Services.GetRequiredService<IErrorReportingService>();
-            var errorReported = false;
-            errorReportingService.OnError = message => errorReported = true;
-
-            await ActionSets(workspace, new ErrorCases.ExceptionInCodeAction());
-
-            Assert.True(errorReported);
-        }
-
         private static async Task GetPreview(TestWorkspace workspace, CodeRefactoringProvider provider)
         {
             var codeActions = new List<CodeAction>();
@@ -87,19 +72,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
                 workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
                 workspace, workspace.CurrentSolution, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
             _ = suggestedAction.DisplayText;
-            Assert.True(extensionManager.IsDisabled(provider));
-            Assert.False(extensionManager.IsIgnored(provider));
-        }
-
-        private static async Task ActionSets(TestWorkspace workspace, CodeRefactoringProvider provider)
-        {
-            var codeActions = new List<CodeAction>();
-            RefactoringSetup(workspace, provider, codeActions, out var extensionManager, out var textBuffer);
-            var suggestedAction = new CodeRefactoringSuggestedAction(
-                workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
-                workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
-                workspace, workspace.CurrentSolution, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
-            _ = await suggestedAction.GetActionSetsAsync(CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/PreviewTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PreviewTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             return (document, previews);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/14421")]
+        [WpfFact]
         public async Task TestPickTheRightPreview_NoPreference()
         {
             var parameters = new TestParameters();

--- a/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesSuggestedAction.cs
@@ -4,8 +4,6 @@
 
 #nullable disable
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Text;
 
@@ -31,21 +29,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
             }
 
-            public static async Task<SuggestedAction> CreateAsync(
-                SuggestedActionWithNestedFlavors suggestedAction, CancellationToken cancellationToken)
+            public static SuggestedAction Create(SuggestedActionWithNestedFlavors suggestedAction)
             {
-                var previewResult = await suggestedAction.GetPreviewResultAsync(cancellationToken).ConfigureAwait(true);
-                if (previewResult == null)
-                {
-                    return null;
-                }
-
-                var changeSummary = previewResult.ChangeSummary;
-                if (changeSummary == null)
-                {
-                    return null;
-                }
-
                 return new PreviewChangesSuggestedAction(
                     suggestedAction.ThreadingContext,
                     suggestedAction.SourceProvider,
@@ -54,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     suggestedAction.SubjectBuffer,
                     suggestedAction.Provider,
                     new PreviewChangesCodeAction(
-                        suggestedAction.Workspace, suggestedAction.CodeAction, changeSummary));
+                        suggestedAction.Workspace, suggestedAction.CodeAction, suggestedAction.GetPreviewResultAsync));
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -218,14 +218,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         protected async Task<SolutionPreviewResult> GetPreviewResultAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // We will always invoke this from the UI thread.
-            AssertIsForeground();
-
-            // We use ConfigureAwait(true) to stay on the UI thread.
             var operations = await GetPreviewOperationsAsync(cancellationToken).ConfigureAwait(true);
 
+            await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return await EditHandler.GetPreviewsAsync(Workspace, operations, cancellationToken).ConfigureAwait(true);
         }
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/Preview/PreviewTests.vb
@@ -5,7 +5,11 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Preview
+Imports Microsoft.CodeAnalysis.Editor.UnitTests
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Text
 
@@ -13,12 +17,22 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
     Public Class PreviewTests
         Inherits AbstractVisualBasicCodeActionTest
 
+        Private Shared ReadOnly s_composition As TestComposition = EditorTestCompositions.EditorFeaturesWpf _
+            .AddExcludedPartTypes(GetType(IDiagnosticUpdateSourceRegistrationService)) _
+            .AddParts(
+                GetType(MockDiagnosticUpdateSourceRegistrationService),
+                GetType(MockPreviewPaneService))
+
         Private Const s_addedDocumentName As String = "AddedDocument"
         Private Const s_addedDocumentText As String = "Class C1 : End Class"
         Private Shared s_removedMetadataReferenceDisplayName As String = ""
         Private Const s_addedProjectName As String = "AddedProject"
         Private Shared ReadOnly s_addedProjectId As ProjectId = ProjectId.CreateNewId()
         Private Const s_changedDocumentText As String = "Class C : End Class"
+
+        Protected Overrides Function GetComposition() As TestComposition
+            Return s_composition
+        End Function
 
         Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
             Return New MyCodeRefactoringProvider()
@@ -82,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
             Return (document, previews)
         End Function
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/14421")>
+        <WpfFact>
         Public Async Function TestPickTheRightPreview_NoPreference() As Task
             Dim parameters As New TestParameters()
             Using workspace = CreateWorkspaceFromOptions("Class D : End Class", parameters)


### PR DESCRIPTION
This commit changes the behavior of the following button in the presence of a code fix or refactoring which does not apply any "previewable" code actions.
![image](https://github.com/dotnet/roslyn/assets/1408396/89dda5e1-fa84-4605-a159-8edd7e4997a2)

Previously, the light bulb would show the **Preview changes** button only when one or more changes existed for preview. In the new behavior, the **Preview changes** button always appears, even in cases where clicking it results in a preview that shows no actual changes. Lazily computing the content of the preview allows us to (much) more quickly gather a list of all actions showing on the light bulb, which is an operation performed many thousands of times in product testing.

This pull request assumes the change in product behavior is acceptable. If we want to avoid the change in product behavior, we could introduce an internal option that allows us to switch between eagerly computing the preview operations (default) or lazily doing so.