### PR TITLE
Fix indentation behavior of convert to block-body namespace

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceCodeFixProvider.cs
@@ -11,21 +11,15 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
 {
-    using static ConvertNamespaceAnalysis;
-    using static ConvertNamespaceTransform;
-
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.ConvertNamespace), Shared]
     internal class ConvertNamespaceCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
@@ -41,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
         {
             var diagnostic = context.Diagnostics.First();
 
-            var (title, equivalenceKey) = GetInfo(
+            var (title, equivalenceKey) = ConvertNamespaceAnalysis.GetInfo(
                 diagnostic.Id switch
                 {
                     IDEDiagnosticIds.UseBlockScopedNamespaceDiagnosticId => NamespaceDeclarationPreference.BlockScoped,
@@ -65,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             var namespaceDecl = (BaseNamespaceDeclarationSyntax)diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
 
             var options = await document.GetCSharpCodeFixOptionsProviderAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var converted = await ConvertAsync(document, namespaceDecl, options.GetFormattingOptions(), cancellationToken).ConfigureAwait(false);
+            var converted = await ConvertNamespaceTransform.ConvertAsync(document, namespaceDecl, options.GetFormattingOptions(), cancellationToken).ConfigureAwait(false);
 
             editor.ReplaceNode(
                 editor.OriginalRoot,

--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             var openBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.OpenBraceToken.SpanStart).LineNumber;
             var closeBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.CloseBraceToken.SpanStart).LineNumber;
 
-            using var _ = ArrayBuilder<TextChange>.GetInstance(out var changes);
+            using var _ = ArrayBuilder<TextChange>.GetInstance(Math.Max(0, closeBraceLine - openBraceLine - 1), out var changes);
             for (var line = openBraceLine + 1; line < closeBraceLine; line++)
                 changes.AddIfNotNull(TryIndentLine(syntaxTree, root, indentation, text.Lines[line], cancellationToken));
 
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 .WithAppendedTrailingTrivia(newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes) ? SyntaxFactory.EndOfLine(lineEnding) : SyntaxFactory.Space);
             var openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
 
-            if (openBraceToken.TrailingTrivia is not [.., { RawKind: (int)SyntaxKind.EndOfLineTrivia }])
+            if (openBraceToken.TrailingTrivia is not [.., SyntaxTrivia(SyntaxKind.EndOfLineTrivia)])
             {
                 openBraceToken = openBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
             }

--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -175,8 +175,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 return null;
 
             // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
-            // touch what is inside there.  Note: this will not apply to raw-string literals, which can potentially be
-            // dedented safely depending on the position of their close terminator.
+            // touch what is inside there.  Note: this will not apply to raw-string literals, which can be indented
+            // safely.
             if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, cancellationToken))
                 return null;
 
