### PR TITLE
Expect mapped paths in InterceptsLocationAttribute

### DIFF
--- a/docs/features/interceptors.md
+++ b/docs/features/interceptors.md
@@ -69,11 +69,20 @@ https://github.com/dotnet/roslyn/issues/67079 is a bug which causes file-local s
 
 #### File paths
 
-File paths used in `[InterceptsLocation]` must exactly match the paths on the syntax trees they refer to by ordinal comparison. `SyntaxTree.FilePath` has already applied `/pathmap` substitution, so the paths used in the attribute will be less environment-specific in many projects.
+File paths used in `[InterceptsLocation]` are expected to have `/pathmap` substitution already applied. Generators should accomplish this by locally recreating the file path transformation performed by the compiler:
+
+```cs
+using Microsoft.CodeAnalysis;
+
+string GetInterceptorFilePath(SyntaxTree tree, Compilation compilation)
+{
+    return compilation.Options.SourceReferenceResolver?.NormalizePath(tree.FilePath, baseFilePath: null) ?? tree.FilePath;
+}
+```
+
+The file path given in the attribute must be equal by ordinal comparison to the value given by the above function.
 
 The compiler does not map `#line` directives when determining if an `[InterceptsLocation]` attribute intercepts a particular call in syntax.
-
-PROTOTYPE(ic): editorconfig support matches paths in cross-platform fashion (e.g. normalizing slashes). We should revisit how that works and consider if the same matching strategy should be used instead of ordinal comparison.
 
 #### Position
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7544,9 +7544,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_InterceptorSignatureMismatch_Title" xml:space="preserve">
     <value>Signatures of interceptable and interceptor methods do not match.</value>
   </data>
-  <data name="ERR_InterceptableMethodMustBeOrdinary" xml:space="preserve">
-    <value>An interceptable method must be an ordinary member method.</value>
-  </data>
   <data name="ERR_InterceptorMethodMustBeOrdinary" xml:space="preserve">
     <value>An interceptor method must be an ordinary member method.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7517,6 +7517,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InterceptorPathNotInCompilationWithCandidate" xml:space="preserve">
     <value>Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</value>
   </data>
+  <data name="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate" xml:space="preserve">
+    <value>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</value>
+  </data>
   <data name="ERR_InterceptorLineOutOfRange" xml:space="preserve">
     <value>The given file has '{0}' lines, which is fewer than the provided line number '{1}'.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -154,6 +154,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private readonly ConcurrentCache<TypeSymbol, NamedTypeSymbol> _typeToNullableVersion = new ConcurrentCache<TypeSymbol, NamedTypeSymbol>(size: 100);
 
