### PR TITLE
Move tests of `IDE0060` to `VerifyCS`

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                     """,
                 Options =
                 {
-                    { CodeStyleOptions2.UnusedParameters, UnusedParametersPreference.NonPublicMethods, NotificationOption2.Suggestion }
+                    { CodeStyleOptions2.UnusedParameters, UnusedParametersPreference.NonPublicMethods },
                 }
             }.RunAsync();
         }

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
             await VerifyAnalyzerAsync("""
                 class B
                 {
-                    protected B(int p) { var x = p; }
+                    protected B(int {|IDE0060:p|}) { }
                 }
 
                 class C: B
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
             await VerifyAnalyzerAsync("""
                 class B
                 {
-                    protected B(int p) { var x = p; }
+                    protected B(int {|IDE0060:p|}) { }
                 }
 
                 class C: B
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
             await VerifyAnalyzerAsync("""
                 class B
                 {
-                    protected B(int p) { var x = p; }
+                    protected B(int {|IDE0060:p|}) { }
                 }
 
                 class C: B
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(() => { });
                     }
 
-                    private static void M2(Action a) { var x = a; }
+                    private static void M2(Action {|IDE0060:a|}) { }
                 }
                 """);
         }
@@ -422,9 +422,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(() => { M3(p); });
                     }
 
-                    private static void M2(Action a) { var x = a; }
+                    private static void M2(Action {|IDE0060:a|}) { }
 
-                    private static void M3(object o) { var x = o; }
+                    private static void M3(object {|IDE0060:o|}) { }
                 }
                 """);
         }
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(() => { M3(out p); });
                     }
 
-                    private static void M2(Action a) { var x = a; }
+                    private static void M2(Action {|IDE0060:a|}) { }
 
                     private static void M3(out object o) { o = null; }
                 }
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(x => x.M3());
                     }
 
-                    private static C M2(Expression<Func<C, int>> a) { var x = a; return null; }
+                    private static C M2(Expression<Func<C, int>> {|IDE0060:a|}) { return null; }
                     private int M3() { return 0; }
                 }
                 """);
@@ -483,8 +483,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(x => x.M3(p));
                     }
 
-                    private static C M2(Expression<Func<C, int>> a) { var x = a; return null; }
-                    private int M3(object o) { var x = o; return 0; }
+                    private static C M2(Expression<Func<C, int>> {|IDE0060:a|}) { return null; }
+                    private int M3(object {|IDE0060:o|}) { return 0; }
                 }
                 """);
         }
@@ -503,7 +503,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         M2(x => x.M3(out p));
                     }
 
