### PR TITLE
Don't bind named members on missing attribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -507,8 +507,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (attributeType.IsErrorType())
             {
                 var badLHS = BadExpression(nameSyntax, lookupResultKind: LookupResultKind.Empty);
-                var badRHS = this.BindValue(namedArgument.Expression, diagnostics, BindValueKind.RValue);
-                return new BoundAssignmentOperator(namedArgument, badLHS, badRHS, CreateErrorType());
+                var rhs = BindRValueWithoutTargetType(namedArgument.Expression, diagnostics);
+                return new BoundAssignmentOperator(namedArgument, badLHS, rhs, CreateErrorType());
             }
 
             bool wasError;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -503,11 +503,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             bool wasError;
             LookupResultKind resultKind;
-            Symbol namedArgumentNameSymbol = BindNamedAttributeArgumentName(namedArgument, attributeType, diagnostics, out wasError, out resultKind);
+            Symbol? namedArgumentNameSymbol;
 
-            ReportDiagnosticsIfObsolete(diagnostics, namedArgumentNameSymbol, namedArgument, hasBaseReceiver: false);
+            if (attributeType.IsErrorType())
+            {
+                namedArgumentNameSymbol = null;
+                wasError = true;
+                resultKind = LookupResultKind.Empty;
+            }
+            else
+            {
+                namedArgumentNameSymbol = BindNamedAttributeArgumentName(namedArgument, attributeType, diagnostics, out wasError, out resultKind);
+                ReportDiagnosticsIfObsolete(diagnostics, namedArgumentNameSymbol, namedArgument, hasBaseReceiver: false);
+            }
 
-            if (namedArgumentNameSymbol.Kind == SymbolKind.Property)
+            if (namedArgumentNameSymbol?.Kind == SymbolKind.Property)
             {
                 var propertySymbol = (PropertySymbol)namedArgumentNameSymbol;
                 var setMethod = propertySymbol.GetOwnOrInheritedSetMethod();
@@ -532,6 +542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                Debug.Assert(namedArgumentNameSymbol is not null);
                 namedArgumentType = BindNamedAttributeArgumentType(namedArgument, namedArgumentNameSymbol, attributeType, diagnostics);
             }
 

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -11295,18 +11295,53 @@ class A<T> : System.Attribute
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68370")]
         public void AvoidCascadingDiagnosticsOnMissingAttribute()
         {
-            var source = @"
-[assembly: Inexistent(SomeProperty = 1, F = null)]
-";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (2,12): error CS0246: The type or namespace name 'InexistentAttribute' could not be found (are you missing a using directive or an assembly reference?)
-                // [assembly: Inexistent(SomeProperty = 1, F = null)]
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("InexistentAttribute").WithLocation(2, 12),
-                // (2,12): error CS0246: The type or namespace name 'Inexistent' could not be found (are you missing a using directive or an assembly reference?)
-                // [assembly: Inexistent(SomeProperty = 1, F = null)]
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("Inexistent").WithLocation(2, 12)
-                );
+            var source = """
+[assembly: /*<bind>*/Inexistent(SomeProperty = 1, F = null, G = 0 switch { _ => 1 })/*</bind>*/]
+""";
+
+            string expectedOperationTree = """
+IAttributeOperation (OperationKind.Attribute, Type: null, IsInvalid) (Syntax: 'Inexistent( ... { _ => 1 })')
+  IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'Inexistent( ... { _ => 1 })')
+    Children(3):
+        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?) (Syntax: 'SomeProperty = 1')
+          Left:
+            IInvalidOperation (OperationKind.Invalid, Type: ?) (Syntax: 'SomeProperty')
+              Children(0)
+          Right:
+            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?) (Syntax: 'F = null')
+          Left:
+            IInvalidOperation (OperationKind.Invalid, Type: ?) (Syntax: 'F')
+              Children(0)
+          Right:
+            ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
+        ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?) (Syntax: 'G = 0 switch { _ => 1 }')
+          Left:
+            IInvalidOperation (OperationKind.Invalid, Type: ?) (Syntax: 'G')
+              Children(0)
+          Right:
+            ISwitchExpressionOperation (1 arms, IsExhaustive: True) (OperationKind.SwitchExpression, Type: System.Int32) (Syntax: '0 switch { _ => 1 }')
+              Value:
+                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+              Arms(1):
+                  ISwitchExpressionArmOperation (0 locals) (OperationKind.SwitchExpressionArm, Type: null) (Syntax: '_ => 1')
+                    Pattern:
+                      IDiscardPatternOperation (OperationKind.DiscardPattern, Type: null) (Syntax: '_') (InputType: System.Int32, NarrowedType: System.Int32)
+                    Value:
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+
+""";
+            var expectedDiagnostics = new[]
+            {
+                // (1,22): error CS0246: The type or namespace name 'InexistentAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // [assembly: /*<bind>*/Inexistent(SomeProperty = 1, F = null, G = 0 switch { _ => 1 })/*</bind>*/]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("InexistentAttribute").WithLocation(1, 22),
+                // (1,22): error CS0246: The type or namespace name 'Inexistent' could not be found (are you missing a using directive or an assembly reference?)
+                // [assembly: /*<bind>*/Inexistent(SomeProperty = 1, F = null, G = 0 switch { _ => 1 })/*</bind>*/]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("Inexistent").WithLocation(1, 22)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<AttributeSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
         #endregion
     }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -11291,6 +11291,23 @@ class A<T> : System.Attribute
                 // [A<int*[]>] // 1
                 Diagnostic(ErrorCode.ERR_UnsafeNeeded, "int*").WithLocation(2, 4));
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68370")]
+        public void AvoidCascadingDiagnosticsOnMissingAttribute()
+        {
+            var source = @"
+[assembly: Inexistent(SomeProperty = 1, F = null)]
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,12): error CS0246: The type or namespace name 'InexistentAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // [assembly: Inexistent(SomeProperty = 1, F = null)]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("InexistentAttribute").WithLocation(2, 12),
+                // (2,12): error CS0246: The type or namespace name 'Inexistent' could not be found (are you missing a using directive or an assembly reference?)
+                // [assembly: Inexistent(SomeProperty = 1, F = null)]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Inexistent").WithArguments("Inexistent").WithLocation(2, 12)
+                );
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Small fix to remove some unhelpful cascading diagnostics.
Fixes https://github.com/dotnet/roslyn/issues/68370