### PR TITLE
Fix LSIF indexing handling of duplicate analyzer references

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/CommandLineProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/CommandLineProject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -23,12 +21,12 @@ namespace Microsoft.CodeAnalysis
         /// Create a <see cref="ProjectInfo"/> structure initialized from a compilers command line arguments.
         /// </summary>
 #pragma warning disable RS0026 // Type is forwarded from MS.CA.Workspaces.Desktop.
-        public static ProjectInfo CreateProjectInfo(string projectName, string language, IEnumerable<string> commandLineArgs, string projectDirectory, Workspace workspace = null)
+        public static ProjectInfo CreateProjectInfo(string projectName, string language, IEnumerable<string> commandLineArgs, string projectDirectory, Workspace? workspace = null)
 #pragma warning restore RS0026 // Type is forwarded from MS.CA.Workspaces.Desktop.
         {
             // TODO (tomat): the method may throw all sorts of exceptions.
-            var tmpWorkspace = workspace ?? new AdhocWorkspace();
-            var languageServices = tmpWorkspace.Services.SolutionServices.GetLanguageServices(language);
+            workspace ??= new AdhocWorkspace();
+            var languageServices = workspace.Services.SolutionServices.GetLanguageServices(language);
             if (languageServices == null)
             {
                 throw new ArgumentException(WorkspacesResources.Unrecognized_language_name);
@@ -202,7 +200,7 @@ namespace Microsoft.CodeAnalysis
         /// Create a <see cref="ProjectInfo"/> structure initialized with data from a compiler command line.
         /// </summary>
 #pragma warning disable RS0026 // Type is forwarded from MS.CA.Workspaces.Desktop.
-        public static ProjectInfo CreateProjectInfo(string projectName, string language, string commandLine, string baseDirectory, Workspace workspace = null)
+        public static ProjectInfo CreateProjectInfo(string projectName, string language, string commandLine, string baseDirectory, Workspace? workspace = null)
 #pragma warning restore RS0026 // Type is forwarded from MS.CA.Workspaces.Desktop.
         {
             var args = CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: true);

--- a/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
+++ b/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
@@ -130,6 +130,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestAnalyzerConfigFiles()
+        {
+            var commandLine = @"/analyzerconfig:.editorconfig";
+            var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, @"C:\ProjectDirectory");
+
+            var document = Assert.Single(info.AnalyzerConfigDocuments);
+            Assert.Equal(".editorconfig", document.Name);
+            Assert.Equal(Path.Combine(@"C:\ProjectDirectory", ".editorconfig"), document.FilePath);
+        }
+
+        [Fact]
         public void TestAnalyzerReferences()
         {
             var pathToAssembly = typeof(object).Assembly.Location;


### PR DESCRIPTION
The LSIF tool supports many types of inputs, but two in particular:

1. A JSON file that contains the command line arguments passed to the compiler.
2. A binlog which will be searched for invocations.

When the binlog support was implemented, it called into the implementation for JSON files to do the heavy lifting of actually parsing the command line. But oddly, that code somewhat reinvented the implementation of our CommandLineProject type, so it could also support some specific path mapping logic. Unfortunately implementation for JSON inputs has a bunch of bugs that don't exist in the CommandLineProject code. Specifically, duplicate analyzer references are not correctly handled which triggered this investigation.

In this commit, I'm fixing some bugs in CommandLineProject and then making the binlog code just directly call into CommandLineProject which removes the buggy code for processing JSON inputs from the binlog path. As a follow up, we should either also move the JSON input handling to CommandLineProject after adding path mapping support to it, or just deprecate that support entirely.