### PR TITLE
Package Microsoft.CodeAnalysis.Test.Utilities for razor

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -19,7 +19,7 @@
       "Microsoft.CodeAnalysis.CSharp.Features": "arcade",
       "Microsoft.CodeAnalysis.CSharp.Scripting": "arcade",
       "Microsoft.CodeAnalysis.CSharp.Workspaces": "vssdk",
-      "Microsoft.CodeAnalysis.Test.Utilities": "arcade",
+      "Microsoft.CodeAnalysis.Test.Utilities": "vs-impl",
       "Microsoft.CodeAnalysis.VisualBasic": "vssdk",
       "Microsoft.CodeAnalysis.VisualBasic.CodeStyle": "arcade",
       "Microsoft.CodeAnalysis.VisualBasic.Features": "arcade",

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -19,6 +19,7 @@
       "Microsoft.CodeAnalysis.CSharp.Features": "arcade",
       "Microsoft.CodeAnalysis.CSharp.Scripting": "arcade",
       "Microsoft.CodeAnalysis.CSharp.Workspaces": "vssdk",
+      "Microsoft.CodeAnalysis.Test.Utilities": "arcade",
       "Microsoft.CodeAnalysis.VisualBasic": "vssdk",
       "Microsoft.CodeAnalysis.VisualBasic.CodeStyle": "arcade",
       "Microsoft.CodeAnalysis.VisualBasic.Features": "arcade",

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <IsShipping>false</IsShipping>
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.CodeAnalysis.Test.Utilities</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Test\Resources\Core\Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj" />

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -8,6 +8,7 @@
     <IsShipping>false</IsShipping>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.Test.Utilities</PackageId>
+   <PackageDescription>This is an internal package for testing. Not meant for external or production uses. The API can and will break at our discretion.</PackageDescription>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Test\Resources\Core\Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj" />


### PR DESCRIPTION
We keep copying utilities out of here into razor. Rather than duplicating all of this code, we'll publish a package on an internal feed for razor's tests to consume. This package will not be published on non-internal feeds.
