### PR TITLE
Skip checks for overridden or hidden members in overload resolution with extension methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7397,7 +7397,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isMethodGroupConversion: isMethodGroupConversion,
                     allowRefOmittedArguments: allowRefOmittedArguments,
                     returnRefKind: returnRefKind,
-                    returnType: returnType);
+                    returnType: returnType,
+                    isExtensionMethodResolution: true);
                 diagnostics.Add(expression, useSiteInfo);
                 var sealedDiagnostics = diagnostics.ToReadOnlyAndFree();
 
@@ -9151,6 +9152,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     returnRefKind,
                     returnType,
                     isFunctionPointerResolution,
+                    isExtensionMethodResolution: false,
                     callingConvention);
 
                 // Note: the MethodGroupResolution instance is responsible for freeing its copy of analyzed arguments

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -296,7 +296,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             RemoveInaccessibleTypeArguments(results, ref useSiteInfo);
 
             // SPEC: The set of candidate methods is reduced to contain only methods from the most derived types.
-            RemoveLessDerivedMembers(results, ref useSiteInfo);
+            if (checkOverriddenOrHidden)
+            {
+                RemoveLessDerivedMembers(results, ref useSiteInfo);
+            }
 
             if (Compilation.LanguageVersion.AllowImprovedOverloadCandidates())
             {
@@ -1656,7 +1659,7 @@ outerDefault:
         /// <summary>
         /// Returns the parameter type (considering params).
         /// </summary>
-        private TypeSymbol GetParameterType(ParameterSymbol parameter, MemberAnalysisResult result)
+        private static TypeSymbol GetParameterType(ParameterSymbol parameter, MemberAnalysisResult result)
         {
             var type = parameter.Type;
             if (result.Kind == MemberResolutionKind.ApplicableInExpandedForm &&

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -128,12 +128,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
+            bool isExtensionMethodResolution = false,
             in CallingConventionInfo callingConventionInfo = default)
         {
             MethodOrPropertyOverloadResolution(
                 methods, typeArguments, receiver, arguments, result,
                 isMethodGroupConversion, allowRefOmittedArguments, ref useSiteInfo, inferWithDynamic,
-                allowUnexpandedForm, returnRefKind, returnType, isFunctionPointerResolution, in callingConventionInfo);
+                allowUnexpandedForm, returnRefKind, returnType, isFunctionPointerResolution: isFunctionPointerResolution,
+                isExtensionMethodResolution: isExtensionMethodResolution, in callingConventionInfo);
         }
 
         // Perform overload resolution on the given property group, with the given arguments and
@@ -168,16 +170,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             RefKind returnRefKind = default,
             TypeSymbol returnType = null,
             bool isFunctionPointerResolution = false,
+            bool isExtensionMethodResolution = false,
             in CallingConventionInfo callingConventionInfo = default)
             where TMember : Symbol
         {
             var results = result.ResultsBuilder;
 
+            // No need to check for overridden or hidden methods if the members are extension methods.
+            bool checkOverriddenOrHidden = !isExtensionMethodResolution;
+
             // First, attempt overload resolution not getting complete results.
             PerformMemberOverloadResolution(
                 results, members, typeArguments, receiver, arguments, completeResults: false, isMethodGroupConversion,
                 returnRefKind, returnType, allowRefOmittedArguments, isFunctionPointerResolution, callingConventionInfo,
-                ref useSiteInfo, inferWithDynamic, allowUnexpandedForm);
+                ref useSiteInfo, inferWithDynamic: inferWithDynamic, allowUnexpandedForm: allowUnexpandedForm, checkOverriddenOrHidden: checkOverriddenOrHidden);
 
             if (!OverloadResolutionResultIsValid(results, arguments.HasDynamicArgument))
             {
@@ -187,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     results, members, typeArguments, receiver, arguments,
                     completeResults: true, isMethodGroupConversion, returnRefKind, returnType,
                     allowRefOmittedArguments, isFunctionPointerResolution, callingConventionInfo,
-                    ref useSiteInfo, allowUnexpandedForm: allowUnexpandedForm);
+                    ref useSiteInfo, inferWithDynamic: false, allowUnexpandedForm: allowUnexpandedForm, checkOverriddenOrHidden: checkOverriddenOrHidden);
             }
         }
 
@@ -239,8 +245,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isFunctionPointerResolution,
             in CallingConventionInfo callingConventionInfo,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-            bool inferWithDynamic = false,
