### PR TITLE
Ensure that we always run all diagnostic suppressors for single file analysis

### DIFF
--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -997,6 +997,30 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class SemanticModelAnalyzerWithId : DiagnosticAnalyzer
+        {
+            public SemanticModelAnalyzerWithId(string diagnosticId)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    diagnosticId,
+                    "Description1",
+                    string.Empty,
+                    "Analysis",
+                    DiagnosticSeverity.Warning,
+                    isEnabledByDefault: true);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+            public override void Initialize(AnalysisContext context) =>
+                context.RegisterSemanticModelAction(context =>
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(Descriptor, context.SemanticModel.SyntaxTree.GetRoot().GetLocation())));
+        }
+
         /// <summary>
         /// This analyzer is intended to be used only when concurrent execution is enabled for analyzers.
         /// This analyzer will deadlock if the driver runs analyzers on a single thread OR takes a lock around callbacks into this analyzer to prevent concurrent analyzer execution
@@ -2064,6 +2088,42 @@ namespace Microsoft.CodeAnalysis
                 {
                     Assert.Equal(SuppressionDescriptor.SuppressedDiagnosticId, diagnostic.Id);
                     context.ReportSuppression(Suppression.Create(SuppressionDescriptor, diagnostic));
+                }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressorForMultipleIds : DiagnosticSuppressor
+        {
+            public DiagnosticSuppressorForMultipleIds(params string[] suppressedDiagnosticIds)
+            {
+                var builder = ImmutableArray.CreateBuilder<SuppressionDescriptor>();
+                int i = 1;
+                foreach (var suppressedDiagnosticId in suppressedDiagnosticIds)
+                {
+                    var descriptor = new SuppressionDescriptor(
+                        id: $"SPR000{i++}",
+                        suppressedDiagnosticId: suppressedDiagnosticId,
+                        justification: $"Suppress {suppressedDiagnosticId}");
+                    builder.Add(descriptor);
+                }
+
+                SupportedSuppressions = builder.ToImmutable();
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; }
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                foreach (var diagnostic in context.ReportedDiagnostics)
+                {
+                    foreach (var suppressionDescriptor in SupportedSuppressions)
+                    {
+                        if (suppressionDescriptor.SuppressedDiagnosticId == diagnostic.Id)
+                        {
+                            context.ReportSuppression(Suppression.Create(suppressionDescriptor, diagnostic));
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes [AB#1819603](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1819603)

If CompilationWithAnalyzers host passes in suppressors into CompilationWithAnalyzers constructor, but does not pass these suppressors into the public APIs on it that compute and return diagnostics for a given subset of analyzers, then the driver was skipping executing these suppressors on the reported diagnostics.

This change ensures that the AnalyzerDriver is always passed in all the DiagnosticSuppressors to execute, regardless of whether or not they are part of the input set of analyzers passed into the public APIs on CompilationWithAnalyzers.

Verified that the added unit test fails before this change.