### PR TITLE
Fix issues with pkgdef generation

### DIFF
--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -145,7 +145,8 @@
     Populates PkgDefBindingRedirect and PkgDefCodeBase items from references.
   -->
   <Target Name="_AddPkgDefEntriesFromReferences"
-          BeforeTargets="AfterResolveReferences;GeneratePkgDef">
+          BeforeTargets="GeneratePkgDef"
+          DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <PkgDefBindingRedirect Include="@(ReferencePath)" Condition="'%(ReferencePath.PkgDefEntry)' == 'BindingRedirect'" />
       <PkgDefCodeBase Include="@(ReferencePath)" Condition="'%(ReferencePath.PkgDefEntry)' == 'CodeBase'" />

--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -155,7 +155,7 @@
   <!--
     Generates a .pkgdef file based on items in PkgDef* groups.
   -->
-  <Target Name="GeneratePkgDef"          
+  <Target Name="GeneratePkgDef"
           DependsOnTargets="$(GeneratePkgDefDependsOn);_SetGeneratePkgDefInputsOutputs"
           Inputs="$(MSBuildAllProjects);@(PkgDefFileContent)"
           Outputs="$(_GeneratePkgDefOutputFile)">


### PR DESCRIPTION
@CyrusNajmabadi has been running into an intermittent issue where sometimes his pkgdefs are missing the binding redirects for Roslyn assemblies; this means Roslyn won't actually load. We don't have a perfect analysis of what's going wrong, but we've discovered:

1. Clean builds generally work fine.
2. Incremental builds would sometimes skip generating the pkgdef, and at that point the pkgdef was incorrect on disk and was missing redireects.
3. Closing VS once helped.

My hunch is due to bad targets scheduling and bad input/output specifications, we're seeing cases where we are sometimes running the pkgdef generation before we ran reference resolution, and then that got "sticky" since the files were up to date.

I sent @CyrusNajmabadi a targets file to work with that really forced the pkgdef generation to always run and run completely, and that seemed to help. This PR is me trying to be a bit less aggressive and more "correct" with the targets. I'm going to have @CyrusNajmabadi run with this for a bit and we'll see if this helps.