@@ -339,18 +339,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
 
         private static NamespaceDeclarationSyntax ConvertFileScopedNamespace(ParsedDocument document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, string lineEnding, NewLinePlacement newLinePlacement)
         {
-            var nameSyntax = fileScopedNamespace.Name.WithAppendedTrailingTrivia(fileScopedNamespace.SemicolonToken.LeadingTrivia);
-            SyntaxToken openBraceToken;
-            if (newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes))
-            {
-                nameSyntax = nameSyntax.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
-                openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
-            }
-            else
-            {
-                nameSyntax = nameSyntax.WithAppendedTrailingTrivia(SyntaxFactory.Space);
-                openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
-            }
+            var nameSyntax = fileScopedNamespace.Name.WithAppendedTrailingTrivia(fileScopedNamespace.SemicolonToken.LeadingTrivia)
+                .WithAppendedTrailingTrivia(newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes) ? SyntaxFactory.EndOfLine(lineEnding) : SyntaxFactory.Space);
+            var openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
 
             if (openBraceToken.TrailingTrivia is not [.., { RawKind: (int)SyntaxKind.EndOfLineTrivia }])
             {

--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -3,21 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO.Pipes;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Indentation;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -27,12 +20,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
 {
     internal static class ConvertNamespaceTransform
     {
-        public static async Task<Document> ConvertAsync(Document document, BaseNamespaceDeclarationSyntax baseNamespace, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public static async Task<Document> ConvertAsync(Document document, BaseNamespaceDeclarationSyntax baseNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
         {
             switch (baseNamespace)
             {
                 case FileScopedNamespaceDeclarationSyntax fileScopedNamespace:
-                    return await ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, cancellationToken).ConfigureAwait(false);
+                    return await ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, options, cancellationToken).ConfigureAwait(false);
 
                 case NamespaceDeclarationSyntax namespaceDeclaration:
                     return await ConvertNamespaceDeclarationAsync(document, namespaceDeclaration, options, cancellationToken).ConfigureAwait(false);
@@ -156,11 +149,112 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             return new TextChange(new TextSpan(textLine.Start, commonIndentation), newText: "");
         }
 
-        public static async Task<Document> ConvertFileScopedNamespaceAsync(
-            Document document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, CancellationToken cancellationToken)
+        private static SourceText IndentNamespace(
+            ParsedDocument document, string indentation, SyntaxAnnotation annotation, CancellationToken cancellationToken)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            return document.WithSyntaxRoot(root.ReplaceNode(fileScopedNamespace, ConvertFileScopedNamespace(fileScopedNamespace)));
+            var syntaxTree = document.SyntaxTree;
+            var text = document.Text;
+            var root = document.Root;
+
+            var blockScopedNamespace = (NamespaceDeclarationSyntax)root.GetAnnotatedNodes(annotation).Single();
+            var openBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.OpenBraceToken.SpanStart).LineNumber;
+            var closeBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.CloseBraceToken.SpanStart).LineNumber;
+
+            using var _ = ArrayBuilder<TextChange>.GetInstance(out var changes);
+            for (var line = openBraceLine + 1; line < closeBraceLine; line++)
+                changes.AddIfNotNull(TryIndentLine(syntaxTree, root, indentation, text.Lines[line], cancellationToken));
+
+            var dedentedText = text.WithChanges(changes);
+            return dedentedText;
+        }
+
+        private static TextChange? TryIndentLine(
+            SyntaxTree tree, SyntaxNode root, string indentation, TextLine textLine, CancellationToken cancellationToken)
+        {
+            if (textLine.IsEmptyOrWhitespace())
+                return null;
+
+            // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
+            // touch what is inside there.  Note: this will not apply to raw-string literals, which can potentially be
+            // dedented safely depending on the position of their close terminator.
+            if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, cancellationToken))
+                return null;
+
+            if (textLine.Text![textLine.Start] == '#')
+            {
+                var token = root.FindToken(textLine.Start, findInsideTrivia: true);
+                if (token.IsKind(SyntaxKind.HashToken) && token.Parent!.Kind() is not (SyntaxKind.RegionDirectiveTrivia or SyntaxKind.EndRegionDirectiveTrivia))
+                {
+                    // only #region and #endregion get indented
+                    return null;
+                }
+            }
+
+            return new TextChange(new TextSpan(textLine.Start, 0), newText: indentation);
+        }
+
+        public static async Task<Document> ConvertFileScopedNamespaceAsync(
+            Document document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
+        {
+            var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+            // Replace the block namespace with the file scoped namespace.
+            var annotation = new SyntaxAnnotation();
+            var updatedRoot = ReplaceWithBlockScopedNamespace(parsedDocument, fileScopedNamespace, options.NewLine, options.NewLines, annotation);
+            var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+
+            // Auto-formatting options are not relevant since they only control behavior on typing.
+            var indentation = FormattingExtensions.CreateIndentationString(options.IndentationSize, options.UseTabs, options.TabSize);
+            if (indentation == "")
+                return updatedDocument;
+
+            // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
+            var updatedParsedDocument = await ParsedDocument.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
+            var indentedText = IndentNamespace(updatedParsedDocument, indentation, annotation, cancellationToken);
+            return document.WithText(indentedText);
+        }
+
+        private static SyntaxNode ReplaceWithBlockScopedNamespace(
+            ParsedDocument document, FileScopedNamespaceDeclarationSyntax namespaceDeclaration, string lineEnding, NewLinePlacement newLinePlacement, SyntaxAnnotation annotation)
+        {
+            var converted = ConvertFileScopedNamespace(document, namespaceDeclaration, lineEnding, newLinePlacement);
+
+            // If the leading trivia of the token after the end of the file scoped namespace spans multiple lines, make
+            // sure all the lines preceding the line with the next token are placed inside the block body namespace.
+            var tokenAfterNamespace = namespaceDeclaration.GetLastToken(includeZeroWidth: true, includeSkipped: true).GetNextTokenOrEndOfFile(includeZeroWidth: true, includeSkipped: true);
+            var lineWithNextToken = document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart);
+            var (splitPosition, needsAdditionalLineEnding) = lineWithNextToken.GetFirstNonWhitespacePosition() < tokenAfterNamespace.SpanStart
+                ? (tokenAfterNamespace.SpanStart, true)
+                : (document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart).Start, false);
+            var triviaBeforeSplit = tokenAfterNamespace.LeadingTrivia.TakeWhile(trivia => trivia.SpanStart < splitPosition).ToArray();
+            var triviaAfterSplit = tokenAfterNamespace.LeadingTrivia.Skip(triviaBeforeSplit.Length).ToArray();
+
+            if (triviaBeforeSplit.Length > 0)
+            {
+                if (needsAdditionalLineEnding)
+                    triviaBeforeSplit = triviaBeforeSplit.Append(SyntaxFactory.EndOfLine(lineEnding));
+
+                converted = converted.WithCloseBraceToken(converted.CloseBraceToken.WithPrependedLeadingTrivia(triviaBeforeSplit));
+            }
+
+            // If the block namespace starts with a blank line, remove one blank line as an adjustment relative to the
+            // file scoped namespace. This check is performed here to account for cases where the token after the
+            // opening brace is the closing brace token, and the leading newline for the closing brace token was
+            // introduced by the trivia relocation above.
+            var firstBodyToken = converted.OpenBraceToken.GetNextToken(includeZeroWidth: true, includeSkipped: true);
+            if (firstBodyToken.Kind() != SyntaxKind.EndOfFileToken
+                && HasLeadingBlankLine(firstBodyToken, out var firstBodyTokenWithoutBlankLine))
+            {
+                converted = converted.ReplaceToken(firstBodyToken, firstBodyTokenWithoutBlankLine);
+            }
+
+            return document.Root.ReplaceSyntax(
+                new SyntaxNode[] { namespaceDeclaration },
+                (_, _) => converted.WithAdditionalAnnotations(annotation),
+                new SyntaxToken[] { tokenAfterNamespace },
+                (_, _) => tokenAfterNamespace.WithLeadingTrivia(triviaAfterSplit),
+                Array.Empty<SyntaxTrivia>(),
+                (_, _) => throw ExceptionUtilities.Unreachable());
         }
 
         private static bool HasLeadingBlankLine(
@@ -243,28 +337,68 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             return fileScopedNamespace;
         }
 
