### PR TITLE
Move LongPath check to MSBuild target

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -711,11 +711,6 @@ try {
     exit 1
   }
 
-  $regKeyProperty = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name "LongPathsEnabled" -ErrorAction Ignore
-  if (($null -eq $regKeyProperty) -or ($regKeyProperty.LongPathsEnabled -ne 1)) {
-    Write-Host "LongPath is not enabled, you may experience build errors. You can avoid these by enabling LongPath with `"reg ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1`""
-  }
-
   Process-Arguments
 
   . (Join-Path $PSScriptRoot "build-utils.ps1")

--- a/eng/enable-long-paths.reg
+++ b/eng/enable-long-paths.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem]
+"LongPathsEnabled"=dword:00000001

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -154,6 +154,14 @@
                  Condition="$(_VersionComparisonResult) &lt; 0"/>
   </Target> 
 
+  <Target Name="_CheckLongPathSupport" BeforeTargets="BeforeBuild" Condition="'$(MSBuildRuntimeType)' == 'Full'">
+    <PropertyGroup>
+      <_RoslynLongPathsEnabled>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\FileSystem', 'LongPathsEnabled', null, RegistryView.Registry64, RegistryView.Registry32))</_RoslynLongPathsEnabled>
+    </PropertyGroup>
+    
+    <Warning Condition="'$(_RoslynLongPathsEnabled)' != '1'" Text="Long paths are required for this project. Please run eng\enable-long-paths.reg" />
+  </Target> 
+
   <!-- 
     This target is used to copy referenced projects to a sub-directory vs. the direct output 
     directory of the build. Useful when the referenced project is an EXE and the referencing 


### PR DESCRIPTION
The Roslyn repository effectively depends on having long paths enabled at this point. Between NuGet and the VSSDK, both outside our control, our repository runs right up against `MAX_PATH` limits even with a very short user name. A user name of any significant length will quickly run into issues in our repo.

The repository already warns about long path support, and has for some time, but it does so in command line builds. That was a fine experience when it was added as long path support was new and was only needed in a few cases. Now though it's effectivtely needed for everyone so need to give it more visibility by elevating it to an MSBuild warning.

This warning is _deliberately_ not configurable. Having long paths disabled at this point means your inner loop dev experience is broken in strange, hard to diagnose ways.