### PR TITLE
Add new (hopefully easier) telemetry mechanism

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Core.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
@@ -112,6 +113,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         {
             try
             {
+                using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Application_Summary, $"Total");
+
                 using var token = SourceProvider.OperationListener.BeginAsyncOperation($"{nameof(SuggestedAction)}.{nameof(Invoke)}");
                 using var context = SourceProvider.UIThreadOperationExecutor.BeginExecute(
                     EditorFeaturesResources.Execute_Suggested_Action, CodeAction.Title, allowCancellation: true, showProgress: true);

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,8 +18,6 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.CodeAnalysis.UnifiedSuggestions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.UnifiedSuggestions;
@@ -112,11 +113,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         // then pass it continuously from one priority group to the next.
                         var lowPriorityAnalyzers = new ConcurrentSet<DiagnosticAnalyzer>();
 
+                        using var _2 = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Summary, $"Total");
+
                         // Collectors are in priority order.  So just walk them from highest to lowest.
                         foreach (var collector in collectors)
                         {
                             if (TryGetPriority(collector.Priority) is CodeActionRequestPriority priority)
                             {
+                                using var _3 = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Summary, $"Total.Pri{(int)priority}");
+
                                 var allSets = GetCodeFixesAndRefactoringsAsync(
                                     state, requestedActionCategories, document,
                                     range, selection,
@@ -231,48 +236,52 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 yield break;
 
-                Task<ImmutableArray<UnifiedSuggestedActionSet>> GetCodeFixesAsync()
+                async Task<ImmutableArray<UnifiedSuggestedActionSet>> GetCodeFixesAsync()
                 {
+                    using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Summary, $"Total.Pri{(int)priorityProvider.Priority}.{nameof(GetCodeFixesAsync)}");
+
                     if (owner._codeFixService == null ||
                         !supportsFeatureService.SupportsCodeFixes(target.SubjectBuffer) ||
                         !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
                     {
-                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                        return ImmutableArray<UnifiedSuggestedActionSet>.Empty;
                     }
 
-                    return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
+                    return await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                         workspace, owner._codeFixService, document, range.Span.ToTextSpan(),
-                        priorityProvider, options, addOperationScope, cancellationToken).AsTask();
+                        priorityProvider, options, addOperationScope, cancellationToken).ConfigureAwait(false);
                 }
 
-                Task<ImmutableArray<UnifiedSuggestedActionSet>> GetRefactoringsAsync()
+                async Task<ImmutableArray<UnifiedSuggestedActionSet>> GetRefactoringsAsync()
                 {
+                    using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Summary, $"Total.Pri{(int)priorityProvider.Priority}.{nameof(GetRefactoringsAsync)}");
+
                     if (!selection.HasValue)
                     {
                         // this is here to fail test and see why it is failed.
                         Trace.WriteLine("given range is not current");
-                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                        return ImmutableArray<UnifiedSuggestedActionSet>.Empty;
                     }
 
                     if (!this.GlobalOptions.GetOption(EditorComponentOnOffOptions.CodeRefactorings) ||
                         owner._codeRefactoringService == null ||
                         !supportsFeatureService.SupportsRefactorings(subjectBuffer))
                     {
-                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                        return ImmutableArray<UnifiedSuggestedActionSet>.Empty;
                     }
 
                     // 'CodeActionRequestPriority.Lowest' is reserved for suppression/configuration code fixes.
                     // No code refactoring should have this request priority.
                     if (priorityProvider.Priority == CodeActionRequestPriority.Lowest)
-                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                        return ImmutableArray<UnifiedSuggestedActionSet>.Empty;
 
                     // If we are computing refactorings outside the 'Refactoring' context, i.e. for example, from the lightbulb under a squiggle or selection,
                     // then we want to filter out refactorings outside the selection span.
                     var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);
 
-                    return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
+                    return await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
                         workspace, owner._codeRefactoringService, document, selection.Value, priorityProvider.Priority, options,