-            bool allowUnexpandedForm = true)
+            bool inferWithDynamic,
+            bool allowUnexpandedForm,
+            bool checkOverriddenOrHidden)
             where TMember : Symbol
         {
             // SPEC: The binding-time processing of a method invocation of the form M(A), where M is a 
@@ -256,7 +263,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // overriding or hiding member is not in a subtype of the type containing the
             // (potentially) overridden or hidden member.
             Dictionary<NamedTypeSymbol, ArrayBuilder<TMember>> containingTypeMapOpt = null;
-            if (members.Count > 50) // TODO: fine-tune this value
+            if (checkOverriddenOrHidden && members.Count > 50) // TODO: fine-tune this value
             {
                 containingTypeMapOpt = PartitionMembersByContainingType(members);
             }
@@ -276,7 +283,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     containingTypeMapOpt,
                     inferWithDynamic: inferWithDynamic,
                     useSiteInfo: ref useSiteInfo,
-                    allowUnexpandedForm: allowUnexpandedForm);
+                    allowUnexpandedForm: allowUnexpandedForm,
+                    checkOverriddenOrHidden: checkOverriddenOrHidden);
             }
 
             // CONSIDER: use containingTypeMapOpt for RemoveLessDerivedMembers?
@@ -824,9 +832,12 @@ outerDefault:
             Dictionary<NamedTypeSymbol, ArrayBuilder<TMember>> containingTypeMapOpt,
             bool inferWithDynamic,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-            bool allowUnexpandedForm)