-                    private static C M2(Expression<Func<C, int>> a) { var x = a; return null; }
+                    private static C M2(Expression<Func<C, int>> {|IDE0060:a|}) { return null; }
                     private int M3(out object o) { o = null; return 0; }
                 }
                 """);
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                         return c;
                     }
 
-                    private void M2(object p) { var x = p; }
+                    private void M2(object {|IDE0060:p|}) { }
                 }
                 """);
         }

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1153,11 +1153,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                     """,
                 ExpectedDiagnostics =
                 {
-                    VerifyCS.Diagnostic("IDE0060").WithLocation(0).WithMessage("Remove unused parameter 'p1'"),
-                    VerifyCS.Diagnostic("IDE0060").WithLocation(1).WithMessage("Parameter 'p2' can be removed; its initial value is never used"),
-                    VerifyCS.Diagnostic("IDE0060").WithLocation(2).WithMessage("Remove unused parameter 'p3' if it is not part of a shipped public API"),
-                    VerifyCS.Diagnostic("IDE0060").WithLocation(3).WithMessage("Parameter 'p4' can be removed if it is not part of a shipped public API; its initial value is never used"),
-                    VerifyCS.Diagnostic("IDE0060").WithLocation(4).WithMessage("Parameter 'p5' can be removed; its initial value is never used"),
+                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(0).WithMessage("Remove unused parameter 'p1'"),
+                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(1).WithMessage("Parameter 'p2' can be removed; its initial value is never used"),
+                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(2).WithMessage("Remove unused parameter 'p3' if it is not part of a shipped public API"),
+                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(3).WithMessage("Parameter 'p4' can be removed if it is not part of a shipped public API; its initial value is never used"),
+                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(4).WithMessage("Parameter 'p5' can be removed; its initial value is never used"),
                 }
             }.RunAsync();
         }

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
             {
                 TestCode = source,
                 // This test is about unused parameters, so disable other diagnostics from the analyzer to not make additional noise
-                DisabledDiagnostics = { "IDE0058", "IDE0059" },
+                DisabledDiagnostics = { IDEDiagnosticIds.ExpressionValueIsUnusedDiagnosticId, IDEDiagnosticIds.ValueAssignedIsUnusedDiagnosticId },
                 LanguageVersion = LanguageVersion.Preview,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60
             }.RunAsync();
@@ -127,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                 {
                     { CSharpCodeStyleOptions.UnusedValueAssignment, UnusedValuePreference.DiscardVariable, NotificationOption2.None }
                 },
-                DisabledDiagnostics = { "IDE0059" }
+                DisabledDiagnostics = { IDEDiagnosticIds.ValueAssignedIsUnusedDiagnosticId }
             }.RunAsync();
         }
 
@@ -1153,11 +1154,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                     """,
                 ExpectedDiagnostics =
                 {
-                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(0).WithMessage("Remove unused parameter 'p1'"),
-                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(1).WithMessage("Parameter 'p2' can be removed; its initial value is never used"),
-                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(2).WithMessage("Remove unused parameter 'p3' if it is not part of a shipped public API"),
-                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(3).WithMessage("Parameter 'p4' can be removed if it is not part of a shipped public API; its initial value is never used"),
-                    VerifyCS.Diagnostic("IDE0060").WithSeverity(DiagnosticSeverity.Info).WithLocation(4).WithMessage("Parameter 'p5' can be removed; its initial value is never used"),
+                    VerifyCS.Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId).WithSeverity(DiagnosticSeverity.Info).WithLocation(0).WithMessage("Remove unused parameter 'p1'"),
+                    VerifyCS.Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId).WithSeverity(DiagnosticSeverity.Info).WithLocation(1).WithMessage("Parameter 'p2' can be removed; its initial value is never used"),
+                    VerifyCS.Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId).WithSeverity(DiagnosticSeverity.Info).WithLocation(2).WithMessage("Remove unused parameter 'p3' if it is not part of a shipped public API"),
+                    VerifyCS.Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId).WithSeverity(DiagnosticSeverity.Info).WithLocation(3).WithMessage("Parameter 'p4' can be removed if it is not part of a shipped public API; its initial value is never used"),
+                    VerifyCS.Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId).WithSeverity(DiagnosticSeverity.Info).WithLocation(4).WithMessage("Parameter 'p5' can be removed; its initial value is never used"),
                 }
             }.RunAsync();
         }
@@ -1406,7 +1407,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                 {
                     { CodeStyleOptions2.UnusedParameters, default, NotificationOption2.Suggestion }
                 },
-                DisabledDiagnostics = { "IDE0058" }
+                DisabledDiagnostics = { IDEDiagnosticIds.ExpressionValueIsUnusedDiagnosticId }
             }.RunAsync();
         }
 
@@ -1441,7 +1442,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                 {
                     { CodeStyleOptions2.UnusedParameters, (UnusedParametersPreference)2, NotificationOption2.Suggestion }
                 },
-                DisabledDiagnostics = { "IDE0058" }
+                DisabledDiagnostics = { IDEDiagnosticIds.ExpressionValueIsUnusedDiagnosticId }
             }.RunAsync();
         }
 #endif

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1502,7 +1502,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
                 """);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/57814")]
         public async Task ParameterInPartialMethodDefinition_NoDiagnostic()
         {
             await VerifyAnalyzerAsync("""