-                        addOperationScope, filterOutsideSelection, cancellationToken);
+                        addOperationScope, filterOutsideSelection, cancellationToken).ConfigureAwait(false);
                 }
 
                 [return: NotNullIfNotNull(nameof(unifiedSuggestedActionSet))]

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             {
                 m[Id] = correlationId;
                 m[AnalyzerCount] = reordered.Length;
-            }));
+            }, LogLevel.Debug));
 
             foreach (var analyzer in reordered)
             {
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     m[Id] = correlationId;
                     m[Analyzer] = analyzer.ToString();
-                }));
+                }, LogLevel.Debug));
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -27,6 +27,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes
@@ -99,9 +100,17 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public async Task<FirstFixResult> GetMostSevereFixAsync(
             TextDocument document, TextSpan range, ICodeActionRequestPriorityProvider priorityProvider, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
         {
-            var (allDiagnostics, upToDate) = await _diagnosticService.TryGetDiagnosticsForSpanAsync(
-                document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
-                includeSuppressedDiagnostics: false, priorityProvider, DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+            using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"Pri{(int)priorityProvider.Priority}.{nameof(GetMostSevereFixAsync)}");
+
+            ImmutableArray<DiagnosticData> allDiagnostics;
+            bool upToDate;
+
+            using (TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"Pri{(int)priorityProvider.Priority}.{nameof(GetMostSevereFixAsync)}.{nameof(_diagnosticService.GetDiagnosticsForSpanAsync)}"))
+            {
+                (allDiagnostics, upToDate) = await _diagnosticService.TryGetDiagnosticsForSpanAsync(
+                    document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
+                    includeSuppressedDiagnostics: false, priorityProvider, DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+            }
 
             var buildOnlyDiagnosticsService = document.Project.Solution.Services.GetRequiredService<IBuildOnlyDiagnosticsService>();
             allDiagnostics.AddRange(buildOnlyDiagnosticsService.GetBuildOnlyDiagnostics(document.Id));
@@ -162,6 +171,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             Func<string, IDisposable?> addOperationScope,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
+            using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"Pri{(int)priorityProvider.Priority}");
+
             // We only need to compute suppression/configuration fixes when request priority is
             // 'CodeActionPriorityRequest.Lowest' or 'CodeActionPriorityRequest.None'.
             var includeSuppressionFixes = priorityProvider.Priority is CodeActionRequestPriority.Lowest or CodeActionRequestPriority.None;
@@ -176,10 +187,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             // We mark requests to GetDiagnosticsForSpanAsync as 'isExplicit = true' to indicate
             // user-invoked diagnostic requests, for example, user invoked Ctrl + Dot operation for lightbulb.
-            var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
-                document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
-                includeCompilerDiagnostics: true, includeSuppressedDiagnostics: includeSuppressionFixes, priorityProvider,
-                addOperationScope, DiagnosticKind.All, isExplicit: true, cancellationToken).ConfigureAwait(false);
+            ImmutableArray<DiagnosticData> diagnostics;
+
+            using (TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"Pri{(int)priorityProvider.Priority}.{nameof(_diagnosticService.GetDiagnosticsForSpanAsync)}"))
+            {
+                diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
+                    document, range, GetShouldIncludeDiagnosticPredicate(document, priorityProvider),
+                    includeCompilerDiagnostics: true, includeSuppressedDiagnostics: includeSuppressionFixes, priorityProvider,
+                    addOperationScope, DiagnosticKind.All, isExplicit: true, cancellationToken).ConfigureAwait(false);
+            }
 
             var buildOnlyDiagnosticsService = document.Project.Solution.Services.GetRequiredService<IBuildOnlyDiagnosticsService>();
             var buildOnlyDiagnostics = buildOnlyDiagnosticsService.GetBuildOnlyDiagnostics(document.Id);
@@ -258,9 +274,16 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
-                document, range, diagnosticId, includeSuppressedDiagnostics: false, priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
-                addOperationScope: null, DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+            using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"{nameof(GetDocumentFixAllForIdInSpanAsync)}");
+            ImmutableArray<DiagnosticData> diagnostics;
+
+            using (TelemetryLogging.LogBlockTimeAggregated(FunctionId.CodeFix_Summary, $"{nameof(GetDocumentFixAllForIdInSpanAsync)}.{nameof(_diagnosticService.GetDiagnosticsForSpanAsync)}"))
+            {
+                diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
+                    document, range, diagnosticId, includeSuppressedDiagnostics: false, priorityProvider: new DefaultCodeActionRequestPriorityProvider(),
+                    addOperationScope: null, DiagnosticKind.All, isExplicit: false, cancellationToken).ConfigureAwait(false);
+            }
+
             diagnostics = diagnostics.WhereAsArray(d => d.Severity.IsMoreSevereThanOrEqualTo(minimumSeverity));
             if (!diagnostics.Any())
                 return null;
