### PR TITLE
Move `UseSimpleUsingStatement` tests to `VerifyCS`

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
     internal class UseSimpleUsingStatementCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public UseSimpleUsingStatementCodeFixProvider()
         {
         }

--- a/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -18,185 +19,183 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseSimpleUsingStatement
 {
+    using VerifyCS = CSharpCodeFixVerifier<
+        UseSimpleUsingStatementDiagnosticAnalyzer,
+        UseSimpleUsingStatementCodeFixProvider>;
+
     [Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
-    public partial class UseSimpleUsingStatementTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public class UseSimpleUsingStatementTests
     {
-        public UseSimpleUsingStatementTests(ITestOutputHelper logger)
-          : base(logger)
-        {
-        }
-
-        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (new UseSimpleUsingStatementDiagnosticAnalyzer(), new UseSimpleUsingStatementCodeFixProvider());
-
-        private static readonly ParseOptions CSharp72ParseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_2);
-        private static readonly ParseOptions CSharp8ParseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp8);
-
         [Fact]
         public async Task TestAboveCSharp8()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestWithOptionOff()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        [||]using (var a = b)
+                        void M()
                         {
+                            using (var a = {|CS0103:b|})
+                            {
+                            }
                         }
                     }
+                    """,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferSimpleUsingStatement, CodeStyleOption2.FalseWithSilentEnforcement }
                 }
-                """,
-new TestParameters(
-    parseOptions: CSharp8ParseOptions,
-    options: Option(CSharpCodeStyleOptions.PreferSimpleUsingStatement, CodeStyleOption2.FalseWithSilentEnforcement)));
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMultiDeclaration()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b, c = d)
+                        [|using|] ({|CS0819:var a = {|CS0103:b|}, c = {|CS0103:d|}|})
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b, c = d;
+                        using {|CS0819:var a = {|CS0103:b|}, c = {|CS0103:d|}|};
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestMissingIfOnSimpleUsingStatement()
         {
-            await TestMissingAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        [||]using var a = b;
+                        void M()
+                        {
+                            using var a = {|CS0103:b|};
+                        }
                     }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestMissingPriorToCSharp8()
         {
-            await TestMissingAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        [||]using (var a = b)
+                        void M()
                         {
+                            using (var a = {|CS0103:b|})
+                            {
+                            }
                         }
                     }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp72ParseOptions));