--- a/src/Compilers/Test/Core/Assert/WorkItemAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/WorkItemAttribute.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
+using System.ComponentModel;
 
 namespace Roslyn.Test.Utilities
 {
@@ -14,15 +13,9 @@ namespace Roslyn.Test.Utilities
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
     public sealed class WorkItemAttribute : Attribute
     {
-        public int Id
-        {
-            get;
-        }
+        public int Id { get; }
 
-        public string Location
-        {
-            get;
-        }
+        public string Location { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkItemAttribute"/>.
@@ -31,6 +24,7 @@ namespace Roslyn.Test.Utilities
         /// could be a GitHub issue or pull request number, or the number of a Microsoft-internal bug.</param>
         /// <param name="issueUri">The URI where the work item can be viewed. This is a link to work item
         /// <paramref name="id"/> in the original source.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public WorkItemAttribute(int id, string issueUri)
         {
             Id = id;
@@ -42,7 +36,8 @@ namespace Roslyn.Test.Utilities
         /// </summary>
         /// <param name="issueUri">The URI where the work item can be viewed. This is a link to work item in the
         /// original source.</param>
-        public WorkItemAttribute(string issueUri) : this(-1, issueUri)
+        public WorkItemAttribute(string issueUri)
+            : this(-1, issueUri)
         {
         }
     }

--- a/src/Compilers/Test/Core/Assert/WorkItemAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/WorkItemAttribute.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
-using System.ComponentModel;
 
 namespace Roslyn.Test.Utilities
 {
@@ -13,9 +14,15 @@ namespace Roslyn.Test.Utilities
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
     public sealed class WorkItemAttribute : Attribute
     {
-        public int Id { get; }
+        public int Id
+        {
+            get;
+        }
 
-        public string Location { get; }
+        public string Location
+        {
+            get;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkItemAttribute"/>.
@@ -24,7 +31,6 @@ namespace Roslyn.Test.Utilities
         /// could be a GitHub issue or pull request number, or the number of a Microsoft-internal bug.</param>
         /// <param name="issueUri">The URI where the work item can be viewed. This is a link to work item
         /// <paramref name="id"/> in the original source.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public WorkItemAttribute(int id, string issueUri)
         {
             Id = id;
@@ -36,8 +42,7 @@ namespace Roslyn.Test.Utilities
         /// </summary>
         /// <param name="issueUri">The URI where the work item can be viewed. This is a link to work item in the
         /// original source.</param>
-        public WorkItemAttribute(string issueUri)
-            : this(-1, issueUri)
+        public WorkItemAttribute(string issueUri) : this(-1, issueUri)
         {
         }
     }

--- a/src/Workspaces/Core/Portable/ExtensionOrderAttribute.cs
+++ b/src/Workspaces/Core/Portable/ExtensionOrderAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 
@@ -17,8 +15,8 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        public string After { get; set; }
+        public string? After { get; set; }
 
-        public string Before { get; set; }
+        public string? Before { get; set; }
     }
 }


### PR DESCRIPTION
- Disabled `IDE0058` and `IDE0059` in these tests since they introduce too much noise
- Fixed some compilation errors, which doesn't seem to be part of the test case
- 1 test is gone, since it is now covered by another case
- There were 2 tests like `void M(_, _)`, where in one case `M` is a method and in another - a local function. I don't understand what value these tests bring since such code is not even syntactically correct. I didn't remove them, but disabled verifying compilation errors in them to not make too much noise
- There were cases when parameter is passed into different method and the test case was to not report diagnostic there. But since the calee method wasn't doing anything with its parameter, it triggered diagnostic. In such cases I added `var x = <parameter>;` to the calee to not shift focus from the main purpose of that particular test case.
- Сompacted raw string markers
- In 2 or 3 cases there was a duplicate `Trait`, that replicated the one above the test class. Removed these duplicates
- Introduced raw strings where interpolation was involved
- In 2 last tests legacy `WorkItem` attribute constructor was used. Fixed. ~~Refactored `WorkItemAttribute` to hide this constructor overload when editing~~