+        /// <summary>Lazily caches SyntaxTrees by their mapped path. Used to look up the syntax tree referenced by an interceptor. <see cref="TryGetInterceptor"/></summary>
+        private ImmutableSegmentedDictionary<string, OneOrMany<SyntaxTree>> _mappedPathToSyntaxTree;
+
         public override string Language
         {
             get
@@ -1037,7 +1040,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private ImmutableSegmentedDictionary<string, OneOrMany<SyntaxTree>> _mappedPathToSyntaxTree;
         internal OneOrMany<SyntaxTree> GetSyntaxTreesByMappedPath(string mappedPath)
         {
             // We could consider storing this on SyntaxAndDeclarationManager instead, and updating it incrementally.

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2201,7 +2201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InterceptorLineOutOfRange = 27005,
         ERR_InterceptorCharacterOutOfRange = 27006,
         ERR_InterceptorSignatureMismatch = 27007,
-        ERR_InterceptableMethodMustBeOrdinary = 27008,
+        ERR_InterceptorPathNotInCompilationWithUnmappedCandidate = 27008,
         ERR_InterceptorMethodMustBeOrdinary = 27009,
         ERR_InterceptorMustReferToStartOfTokenPosition = 27010,
         ERR_InterceptorMustHaveMatchingThisParameter = 27011,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2328,10 +2328,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_InterceptorCannotBeGeneric:
                 case ErrorCode.ERR_InterceptorPathNotInCompilation:
                 case ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate:
+                case ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate:
                 case ErrorCode.ERR_InterceptorPositionBadToken:
                 case ErrorCode.ERR_InterceptorLineOutOfRange:
                 case ErrorCode.ERR_InterceptorCharacterOutOfRange:
-                case ErrorCode.ERR_InterceptableMethodMustBeOrdinary:
                 case ErrorCode.ERR_InterceptorMethodMustBeOrdinary:
                 case ErrorCode.ERR_InterceptorMustReferToStartOfTokenPosition:
                 case ErrorCode.ERR_InterceptorFilePathCannotBeNull:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Special case when intercepting an extension method call in reduced form with a non-extension.
                 this._diagnostics.Add(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, attributeLocation, method.Parameters[0], method);
-                // PROTOYPE(ic): use a symbol display format which includes the 'this' modifier?
+                // PROTOTYPE(ic): use a symbol display format which includes the 'this' modifier?
                 //this._diagnostics.Add(ErrorCode.ERR_InterceptorMustHaveMatchingThisParameter, attributeLocation, new FormattedSymbol(method.Parameters[0], SymbolDisplayFormat.CSharpErrorMessageFormat), method);
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -987,10 +987,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var syntaxTrees = DeclaringCompilation.SyntaxTrees;
-            var referenceResolver = DeclaringCompilation.Options.SourceReferenceResolver;
             var matchingTrees = DeclaringCompilation.GetSyntaxTreesByMappedPath(attributeFilePath);
             if (matchingTrees.Count == 0)
             {
+                var referenceResolver = DeclaringCompilation.Options.SourceReferenceResolver;
                 // if we expect '/_/Program.cs':
 
                 // we might get: 'C:\Project\Program.cs' <-- path not mapped

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -967,8 +967,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            var filePath = (string?)attributeArguments[0].Value;
-            if (filePath is null)
+            var attributeFilePath = (string?)attributeArguments[0].Value;
+            if (attributeFilePath is null)
             {
                 diagnostics.Add(ErrorCode.ERR_InterceptorFilePathCannotBeNull, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax));
                 return;
@@ -987,42 +987,46 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var syntaxTrees = DeclaringCompilation.SyntaxTrees;
-            SyntaxTree? matchingTree = null;
-            // PROTOTYPE(ic): we need to resolve the paths before comparing (i.e. respect /pathmap).
-            // At that time, we should look at caching the resolved paths for the trees in a set (or maybe a Map<string, OneOrMany<SyntaxTree>>).
-            // so we can reduce the cost of these checks.
-            foreach (var tree in syntaxTrees)
+            var referenceResolver = DeclaringCompilation.Options.SourceReferenceResolver;
+            var matchingTrees = DeclaringCompilation.GetSyntaxTreesByMappedPath(attributeFilePath);
+            if (matchingTrees.Count == 0)
             {
-                if (tree.FilePath == filePath)
-                {
-                    if (matchingTree == null)
-                    {
-                        matchingTree = tree;
-                        // need to keep searching in case we find another tree with the same path
-                    }
-                    else
-                    {
-                        diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath);
-                        return;
-                    }
-                }
-            }
+                // if we expect '/_/Program.cs':
 
-            if (matchingTree == null)
-            {
-                var suffixMatch = syntaxTrees.FirstOrDefault(static (tree, filePath) => tree.FilePath.EndsWith(filePath), filePath);
+                // we might get: 'C:\Project\Program.cs' <-- path not mapped
+                var unmappedMatch = syntaxTrees.FirstOrDefault(static (tree, filePath) => tree.FilePath == filePath, attributeFilePath);
+                if (unmappedMatch != null)
+                {
+                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath, mapPath(referenceResolver, unmappedMatch));
+                    return;
+                }
+
+                // we might get: '\_\Program.cs' <-- slashes not normalized
+                // we might get: '\_/Program.cs' <-- slashes don't match
+                // we might get: 'Program.cs' <-- suffix match
+                // Force normalization of all '\' to '/', but when we recommend a path in the diagnostic message, ensure it will match what we expect if the user decides to use it.
+                var suffixMatch = syntaxTrees.FirstOrDefault(static (tree, pair)
+                    => mapPath(pair.referenceResolver, tree)
+                        .Replace('\\', '/')
+                        .EndsWith(pair.attributeFilePath),
+                    (referenceResolver, attributeFilePath: attributeFilePath.Replace('\\', '/')));
                 if (suffixMatch != null)
                 {
-                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath, suffixMatch.FilePath);
+                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath, mapPath(referenceResolver, suffixMatch));
+                    return;
                 }
-                else
-                {
-                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), filePath);
-                }
+
+                diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilation, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
 
                 return;
             }
