### PR TITLE
Do not show completion of a static member if it cannot be referenced by name

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -1130,6 +1130,26 @@ class C
             await VerifyItemIsAbsentAsync(markup, "ConsoleColor");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68240")]
+        public async Task TestNotCompilerGeneratedField()
+        {
+            var markup = """
+                class Sample
+                {
+                    public static Sample Instance { get; } = new Sample();
+
+                    private sealed class Nested
+                    {
+                        Sample A()
+                        {
+                            return $$
+                        }
+                    }
+                }
+                """;
+            await VerifyItemIsAbsentAsync(markup, "Sample.<Instance>k__BackingField");
+        }
+
         #region enum members
 
         [Fact]

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -216,6 +216,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 // Build a list of the members with the same type as the target
                 foreach (var member in type.GetMembers())
                 {
+                    if (!member.CanBeReferencedByName)
+                        continue;
+
                     ISymbol staticSymbol;
                     ITypeSymbol symbolType;
                     if (member is IFieldSymbol { IsStatic: true } field)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/68240