### PR TITLE
Show `unsafe` keyword after `using` or `static` in using directive

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/UnsafeKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UnsafeKeywordRecommenderTests.cs
@@ -321,20 +321,6 @@ $$");
         }
 
         [Fact]
-        public async Task TestNotAfterStaticInUsingDirective()
-        {
-            await VerifyAbsenceAsync(
-@"using static $$");
-        }
-
-        [Fact]
-        public async Task TestNotAfterStaticInGlobalUsingDirective()
-        {
-            await VerifyAbsenceAsync(
-@"global using static $$");
-        }
-
-        [Fact]
         public async Task TestNotAfterClass()
             => await VerifyAbsenceAsync(@"class $$");
 
@@ -432,6 +418,18 @@ $$"));
         public async Task TestAfterStaticKeywordInUsingDirective()
         {
             await VerifyKeywordAsync("using static $$");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67984")]
+        public async Task TestAfterUsingKeywordInGlobalUsingDirective()
+        {
+            await VerifyKeywordAsync("global using $$");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67984")]
+        public async Task TestAfterStaticKeywordInGlobalUsingDirective()
+        {
+            await VerifyKeywordAsync("global using static $$");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UnsafeKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UnsafeKeywordRecommenderTests.cs
@@ -421,5 +421,17 @@ $$"));
             await VerifyKeywordAsync(
 @"public $$ interface IBinaryDocumentMemoryBlock {");
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67984")]
+        public async Task TestAfterUsingKeywordInUsingDirective()
+        {
+            await VerifyKeywordAsync("using $$");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67984")]
+        public async Task TestAfterStaticKeywordInUsingDirective()
+        {
+            await VerifyKeywordAsync("using static $$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnsafeKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnsafeKeywordRecommender.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken) ||
                 syntaxTree.IsLocalFunctionDeclarationContext(position, s_validLocalFunctionModifiers, cancellationToken) ||
-                context.IsInImportsDirective && context.TargetToken.Kind() is SyntaxKind.UsingKeyword or SyntaxKind.StaticKeyword;
+                (context.IsInImportsDirective && context.TargetToken.Kind() is SyntaxKind.UsingKeyword or SyntaxKind.StaticKeyword);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnsafeKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnsafeKeywordRecommender.cs
@@ -12,53 +12,53 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
     internal class UnsafeKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
         private static readonly ISet<SyntaxKind> s_validTypeModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.AbstractKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ProtectedKeyword,
-                SyntaxKind.SealedKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.FileKeyword,
-            };
+        {
+            SyntaxKind.AbstractKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.SealedKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.FileKeyword,
+        };
 
         private static readonly ISet<SyntaxKind> s_validMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.AbstractKeyword,
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.OverrideKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ProtectedKeyword,
-                SyntaxKind.ReadOnlyKeyword,
-                SyntaxKind.SealedKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.VirtualKeyword,
-                SyntaxKind.VolatileKeyword,
-            };
+        {
+            SyntaxKind.AbstractKeyword,
+            SyntaxKind.ExternKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.OverrideKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.ReadOnlyKeyword,
+            SyntaxKind.SealedKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.VirtualKeyword,
+            SyntaxKind.VolatileKeyword,
+        };
 
         private static readonly ISet<SyntaxKind> s_validGlobalMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ReadOnlyKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.VolatileKeyword,
-            };
+        {
+            SyntaxKind.ExternKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ReadOnlyKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.VolatileKeyword,
+        };
 
         private static readonly ISet<SyntaxKind> s_validLocalFunctionModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.AsyncKeyword
-            };
+        {
+            SyntaxKind.ExternKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.AsyncKeyword
+        };
 
         public UnsafeKeywordRecommender()
             : base(SyntaxKind.UnsafeKeyword)
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
                     canBePartial: false,
                     cancellationToken: cancellationToken) ||
-                syntaxTree.IsLocalFunctionDeclarationContext(position, s_validLocalFunctionModifiers, cancellationToken);
+                syntaxTree.IsLocalFunctionDeclarationContext(position, s_validLocalFunctionModifiers, cancellationToken) ||
+                context.IsInImportsDirective && context.TargetToken.Kind() is SyntaxKind.UsingKeyword or SyntaxKind.StaticKeyword;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/67984