### PR TITLE
Cache evaluated parameters for public method symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1558,7 +1558,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.TupleLiteral:
                 case BoundKind.ConvertedTupleLiteral:
-                    ((BoundTupleExpression)node).VisitAllElements((x, self) => self.Assign(x, value: null, isRef: isRef), this);
+                    ((BoundTupleExpression)node).VisitAllElements(static (x, arg) => arg.self.Assign(x, value: null, isRef: arg.isRef), (self: this, isRef));
                     break;
 
                 default:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6566,8 +6566,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!parametersOpt.IsDefault)
             {
                 parameterAnnotationsOpt = arguments.SelectAsArray(
-                    (argument, i, arg) => GetCorrespondingParameter(i, arg.parametersOpt, arg.argsToParamsOpt, arg.expanded).Annotations,
-                    (parametersOpt, argsToParamsOpt, expanded));
+                    static (argument, i, arg) => arg.self.GetCorrespondingParameter(i, arg.parametersOpt, arg.argsToParamsOpt, arg.expanded).Annotations,
+                    (self: this, parametersOpt, argsToParamsOpt, expanded));
             }
 
             return parameterAnnotationsOpt;

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/MethodSymbol.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         private readonly Symbols.MethodSymbol _underlying;
         private ITypeSymbol _lazyReturnType;
         private ImmutableArray<ITypeSymbol> _lazyTypeArguments;
+        private ImmutableArray<IParameterSymbol> _lazyParameters;
         private ITypeSymbol _lazyReceiverType;
 
         public MethodSymbol(Symbols.MethodSymbol underlying)
@@ -100,13 +101,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         {
             get
             {
-                if (_lazyTypeArguments.IsDefault)
-                {
-
-                    ImmutableInterlocked.InterlockedCompareExchange(ref _lazyTypeArguments, _underlying.TypeArgumentsWithAnnotations.GetPublicSymbols(), default);
-                }
-
-                return _lazyTypeArguments;
+                return InterlockedOperations.InterlockedInitialize(
+                    ref _lazyTypeArguments,
+                    static underlying => underlying.TypeArgumentsWithAnnotations.GetPublicSymbols(),
+                    _underlying);
             }
         }
 
@@ -125,7 +123,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         {
             get
             {
-                return _underlying.Parameters.GetPublicSymbols();
+                return InterlockedOperations.InterlockedInitialize(
+                    ref _lazyParameters,
+                    static underlying => underlying.Parameters.GetPublicSymbols(),
+                    _underlying);
             }
         }
 

--- a/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/InterlockedOperations.cs
@@ -78,6 +78,16 @@ namespace Roslyn.Utilities
 
         public static ImmutableArray<T> InterlockedInitialize<T, TArg>(ref ImmutableArray<T> target, Func<TArg, ImmutableArray<T>> createArray, TArg arg)
         {
+            if (!target.IsDefault)
+            {
+                return target;
+            }
+
+            return InterlockedInitialize_Slow(ref target, createArray, arg);
+        }
+
+        private static ImmutableArray<T> InterlockedInitialize_Slow<T, TArg>(ref ImmutableArray<T> target, Func<TArg, ImmutableArray<T>> createArray, TArg arg)
+        {
             ImmutableInterlocked.Update(
                 ref target,
                 static (current, tuple) =>


### PR DESCRIPTION
Contributes to fixing [AB#1815692](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1815692).

Avoids the need to update all analyzers that use the `Parameters` property to avoid calling it more than once. For example:
https://github.com/dotnet/roslyn-analyzers/blob/71f45f3d826c7597cdbcfe94c220c77317413e3f/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs#L354-L376C97