+            else if (matchingTrees.Count > 1)
+            {
+                diagnostics.Add(ErrorCode.ERR_InterceptorNonUniquePath, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath);
+                return;
+            }
 
+            SyntaxTree? matchingTree = matchingTrees[0];
             // Internally, line and character numbers are 0-indexed, but when they appear in code or diagnostic messages, they are 1-indexed.
             int lineNumberZeroBased = lineNumberOneBased - 1;
             int characterNumberZeroBased = characterNumberOneBased - 1;
@@ -1079,7 +1083,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            DeclaringCompilation.AddInterception(filePath, lineNumberZeroBased, characterNumberZeroBased, attributeLocation, this);
+            DeclaringCompilation.AddInterception(matchingTree.FilePath, lineNumberZeroBased, characterNumberZeroBased, attributeLocation, this);
+
+            static string mapPath(SourceReferenceResolver? referenceResolver, SyntaxTree tree)
+            {
+                return referenceResolver?.NormalizePath(tree.FilePath, baseFilePath: null) ?? tree.FilePath;
+            }
         }
 
         private void DecodeUnmanagedCallersOnlyAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -997,7 +997,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var unmappedMatch = syntaxTrees.FirstOrDefault(static (tree, filePath) => tree.FilePath == filePath, attributeFilePath);
                 if (unmappedMatch != null)
                 {
-                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath, mapPath(referenceResolver, unmappedMatch));
+                    diagnostics.Add(
+                        ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate,
+                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeFilePath,
+                        mapPath(referenceResolver, unmappedMatch));
                     return;
                 }
 
@@ -1012,7 +1016,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     (referenceResolver, attributeFilePath: attributeFilePath.Replace('\\', '/')));
                 if (suffixMatch != null)
                 {
-                    diagnostics.Add(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax), attributeFilePath, mapPath(referenceResolver, suffixMatch));
+                    diagnostics.Add(
+                        ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate,
+                        attributeData.GetAttributeArgumentSyntaxLocation(filePathParameterIndex, attributeSyntax),
+                        attributeFilePath,
+                        mapPath(referenceResolver, suffixMatch));
                     return;
                 }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Vlastnosti instance v rozhraních nemůžou mít inicializátory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Instanzeigenschaften in Schnittstellen können keine Initialisierer aufweisen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Las propiedades de la instancia en las interfaces no pueden tener inicializadores.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Les propriétés d'instance dans les interfaces ne peuvent pas avoir d'initialiseurs.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Le proprietà di istanza nelle interfacce non possono avere inizializzatori.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -847,11 +847,6 @@
         <target state="translated">インターフェイス内のインスタンス プロパティは初期化子を持つことができません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -847,11 +847,6 @@
         <target state="translated">인터페이스의 인스턴스 속성은 이니셜라이저를 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Właściwości wystąpienia w interfejsach nie mogą mieć inicjatorów.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -847,11 +847,6 @@
         <target state="translated">As propriedades da instância nas interfaces não podem ter inicializadores.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Свойства экземпляра в интерфейсах не могут иметь инициализаторы.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -847,11 +847,6 @@
         <target state="translated">Arabirimlerdeki örnek özelliklerinin başlatıcıları olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -847,11 +847,6 @@
         <target state="translated">接口中的实例属性不能具有初始值设定项。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -927,6 +927,11 @@
         <target state="new">Cannot intercept: compilation does not contain a file with path '{0}'. Did you mean to use path '{1}'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorPathNotInCompilationWithUnmappedCandidate">
+        <source>Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</source>
+        <target state="new">Cannot intercept: Path '{0}' is unmapped. Expected mapped path '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorPositionBadToken">
         <source>The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</source>
         <target state="new">The provided line and character number does not refer to an interceptable method name, but rather to token '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -847,11 +847,6 @@
         <target state="translated">介面中的執行個體屬性不可有初始設定式。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
-        <source>An interceptable method must be an ordinary member method.</source>
-        <target state="new">An interceptable method must be an ordinary member method.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</source>
         <target state="new">Method '{0}' cannot be used as an interceptor because it or its containing type has type parameters.</target>

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -318,5 +318,73 @@ $@"        if (F({i}))
                 });
             }
         }
