### PR TITLE
Fix Color Color const field initialization accessing the Color type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ConstantFieldsInProgress.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ConstantFieldsInProgress.cs
@@ -39,5 +39,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             _dependencies.Add(field);
         }
+        internal void RemoveDepencency(SourceFieldSymbolWithSyntaxReference field)
+        {
+            _dependencies?.Remove(field);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -2366,5 +2366,29 @@ public class Tree2 : Tree1
 
             compilation.VerifyDiagnostics();
         }
+
+        [WorkItem(45739, "https://github.com/dotnet/roslyn/issues/45739")]
+        [Fact]
+        public void ConstFieldColorColorEnum()
+        {
+            string source = @"
+enum Color
+{
+    Red,
+    Green,
+    Blue,
+    Yellow,
+}
+
+class M
+{
+    public const Color Color = Color.Red;
+}
+";
+
+            var compilation = CreateCompilation(source, assemblyName: "Color");
+
+            compilation.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3292,8 +3292,7 @@ class Program
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 36),
                 // (6,14): warning CS8321: The local function 'f' is declared but never used
                 //         void f() { if () const int i = 0; }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(6, 14)
-                );
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(6, 14));
         }
 
         [Fact]
@@ -3309,10 +3308,9 @@ class C
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-    // (6,51): error CS0133: The expression being assigned to 'b' must be constant
-    //         const Func<int> a = () => { const int b = a(); return 1; };
-    Diagnostic(ErrorCode.ERR_NotConstantExpression, "a()").WithArguments("b").WithLocation(6, 51)
-                );
+                // (6,51): error CS0133: The expression being assigned to 'b' must be constant
+                //         const Func<int> a = () => { const int b = a(); return 1; };
+                Diagnostic(ErrorCode.ERR_NotConstantExpression, "a()").WithArguments("b").WithLocation(6, 51));
         }
 
         [Fact]
@@ -3327,10 +3325,9 @@ class C
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-    // (5,27): error CS0110: The evaluation of the constant value for 'z' involves a circular definition
-    //         const int z = 1 + z + 1;
-    Diagnostic(ErrorCode.ERR_CircConstValue, "z").WithArguments("z").WithLocation(5, 27)
-                );
+                // (5,27): error CS0110: The evaluation of the constant value for 'z' involves a circular definition
+                //         const int z = 1 + z + 1;
+                Diagnostic(ErrorCode.ERR_CircConstValue, "z").WithArguments("z").WithLocation(5, 27));
         }
 
         [Fact, WorkItem(1098197, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1098197")]
@@ -3341,19 +3338,18 @@ class C
 void f() { if () const int i = 0; }
 ";
             CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
-    // (2,6): warning CS8321: The local function 'f' is declared but never used
-    // void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(2, 6),
-    // (2,16): error CS1525: Invalid expression term ')'
-    // void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(2, 16),
-    // (2,18): error CS1023: Embedded statement cannot be a declaration or labeled statement
-    // void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(2, 18),
-    // (2,28): warning CS0219: The variable 'i' is assigned but its value is never used
-    // void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(2, 28)
-                );
+                // (2,6): warning CS8321: The local function 'f' is declared but never used
+                // void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(2, 6),
+                // (2,16): error CS1525: Invalid expression term ')'
+                // void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(2, 16),
+                // (2,18): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                // void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(2, 18),
+                // (2,28): warning CS0219: The variable 'i' is assigned but its value is never used
+                // void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(2, 28));
         }
 
         [Fact, WorkItem(1098605, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1098605")]


### PR DESCRIPTION
Closes #45739

## Summary

Color Color cases of const field initializations would trigger a circular dependency error. This bug was being caused in the constant initializer dependency graph calculation. Another contributor was the binder resolving `Color` as the field, rather than the type itself.

To counter this bug, when accessing a constant field, we always rebind the LHS of the member access expression to attempt to find another candidate, in which case is our enum type. It can also safely resolve to other containers that provide a viable const expression.

## Details

When binding inside `BindLeftIdentifierOfPotentialColorColorMemberAccess` in `Binder_Expressions.cs`, we additionally evaluate whether the bound value is a const field, after having ensured that we are in a Color Color case. This then triggers a rebinding of the expression, to avoid this circular reference.

After successfully rebinding to another expression, we remove the dependency of the const field itself from the graph, which in turn eliminates the circular dependency error. This came with the introduction of a `RemoveDepencency` method in `ConstantFieldsInProgress`, to directly remove the dependency from the set that was passed down during the evaluation of the field's constant initialization.

## Example

As added in the test, the following simple case determines the existence of the bug:
```csharp
enum Color
{
    Red,
    Green,
    Blue,
    Yellow,
}

class M
{
    public const Color Color = Color.Red;
}
```

`Color.Red` was previously referring to the const field `Color`, rather than the enum `Color`. This caused a viable circular dependency error, due to the mistaken binding.

Now, `Color.Red` is resolved as accessing the `Red` member of the `Color` enum type.