-        private static NamespaceDeclarationSyntax ConvertFileScopedNamespace(FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
+        private static NamespaceDeclarationSyntax ConvertFileScopedNamespace(ParsedDocument document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, string lineEnding, NewLinePlacement newLinePlacement)
         {
-            var namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
-                fileScopedNamespace.AttributeLists,
-                fileScopedNamespace.Modifiers,
-                fileScopedNamespace.NamespaceKeyword,
-                fileScopedNamespace.Name,
-                SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia),
-                fileScopedNamespace.Externs,
-                fileScopedNamespace.Usings,
-                fileScopedNamespace.Members,
-                SyntaxFactory.Token(SyntaxKind.CloseBraceToken),
-                semicolonToken: default).WithAdditionalAnnotations(Formatter.Annotation);
-
-            // Ensure there is no errant blank line between the open curly and the first body element.
-            var firstBodyToken = namespaceDeclaration.OpenBraceToken.GetNextToken();
-            if (firstBodyToken != namespaceDeclaration.CloseBraceToken &&
-                firstBodyToken.Kind() != SyntaxKind.EndOfFileToken &&
-                HasLeadingBlankLine(firstBodyToken, out var firstBodyTokenWithoutBlankLine))
+            var nameSyntax = fileScopedNamespace.Name.WithAppendedTrailingTrivia(fileScopedNamespace.SemicolonToken.LeadingTrivia);
+            SyntaxToken openBraceToken;
+            if (newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes))
             {
-                namespaceDeclaration = namespaceDeclaration.ReplaceToken(firstBodyToken, firstBodyTokenWithoutBlankLine);
+                nameSyntax = nameSyntax.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
+                openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
             }