+
+        [Fact]
+        public void Interceptors()
+        {
+            const int numberOfInterceptors = 10000;
+
+            // write a program which has many intercepted calls.
+            // each interceptor is in a different file.
+            var files = ArrayBuilder<(string source, string path)>.GetInstance();
+
+            // Build a top-level-statements main like:
+            //    C.M();
+            //    C.M();
+            //    C.M();
+            //    ...
+            var builder = new StringBuilder();
+            for (int i = 0; i < numberOfInterceptors; i++)
+            {
+                builder.AppendLine("C.M();");
+            }
+
+            files.Add((builder.ToString(), "Program.cs"));
+
+            files.Add(("""
+                class C
+                {
+                    public static void M() => throw null!;
+                }
+
+                namespace System.Runtime.CompilerServices
+                {
+                    public class InterceptsLocationAttribute : Attribute
+                    {
+                        public InterceptsLocationAttribute(string path, int line, int column) { }
+                    }
+                }
+                """, "C.cs"));
+
+            for (int i = 0; i < numberOfInterceptors; i++)
+            {
+                files.Add(($$"""
+                    using System;
+                    using System.Runtime.CompilerServices;
+
+                    class C{{i}}
+                    {
+                        [InterceptsLocation("Program.cs", {{i + 1}}, 3)]
+                        public static void M()
+                        {
+                            Console.WriteLine({{i}});
+                        }
+                    }
+                    """, $"C{i}.cs"));
+            }
+
+            var verifier = CompileAndVerify(files.ToArrayAndFree(), parseOptions: TestOptions.Regular.WithFeature("interceptors"), expectedOutput: makeExpectedOutput());
+            verifier.VerifyDiagnostics();
+
+            string makeExpectedOutput()
+            {
+                builder.Clear();
+                for (int i = 0; i < numberOfInterceptors; i++)
+                {
+                    builder.AppendLine($"{i}");
+                }
+                return builder.ToString();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -373,7 +373,7 @@ $@"        if (F({i}))
                     """, $"C{i}.cs"));
             }
 
-            var verifier = CompileAndVerify(files.ToArrayAndFree(), parseOptions: TestOptions.Regular.WithFeature("interceptors"), expectedOutput: makeExpectedOutput());
+            var verifier = CompileAndVerify(files.ToArrayAndFree(), parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreview"), expectedOutput: makeExpectedOutput());
             verifier.VerifyDiagnostics();
 
             string makeExpectedOutput()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -3578,14 +3578,10 @@ partial struct CustomHandler
             parseOptions: RegularWithInterceptors,
             options: TestOptions.DebugExe.WithSourceReferenceResolver(
                 new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)));
-        comp.VerifyEmitDiagnostics(PlatformInformation.IsWindows
+        comp.VerifyEmitDiagnostics(
                 // C:\My\Machine\Specific\Path\Program.cs(11,25): error CS27008: Cannot intercept: Path 'C:\My\Machine\Specific\Path\Program.cs' is unmapped. Expected mapped path '/_/Program.cs'.
                 //     [InterceptsLocation(@"C:\My\Machine\Specific\Path\Program.cs", 5, 3)]
-                ? Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, @"@""C:\My\Machine\Specific\Path\Program.cs""").WithArguments(@"C:\My\Machine\Specific\Path\Program.cs", "/_/Program.cs").WithLocation(11, 25)
-
-                // /My/Machine/Specific/Path/Program.cs(11,25): error CS27008: Cannot intercept: Path '/My/Machine/Specific/Path/Program.cs' is unmapped. Expected mapped path '/_/Program.cs'.
-                //     [InterceptsLocation(@"/My/Machine/Specific/Path/Program.cs", 5, 3)]
-                : Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, @"@""/My/Machine/Specific/Path/Program.cs""").WithArguments("/My/Machine/Specific/Path/Program.cs", "/_/Program.cs").WithLocation(11, 25)
+                Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, $@"@""{path}""").WithArguments(path, "/_/Program.cs").WithLocation(11, 25)
             );
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -3662,7 +3662,7 @@ partial struct CustomHandler
             """;
 
         var pathPrefix1 = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path1\""" : "/My/Machine/Specific/Path1/";
-        var pathPrefix2 = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path1\""" : "/My/Machine/Specific/Path2/";
+        var pathPrefix2 = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path2\""" : "/My/Machine/Specific/Path2/";
         var path1 = pathPrefix1 + "Program.cs";
         var path2 = pathPrefix2 + "Program.cs";
         var pathMap = ImmutableArray.Create(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
@@ -3419,5 +3423,391 @@ partial struct CustomHandler
 
         var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "1");
         verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathMapping_01()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation("/_/Program.cs", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathPrefix = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path\""" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, "/_/"));
+
+        var verifier = CompileAndVerify(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)),
+            expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathMapping_02()
+    {
+        // Attribute uses a physical path, but we expected a mapped path.
+        // Diagnostic can suggest using the mapped path instead.
+        var pathPrefix = PlatformInformation.IsWindows ? @"C:\My\Machine\Specific\Path\" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var source = $$"""
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"{{path}}", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, "/_/"));
+
+        var comp = CreateCompilation(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)));
+        comp.VerifyEmitDiagnostics(PlatformInformation.IsWindows
+                // C:\My\Machine\Specific\Path\Program.cs(11,25): error CS27008: Cannot intercept: Path 'C:\My\Machine\Specific\Path\Program.cs' is unmapped. Expected mapped path '/_/Program.cs'.
+                //     [InterceptsLocation(@"C:\My\Machine\Specific\Path\Program.cs", 5, 3)]
+                ? Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, @"@""C:\My\Machine\Specific\Path\Program.cs""").WithArguments(@"C:\My\Machine\Specific\Path\Program.cs", "/_/Program.cs").WithLocation(11, 25)
+
+                // /My/Machine/Specific/Path/Program.cs(11,25): error CS27008: Cannot intercept: Path '/My/Machine/Specific/Path/Program.cs' is unmapped. Expected mapped path '/_/Program.cs'.
+                //     [InterceptsLocation(@"/My/Machine/Specific/Path/Program.cs", 5, 3)]
+                : Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithUnmappedCandidate, @"@""/My/Machine/Specific/Path/Program.cs""").WithArguments("/My/Machine/Specific/Path/Program.cs", "/_/Program.cs").WithLocation(11, 25)
+            );
+    }
+
+    [Fact]
+    public void PathMapping_03()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"\_\Program.cs", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathPrefix = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path\""" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, "/_/"));
+
+        var comp = CreateCompilation(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)));
+        comp.VerifyEmitDiagnostics(
+            // C:\My\Machine\Specific\Path\Program.cs(11,25): error CS27003: Cannot intercept: compilation does not contain a file with path '\_\Program.cs'. Did you mean to use path '/_/Program.cs'?
+            //     [InterceptsLocation(@"\_\Program.cs", 5, 3)]
+            Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, @"@""\_\Program.cs""").WithArguments(@"\_\Program.cs", "/_/Program.cs").WithLocation(11, 25));
+    }
+
+    [Fact]
+    public void PathMapping_04()
+    {
+        // Test when unmapped file paths are distinct, but mapped paths are equal.
+        var source1 = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            namespace NS1;
+
+            class C
+            {
+                public static void M0()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"/_/Program.cs", 11, 9)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+
+        var source2 = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            namespace NS2;
+
+            class C
+            {
+                public static void M0()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+            }
+            """;
+
+        var pathPrefix1 = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path1\""" : "/My/Machine/Specific/Path1/";
+        var pathPrefix2 = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path1\""" : "/My/Machine/Specific/Path2/";
+        var path1 = pathPrefix1 + "Program.cs";
+        var path2 = pathPrefix2 + "Program.cs";
+        var pathMap = ImmutableArray.Create(
+            new KeyValuePair<string, string>(pathPrefix1, "/_/"),
+            new KeyValuePair<string, string>(pathPrefix2, "/_/")
+            );
+
+        var comp = CreateCompilation(
+            new[] { (source1, path1), (source2, path2), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugDll.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)));
+        comp.VerifyEmitDiagnostics(
+            // C:\My\Machine\Specific\Path1\Program.cs(16,25): error CS27015: Cannot intercept a call in file with path '/_/Program.cs' because multiple files in the compilation have this path.
+            //     [InterceptsLocation(@"/_/Program.cs", 11, 9)]
+            Diagnostic(ErrorCode.ERR_InterceptorNonUniquePath, @"@""/_/Program.cs""").WithArguments("/_/Program.cs").WithLocation(16, 25));
+    }
+
+    [Fact]
+    public void PathMapping_05()
+    {
+        // Pathmap replacement contains backslashes, and attribute path contains backslashes.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"\_\Program.cs", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathPrefix = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path\""" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, @"\_\"));
+
+        var verifier = CompileAndVerify(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)),
+            expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathMapping_06()
+    {
+        // Pathmap mixes slashes and backslashes, attribute path is normalized to slashes
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"/_/Program.cs", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathPrefix = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path\""" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, @"\_/"));
+
+        var comp = CreateCompilation(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)));
+        comp.VerifyEmitDiagnostics(
+            // C:\My\Machine\Specific\Path\Program.cs(11,25): error CS27003: Cannot intercept: compilation does not contain a file with path '/_/Program.cs'. Did you mean to use path '\_/Program.cs'?
+            //     [InterceptsLocation(@"/_/Program.cs", 5, 3)]
+            Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, @"@""/_/Program.cs""").WithArguments("/_/Program.cs", @"\_/Program.cs").WithLocation(11, 25));
+    }
+
+    [Fact]
+    public void PathMapping_07()
+    {
+        // Pathmap replacement mixes slashes and backslashes, attribute path matches it
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            C c = new C();
+            c.M();
+
+            class C
+            {
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"\_/Program.cs", 5, 3)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+        var pathPrefix = PlatformInformation.IsWindows ? """C:\My\Machine\Specific\Path\""" : "/My/Machine/Specific/Path/";
+        var path = pathPrefix + "Program.cs";
+        var pathMap = ImmutableArray.Create(new KeyValuePair<string, string>(pathPrefix, @"\_/"));
+
+        var verifier = CompileAndVerify(
+            new[] { (source, path), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            options: TestOptions.DebugExe.WithSourceReferenceResolver(
+                new SourceFileResolver(ImmutableArray<string>.Empty, null, pathMap)),
+            expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathNormalization_01()
+    {
+        // No pathmap is present and slashes in the attribute match the FilePath on the syntax tree.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            class C
+            {
+                public static void Main()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+
+                [InterceptsLocation("src/Program.cs", 9, 11)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+
+        var verifier = CompileAndVerify(
+            new[] { (source, "src/Program.cs"), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathNormalization_02()
+    {
+        // No pathmap is present and backslashes in the attribute match the FilePath on the syntax tree.
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            class C
+            {
+                public static void Main()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"src\Program.cs", 9, 11)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+
+        var verifier = CompileAndVerify(
+            new[] { (source, @"src\Program.cs"), s_attributesSource },
+            parseOptions: RegularWithInterceptors,
+            expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void PathNormalization_03()
+    {
+        // Relative paths do not have slashes normalized when pathmap is not present
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            class C
+            {
+                public static void Main()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+
+                [InterceptsLocation(@"src/Program.cs", 9, 11)]
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { (source, @"src\Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors);
+        comp.VerifyEmitDiagnostics(
+            // src\Program.cs(14,25): error CS27003: Cannot intercept: compilation does not contain a file with path 'src/Program.cs'. Did you mean to use path 'src\Program.cs'?
+            //     [InterceptsLocation(@"src/Program.cs", 9, 11)]
+            Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, @"@""src/Program.cs""").WithArguments("src/Program.cs", @"src\Program.cs").WithLocation(14, 25));
+    }
+
+    [Fact]
+    public void PathNormalization_04()
+    {
+        // Absolute paths do not have slashes normalized when no pathmap is present
+        // Note that any such normalization step would be specific to Windows
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System;
+
+            class C
+            {
+                public static void Main()
+                {
+                    C c = new C();
+                    c.M();
+                }
+
+                public void M() => throw null!;
+
+                [InterceptsLocation("C:/src/Program.cs", 9, 11)] // 1
+                public void Interceptor() => Console.Write(1);
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { (source, @"C:\src\Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors);
+        comp.VerifyEmitDiagnostics(
+            // C:\src\Program.cs(14,25): error CS27003: Cannot intercept: compilation does not contain a file with path 'C:/src/Program.cs'. Did you mean to use path 'C:\src\Program.cs'?
+            //     [InterceptsLocation("C:/src/Program.cs", 9, 11)] // 1
+            Diagnostic(ErrorCode.ERR_InterceptorPathNotInCompilationWithCandidate, @"""C:/src/Program.cs""").WithArguments("C:/src/Program.cs", @"C:\src\Program.cs").WithLocation(14, 25));
     }
 }


### PR DESCRIPTION
Test plan: #67421

PR primarily implements the following:
- Add handling requirement for pathmap including feature doc change.
- Add pathmap tests

Incidentally have also done:
- Add tests for GetEnumerator/Dispose/Deconstruct
- Add EndToEndTest (large number of interceptors)

The goal of this change is to eliminate machine-specific paths from source code, which is bad for portability and determinism.

Further discussion of the `#line` question can be found in https://github.com/dotnet/aspnetcore/issues/47918#issuecomment-1526139802