@@ -482,12 +505,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
                     foreach (var (span, diagnostics) in fixerToRangesAndDiagnostics[fixer])
                     {
+                        // Log an individual telemetry event for slow codefix computations to
+                        // allow targeted trace notifications for further investigation. 500 ms seemed like
+                        // a good value so as to not be too noisy, but if fired, indicates a potential
+                        // area requiring investigation.
+                        const int CodeFixTelemetryDelay = 500;
+
+                        var fixerName = fixer.GetType().Name;
+                        using var _ = TelemetryLogging.LogBlockTime(FunctionId.CodeFix_Delay, $"{fixerName}", CodeFixTelemetryDelay);
+
                         var codeFixCollection = await TryGetFixesOrConfigurationsAsync(
                             document, span, diagnostics, fixAllForInSpan, fixer,
                             hasFix: d => this.GetFixableDiagnosticIds(fixer, extensionManager).Contains(d.Id),
                             getFixes: dxs =>
                             {
-                                var fixerName = fixer.GetType().Name;
                                 var fixerMetadata = TryGetMetadata(fixer);
 
                                 using (addOperationScope(fixerName))

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
@@ -235,6 +236,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (_lazySyntaxDiagnostics == null)
             {
+                using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"{nameof(GetSyntaxDiagnosticsAsync)}.{nameof(GetAnalysisResultAsync)}");
+
                 var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedAnalyzersInAnalysisScope);
                 var syntaxDiagnostics = await GetAnalysisResultAsync(analysisScope, cancellationToken).ConfigureAwait(false);
                 Interlocked.CompareExchange(ref _lazySyntaxDiagnostics, syntaxDiagnostics, null);
@@ -269,6 +272,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (_lazySemanticDiagnostics == null)
             {
+                using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"{nameof(GetSemanticDiagnosticsAsync)}.{nameof(GetAnalysisResultAsync)}");
+
                 var analysisScope = AnalysisScope.WithAnalyzers(_compilationBasedAnalyzersInAnalysisScope);
                 var semanticDiagnostics = await GetAnalysisResultAsync(analysisScope, cancellationToken).ConfigureAwait(false);
                 Interlocked.CompareExchange(ref _lazySemanticDiagnostics, semanticDiagnostics, null);

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -215,6 +216,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     // to the span-based analyzer set as we want to compute diagnostics only for the given span.
                     using var _2 = ArrayBuilder<AnalyzerWithState>.GetInstance(out var semanticSpanBasedAnalyzers);
                     using var _3 = ArrayBuilder<AnalyzerWithState>.GetInstance(out var semanticDocumentBasedAnalyzers);
+
+                    using var _4 = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"Pri{(int)_priorityProvider.Priority}");
 
                     foreach (var stateSet in _stateSets)
                     {
@@ -420,6 +423,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> diagnosticsMap;
                 if (incrementalAnalysis)
                 {
+                    using var _2 = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"Pri{(int)_priorityProvider.Priority}.Incremental");
+
                     diagnosticsMap = await _owner._incrementalMemberEditAnalyzer.ComputeDiagnosticsAsync(
                         executor,
                         analyzersWithState,
@@ -430,6 +435,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
                 else
                 {
+                    using var _2 = TelemetryLogging.LogBlockTimeAggregated(FunctionId.RequestDiagnostics_Summary, $"Pri{(int)_priorityProvider.Priority}.Document");
+
                     diagnosticsMap = await ComputeDocumentDiagnosticsCoreAsync(executor, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.WorkspaceEventListener.cs
@@ -4,12 +4,10 @@
 
 using System;
 using System.Composition;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -70,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             private static void LogWorkspaceAnalyzerCount(int analyzerCount)
             {
-                Logger.Log(FunctionId.DiagnosticAnalyzerService_Analyzers, KeyValueLogMessage.Create(m => m["AnalyzerCount"] = analyzerCount));
+                Logger.Log(FunctionId.DiagnosticAnalyzerService_Analyzers, KeyValueLogMessage.Create(m => m["AnalyzerCount"] = analyzerCount, LogLevel.Debug));
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLog.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.Telemetry.Metrics;
+using Microsoft.VisualStudio.Telemetry.Metrics.Events;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    /// <summary>
+    /// Provides a wrapper around the VSTelemetry histogram APIs to support aggregated telemetry. Each instance
+    /// of this class corresponds to a specific FunctionId operation and can support aggregated values for each
+    /// metric name logged.
+    /// </summary>
+    internal sealed class AggregatingTelemetryLog : ITelemetryLog
+    {
+        // Indicates version information which vs telemetry will use for our aggregated telemetry. This can be used
+        // by Kusto queries to filter against telemetry versions which have the specified version and thus desired shape.
+        private const string MeterVersion = "0.40";
+
+        private readonly IMeter _meter;
+        private readonly TelemetrySession _session;
+        private readonly HistogramConfiguration? _histogramConfiguration;
+        private readonly string _eventName;
+        private readonly AggregatingTelemetryLogManager _aggregatingTelemetryLogManager;
+
+        private ImmutableDictionary<string, IHistogram<int>> _histograms = ImmutableDictionary<string, IHistogram<int>>.Empty;
+
+        /// <summary>
+        /// Creates a new aggregating telemetry log
+        /// </summary>
+        /// <param name="session">Telemetry session used to post events</param>
+        /// <param name="functionId">Used to derive meter name</param>
+        /// <param name="bucketBoundaries">Optional values indicating bucket boundaries in milliseconds. If not specified, 
+        /// all histograms created will use the default histogram configuration</param>
+        public AggregatingTelemetryLog(TelemetrySession session, FunctionId functionId, double[]? bucketBoundaries, AggregatingTelemetryLogManager aggregatingTelemetryLogManager)
+        {
+            var meterName = TelemetryLogger.GetPropertyName(functionId, "meter");
+            var meterProvider = new VSTelemetryMeterProvider();
+
+            _session = session;
+            _meter = meterProvider.CreateMeter(meterName, version: MeterVersion);
+            _eventName = TelemetryLogger.GetEventName(functionId);
+            _aggregatingTelemetryLogManager = aggregatingTelemetryLogManager;
+
+            if (bucketBoundaries != null)
+            {
+                _histogramConfiguration = new HistogramConfiguration(bucketBoundaries);
+            }
+        }
+
+        /// <summary>
+        /// Adds aggregated information for the metric and value passed in via logMessage. The Name/Value properties
+        /// are used as the metric name and value to record.
+        /// </summary>
+        /// <param name="logMessage"></param>
+        public void Log(LogMessage logMessage)
+        {
+            if (!IsEnabled)
+                return;
+
+            if (logMessage is not KeyValueLogMessage kvLogMessage)
+                throw ExceptionUtilities.Unreachable();
+
+            if (!kvLogMessage.TryGetValue(TelemetryLogging.AggregatedKeyName, out var nameValue) || nameValue is not string metricName)
+                throw ExceptionUtilities.Unreachable();
+
+            if (!kvLogMessage.TryGetValue(TelemetryLogging.AggregatedKeyValue, out var valueValue) || valueValue is not int value)
+                throw ExceptionUtilities.Unreachable();
+
+            var histogram = ImmutableInterlocked.GetOrAdd(ref _histograms, metricName, metricName => _meter.CreateHistogram<int>(metricName, _histogramConfiguration));
+
+            histogram.Record(value);
+
+            _aggregatingTelemetryLogManager.EnsureTelemetryWorkQueued();
+        }
+
+        public IDisposable? LogBlockTime(string name, int minThresholdMs)
+        {
+            if (!IsEnabled)
+                return null;
+
+            return new TimedTelemetryLogBlock(name, minThresholdMs, telemetryLog: this);
+        }
+
+        private bool IsEnabled => _session.IsOptedIn;
+
+        public void PostTelemetry(TelemetrySession session)
+        {
+            foreach (var histogram in _histograms.Values)
+            {
+                var telemetryEvent = new TelemetryEvent(_eventName);
+                var histogramEvent = new TelemetryHistogramEvent<int>(telemetryEvent, histogram);
+
+                session.PostMetricEvent(histogramEvent);
+            }
+
+            _histograms = ImmutableDictionary<string, IHistogram<int>>.Empty;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLogManager.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/AggregatingTelemetryLogManager.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Telemetry;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    /// <summary>
+    /// Manages creation and obtaining aggregated telemetry logs. Also, notifies logs to
+    /// send aggregated events every 30 minutes.
+    /// </summary>
+    internal sealed class AggregatingTelemetryLogManager
+    {
+        private static readonly TimeSpan s_batchedTelemetryCollectionPeriod = TimeSpan.FromMinutes(30);
+
+        private readonly TelemetrySession _session;
+        private readonly AsyncBatchingWorkQueue _postTelemetryQueue;
+
+        private ImmutableDictionary<FunctionId, AggregatingTelemetryLog> _aggregatingLogs = ImmutableDictionary<FunctionId, AggregatingTelemetryLog>.Empty;
+
+        public AggregatingTelemetryLogManager(TelemetrySession session, IAsynchronousOperationListener asyncListener)
+        {
+            _session = session;
+
+            _postTelemetryQueue = new AsyncBatchingWorkQueue(
+                s_batchedTelemetryCollectionPeriod,
+                PostCollectedTelemetryAsync,
+                asyncListener,
+                CancellationToken.None);
+        }
+
+        public ITelemetryLog? GetLog(FunctionId functionId, double[]? bucketBoundaries)
+        {
+            if (!_session.IsOptedIn)
+                return null;
+
+            return ImmutableInterlocked.GetOrAdd(ref _aggregatingLogs, functionId, functionId => new AggregatingTelemetryLog(_session, functionId, bucketBoundaries, this));
+        }
+
+        public void EnsureTelemetryWorkQueued()
+        {
+            // Ensure PostCollectedTelemetryAsync will get fired after the collection period.
+            _postTelemetryQueue.AddWork();
+        }
+
+        private ValueTask PostCollectedTelemetryAsync(CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            PostCollectedTelemetry();
+
+            return ValueTaskFactory.CompletedTask;
+        }
+
+        private void PostCollectedTelemetry()
+        {
+            if (!_session.IsOptedIn)
+                return;
+
+            foreach (var log in _aggregatingLogs.Values)
+            {
+                log.PostTelemetry(_session);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Telemetry/TelemetryLogProvider.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/TelemetryLogProvider.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Telemetry;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.LanguageServices.Telemetry
+{
+    /// <summary>
+    /// Provides access to an appropriate <see cref="ITelemetryLogProvider"/> for logging telemetry.
+    /// </summary>
+    internal sealed class TelemetryLogProvider : ITelemetryLogProvider
+    {
+        private readonly AggregatingTelemetryLogManager _aggregatingTelemetryLogManager;
+        private readonly VisualStudioTelemetryLogManager _visualStudioTelemetryLogManager;
+
+        private TelemetryLogProvider(TelemetrySession session, ILogger telemetryLogger, IAsynchronousOperationListener asyncListener)
+        {
+            _aggregatingTelemetryLogManager = new AggregatingTelemetryLogManager(session, asyncListener);
+            _visualStudioTelemetryLogManager = new VisualStudioTelemetryLogManager(session, telemetryLogger);
+        }
+
+        public static TelemetryLogProvider Create(TelemetrySession session, ILogger telemetryLogger, IAsynchronousOperationListener asyncListener)
+        {
+            var logProvider = new TelemetryLogProvider(session, telemetryLogger, asyncListener);
+
+            TelemetryLogging.SetLogProvider(logProvider);
+
+            return logProvider;
+        }
+
+        /// <summary>
+        /// Returns an <see cref="ITelemetryLog"/> for logging telemetry.
+        /// </summary>
+        public ITelemetryLog? GetLog(FunctionId functionId)
+        {
+            return _visualStudioTelemetryLogManager.GetLog(functionId);
+        }
+
+        /// <summary>
+        /// Returns an aggregating <see cref="ITelemetryLog"/> for logging telemetry.
+        /// </summary>
+        public ITelemetryLog? GetAggregatingLog(FunctionId functionId, double[]? bucketBoundaries)
+        {
+            return _aggregatingTelemetryLogManager.GetLog(functionId, bucketBoundaries);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Telemetry/TimedTelemetryLogBlock.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/TimedTelemetryLogBlock.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    /// <summary>
+    /// Provides a mechanism to log telemetry information containing the execution time between
+    /// creation and disposal of this object.
+    /// </summary>
+    internal sealed class TimedTelemetryLogBlock : IDisposable
+    {
+#pragma warning disable IDE0052 // Remove unread private members - Not used in debug builds
+        private readonly string _name;
+        private readonly int _minThresholdMs;
+        private readonly ITelemetryLog _telemetryLog;
+        private readonly SharedStopwatch _stopwatch;
+#pragma warning restore IDE0052 // Remove unread private members
+
+        public TimedTelemetryLogBlock(string name, int minThresholdMs, ITelemetryLog telemetryLog)
+        {
+            _name = name;
+            _minThresholdMs = minThresholdMs;
+            _telemetryLog = telemetryLog;
+            _stopwatch = SharedStopwatch.StartNew();
+        }
+
+        public void Dispose()
+        {
+            // Don't add elapsed information in debug bits or while under debugger.
+#if !DEBUG
+            if (Debugger.IsAttached)
+                return;
+
+            var elapsed = (int)_stopwatch.Elapsed.TotalMilliseconds;
+            if (elapsed >= _minThresholdMs)
+            {
+                var logMessage = KeyValueLogMessage.Create(m =>
+                {
+                    m[TelemetryLogging.AggregatedKeyName] = _name;
+                    m[TelemetryLogging.AggregatedKeyValue] = elapsed;
+                });
+
+                _telemetryLog.Log(logMessage);
+            }
+#endif
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLog.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Telemetry;
+
+namespace Microsoft.VisualStudio.LanguageServices.Telemetry
+{
+    internal sealed class VisualStudioTelemetryLog : ITelemetryLog
+    {
+        private readonly ILogger _telemetryLogger;
+        private readonly FunctionId _functionId;
+
+        public VisualStudioTelemetryLog(ILogger telemetryLogger, FunctionId functionId)
+        {
+            _telemetryLogger = telemetryLogger;
+            _functionId = functionId;
+        }
+
+        public void Log(LogMessage logMessage)
+        {
+            _telemetryLogger.Log(_functionId, logMessage);
+        }
+
+        public IDisposable? LogBlockTime(string name, int minThresholdMs)
+        {
+            return new TimedTelemetryLogBlock(name, minThresholdMs, telemetryLog: this);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLogManager.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLogManager.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Telemetry;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.LanguageServices.Telemetry
+{
+    internal sealed class VisualStudioTelemetryLogManager
+    {
+        private readonly TelemetrySession _session;
+        private readonly ILogger _telemetryLogger;
+
+        private ImmutableDictionary<FunctionId, VisualStudioTelemetryLog> _logs = ImmutableDictionary<FunctionId, VisualStudioTelemetryLog>.Empty;
+
+        public VisualStudioTelemetryLogManager(TelemetrySession session, ILogger telemetryLogger)
+        {
+            _session = session;
+            _telemetryLogger = telemetryLogger;
+        }
+
+        public ITelemetryLog? GetLog(FunctionId functionId)
+        {
+            if (!_session.IsOptedIn)
+                return null;
+
+            return ImmutableInterlocked.GetOrAdd(ref _logs, functionId, functionId => new VisualStudioTelemetryLog(_telemetryLogger, functionId));
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     }
 
                     var completionTask = status.WaitForCompletionAsync();
-                    Logger.Log(FunctionId.PartialLoad_FullyLoaded, KeyValueLogMessage.Create(LogType.Trace, m => m["AlreadyFullyLoaded"] = completionTask.IsCompleted));
+                    Logger.Log(FunctionId.PartialLoad_FullyLoaded, KeyValueLogMessage.Create(LogType.Trace, m => m["AlreadyFullyLoaded"] = completionTask.IsCompleted, LogLevel.Debug));
 
                     // TODO: WaitForCompletionAsync should accept cancellation directly.
                     //       for now, use WithCancellation to indirectly add cancellation

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -17,13 +17,14 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Tags;
+using Microsoft.CodeAnalysis.Telemetry;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeActions
@@ -169,6 +170,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
         internal async Task<ImmutableArray<CodeActionOperation>> GetPreviewOperationsAsync(
             Solution originalSolution, CancellationToken cancellationToken)
         {
+            using var _ = TelemetryLogging.LogBlockTimeAggregated(FunctionId.SuggestedAction_Preview_Summary, $"Total");
+
             var operations = await this.ComputePreviewOperationsAsync(cancellationToken).ConfigureAwait(false);
 
             if (operations != null)

--- a/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
+++ b/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
@@ -81,6 +81,12 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             }
         }
 
+        public bool TryGetValue(string key, out object? value)
+        {
+            EnsureMap();
+            return _lazyMap.TryGetValue(key, out value);
+        }
+
         protected override string CreateMessage()
         {
             EnsureMap();

--- a/src/Workspaces/Core/Portable/Telemetry/ITelemetryLog.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/ITelemetryLog.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    internal interface ITelemetryLog
+    {
+        /// <summary>
+        /// Adds a telemetry event with values obtained from context message <paramref name="logMessage"/>
+        /// </summary>
+        public void Log(LogMessage logMessage);
+
+        /// <summary>
+        /// Adds an execution time telemetry event representing the <paramref name="name"/> operation
+        /// only if  block duration meets or exceeds <paramref name="minThresholdMs"/> milliseconds.
+        /// </summary>
+        /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event (in milliseconds)</param>
+        public IDisposable? LogBlockTime(string name, int minThresholdMs = -1);
+    }
+}

--- a/src/Workspaces/Core/Portable/Telemetry/ITelemetryLogProvider.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/ITelemetryLogProvider.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    internal interface ITelemetryLogProvider
+    {
+        /// <summary>
+        /// Returns an <see cref="ITelemetryLog"/> for logging telemetry.
+        /// </summary>
+        /// <param name="functionId">FunctionId representing the telemetry operation</param>
+        public ITelemetryLog? GetLog(FunctionId functionId);
+
+        /// <summary>
+        /// Returns an aggregating <see cref="ITelemetryLog"/> for logging telemetry.
+        /// </summary>
+        /// <param name="functionId">FunctionId representing the telemetry operation</param>
+        /// <param name="bucketBoundaries">Optional values indicating bucket boundaries in milliseconds. If not specified, 
+        /// all aggregating events created will use a default configuration</param>
+        public ITelemetryLog? GetAggregatingLog(FunctionId functionId, double[]? bucketBoundaries = null);
+    }
+}

--- a/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    /// <summary>
+    /// Provides access to posting telemetry events or adding information
+    /// to aggregated telemetry events.
+    /// </summary>
+    internal static class TelemetryLogging
+    {
+        private static ITelemetryLogProvider? s_logProvider;
+
+        public const string AggregatedKeyName = "Name";
+        public const string AggregatedKeyValue = "Value";
+
+        public static void SetLogProvider(ITelemetryLogProvider logProvider)
+        {
+            s_logProvider = logProvider;
+        }
+
+        /// <summary>
+        /// Posts a telemetry event representing the <paramref name="functionId"/> operation with context message <paramref name="logMessage"/>
+        /// </summary>
+        public static void Log(FunctionId functionId, LogMessage logMessage)
+        {
+            GetLog(functionId)?.Log(logMessage);
+        }
+
+        /// <summary>
+        /// Posts a telemetry event representing the <paramref name="functionId"/> operation 
+        /// only if the block duration meets or exceeds <paramref name="minThresholdMs"/> milliseconds.
+        /// This event will contain properties from which both <paramref name="name"/> and <paramref name="minThresholdMs"/>.
+        /// and block execution time can be determined.
+        /// </summary>
+        /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event</param>
+        public static IDisposable? LogBlockTime(FunctionId functionId, TelemetryLoggingInterpolatedStringHandler name, int minThresholdMs = -1)
+        {
+            return GetLog(functionId)?.LogBlockTime(name.GetFormattedText(), minThresholdMs);
+        }
+
+        /// <summary>
+        /// Adds information to an aggregated telemetry event representing the <paramref name="functionId"/> operation 
+        /// with the specified name and value.
+        /// </summary>
+        public static void LogAggregated(FunctionId functionId, TelemetryLoggingInterpolatedStringHandler name, int value)
+        {
+            if (GetAggregatingLog(functionId) is not { } aggregatingLog)
+                return;
+
+            var logMessage = KeyValueLogMessage.Create(m =>
+            {
+                m[AggregatedKeyName] = name.GetFormattedText();
+                m[AggregatedKeyValue] = value;
+            });
+
+            aggregatingLog.Log(logMessage);
+        }
+
+        /// <summary>
+        /// Adds block execution time to an aggregated telemetry event representing the <paramref name="functionId"/> operation 
+        /// with metric <paramref name="metricName"/> only if the block duration meets or exceeds <paramref name="minThresholdMs"/> milliseconds.
+        /// </summary>
+        /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event</param>
+        public static IDisposable? LogBlockTimeAggregated(FunctionId functionId, TelemetryLoggingInterpolatedStringHandler metricName, int minThresholdMs = -1)
+        {
+            return GetAggregatingLog(functionId)?.LogBlockTime(metricName.GetFormattedText(), minThresholdMs);
+        }
+
+        /// <summary>
+        /// Returns non-aggregating telemetry log.
+        /// </summary>
+        public static ITelemetryLog? GetLog(FunctionId functionId)
+        {
+            return s_logProvider?.GetLog(functionId);
+        }
+
+        /// <summary>
+        /// Returns aggregating telemetry log.
+        /// </summary>
+        public static ITelemetryLog? GetAggregatingLog(FunctionId functionId, double[]? bucketBoundaries = null)
+        {
+            return s_logProvider?.GetAggregatingLog(functionId, bucketBoundaries);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Telemetry/TelemetryLoggingInterpolatedStringHandler.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/TelemetryLoggingInterpolatedStringHandler.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Telemetry
+{
+    [InterpolatedStringHandler]
+    internal readonly struct TelemetryLoggingInterpolatedStringHandler
+    {
+        private readonly StringBuilder _stringBuilder;
+
+        public TelemetryLoggingInterpolatedStringHandler(int literalLength, int _)
+        {
+            _stringBuilder = new StringBuilder(capacity: literalLength);
+        }
+
+        public void AppendLiteral(string value) => _stringBuilder.Append(value);
+
+        public void AppendFormatted<T>(T value) => _stringBuilder.Append(value?.ToString());
+
+        public string GetFormattedText() => _stringBuilder.ToString();
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
@@ -39,8 +39,14 @@
     <Compile Include="..\..\..\VisualStudio\Core\Def\Storage\CloudCachePersistentStorage.cs" Link="Host\Storage\CloudCachePersistentStorage.cs" />
     <Compile Include="..\..\..\VisualStudio\Core\Def\Storage\ProjectContainerKeyCache.cs" Link="Host\Storage\ProjectContainerKeyCache.cs" />
     <Compile Include="..\..\..\VisualStudio\Core\Def\Storage\FileDownloader.cs" Link="Host\Storage\FileDownloader.cs" />
-    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\TelemetryLogger.cs" Link="Services\ProcessTelemetry\TelemetryLogger.cs" />
     <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\AbstractWorkspaceTelemetryService.cs" Link="Services\ProcessTelemetry\AbstractWorkspaceTelemetryService.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\AggregatingTelemetryLog.cs" Link="Services\ProcessTelemetry\AggregatingTelemetryLog.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\AggregatingTelemetryLogManager.cs" Link="Services\ProcessTelemetry\AggregatingTelemetryLogManager.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\TelemetryLogger.cs" Link="Services\ProcessTelemetry\TelemetryLogger.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\TelemetryLogProvider.cs" Link="Services\ProcessTelemetry\TelemetryLogProvider.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\TimedTelemetryLogBlock.cs" Link="Services\ProcessTelemetry\TimedTelemetryLogBlock.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\VisualStudioTelemetryLog.cs" Link="Services\ProcessTelemetry\VisualStudioTelemetryLog.cs" />
+    <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\VisualStudioTelemetryLogManager.cs" Link="Services\ProcessTelemetry\VisualStudioTelemetryLogManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.LiveUnitTesting.BuildManager" Partner="UnitTesting" Key="$(UnitTestingKey)" />

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -13,6 +11,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.CodeAnalysis.Telemetry;
 using Roslyn.Utilities;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
@@ -58,6 +57,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // Complete RPC right away so the client can start reading from the stream.
             // The fire-and forget task starts writing to the output stream and the client will read it until it reads all expected data.
 
+            using (TelemetryLogging.LogBlockTimeAggregated(FunctionId.PerformAnalysis_Summary, $"Total"))
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, cancellationToken))
             {
                 return await RunWithSolutionAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -79,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Remote
                                 m[nameof(analyzerInfo.Average)] = analyzerInfo.Average;
                                 m[nameof(analyzerInfo.AdjustedStandardDeviation)] = analyzerInfo.AdjustedStandardDeviation;
                                 m[nameof(forSpanAnalysis)] = forSpanAnalysis;
-                            }));
+                            }, LogLevel.Debug));
                         }
                     }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
-using Microsoft.CodeAnalysis.Storage;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.LanguageServices.Telemetry;
 using Microsoft.VisualStudio.Telemetry;

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteWorkspaceTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteWorkspaceTelemetryService.cs
@@ -6,7 +6,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
 
@@ -15,15 +15,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
     [ExportWorkspaceService(typeof(IWorkspaceTelemetryService)), Shared]
     internal sealed class RemoteWorkspaceTelemetryService : AbstractWorkspaceTelemetryService
     {
+        private readonly IAsynchronousOperationListenerProvider _asyncListenerProvider;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public RemoteWorkspaceTelemetryService()
+        public RemoteWorkspaceTelemetryService(IAsynchronousOperationListenerProvider asyncListenerProvider)
         {
+            _asyncListenerProvider = asyncListenerProvider;
         }
 
         protected override ILogger CreateLogger(TelemetrySession telemetrySession, bool logDelta)
             => AggregateLogger.Create(
-                TelemetryLogger.Create(telemetrySession, logDelta),
+                TelemetryLogger.Create(telemetrySession, logDelta, _asyncListenerProvider),
                 Logger.GetLogger());
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -594,5 +594,27 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         // 680-690 LSP Initialization info ids.
         LSP_Initialize = 680,
+
+        // 700-799 Performance logging. Typically pairs with Delay/Summary values.
+        //  Summary is a aggregation of all times collected.
+        //  Delay is used as a non-aggregated value for an unexpectedly poor performing scenario.
+        CodeFix_Delay = 700,
+        CodeFix_Summary = 701,
+
+        CodeRefactoring_Delay = 710,
+        CodeRefactoring_Summary = 711,
+
+        PerformAnalysis_Delay = 720,
+        PerformAnalysis_Summary = 721,
+
+        RequestDiagnostics_Delay = 730,
+        RequestDiagnostics_Summary = 731,
+
+        SuggestedAction_Delay = 740,
+        SuggestedAction_Summary = 741,
+        SuggestedAction_Application_Delay = 742,
+        SuggestedAction_Application_Summary = 743,
+        SuggestedAction_Preview_Delay = 744,
+        SuggestedAction_Preview_Summary = 745,
     }
 }


### PR DESCRIPTION
The intent here is to provide a telemetry mechanism that is easy to use, and hopefully provides enough functionality that most telemetry users can use it directly.

The currently most common mechanism how Roslyn uses telemetry (that I've found) is through the Logger.Log call. This call aggregates multiple loggers through the ILogger interface and funnels the logging call to each implementationi (TelemetryLogger being one). I wanted to separate the telemetry calls out from this interface as I needed to add a minimum time threshold for some of the telemetry logging. Separating these calls out seems to make sense as I wanted to make it explicit that these calls were logging telemetry.

Additionally, the existing telemetry calls through ILogger don't support aggregating values. The new implementation supports this through the VSTelemetry histogram support (based on OTel). There is yet another telemetry mechanism in roslyn that does support histogram/count calls. The intent here is to switch over callers of that implementation to this new one (I can't yet though as I didn't add support for the Count part of the API).

The aggregated support will send histogram telemetry events every 30 minutes or upon process exit. For targeted notification support, non-aggregated telemetry calls are added upon a minimum time threshold being met.

Telemetry dashboards consuming these telemetry events [here](https://dataexplorer.azure.com/dashboards/31bfd6e9-daa4-4273-acdb-e02cb156c289) (work in progress)