### PR TITLE
[EnC] Upgrade change types for containing types

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -5103,38 +5103,33 @@ class C
                     edits: new[] {
                         // Note: Nested type edit needs to be seen first to repro the bug. Real world scenario requires the nested
                         // class to be in a separate file.
-                        Edit(SemanticEditKind.Update, c => c.GetMember("C.D")),
+                        Edit(SemanticEditKind.Update, c => c.GetMember("C.D.M")),
                         Edit(SemanticEditKind.Replace, c => null, newSymbolProvider: c => c.GetMember("C")),
                     },
                     validator: g =>
                     {
-                        g.VerifyTypeDefNames("D", "C#1");
-                        g.VerifyMethodDefNames("N", ".ctor", "M", ".ctor");
+                        g.VerifyTypeDefNames("C#1");
+                        g.VerifyMethodDefNames("M", "N", ".ctor", ".ctor");
                         g.VerifyEncLogDefinitions(new[]
                         {
-                            Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
                             Row(5, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                            Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
                             Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
                             Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default),
                             Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
                             Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                             Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
                             Row(9, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                            Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                            Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                            Row(8, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                            Row(2, TableIndex.NestedClass, EditAndContinueOperation.Default)
+                            Row(8, TableIndex.CustomAttribute, EditAndContinueOperation.Default)
                         });
                         g.VerifyEncMapDefinitions(new[]
                         {
-                            Handle(4, TableIndex.TypeDef),
                             Handle(5, TableIndex.TypeDef),
+                            Handle(5, TableIndex.MethodDef),
                             Handle(7, TableIndex.MethodDef),
                             Handle(8, TableIndex.MethodDef),
                             Handle(9, TableIndex.MethodDef),
-                            Handle(10, TableIndex.MethodDef),
-                            Handle(8, TableIndex.CustomAttribute),
-                            Handle(2, TableIndex.NestedClass)
+                            Handle(8, TableIndex.CustomAttribute)
                         });
                     })
                 .Verify();

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -494,7 +494,17 @@ namespace Microsoft.CodeAnalysis.Emit
                 }
 
                 AddContainingTypesAndNamespaces(changesBuilder, member);
-                changesBuilder.Add(member, change);
+
+                // If we saw an edit for a symbol that is a nested type of this symbol, we might already have a dictionary entry
+                // for it, flagging that it contains changes. If so we "upgrade" the change to the real one.
+                if (changesBuilder.TryGetValue(member, out var existingChange) && existingChange == SymbolChange.ContainsChanges)
+                {
+                    changesBuilder[member] = change;
+                }
+                else
+                {
+                    changesBuilder.Add(member, change);
+                }
             }
 
             changes = changesBuilder;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -499,6 +499,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 // for it, flagging that it contains changes. If so we "upgrade" the change to the real one.
                 if (changesBuilder.TryGetValue(member, out var existingChange) && existingChange == SymbolChange.ContainsChanges)
                 {
+                    Debug.Assert(member is INamedTypeSymbol);
                     changesBuilder[member] = change;
                 }
                 else

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -4909,7 +4909,7 @@ record C(int X)
         #region Nested Types
 
         [Fact]
-        public void NestedType_Replace_WithUpdateInNestedType_Partial_DiffertDocument()
+        public void NestedType_Replace_WithUpdateInNestedType_Partial_DifferentDocument()
         {
             var srcA1 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]partial class C { int N() => 1; }";
             var srcB1 = "partial class C { class D { int M() => 1; } }";

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -4909,6 +4909,87 @@ record C(int X)
         #region Nested Types
 
         [Fact]
+        public void NestedType_Replace_WithUpdateInNestedType_Partial_DiffertDocument()
+        {
+            var srcA1 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]partial class C { int N() => 1; }";
+            var srcB1 = "partial class C { class D { int M() => 1; } }";
+            var srcA2 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]partial class C { int N() => 2; }";
+            var srcB2 = "partial class C { class D { int M() => 2; } }";
+
+            var editsA = GetTopEdits(srcA1, srcA2);
+            var editsB = GetTopEdits(srcB1, srcB2);
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { editsA, editsB },
+                new[]
+                {
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Replace, c => c.GetMember("C"), partialType: "C")
+                    }),
+                    DocumentResults(semanticEdits: new[]
+                    {
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.D.M"))
+                    })
+                },
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+        }
+
+        [Fact]
+        public void NestedType_Replace_WithUpdateInNestedType_Partial_SameDocument()
+        {
+            var src1 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]partial class C { int N() => 1; } partial class C { class D { int M() => 1; } }";
+            var src2 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]partial class C { int N() => 2; } partial class C { class D { int M() => 2; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            EditAndContinueValidation.VerifySemantics(
+                edits,
+                semanticEdits: new[]
+                {
+                    SemanticEdit(SemanticEditKind.Replace, c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.D.M"))
+                },
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+        }
+
+        [Fact]
+        public void NestedType_Replace_WithUpdateInNestedType()
+        {
+            var src1 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]class C { int N() => 1; class D { int M() => 1; } }";
+            var src2 = ReloadableAttributeSrc + "[CreateNewOnMetadataUpdate]class C { int N() => 2; class D { int M() => 2; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            EditAndContinueValidation.VerifySemantics(
+                edits,
+                semanticEdits: new[]
+                {
+                    SemanticEdit(SemanticEditKind.Replace, c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.D.M"))
+                },
+                capabilities: EditAndContinueCapabilities.NewTypeDefinition);
+        }
+
+        [Fact]
+        public void NestedType_Update_WithUpdateInNestedType()
+        {
+            var src1 = @"[System.Obsolete(""A"")]class C { int N() => 1; class D { int M() => 1; } }";
+            var src2 = @"[System.Obsolete(""B"")]class C { int N() => 1; class D { int M() => 2; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            EditAndContinueValidation.VerifySemantics(
+                edits,
+                semanticEdits: new[]
+                {
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.D.M"))
+                },
+                capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
+        }
+
+        [Fact]
         public void NestedType_Move_Sideways()
         {
             var src1 = @"class N { class C {} } class M {            }";


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68335

Minimal repo:

A.cs:
```cs
internal partial class C
{
    public void M()
    {
        Console.WriteLine("C.M");
    }
}
```

B.cs:
```cs
[CreateNewOnMetadataUpdate]
internal partial class C
{
    public class A
    {
        public void M()
        {
            Console.WriteLine("C.A.M25");
        }
    }
}
```