+                    """,
+                LanguageVersion = LanguageVersion.CSharp7_2
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestMissingIfExpressionUsing()
         {
-            await TestMissingAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        [||]using (a)
+                        void M()
                         {
+                            using ({|CS0103:a|})
+                            {
+                            }
                         }
                     }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestMissingIfCodeFollows()
         {
-            await TestMissingAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        [||]using (var a = b)
+                        void M()
                         {
+                            using (var a = {|CS0103:b|})
+                            {
+                            }
+                            Console.WriteLine();
                         }
-                        Console.WriteLine();
                     }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestAsyncUsing()
         {
             // not actually legal code.
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
                 using System.Threading.Tasks;
 
@@ -204,13 +203,12 @@ parseOptions: CSharp8ParseOptions);
                 {
                     void M()
                     {
-                        async [||]using (var a = b)
+                        {|CS0103:async|} {|CS1002:[|using|]|} (var a = {|CS0103:b|})
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
                 using System.Threading.Tasks;
 
@@ -218,19 +216,16 @@ parseOptions: CSharp8ParseOptions);
                 {
                     void M()
                     {
-                        async using var a = b;
+                        {|CS0103:async|} {|CS1002:using|} var a = {|CS0103:b|};
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
         public async Task TestAwaitUsing()
         {
-            // not actually legal code.
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
                 using System.Threading.Tasks;
 
@@ -238,13 +233,12 @@ parseOptions: CSharp8ParseOptions);
                 {
                     void M()
                     {
-                        await [||]using (var a = b)
+                        {|CS4033:await|} [|using|] (var a = {|CS0103:b|})
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
                 using System.Threading.Tasks;
 
@@ -252,380 +246,276 @@ parseOptions: CSharp8ParseOptions);
                 {
                     void M()
                     {
-                        await using var a = b;
+                        {|CS4033:await|} using var a = {|CS0103:b|};
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestWithBlockBodyWithContents()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         {
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestWithNonBlockBody()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                             Console.WriteLine(a);
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
-        public async Task TestMultiUsing1()
+        public async Task TestMultiUsing()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
-                        using (var c = d)
+                        [|using|] (var a = {|CS0103:b|})
+                        using (var c = {|CS0103:d|})
                         {
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
-                        using var c = d;
+                        using var a = {|CS0103:b|};
+                        using var c = {|CS0103:d|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
-        }
-
-        [Fact]
-        public async Task TestMultiUsingOnlyOnTopmostUsing()
-        {
-            await TestMissingAsync(
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        using (var a = b)
-                        [||]using (var c = d)
-                        {
-                            Console.WriteLine(a);
-                        }
-                    }
-                }
-                """,
-new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact]
         public async Task TestFixAll1()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        {|FixAllInDocument:|}using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         {
-                            using (var c = d)
+                            [|using|] (var c = {|CS0103:d|})
                             {
                                 Console.WriteLine(a);
                             }
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
-                        using var c = d;
+                        using var a = {|CS0103:b|};
+                        using var c = {|CS0103:d|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestFixAll2()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
+                        using (var c = {|CS0103:d|})
                         {
-                            {|FixAllInDocument:|}using (var c = d)
+                            [|using|] (var e = {|CS0103:f|})
+                            using (var g = {|CS0103:h|})
                             {
                                 Console.WriteLine(a);
                             }
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
-                        using var c = d;
+                        using var a = {|CS0103:b|};
+                        using var c = {|CS0103:d|};
+                        using var e = {|CS0103:f|};
+                        using var g = {|CS0103:h|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestFixAll3()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        {|FixAllInDocument:|}using (var a = b)
-                        using (var c = d)
+                        [|using|] (var a = {|CS0103:b|})
+                        using (var c = {|CS0103:d|})
                         {
-                            using (var e = f)
-                            using (var g = h)
+                            using ({|CS0103:e|})
+                            using ({|CS0103:f|})
                             {
                                 Console.WriteLine(a);
                             }
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
-                        using var c = d;
-                        using var e = f;
-                        using var g = h;
-                        Console.WriteLine(a);
-                    }
-                }
-                """,
-parseOptions: CSharp8ParseOptions);
-        }
-
-        [Fact]
-        public async Task TestFixAll4()
-        {
-            await TestInRegularAndScriptAsync(
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        {|FixAllInDocument:|}using (var a = b)
-                        using (var c = d)
-                        {
-                            using (e)
-                            using (f)
-                            {
-                                Console.WriteLine(a);
-                            }
-                        }
-                    }
-                }
-                """,
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        using var a = b;
-                        using var c = d;
-                        using (e)
-                        using (f)
+                        using var a = {|CS0103:b|};
+                        using var c = {|CS0103:d|};
+                        using ({|CS0103:e|})
+                        using ({|CS0103:f|})
                         {
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
-        public async Task TestFixAll5()
+        public async Task TestFixAll4()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        {|FixAllInDocument:|}using (var a = b) { }
-                        using (var c = d) { }
+                        using (var a = {|CS0103:b|}) { }
+                        [|using|] (var c = {|CS0103:d|}) { }
                     }
                 }
-                """,
-new TestParameters(parseOptions: CSharp8ParseOptions));
-        }
-
-        [Fact]
-        public async Task TestFixAll6()
-        {
-            await TestInRegularAndScriptAsync(
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using (var a = b) { }
-                        {|FixAllInDocument:|}using (var c = d) { }
+                        using (var a = {|CS0103:b|}) { }
+                        using var c = {|CS0103:d|};
                     }
                 }
-                """,
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        using (var a = b) { }
-                        using var c = d;
-                    }
-                }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestWithFollowingReturn()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         {
                         }
                         return;
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         return;
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact]
         public async Task TestWithFollowingBreak()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