+            else
+            {
+                nameSyntax = nameSyntax.WithAppendedTrailingTrivia(SyntaxFactory.Space);
+                openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
+            }
+
+            if (openBraceToken.TrailingTrivia is not [.., { RawKind: (int)SyntaxKind.EndOfLineTrivia }])
+            {
+                openBraceToken = openBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
+            }
+
+            FileScopedNamespaceDeclarationSyntax adjustedFileScopedNamespace;
+            var closeBraceToken = SyntaxFactory.Token(SyntaxKind.CloseBraceToken).WithoutLeadingTrivia().WithoutTrailingTrivia();
+
+            // Normally the block scoped namespace will have a newline after the closing brace. The only exception to
+            // this occurs when there are no tokens after the closing brace and the document with a file scoped
+            // namespace did not end in a trailing newline. For this case, we want the converted block scope namespace
+            // to also terminate without a final newline.
+            if (!fileScopedNamespace.GetLastToken().GetNextTokenOrEndOfFile().IsKind(SyntaxKind.EndOfFileToken)
+                || document.Text.Lines.GetLinePosition(document.Text.Length).Character == 0)
+            {
+                closeBraceToken = closeBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
+                adjustedFileScopedNamespace = fileScopedNamespace;
+            }
+            else
+            {
+                // Make sure the body of the file scoped namespace ends with a trailing new line (so the closing brace
+                // of the converted block-body namespace appears on its own line), but don't add a new line after the
+                // closing brace.
+                adjustedFileScopedNamespace = fileScopedNamespace.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
+            }
+
+            // If the file scoped namespace is indented, also indent the newly added braces to match
+            var outerIndentation = document.Text.GetLeadingWhitespaceOfLineAtPosition(fileScopedNamespace.SpanStart);
+            if (outerIndentation.Length > 0)
+            {
+                if (newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes))
+                    openBraceToken = openBraceToken.WithLeadingTrivia(openBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
+
+                closeBraceToken = closeBraceToken.WithLeadingTrivia(closeBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
+            }
+
+            var namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
+                adjustedFileScopedNamespace.AttributeLists,
+                adjustedFileScopedNamespace.Modifiers,
+                adjustedFileScopedNamespace.NamespaceKeyword,
+                nameSyntax,
+                openBraceToken,
+                adjustedFileScopedNamespace.Externs,
+                adjustedFileScopedNamespace.Usings,
+                adjustedFileScopedNamespace.Members,
+                closeBraceToken,
+                semicolonToken: default);
 
             return namespaceDeclaration;
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -104,7 +104,8 @@ namespace Goo
     internal class C
     {
     }
