### PR TITLE
Fix inserting new values with source generators

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
@@ -1311,7 +1311,7 @@ class C { }
         runResult = driver.GetRunResult().Results[0];
 
         Assert.Collection(runResult.TrackedSteps["result_ForAttribute"],
-    step => Assert.True(step.Outputs.Single().Value is ClassDeclarationSyntax { Identifier.ValueText: "C" }));
+            step => Assert.True(step.Outputs.Single().Value is ClassDeclarationSyntax { Identifier.ValueText: "C" }));
 
         Assert.Collection(runResult.TrackedSteps["individualFileGlobalAliases_ForAttribute"],
             s => Assert.Equal(IncrementalStepRunReason.Modified, s.Outputs.Single().Reason),

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
@@ -1311,7 +1311,11 @@ class C { }
         runResult = driver.GetRunResult().Results[0];
 
         Assert.Collection(runResult.TrackedSteps["result_ForAttribute"],
-            step => Assert.True(step.Outputs.Single().Value is ClassDeclarationSyntax { Identifier.ValueText: "C" }));
+            step =>
+            {
+                Assert.True(step.Outputs.Single().Value is ClassDeclarationSyntax { Identifier.ValueText: "C" });
+                Assert.Equal(IncrementalStepRunReason.Removed, step.Outputs.Single().Reason);
+            });
 
         Assert.Collection(runResult.TrackedSteps["individualFileGlobalAliases_ForAttribute"],
             s => Assert.Equal(IncrementalStepRunReason.Modified, s.Outputs.Single().Reason),

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests_Attributes_SimpleName.cs
@@ -1310,13 +1310,21 @@ class C { }
             compilation.SyntaxTrees.First()));
         runResult = driver.GetRunResult().Results[0];
 
-        Assert.False(runResult.TrackedSteps.ContainsKey("result_ForAttribute"));
-        Assert.False(runResult.TrackedSteps.ContainsKey("individualFileGlobalAliases_ForAttribute"));
-        Assert.False(runResult.TrackedSteps.ContainsKey("collectedGlobalAliases_ForAttribute"));
-        Assert.False(runResult.TrackedSteps.ContainsKey("allUpGlobalAliases_ForAttribute"));
+        Assert.Collection(runResult.TrackedSteps["result_ForAttribute"],
+    step => Assert.True(step.Outputs.Single().Value is ClassDeclarationSyntax { Identifier.ValueText: "C" }));
 