@@ -636,7 +526,7 @@ parseOptions: CSharp8ParseOptions);
                         {
                             case 0:
                                 {
-                                    [||]using (var a = b)
+                                    [|using|] (var a = {|CS0103:b|})
                                     {
                                     }
                                     break;
@@ -644,8 +534,7 @@ parseOptions: CSharp8ParseOptions);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
@@ -656,112 +545,117 @@ parseOptions: CSharp8ParseOptions);
                         {
                             case 0:
                                 {
-                                    using var a = b;
+                                    using var a = {|CS0103:b|};
                                     break;
                                 }
                         }
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [Fact]
         public async Task TestMissingInSwitchSection()
         {
-            await TestMissingAsync(
-                """
-                using System;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
 
-                class C
-                {
-                    void M()
+                    class C
                     {
-                        switch (0)
+                        void M()
                         {
-                            case 0:
-                                [||]using (var a = b)
-                                {
-                                }
-                                break;
-                        }
-                    }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
-        public async Task TestMissingWithJumpInsideToOutside()
-        {
-            await TestMissingAsync(
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        label:
-                        [||]using (var a = b)
-                        {
-                            goto label;
-                        }
-                    }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
-        public async Task TestMissingWithJumpBeforeToAfter()
-        {
-            await TestMissingAsync(
-                """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        {
-                            goto label;
-                            [||]using (var a = b)
+                            switch (0)
                             {
+                                case 0:
+                                    using (var a = {|CS0103:b|})
+                                    {
+                                    }
+                                    break;
                             }
                         }
-                        label:
                     }
-                }
-                """, parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestMissingWithJumpInsideToOutside()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
+
+                    class C
+                    {
+                        void M()
+                        {
+                            label:
+                            using (var a = {|CS0103:b|})
+                            {
+                                goto label;
+                            }
+                        }
+                    }
+                    """
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestMissingWithJumpBeforeToAfter()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System;
+
+                    class C
+                    {
+                        void M()
+                        {
+                            {
+                                goto label;
+                                using (var a = {|CS0103:b|})
+                                {
+                                }
+                            }
+                            label:;
+                        }
+                    }
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestCollision1()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class Program
-                {
-                    static void Main()
+                    class Program
                     {
-                        using (Stream stream = File.OpenRead("test"))
+                        static void Main()
                         {
-                        }
-                        [||]using (Stream stream = File.OpenRead("test"))
-                        {
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                            }
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                            }
                         }
                     }
-                }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestNoCollision1()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class Program
@@ -771,13 +665,12 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using (Stream stream = File.OpenRead("test"))
                         {
                         }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
+                        [|using|] (Stream stream1 = File.OpenRead("test"))
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class Program
@@ -790,39 +683,38 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using Stream stream1 = File.OpenRead("test");
                     }
                 }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestCollision2()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class Program
-                {
-                    static void Main()
+                    class Program
                     {
-                        using (Stream stream = File.OpenRead("test"))
+                        static void Main()
                         {
-                        }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
-                        {
-                            Stream stream;
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                            }
+                            using (Stream stream1 = File.OpenRead("test"))
+                            {
+                                Stream stream;
+                            }
                         }
                     }
-                }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestNoCollision2()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class Program
@@ -832,14 +724,13 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using (Stream stream = File.OpenRead("test"))
                         {
                         }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
+                        [|using|] (Stream stream1 = File.OpenRead("test"))
                         {
                             Stream stream2;
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class Program
@@ -853,39 +744,38 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         Stream stream2;
                     }
                 }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestCollision3()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class Program
-                {
-                    static void Main()
+                    class Program
                     {
-                        using (Stream stream = File.OpenRead("test"))
+                        static void Main()
                         {
-                        }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
-                        {
-                            Goo(out var stream);
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                            }
+                            using (Stream stream1 = File.OpenRead("test"))
+                            {
+                                {|CS0103:Goo|}(out var stream);
+                            }
                         }
                     }
-                }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestNoCollision3()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class Program
@@ -895,14 +785,13 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using (Stream stream = File.OpenRead("test"))
                         {
                         }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