-}",
+}
+",
             options: new OptionsCollection(LanguageNames.CSharp)
             {
                 { CSharpCodeStyleOptions.NamespaceDeclarations, new CodeStyleOption2<NamespaceDeclarationPreference>(NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Error) }

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -18,6 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 {
     public class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumentFormattingServiceTests
     {
+        public static IEnumerable<object[]> EndOfDocumentSequences
+        {
+            get
+            {
+                yield return new object[] { "" };
+                yield return new object[] { "\r\n" };
+            }
+        }
+
         protected override string Language => LanguageNames.CSharp;
         protected override TestWorkspace CreateTestWorkspace(string testCode, ParseOptions? parseOptions)
             => TestWorkspace.CreateCSharp(testCode, parseOptions);
@@ -88,24 +98,23 @@ namespace Goo
                 parseOptions: new CSharpParseOptions(LanguageVersion.CSharp9));
         }
 
-        [Fact]
-        public async Task TestBlockScopedNamespaces()
+        [Theory]
+        [MemberData(nameof(EndOfDocumentSequences))]
+        public async Task TestBlockScopedNamespaces(string endOfDocumentSequence)
         {
-            await TestAsync(testCode: @"
+            await TestAsync(testCode: $@"
 namespace Goo;
 
 internal class C
-{
-}
-",
-            expected: @"
+{{
+}}{endOfDocumentSequence}",
+            expected: $@"
 namespace Goo
-{
+{{
     internal class C
-    {
-    }
-}
-",
+    {{
+    }}
+}}{endOfDocumentSequence}",
             options: new OptionsCollection(LanguageNames.CSharp)
             {
                 { CSharpCodeStyleOptions.NamespaceDeclarations, new CodeStyleOption2<NamespaceDeclarationPreference>(NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Error) }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 }
                 else
                 {
-                    Assert.Equal(expected, actual);
+                    AssertEx.EqualOrDiff(expected, actual);
                 }
             }
         }

--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_TopLevelStatements.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -11,6 +10,7 @@ using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -52,16 +52,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertProgram
 
             // if we have a file scoped namespace after converting to top-level-statements, then convert it to a
             // block-namespace.  Top level statements and file-scoped-namespaces are not allowed together.
-            document = await ConvertFileScopedNamespaceAsync(document, cancellationToken).ConfigureAwait(false);
+            document = await ConvertFileScopedNamespaceAsync(document, cleanupOptions, cancellationToken).ConfigureAwait(false);
 
             return document;
         }
 
-        private static async Task<Document> ConvertFileScopedNamespaceAsync(Document document, CancellationToken cancellationToken)
+        private static async Task<Document> ConvertFileScopedNamespaceAsync(Document document, CodeCleanupOptions cleanupOptions, CancellationToken cancellationToken)
         {
             var root = (CompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             return root.Members.OfType<FileScopedNamespaceDeclarationSyntax>().FirstOrDefault() is { } fileScopedNamespace
-                ? await ConvertNamespaceTransform.ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, cancellationToken).ConfigureAwait(false)
+                ? await ConvertNamespaceTransform.ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, (CSharpSyntaxFormattingOptions)cleanupOptions.FormattingOptions, cancellationToken).ConfigureAwait(false)
                 : document;
         }
 

--- a/src/Features/CSharp/Portable/Formatting/CSharpNamespaceDeclarationNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpNamespaceDeclarationNewDocumentFormattingProvider.cs
@@ -10,13 +10,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
@@ -40,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (namespaces.Count != 1)
                 return document;
 
-            return await ConvertNamespaceTransform.ConvertAsync(document, namespaces[0], options.FormattingOptions, cancellationToken).ConfigureAwait(false);
+            return await ConvertNamespaceTransform.ConvertAsync(document, namespaces[0], formattingOptions, cancellationToken).ConfigureAwait(false);
         }
 
         private static IEnumerable<BaseNamespaceDeclarationSyntax> GetNamespacesToReplace(Document document, CompilationUnitSyntax root, CodeStyleOption2<NamespaceDeclarationPreference> option)