-        Assert.False(runResult.TrackedSteps.ContainsKey("compilationUnit_ForAttribute"));
-        Assert.False(runResult.TrackedSteps.ContainsKey("compilationUnitAndGlobalAliases_ForAttribute"));
+        Assert.Collection(runResult.TrackedSteps["individualFileGlobalAliases_ForAttribute"],
+            s => Assert.Equal(IncrementalStepRunReason.Modified, s.Outputs.Single().Reason),
+            s => Assert.Equal(IncrementalStepRunReason.Removed, s.Outputs.Single().Reason));
+        Assert.Equal(IncrementalStepRunReason.Modified, runResult.TrackedSteps["collectedGlobalAliases_ForAttribute"].Single().Outputs.Single().Reason);
+        Assert.Equal(IncrementalStepRunReason.Modified, runResult.TrackedSteps["allUpGlobalAliases_ForAttribute"].Single().Outputs.Single().Reason);
+
+        Assert.Collection(runResult.TrackedSteps["compilationUnit_ForAttribute"].Single().Outputs,
+            o => Assert.Equal(IncrementalStepRunReason.Modified, o.Reason),
+            o => Assert.Equal(IncrementalStepRunReason.Modified, o.Reason),
+            o => Assert.Equal(IncrementalStepRunReason.Removed, o.Reason));
+        Assert.Equal(IncrementalStepRunReason.Removed, runResult.TrackedSteps["compilationUnitAndGlobalAliases_ForAttribute"].Single().Outputs.Single().Reason);
+        Assert.Equal(IncrementalStepRunReason.Removed, runResult.TrackedSteps["result_ForAttribute"].Single().Outputs.Single().Reason);
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -1137,7 +1137,41 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(table, ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("inserted", EntryState.Modified, 0), ("1.2", EntryState.Added, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
             Assert.Equal(5, table.AsCached().Count); // [1.1, inserted, 1.2, 2.1, 2.2]
             AssertTableEntries(table.AsCached(), ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("inserted", EntryState.Cached, 0), ("1.2", EntryState.Cached, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+        }
 
+        [Fact, WorkItem(66451, "https://github.com/dotnet/roslyn/issues/67123")]
+        public void Node_Table_When_Previous_Was_Larger_2()
+        {
+            ImmutableArray<string> values = ImmutableArray.Create("1", "2");
+            var inputNode = new InputNode<string>(_ => values).WithTrackingName("Input");
+
+            var transformNode = new TransformNode<string, string>(inputNode, (a, ct) =>
+            {
+                return a switch
+                {
+                    "1" => ImmutableArray.Create("1.1", "1.2"),
+                    "2" => ImmutableArray.Create("2.1", "2.2"),
+                    _ => ImmutableArray.Create("1.1")
+                };
+            }, name: "Select");
+
+            var select2 = new TransformNode<string, string>(transformNode, (a, ct) => a, name: "Select2");
+
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty, trackIncrementalGeneratorSteps: false);
+            var table = dstBuilder.GetLatestStateTableForNode(select2);
+
+            AssertTableEntries(table, ImmutableArray.Create(("1.1", EntryState.Added, 0), ("1.2", EntryState.Added, 0), ("2.1", EntryState.Added, 0), ("2.2", EntryState.Added, 0)));
+            Assert.Equal(4, table.AsCached().Count); // [1.1, 1.2, 2.1, 2.2]
+            AssertTableEntries(table.AsCached(), ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("1.2", EntryState.Cached, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+
+            // change the input so we can re-run, this time when we produce less values
+            values = ImmutableArray.Create("3", "2");
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable(), trackIncrementalGeneratorSteps: false);
+            table = dstBuilder.GetLatestStateTableForNode(select2);
+
+            AssertTableEntries(table, ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("1.2", EntryState.Removed, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+            Assert.Equal(3, table.AsCached().Count); // [1.1, 2.1, 2.2]
+            AssertTableEntries(table.AsCached(), ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
         }
 
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T Item, EntryState State, int OutputIndex)> expected)

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -82,24 +82,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             var previousTable = builder.ToImmutableAndFree();
 
             builder = previousTable.ToBuilder(stepName: null, false);
-            builder.AddEntries(ImmutableArray.Create(10, 11), EntryState.Added, TimeSpan.Zero, default, EntryState.Added);
+            builder.TryModifyEntries(ImmutableArray.Create(10, 11), EqualityComparer<int>.Default, TimeSpan.Zero, default, EntryState.Modified);
             builder.TryUseCachedEntries(TimeSpan.Zero, default, out var cachedEntries); // ((2, EntryState.Cached), (3, EntryState.Cached))
-            builder.AddEntries(ImmutableArray.Create(20, 21, 22), EntryState.Modified, TimeSpan.Zero, default, EntryState.Modified);
+            builder.TryModifyEntries(ImmutableArray.Create(20, 21, 22), EqualityComparer<int>.Default, TimeSpan.Zero, default, EntryState.Modified);
             bool didRemoveEntries = builder.TryRemoveEntries(TimeSpan.Zero, default, out var removedEntries); //((6, EntryState.Removed))
             var newTable = builder.ToImmutableAndFree();
 
-            var expected = ImmutableArray.Create((10, EntryState.Added, 0), (11, EntryState.Added, 1), (2, EntryState.Cached, 0), (3, EntryState.Cached, 1), (20, EntryState.Modified, 0), (21, EntryState.Modified, 1), (22, EntryState.Modified, 2), (6, EntryState.Removed, 0));
+            var expected = ImmutableArray.Create((10, EntryState.Modified, 0), (11, EntryState.Added, 1), (2, EntryState.Cached, 0), (3, EntryState.Cached, 1), (20, EntryState.Modified, 0), (21, EntryState.Modified, 1), (22, EntryState.Added, 2), (6, EntryState.Removed, 0));
             AssertTableEntries(newTable, expected);
             Assert.Equal(new[] { 2, 3 }, YieldItems(cachedEntries.Items));
             Assert.Equal(1, removedEntries.Count);
             Assert.Equal(6, removedEntries[0]);
             Assert.True(didRemoveEntries);
-        }
 
-        private static IEnumerable<int> YieldItems(OneOrMany<int> items)
-        {
-            foreach (var value in items)
-                yield return value;
+            static IEnumerable<int> YieldItems(OneOrMany<int> items)
+            {
+                foreach (var value in items)
+                    yield return value;
+            }
         }
 
         [Fact]
@@ -1102,6 +1102,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(table, ImmutableArray.Create(("class4", EntryState.Removed, 0), ("class4.1", EntryState.Removed, 1), ("class1", EntryState.Added, 0), ("class1.1", EntryState.Added, 1)));
             Assert.Equal(1, table.AsCached().Count); // [class1, class1.1]
             AssertTableEntries(table.AsCached(), ImmutableArray.Create(("class1", EntryState.Cached, 0), ("class1.1", EntryState.Cached, 1)));
+        }
+
+        [Fact, WorkItem(66451, "https://github.com/dotnet/roslyn/issues/67123")]
+        public void Node_Table_When_Previous_Was_Smaller()
+        {
+            ImmutableArray<string> values = ImmutableArray.Create("1", "2");
+            var inputNode = new InputNode<string>(_ => values).WithTrackingName("Input");
+
+            var transformNode = new TransformNode<string, string>(inputNode, (a, ct) =>
+            {
+                return a switch
+                {
+                    "1" => ImmutableArray.Create("1.1", "1.2"),
+                    "2" => ImmutableArray.Create("2.1", "2.2"),
+                    _ => ImmutableArray.Create("1.1", "inserted", "1.2")
+                };
+            }, name: "Select");
+
+            var select2 = new TransformNode<string, string>(transformNode, (a, ct) => a, name: "Select2");
+
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty, trackIncrementalGeneratorSteps: false);
+            var table = dstBuilder.GetLatestStateTableForNode(select2);
+
+            AssertTableEntries(table, ImmutableArray.Create(("1.1", EntryState.Added, 0), ("1.2", EntryState.Added, 0), ("2.1", EntryState.Added, 0), ("2.2", EntryState.Added, 0)));
+            Assert.Equal(4, table.AsCached().Count); // [1.1, 1.2, 2.1, 2.2]
+            AssertTableEntries(table.AsCached(), ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("1.2", EntryState.Cached, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+
+            // change the input so we can re-run, this time with the extra value inserted
+            values = ImmutableArray.Create("3", "2");
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable(), trackIncrementalGeneratorSteps: false);
+            table = dstBuilder.GetLatestStateTableForNode(select2);
+
+            AssertTableEntries(table, ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("inserted", EntryState.Modified, 0), ("1.2", EntryState.Added, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+            Assert.Equal(5, table.AsCached().Count); // [1.1, inserted, 1.2, 2.1, 2.2]
+            AssertTableEntries(table.AsCached(), ImmutableArray.Create(("1.1", EntryState.Cached, 0), ("inserted", EntryState.Cached, 0), ("1.2", EntryState.Cached, 0), ("2.1", EntryState.Cached, 0), ("2.2", EntryState.Cached, 0)));
+
         }
 
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T Item, EntryState State, int OutputIndex)> expected)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis
                 // to the current table, as they didn't exist in the previous one.
                 var previousTableEntryIndex = _states.Count - _insertedCount;
 
-                var canUsePrevious = _previous._states.Length > (previousTableEntryIndex);
+                var canUsePrevious = _previous._states.Length > previousTableEntryIndex;
                 previousEntry = canUsePrevious ? _previous._states[previousTableEntryIndex] : default;
                 return canUsePrevious;
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -163,6 +163,8 @@ namespace Microsoft.CodeAnalysis
             private readonly IEqualityComparer<T> _equalityComparer;
             private readonly ArrayBuilder<IncrementalGeneratorRunStep>? _steps;
 
+            private int _insertedCount = 0;
+
             [MemberNotNullWhen(true, nameof(_steps))]
             public bool TrackIncrementalSteps => _steps is not null;
 
@@ -196,7 +198,7 @@ namespace Microsoft.CodeAnalysis
 
             public bool TryRemoveEntries(TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs)
             {
-                if (_previous._states.Length <= _states.Count)
+                if (!CanUsePreviousEntries())
                 {
                     // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to remove.
                     return false;
@@ -204,7 +206,7 @@ namespace Microsoft.CodeAnalysis
 
                 // Mark the corresponding entries to this node execution in the previous table as removed.
                 // Since they are removed due to their input having been removed, we won't have to keep placeholders for them.
-                var previousEntries = _previous._states[_states.Count].AsRemovedDueToInputRemoval();
+                var previousEntries = GetPreviousEntry().AsRemovedDueToInputRemoval();
                 _states.Add(previousEntries);
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, EntryState.Removed);
                 return true;
@@ -224,13 +226,13 @@ namespace Microsoft.CodeAnalysis
 
             public bool TryUseCachedEntries(TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs)
             {
-                if (_previous._states.Length <= _states.Count)
+                if (!CanUsePreviousEntries())
                 {
                     // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to copy as cached.
                     return false;
                 }
 
-                var previousEntries = _previous._states[_states.Count];
+                var previousEntries = GetPreviousEntry();
                 Debug.Assert(previousEntries.IsCached);
 
                 _states.Add(previousEntries);
@@ -252,22 +254,23 @@ namespace Microsoft.CodeAnalysis
 
             public bool TryModifyEntry(T value, IEqualityComparer<T> comparer, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
             {
-                if (_previous._states.Length <= _states.Count)
+                if (!CanUsePreviousEntries())
                 {
                     // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to try to modify.
                     return false;
                 }
 
-                Debug.Assert(_previous._states[_states.Count].Count == 1);
-                var (chosen, state, _) = GetModifiedItemAndState(_previous._states[_states.Count].GetItem(0), value, comparer);
+                var previousEntry = GetPreviousEntry();
+                Debug.Assert(previousEntry.Count == 1);
+                var (chosen, state, _) = GetModifiedItemAndState(previousEntry.GetItem(0), value, comparer);
                 _states.Add(new TableEntry(OneOrMany.Create(chosen), state));
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
                 return true;
             }
 
-            public bool TryModifyEntries(ImmutableArray<T> outputs, IEqualityComparer<T> comparer, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
+            public bool TryModifyEntries(ImmutableArray<T> outputs, IEqualityComparer<T> comparer, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState) 
             {
-                if (_previous._states.Length <= _states.Count)
+                if (!CanUsePreviousEntries())
                 {
                     return false;
                 }
@@ -279,7 +282,7 @@ namespace Microsoft.CodeAnalysis
                 // - Removed when old item position > outputs.length
                 // - Added when new item position < previousTable.length
 
-                var previousEntry = _previous._states[_states.Count];
+                var previousEntry = GetPreviousEntry();
 
                 // when both entries have no items, we can short circuit
                 if (previousEntry.Count == 0 && outputs.Length == 0)
@@ -374,6 +377,7 @@ namespace Microsoft.CodeAnalysis
             public void AddEntry(T value, EntryState state, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
             {
                 _states.Add(new TableEntry(OneOrMany.Create(value), state));
+                _insertedCount += state == EntryState.Added ? 1 : 0;
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
             }
 
@@ -381,8 +385,20 @@ namespace Microsoft.CodeAnalysis
             {
                 var tableEntry = new TableEntry(OneOrMany.Create(values), state);
                 _states.Add(tableEntry);
+                _insertedCount += state == EntryState.Added ? 1 : 0;
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
                 return tableEntry;
+            }
+
+            private bool CanUsePreviousEntries()
+            {
+                return _previous._states.Length > (_states.Count - _insertedCount);
+            }
+
+            private TableEntry GetPreviousEntry()
+            {
+                Debug.Assert(CanUsePreviousEntries());
+                return _previous._states[_states.Count - _insertedCount];
             }
 
             private void RecordStepInfoForLastEntry(TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -154,6 +154,9 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
+        /// <remarks>
+        /// The builder is <b>not</b> threadsafe.
+        /// </remarks>
         public sealed class Builder
         {
             private readonly ArrayBuilder<TableEntry> _states;
@@ -388,8 +391,12 @@ namespace Microsoft.CodeAnalysis
 
             private bool TryGetPreviousEntry(out TableEntry previousEntry)
             {
-                var canUsePrevious = _previous._states.Length > (_states.Count - _insertedCount);
-                previousEntry = canUsePrevious ? _previous._states[_states.Count - _insertedCount] : default;
+                // When indexing into the previous table we need to subtract the number of entries that have been explicitly added
+                // to the current table, as they didn't exist in the previous one.
+                var previousTableEntryIndex = _states.Count - _insertedCount;
+
+                var canUsePrevious = _previous._states.Length > (previousTableEntryIndex);
+                previousEntry = canUsePrevious ? _previous._states[previousTableEntryIndex] : default;
                 return canUsePrevious;
             }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (!TryGetPreviousEntry(out var previousEntry))
                 {
-                    // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to try to modify.
+                    // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to remove.
                     return false;
                 }
 
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (!TryGetPreviousEntry(out var previousEntries))
                 {
-                    // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to try to modify.
+                    // The previous table had less node executions than this one, so we don't have any entries from a previous corresponding node execution to copy as cached.
                     return false;
                 }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -58,11 +58,6 @@ namespace Microsoft.CodeAnalysis
                 }
                 else if (entry.State != EntryState.Cached || !nodeTable.TryUseCachedEntries(TimeSpan.Zero, inputs))
                 {
-                    // we don't currently handle modified any differently than added at the output
-                    // we just run the action and mark the new source as added. In theory we could compare
-                    // the diagnostics and sources produced and compare them, to see if they are any different 
-                    // than before.
-
                     var sourcesBuilder = new AdditionalSourcesCollection(_sourceExtension);
                     var diagnostics = DiagnosticBag.GetInstance();
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -72,7 +72,11 @@ namespace Microsoft.CodeAnalysis
                         var stopwatch = SharedStopwatch.StartNew();
                         _action(context, entry.Item, cancellationToken);
                         var sourcesAndDiagnostics = (sourcesBuilder.ToImmutable(), diagnostics.ToReadOnly());
-                        nodeTable.AddEntry(sourcesAndDiagnostics, EntryState.Added, stopwatch.Elapsed, inputs, EntryState.Added);
+
+                        if (entry.State != EntryState.Modified || !nodeTable.TryModifyEntry(sourcesAndDiagnostics, EqualityComparer<TOutput>.Default, stopwatch.Elapsed, inputs, entry.State))
+                        {
+                            nodeTable.AddEntry(sourcesAndDiagnostics, EntryState.Added, stopwatch.Elapsed, inputs, EntryState.Added);
+                        }
                     }
                     finally
                     {


### PR DESCRIPTION
If an upstream node adds more items in the middle of its output, we would incorrectly use a later value as the cached value because the table offset was incorrect. This could lead to the same value being inserted twice and cause the `hintName must be unique` exceptions we see with the MVVM generator.

This fix exposed a slightly incorrect test and required us to properly track the output documents rather than just assuming they are added.

Fixes #67123