+                        [|using|] (Stream stream1 = File.OpenRead("test"))
                         {
-                            Goo(out var stream2);
+                            {|CS0103:Goo|}(out var stream2);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class Program
@@ -913,40 +802,39 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         {
                         }
                         using Stream stream1 = File.OpenRead("test");
-                        Goo(out var stream2);
+                        {|CS0103:Goo|}(out var stream2);
                     }
                 }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestCollision4()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class Program
-                {
-                    static void Main()
+                    class Program
                     {
-                        using (Stream stream = File.OpenRead("test"))
+                        static void Main()
                         {
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                            }
+                            using (Stream stream1 = File.OpenRead("test"))
+                                {|CS0103:Goo|}(out var stream);
                         }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
-                            Goo(out var stream);
                     }
-                }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestNoCollision4()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class Program
@@ -956,12 +844,11 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using (Stream stream = File.OpenRead("test"))
                         {
                         }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
-                            Goo(out var stream2);
+                        [|using|] (Stream stream1 = File.OpenRead("test"))
+                            {|CS0103:Goo|}(out var stream2);
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class Program
@@ -972,42 +859,41 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         {
                         }
                         using Stream stream1 = File.OpenRead("test");
-                        Goo(out var stream2);
+                        {|CS0103:Goo|}(out var stream2);
                     }
                 }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestCollision5()
         {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class Program
-                {
-                    static void Main()
+                    class Program
                     {
-                        using (Stream stream = File.OpenRead("test"))
+                        static void Main()
                         {
-                            Stream stream1;
-                        }
-                        [||]using (Stream stream1 = File.OpenRead("test"))
-                        {
+                            using (Stream stream = File.OpenRead("test"))
+                            {
+                                Stream stream1;
+                            }
+                            using (Stream stream1 = File.OpenRead("test"))
+                            {
+                            }
                         }
                     }
-                }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35879")]
         public async Task TestNoCollision5()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class Program
@@ -1018,13 +904,12 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         {
                             Stream stream1;
                         }
-                        [||]using (Stream stream2 = File.OpenRead("test"))
+                        [|using|] (Stream stream2 = File.OpenRead("test"))
                         {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class Program
@@ -1038,32 +923,29 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         using Stream stream2 = File.OpenRead("test");
                     }
                 }
