### PR TITLE
Drop source suppressed diagnostics in LSP pull diagnostic handler

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
@@ -29,6 +29,12 @@ internal sealed class DocumentDiagnosticSource
         // Also ensure we pass in "includeSuppressedDiagnostics = true" for unnecessary suppressions to be reported.
         var allSpanDiagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(
             Document, range: null, diagnosticKind: this.DiagnosticKind, includeSuppressedDiagnostics: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Drop the source suppressed diagnostics.
+        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824321 tracks
+        // adding LSP support for returning source suppressed diagnostics.
+        allSpanDiagnostics = allSpanDiagnostics.WhereAsArray(diagnostic => !diagnostic.IsSuppressed);
+
         return allSpanDiagnostics;
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -789,7 +789,7 @@ class A
         }
 
         [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1806590")]
-        public async Task TestDocumentDiagnosticsDiagnosticsForUnnecessarySuppressions(bool useVSDiagnostics, bool mutatingLspWorkspace)
+        public async Task TestDocumentDiagnosticsForUnnecessarySuppressions(bool useVSDiagnostics, bool mutatingLspWorkspace)
         {
             var markup = "#pragma warning disable IDE0000";
             await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics, pullDiagnostics: true);
@@ -802,6 +802,31 @@ class A
                 testLspServer, document.GetURI(), useVSDiagnostics);
 
             Assert.Equal(IDEDiagnosticIds.RemoveUnnecessarySuppressionDiagnosticId, results.Single().Diagnostics.Single().Code);
+        }
+
+        [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824321")]
+        public async Task TestDocumentDiagnosticsForSourceSuppressions(bool useVSDiagnostics, bool mutatingLspWorkspace)
+        {
+            var markup = @"
+class C
+{ 
+    void M()
+    {
+#pragma warning disable CS0168 // Variable is declared but never used
+        int x;
+#pragma warning restore CS0168 // Variable is declared but never used
+    }
+}";
+            await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, mutatingLspWorkspace, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics, pullDiagnostics: true);
+
+            var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+            await OpenDocumentAsync(testLspServer, document);
+
+            var results = await RunGetDocumentPullDiagnosticsAsync(
+                testLspServer, document.GetURI(), useVSDiagnostics);
+
+            Assert.Empty(results.Single().Diagnostics);
         }
 
         #endregion


### PR DESCRIPTION
Fixes the regression introduced by https://github.com/dotnet/roslyn/pull/68287

Addresses part of [AB#1824321](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824321)

We now drop source suppressed diagnostics from being returned by the LSP pull diagnostics handler. #1824321 tracks potentially updating the LSP spec/clients to allow source suppressed diagnostics to be returned from LSP server to support IDE features for source suppressed diagnostics in LSP pull diagnostics mode.