--- a/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringFixAllTests.cs
+++ b/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringFixAllTests.cs
@@ -203,17 +203,19 @@ namespace N6;
         <Document>
 namespace N1
 {
-}</Document>
+}        </Document>
         <Document>
 namespace N2
 {
     class C { }
-}</Document>
+
+}        </Document>
         <Document>
 namespace N3.N4
 {
     class C2 { }
-}</Document>
+
+}        </Document>
         <Document>
 namespace N5
 {
@@ -266,17 +268,19 @@ namespace N6;
         <Document>
 namespace N1
 {
-}</Document>
+}        </Document>
         <Document>
 namespace N2
 {
     class C { }
-}</Document>
+
+}        </Document>
         <Document>
 namespace N3.N4
 {
     class C2 { }
-}</Document>
+
+}        </Document>
         <Document>
 namespace N5
 {
@@ -287,7 +291,7 @@ namespace N5
         <Document>
 namespace N6
 {
-}</Document>
+}        </Document>
     </Project>
 </Workspace>
 ", new TestParameters(options: PreferFileScopedNamespace));

--- a/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
 
     public class ConvertNamespaceRefactoringTests
     {
+        public static IEnumerable<object[]> EndOfDocumentSequences
+        {
+            get
+            {
+                yield return new object[] { "" };
+                yield return new object[] { "\r\n" };
+            }
+        }
+
         #region Convert To File Scoped
 
         [Fact]
@@ -597,19 +607,18 @@ public class C
 
         #region Convert To Block Scoped
 
-        [Fact]
-        public async Task TestConvertToBlockScopedInCSharp9()
+        [Theory]
+        [MemberData(nameof(EndOfDocumentSequences))]
+        public async Task TestConvertToBlockScopedInCSharp9(string endOfDocumentSequence)
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
-{|CS8773:namespace|} $$N;
-",
-                FixedCode = @"
+                TestCode = $@"
+{{|CS8773:namespace|}} $$N;{endOfDocumentSequence}",
+                FixedCode = $@"
 namespace $$N
-{
-}
-",
+{{
+}}{endOfDocumentSequence}",
                 LanguageVersion = LanguageVersion.CSharp9,
                 Options =
                 {

--- a/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
+++ b/src/Features/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringTests.cs
@@ -608,7 +608,8 @@ public class C
                 FixedCode = @"
 namespace $$N
 {
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp9,
                 Options =
                 {
@@ -646,7 +647,8 @@ namespace $$N;
                 FixedCode = @"
 namespace $$N
 {
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -666,7 +668,8 @@ $$namespace N;
                 FixedCode = @"
 namespace N
 {
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -749,7 +752,8 @@ namespace $$N
     namespace N2
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -822,7 +826,8 @@ namespace $${|CS8956:N|};
 
 namespace $$N
 {
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -845,7 +850,8 @@ int {|CS0116:i|} = 0;
 namespace $$N
 {
     int {|CS0116:i|} = 0;
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -869,7 +875,8 @@ using System;
 
 namespace $$N
 {
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -892,7 +899,8 @@ using System;
 namespace $$N
 {
     using System;
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -919,7 +927,8 @@ namespace $$N
     class C
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -948,7 +957,8 @@ namespace $$N
     class C
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -973,7 +983,8 @@ namespace N
 {
     /// <summary/>
     class C
-    {}{|CS1513:|}",
+    {
+}{|CS1513:|}",
                 LanguageVersion = LanguageVersion.CSharp10,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 Options =
@@ -1001,7 +1012,8 @@ namespace $$N
     class C
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {
@@ -1030,7 +1042,8 @@ namespace $$N
     class C
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertProgram
 
     public class ConvertToTopLevelStatementsAnalyzerTests
     {
+        public static IEnumerable<object[]> EndOfDocumentSequences
+        {
+            get
+            {
+                yield return new object[] { "" };
+                yield return new object[] { "\r\n" };
+            }
+        }
+
         [Fact]
         public async Task NotOfferedWhenUserPrefersProgramMain()
         {
@@ -1347,40 +1357,39 @@ namespace X.Y
             }.RunAsync();
         }
 
-        [Fact]
-        public async Task TestInTopLevelNamespaceWithOtherType()
+        [Theory]
+        [MemberData(nameof(EndOfDocumentSequences))]
+        public async Task TestInTopLevelNamespaceWithOtherType(string endOfDocumentSequence)
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestCode = $@"
 using System.Threading.Tasks;
 
 namespace X.Y;
 
 class Program
-{
-    static async Task {|IDE0210:Main|}(string[] args)
-    {
+{{
+    static async Task {{|IDE0210:Main|}}(string[] args)
+    {{
         await Task.CompletedTask;
-    }
-}
+    }}
+}}
 
 class Other
-{
-}
-",
-                FixedCode = @"
+{{
+}}{endOfDocumentSequence}",
+                FixedCode = $@"
 using System.Threading.Tasks;
 
 await Task.CompletedTask;
 
 namespace X.Y
-{
+{{
     class Other
-    {
-    }
-}
-",
+    {{
+    }}
+}}{endOfDocumentSequence}",
                 LanguageVersion = LanguageVersion.CSharp10,
                 TestState = { OutputKind = OutputKind.ConsoleApplication },
                 Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },
@@ -1429,41 +1438,40 @@ namespace X.Y
             }.RunAsync();
         }
 
-        [Fact]
-        public async Task TestInTopLevelNamespaceWithOtherTypeThatIsReferenced()
+        [Theory]
+        [MemberData(nameof(EndOfDocumentSequences))]
+        public async Task TestInTopLevelNamespaceWithOtherTypeThatIsReferenced(string endOfDocumentSequence)
         {
             await new VerifyCS.Test
             {
-                TestCode = @"
+                TestCode = $@"
 using System.Threading.Tasks;
 
 namespace X.Y;
 
 class Program
-{
-    static void {|IDE0210:Main|}(string[] args)
-    {
+{{
+    static void {{|IDE0210:Main|}}(string[] args)
+    {{
         System.Console.WriteLine(typeof(Other));
-    }
-}
+    }}
+}}
 
 class Other
-{
-}
-",
-                FixedCode = @"
+{{
+}}{endOfDocumentSequence}",
+                FixedCode = $@"
 using System.Threading.Tasks;
 using X.Y;
 
 System.Console.WriteLine(typeof(Other));
 
 namespace X.Y
-{
+{{
     class Other
-    {
-    }
-}
-",
+    {{
+    }}
+}}{endOfDocumentSequence}",
                 LanguageVersion = LanguageVersion.CSharp10,
                 TestState = { OutputKind = OutputKind.ConsoleApplication },
                 Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },

--- a/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
+++ b/src/Features/CSharpTest/ConvertProgram/ConvertToTopLevelStatementsAnalyzerTests.cs
@@ -1379,7 +1379,8 @@ namespace X.Y
     class Other
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 TestState = { OutputKind = OutputKind.ConsoleApplication },
                 Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },
@@ -1461,7 +1462,8 @@ namespace X.Y
     class Other
     {
     }
-}",
+}
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 TestState = { OutputKind = OutputKind.ConsoleApplication },
                 Options = { { CSharpCodeStyleOptions.PreferTopLevelStatements, true, NotificationOption2.Suggestion } },

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeActions/CSharpCodeFixOptionsProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeActions/CSharpCodeFixOptionsProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
@@ -11,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -65,8 +62,8 @@ internal readonly struct CSharpCodeFixOptionsProvider
     public CodeStyleOption2<NamespaceDeclarationPreference> NamespaceDeclarations => GetOption(CSharpCodeStyleOptions.NamespaceDeclarations, FallbackSyntaxFormattingOptions.NamespaceDeclarations);
     public CodeStyleOption2<bool> PreferTopLevelStatements => GetOption(CSharpCodeStyleOptions.PreferTopLevelStatements, FallbackSyntaxFormattingOptions.PreferTopLevelStatements);
 
-    internal SyntaxFormattingOptions GetFormattingOptions()
-        => new CSharpSyntaxFormattingOptions(_options, FallbackSyntaxFormattingOptions);
+    internal CSharpSyntaxFormattingOptions GetFormattingOptions()
+        => new(_options, FallbackSyntaxFormattingOptions);
 
     // AddImportPlacementOptions
 


### PR DESCRIPTION
Fixes the issues described in https://github.com/dotnet/roslyn/issues/68413#issuecomment-1572977780