### PR TITLE
Remove unexercised C# binaires from VB OptProf test profiling

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -11,10 +11,6 @@
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             },
             {
-              "filename": "/Microsoft.CodeAnalysis.CSharp.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
-            },
-            {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.Text.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             },
@@ -40,10 +36,6 @@
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
-            },
-            {
-              "filename": "/Microsoft.CodeAnalysis.CSharp.Features.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             },
             {


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1822212
Probably caused by us moving to .NET 6 ServiceHub host in test runs.