-                """,
-parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37678")]
         public async Task TestCopyTrivia()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 class Program
                 {
                     static void Main(string[] args)
                     {
-                        [||]using (var x = y)
+                        [|using|] (var x = {|CS0103:y|})
                         {
                             // comment
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 class Program
                 {
                     static void Main(string[] args)
                     {
-                        using var x = y;
+                        using var x = {|CS0103:y|};
                         // comment
                     }
                 }
@@ -1073,27 +955,25 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37678")]
         public async Task TestMultiCopyTrivia()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 class Program
                 {
                     static void Main(string[] args)
                     {
-                        [||]using (var x = y)
-                        using (var a = b)
+                        [|using|] (var x = {|CS0103:y|})
+                        using (var a = {|CS0103:b|})
                         {
                             // comment
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 class Program
                 {
                     static void Main(string[] args)
                     {
-                        using var x = y;
-                        using var a = b;
+                        using var x = {|CS0103:y|};
+                        using var a = {|CS0103:b|};
                         // comment
                     }
                 }
@@ -1103,17 +983,16 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
         [Fact]
         public async Task TestFixAll_WithTrivia()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        {|FixAllInDocument:|}using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         {
-                            using (var c = d)
+                            [|using|] (var c = {|CS0103:d|})
                             {
                                 Console.WriteLine(a);
                                 // comment1
@@ -1122,35 +1001,34 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
-                        using var c = d;
+                        using var a = {|CS0103:b|};
+                        using var c = {|CS0103:d|};
                         Console.WriteLine(a);
                         // comment1
                         // comment2
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveTrivia()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                 #pragma warning disable CS0618, CS0612
                 #if !FOO
@@ -1165,8 +1043,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1184,20 +1063,20 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveAndCommentTrivia_AfterRestore()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                 #pragma warning disable CS0618, CS0612
                 #if !FOO
@@ -1213,8 +1092,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1233,20 +1113,20 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveAndCommentTrivia_BeforeRestore()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                 #pragma warning disable CS0618, CS0612
                 #if !FOO
@@ -1262,8 +1142,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1282,20 +1163,20 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveAndCommentTrivia_AfterDisable()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                 #pragma warning disable CS0618, CS0612
                 #if !FOO
@@ -1311,8 +1192,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1331,20 +1213,20 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveAndCommentTrivia_BeforeDisable()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                             // comment
                 #pragma warning disable CS0618, CS0612
@@ -1360,8 +1242,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1380,20 +1263,20 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38737")]
         public async Task TestCopyCompilerDirectiveTrivia_PreserveCodeBeforeAndAfterDirective()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+
                 class C
                 {
                     static void M()
                     {
-                        [||]using (var obj = Dummy())
+                        [|using|] (var obj = Dummy())
                         {
                             LegacyMethod();
                 #pragma warning disable CS0618, CS0612
@@ -1410,8 +1293,9 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+
                 class C
                 {
                     static void M()
@@ -1431,34 +1315,31 @@ parseOptions: CSharp8ParseOptions);
                     [Obsolete]
                     static void LegacyMethod() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38842")]
         public async Task TestNextLineIndentation1()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void Goo(IDisposable disposable)
                     {
-                        [||]using (var v = disposable)
+                        [|using|] (var v = disposable)
                         {
-                            Bar(1,
+                            {|CS0103:Bar|}(1,
                                 2,
                                 3);
-                            Goo(1,
+                            {|CS1501:Goo|}(1,
                                 2,
                                 3);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
@@ -1466,23 +1347,21 @@ parseOptions: CSharp8ParseOptions);
                     void Goo(IDisposable disposable)
                     {
                         using var v = disposable;
-                        Bar(1,
+                        {|CS0103:Bar|}(1,
                             2,
                             3);
-                        Goo(1,
+                        {|CS1501:Goo|}(1,
                             2,
                             3);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/38842")]
         public async Task TestNextLineIndentation2()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
                 using System.IO;
 
@@ -1490,7 +1369,7 @@ parseOptions: CSharp8ParseOptions);
                 {
                     static void Main()
                     {
-                        [||]using (var stream = new MemoryStream())
+                        [|using|] (var stream = new MemoryStream())
                         {
                             _ = new Action(
                                     () => { }
@@ -1498,8 +1377,7 @@ parseOptions: CSharp8ParseOptions);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
                 using System.IO;
 
@@ -1513,50 +1391,45 @@ parseOptions: CSharp8ParseOptions);
                             );
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48586")]
         public async Task TestKeepSurroundingComments()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b)
+                        [|using|] (var a = {|CS0103:b|})
                         { // Make sure that...
-                            Console.WriteLine(s.CanRead);
+                            Console.WriteLine({|CS0103:s|}.CanRead);
                         } // ...all comments remain
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         // Make sure that...
-                        Console.WriteLine(s.CanRead);
+                        Console.WriteLine({|CS0103:s|}.CanRead);
                         // ...all comments remain
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48586")]
         public async Task TestKeepSurroundingComments2()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
@@ -1564,15 +1437,14 @@ parseOptions: CSharp8ParseOptions);
                     void M()
                     {
                         // Make...
-                        [||]using (var a = b) // ...sure...
+                        [|using|] (var a = {|CS0103:b|}) // ...sure...
                         { // ...that...
-                            Console.WriteLine(s.CanRead); // ...all...
+                            Console.WriteLine({|CS0103:s|}.CanRead); // ...all...
                         } // ...comments...
                         // ...remain
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
@@ -1580,22 +1452,20 @@ parseOptions: CSharp8ParseOptions);
                     void M()
                     {
                         // Make...
-                        using var a = b; // ...sure...
+                        using var a = {|CS0103:b|}; // ...sure...
                                          // ...that...
-                        Console.WriteLine(s.CanRead); // ...all...
+                        Console.WriteLine({|CS0103:s|}.CanRead); // ...all...
                                                       // ...comments...
                                                       // ...remain
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/48586")]
         public async Task TestKeepSurroundingComments3()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
@@ -1603,19 +1473,18 @@ parseOptions: CSharp8ParseOptions);
                     void M()
                     {
                         // Make...
-                        [||]using (var a = b) // ...sure...
-                        using (var c = d) // ...that...
+                        [|using|] (var a = {|CS0103:b|}) // ...sure...
+                        using (var c = {|CS0103:d|}) // ...that...
                         // ...really...
-                        using (var e = f) // ...all...
+                        using (var e = {|CS0103:f|}) // ...all...
                         { // ...comments...
-                            Console.WriteLine(s.CanRead); // ...are...
+                            Console.WriteLine({|CS0103:s|}.CanRead); // ...are...
                         } // ...kept...
                         // ...during...
                         // ...transformation
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
@@ -1623,184 +1492,170 @@ parseOptions: CSharp8ParseOptions);
                     void M()
                     {
                         // Make...
-                        using var a = b; // ...sure...
-                        using var c = d; // ...that...
+                        using var a = {|CS0103:b|}; // ...sure...
+                        using var c = {|CS0103:d|}; // ...that...
                         // ...really...
-                        using var e = f; // ...all...
+                        using var e = {|CS0103:f|}; // ...all...
                                          // ...comments...
-                        Console.WriteLine(s.CanRead); // ...are...
+                        Console.WriteLine({|CS0103:s|}.CanRead); // ...are...
                                                       // ...kept...
                                                       // ...during...
                                                       // ...transformation
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/52970")]
         public async Task TestWithBlockBodyWithOpeningBracketOnSameLine()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b){
+                        [|using|] (var a = {|CS0103:b|}){
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/52970")]
         public async Task TestWithBlockBodyWithOpeningBracketOnSameLine2()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b) {
+                        [|using|] (var a = {|CS0103:b|}) {
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/52970")]
         public async Task TestWithBlockBodyWithOpeningBracketAndCommentOnSameLine()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b) { //comment
+                        [|using|] (var a = {|CS0103:b|}) { //comment
                             Console.WriteLine(a);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;  //comment
+                        using var a = {|CS0103:b|};  //comment
                         Console.WriteLine(a);
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/52970")]
         public async Task TestWithBlockBodyWithOpeningBracketOnSameLineWithNoStatements()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b) {
+                        [|using|] (var a = {|CS0103:b|}) {
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/52970")]
         public async Task TestWithBlockBodyWithOpeningBracketOnSameLineAndCommentInBlock()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        [||]using (var a = b) {
+                        [|using|] (var a = {|CS0103:b|}) {
                             // intentionally empty
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System;
 
                 class C
                 {
                     void M()
                     {
-                        using var a = b;
+                        using var a = {|CS0103:b|};
                         // intentionally empty
                     }
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58911")]
         public async Task TestUsingWithoutSpace()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
+                using System.Collections.Generic;
+
                 public class Test
                 {
                     public IEnumerable<Test> Collection { get; } = new[]
@@ -1809,7 +1664,7 @@ parseOptions: CSharp8ParseOptions);
                         {
                             Prop = () =>
                             {
-                                [||]using(var x = Get())
+                                [|using|](var x = Get())
                                 {
                                     int i = 0;
                                 }
@@ -1817,11 +1672,13 @@ parseOptions: CSharp8ParseOptions);
                         }
                     };
 
-                    public Action? Prop { get; set; }
+                    public Action Prop { get; set; }
                     public static IDisposable Get() => throw new NotImplementedException();
                 }
-                """,
-                """
+                """, """
+                using System;
+                using System.Collections.Generic;
+
                 public class Test
                 {
                     public IEnumerable<Test> Collection { get; } = new[]
@@ -1836,33 +1693,30 @@ parseOptions: CSharp8ParseOptions);
                         }
                     };
 
-                    public Action? Prop { get; set; }
+                    public Action Prop { get; set; }
                     public static IDisposable Get() => throw new NotImplementedException();
                 }
-                """,
-parseOptions: CSharp8ParseOptions);
+                """);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42194")]
         public async Task TestWithConstantReturn1()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class C
                 {
                     bool M()
                     {
-                        [||]using (var foo = new MemoryStream())
+                        [|using|] (var foo = new MemoryStream())
                         {
                         }
 
                         return true;
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class C
@@ -1880,36 +1734,37 @@ parseOptions: CSharp8ParseOptions);
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42194")]
         public async Task TestWithNonConstantReturn1()
         {
-            await TestMissingAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class C
-                {
-                    bool M(int a, int b)
+                    class C
                     {
-                        [||]using (var foo = new MemoryStream())
+                        bool M(int a, int b)
                         {
-                        }
+                            using (var foo = new MemoryStream())
+                            {
+                            }
 
-                        return a > b;
+                            return a > b;
+                        }
                     }
-                }
-                """);
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42194")]
         public async Task TestWithLocalFunctions1()
         {
-            await TestInRegularAndScriptAsync(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class C
                 {
-                    bool M()
+                    void M()
                     {
-                        [||]using (var foo = new MemoryStream())
+                        [|using|] (var foo = new MemoryStream())
                         {
                         }
 
@@ -1917,13 +1772,12 @@ parseOptions: CSharp8ParseOptions);
                         void Inner2() { }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class C
                 {
-                    bool M()
+                    void M()
                     {
                         using var foo = new MemoryStream();
 
@@ -1937,39 +1791,40 @@ parseOptions: CSharp8ParseOptions);
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42194")]
         public async Task TestWithLocalFunctions2()
         {
-            await TestMissingAsync(
-                """
-                using System.IO;
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    using System.IO;
 
-                class C
-                {
-                    bool M(int a, int b)
+                    class C
                     {
-                        [||]using (var foo = new MemoryStream())
+                        bool M(int a, int b)
                         {
+                            using (var foo = new MemoryStream())
+                            {
+                            }
+
+                            void Inner1() { }
+                            void Inner2() { }
+
+                            return a > b;
                         }
-
-                        void Inner1() { }
-                        void Inner2() { }
-
-                        return a > b;
                     }
-                }
-                """);
+                    """
+            }.RunAsync();
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/42194")]
         public async Task TestWithLocalFunctionsAndConstantReturn()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.IO;
 
                 class C
                 {
                     bool M(int a, int b)
                     {
-                        [||]using (var foo = new MemoryStream())
+                        [|using|] (var foo = new MemoryStream())
                         {
                         }
 
@@ -1979,8 +1834,7 @@ parseOptions: CSharp8ParseOptions);
                         return true;
                     }
                 }
-                """,
-                """
+                """, """
                 using System.IO;
 
                 class C
@@ -1998,11 +1852,10 @@ parseOptions: CSharp8ParseOptions);
                 """);
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58897")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58861")]
         public async Task TestOpenBraceTrivia1()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.Security.Cryptography;
 
                 class C
@@ -2010,15 +1863,14 @@ parseOptions: CSharp8ParseOptions);
                     public static byte[] ComputeMD5Hash(byte[] source)
                     {
                 #pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
-                        [||]using (var md5 = MD5.Create())
+                        [|using|] (var md5 = MD5.Create())
                 #pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
                         {
                             return md5.ComputeHash(source);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.Security.Cryptography;
 
                 class C
@@ -2034,11 +1886,10 @@ parseOptions: CSharp8ParseOptions);
                 """);
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58897")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58861")]
         public async Task TestOpenBraceTrivia2()
         {
-            await TestInRegularAndScript1Async(
-                """
+            await VerifyCS.VerifyCodeFixAsync("""
                 using System.Security.Cryptography;
 
                 class C
@@ -2046,15 +1897,14 @@ parseOptions: CSharp8ParseOptions);
                     public static byte[] ComputeMD5Hash(byte[] source)
                     {
                 #pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
-                        [||]using (var md5 = MD5.Create())
+                        [|using|] (var md5 = MD5.Create())
                 #pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
                         { // comment
                             return md5.ComputeHash(source);
                         }
                     }
                 }
-                """,
-                """
+                """, """
                 using System.Security.Cryptography;
 
                 class C


### PR DESCRIPTION
- Preserved compiler errors where it was reasonable. For instance, having error of unknown name `b` in `using (var a = b)` is reasonable, whereas error that `IDisposable` isn't imported is not.
- Several fix-all test cases are gone since they are now covered by other test cases
- Compacted raw string markers
- There were 2 cases with incorrect workitem link. Fixed