+            bool allowUnexpandedForm,
+            bool checkOverriddenOrHidden = true)
             where TMember : Symbol
         {
+            Debug.Assert(checkOverriddenOrHidden || containingTypeMapOpt is null);
+
             // SPEC VIOLATION:
             //
             // The specification states that the method group that resulted from member lookup has
@@ -856,47 +867,50 @@ outerDefault:
             // clever in filtering out methods from less-derived classes later, but we'll cross that
             // bridge when we come to it.
 
-            if (members.Count < 2)
+            if (checkOverriddenOrHidden)
             {
-                // No hiding or overriding possible.
-            }
-            else if (containingTypeMapOpt == null)
-            {
-                if (MemberGroupContainsMoreDerivedOverride(members, member, checkOverrideContainingType: true, ref useSiteInfo))
+                if (members.Count < 2)
                 {
-                    // Don't even add it to the result set.  We'll add only the most-overriding members.
-                    return;
+                    // No hiding or overriding possible.
                 }
-
-                if (MemberGroupHidesByName(members, member, ref useSiteInfo))
+                else if (containingTypeMapOpt == null)
                 {
-                    return;
-                }
-            }
-            else if (containingTypeMapOpt.Count == 1)
-            {
-                // No hiding or overriding since all members are in the same type.
-            }
-            else
-            {
-                // NOTE: only check for overriding/hiding in subtypes of f.ContainingType.
-                NamedTypeSymbol memberContainingType = member.ContainingType;
-                foreach (var pair in containingTypeMapOpt)
-                {
-                    NamedTypeSymbol otherType = pair.Key;
-                    if (otherType.IsDerivedFrom(memberContainingType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref useSiteInfo))
+                    if (MemberGroupContainsMoreDerivedOverride(members, member, checkOverrideContainingType: true, ref useSiteInfo))
                     {
-                        ArrayBuilder<TMember> others = pair.Value;
+                        // Don't even add it to the result set.  We'll add only the most-overriding members.
+                        return;
+                    }
 
-                        if (MemberGroupContainsMoreDerivedOverride(others, member, checkOverrideContainingType: false, ref useSiteInfo))
+                    if (MemberGroupHidesByName(members, member, ref useSiteInfo))
+                    {
+                        return;
+                    }
+                }
+                else if (containingTypeMapOpt.Count == 1)
+                {
+                    // No hiding or overriding since all members are in the same type.
+                }
+                else
+                {
+                    // NOTE: only check for overriding/hiding in subtypes of f.ContainingType.
+                    NamedTypeSymbol memberContainingType = member.ContainingType;
+                    foreach (var pair in containingTypeMapOpt)
+                    {
+                        NamedTypeSymbol otherType = pair.Key;
+                        if (otherType.IsDerivedFrom(memberContainingType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref useSiteInfo))
                         {
-                            // Don't even add it to the result set.  We'll add only the most-overriding members.
-                            return;
-                        }
+                            ArrayBuilder<TMember> others = pair.Value;
 
-                        if (MemberGroupHidesByName(others, member, ref useSiteInfo))
-                        {
-                            return;
+                            if (MemberGroupContainsMoreDerivedOverride(others, member, checkOverrideContainingType: false, ref useSiteInfo))
+                            {
+                                // Don't even add it to the result set.  We'll add only the most-overriding members.
+                                return;
+                            }
+
+                            if (MemberGroupHidesByName(others, member, ref useSiteInfo))
+                            {
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -176,9 +176,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var results = result.ResultsBuilder;
 
-            // No need to check for overridden or hidden methods
-            // if the members were resolved as extension methods.
-            bool checkOverriddenOrHidden = !isExtensionMethodResolution;
+            // No need to check for overridden or hidden methods if the members were
+            // resolved as extension methods and the extension methods are defined in
+            // types derived from System.Object.
+            bool checkOverriddenOrHidden = !(isExtensionMethodResolution &&
+                members.All(static m => m.ContainingSymbol is NamedTypeSymbol { BaseTypeNoUseSiteDiagnostics.SpecialType: SpecialType.System_Object }));
 
             // First, attempt overload resolution not getting complete results.
             PerformMemberOverloadResolution(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1267,35 +1267,38 @@ outerDefault:
             // algorithms without allocating hardly any additional memory, which pushes us towards
             // walking data structures multiple times rather than caching information about them.)
 
-            for (int f = 0; f < results.Count; ++f)
+            if (results.Count(r => r.Result.IsValid) > 1)
             {
-                var result = results[f];
-
-                // As in dev12, we want to drop use site errors from less-derived types.
-                // NOTE: Because of use site warnings, a result with a diagnostic to report
-                // might not have kind UseSiteError.  This could result in a kind being
-                // switched to LessDerived (i.e. loss of information), but it is the most
-                // straightforward way to suppress use site diagnostics from less-derived
-                // members.
-                if (!(result.Result.IsValid || result.HasUseSiteDiagnosticToReport))
+                for (int f = 0; f < results.Count; ++f)
                 {
-                    continue;
-                }
+                    var result = results[f];
 
-                // Note that we are doing something which appears a bit dodgy here: we're modifying
-                // the validity of elements of the set while inside an outer loop which is filtering
-                // the set based on validity. This means that we could remove an item from the set
-                // that we ought to be processing later. However, because the "is a base type of"
-                // relationship is transitive, that's OK. For example, suppose we have members
-                // Cat.M, Mammal.M and Animal.M in the set. The first time through the outer loop we
-                // eliminate Mammal.M and Animal.M, and therefore we never process Mammal.M the
-                // second time through the outer loop. That's OK, because we have already done the
-                // work necessary to eliminate methods on base types of Mammal when we eliminated
-                // methods on base types of Cat.
+                    // As in dev12, we want to drop use site errors from less-derived types.
+                    // NOTE: Because of use site warnings, a result with a diagnostic to report
+                    // might not have kind UseSiteError.  This could result in a kind being
+                    // switched to LessDerived (i.e. loss of information), but it is the most
+                    // straightforward way to suppress use site diagnostics from less-derived
+                    // members.
+                    if (!(result.Result.IsValid || result.HasUseSiteDiagnosticToReport))
+                    {
+                        continue;
+                    }
 
-                if (IsLessDerivedThanAny(result.LeastOverriddenMember.ContainingType, results, ref useSiteInfo))
-                {
-                    results[f] = result.WithResult(MemberAnalysisResult.LessDerived());
+                    // Note that we are doing something which appears a bit dodgy here: we're modifying
+                    // the validity of elements of the set while inside an outer loop which is filtering
+                    // the set based on validity. This means that we could remove an item from the set
+                    // that we ought to be processing later. However, because the "is a base type of"
+                    // relationship is transitive, that's OK. For example, suppose we have members
+                    // Cat.M, Mammal.M and Animal.M in the set. The first time through the outer loop we
+                    // eliminate Mammal.M and Animal.M, and therefore we never process Mammal.M the
+                    // second time through the outer loop. That's OK, because we have already done the
+                    // work necessary to eliminate methods on base types of Mammal when we eliminated
+                    // methods on base types of Cat.
+
+                    if (IsLessDerivedThanAny(result.LeastOverriddenMember.ContainingType, results, ref useSiteInfo))
+                    {
+                        results[f] = result.WithResult(MemberAnalysisResult.LessDerived());
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -176,7 +176,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var results = result.ResultsBuilder;
 
-            // No need to check for overridden or hidden methods if the members are extension methods.
+            // No need to check for overridden or hidden methods
+            // if the members were resolved as extension methods.
             bool checkOverriddenOrHidden = !isExtensionMethodResolution;
 
             // First, attempt overload resolution not getting complete results.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1269,48 +1269,50 @@ outerDefault:
             // algorithms without allocating hardly any additional memory, which pushes us towards
             // walking data structures multiple times rather than caching information about them.)
 
-            if (results.Count(r => r.Result.IsValid) > 1)
+            for (int f = 0; f < results.Count; ++f)
             {
-                for (int f = 0; f < results.Count; ++f)
+                var result = results[f];
+
+                // As in dev12, we want to drop use site errors from less-derived types.
+                // NOTE: Because of use site warnings, a result with a diagnostic to report
+                // might not have kind UseSiteError.  This could result in a kind being
+                // switched to LessDerived (i.e. loss of information), but it is the most
+                // straightforward way to suppress use site diagnostics from less-derived
+                // members.
+                if (!(result.Result.IsValid || result.HasUseSiteDiagnosticToReport))
                 {
-                    var result = results[f];
+                    continue;
+                }
 
-                    // As in dev12, we want to drop use site errors from less-derived types.
-                    // NOTE: Because of use site warnings, a result with a diagnostic to report
-                    // might not have kind UseSiteError.  This could result in a kind being
-                    // switched to LessDerived (i.e. loss of information), but it is the most
-                    // straightforward way to suppress use site diagnostics from less-derived
-                    // members.
-                    if (!(result.Result.IsValid || result.HasUseSiteDiagnosticToReport))
-                    {
-                        continue;
-                    }
+                // Note that we are doing something which appears a bit dodgy here: we're modifying
+                // the validity of elements of the set while inside an outer loop which is filtering
+                // the set based on validity. This means that we could remove an item from the set
+                // that we ought to be processing later. However, because the "is a base type of"
+                // relationship is transitive, that's OK. For example, suppose we have members
+                // Cat.M, Mammal.M and Animal.M in the set. The first time through the outer loop we
+                // eliminate Mammal.M and Animal.M, and therefore we never process Mammal.M the
+                // second time through the outer loop. That's OK, because we have already done the
+                // work necessary to eliminate methods on base types of Mammal when we eliminated
+                // methods on base types of Cat.
 
-                    // Note that we are doing something which appears a bit dodgy here: we're modifying
-                    // the validity of elements of the set while inside an outer loop which is filtering
-                    // the set based on validity. This means that we could remove an item from the set
-                    // that we ought to be processing later. However, because the "is a base type of"
-                    // relationship is transitive, that's OK. For example, suppose we have members
-                    // Cat.M, Mammal.M and Animal.M in the set. The first time through the outer loop we
-                    // eliminate Mammal.M and Animal.M, and therefore we never process Mammal.M the
-                    // second time through the outer loop. That's OK, because we have already done the
-                    // work necessary to eliminate methods on base types of Mammal when we eliminated
-                    // methods on base types of Cat.
-
-                    if (IsLessDerivedThanAny(result.LeastOverriddenMember.ContainingType, results, ref useSiteInfo))
-                    {
-                        results[f] = result.WithResult(MemberAnalysisResult.LessDerived());
-                    }
+                if (IsLessDerivedThanAny(index: f, result.LeastOverriddenMember.ContainingType, results, ref useSiteInfo))
+                {
+                    results[f] = result.WithResult(MemberAnalysisResult.LessDerived());
                 }
             }
         }
 
         // Is this type a base type of any valid method on the list?
-        private static bool IsLessDerivedThanAny<TMember>(TypeSymbol type, ArrayBuilder<MemberResolutionResult<TMember>> results, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private static bool IsLessDerivedThanAny<TMember>(int index, TypeSymbol type, ArrayBuilder<MemberResolutionResult<TMember>> results, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             where TMember : Symbol
         {
             for (int f = 0; f < results.Count; ++f)
             {
+                if (f == index)
+                {
+                    continue;
+                }
+
                 var result = results[f];
 
                 if (!result.Result.IsValid)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -892,6 +892,17 @@ class C
 
             string source = builder.ToString();
             var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,25): error CS1501: No overload for method 'F' takes 0 arguments
+                //         o.F(c, c => { o.F( });
+                Diagnostic(ErrorCode.ERR_BadArgCount, "F").WithArguments("F", "0").WithLocation(7, 25),
+                // (7,28): error CS1026: ) expected
+                //         o.F(c, c => { o.F( });
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "}").WithLocation(7, 28),
+                // (7,28): error CS1002: ; expected
+                //         o.F(c, c => { o.F( });
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(7, 28));
+
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
             var expr = tree.GetCompilationUnitRoot().DescendantNodes().OfType<Syntax.InvocationExpressionSyntax>().Last();


### PR DESCRIPTION
Improves Intellisense performance by ~35% for scenario in #67926.