### PR TITLE
Make ConstantTextAndVersionSource no longer a ValueSource.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ConstantTextAndVersionSource.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ConstantTextAndVersionSource.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis;
 /// <summary>
 /// This value source keeps a strong reference to a value.
 /// </summary>
-internal sealed class ConstantTextAndVersionSource : ValueSource<TextAndVersion>, ITextAndVersionSource
+internal sealed class ConstantTextAndVersionSource : ITextAndVersionSource
 {
     private readonly TextAndVersion _value;
 
@@ -24,26 +24,17 @@ internal sealed class ConstantTextAndVersionSource : ValueSource<TextAndVersion>
     public bool CanReloadText
         => false;
 
-    public override TextAndVersion GetValue(CancellationToken cancellationToken)
+    public TextAndVersion GetValue(LoadTextOptions options, CancellationToken cancellationToken)
         => _value;
 
-    public override Task<TextAndVersion> GetValueAsync(CancellationToken cancellationToken)
+    public Task<TextAndVersion> GetValueAsync(LoadTextOptions options, CancellationToken cancellationToken)
         => Task.FromResult(_value);
 
-    public override bool TryGetValue([MaybeNullWhen(false)] out TextAndVersion value)
+    public bool TryGetValue(LoadTextOptions options, [MaybeNullWhen(false)] out TextAndVersion value)
     {
         value = _value;
         return true;
     }
-
-    public TextAndVersion GetValue(LoadTextOptions options, CancellationToken cancellationToken)
-        => GetValue(cancellationToken);
-
-    public Task<TextAndVersion> GetValueAsync(LoadTextOptions options, CancellationToken cancellationToken)
-        => GetValueAsync(cancellationToken);
-
-    public bool TryGetValue(LoadTextOptions options, [MaybeNullWhen(false)] out TextAndVersion value)
-        => TryGetValue(out value);
 
     public bool TryGetVersion(LoadTextOptions options, out VersionStamp version)
     {


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/68295