### PR TITLE
Ensure we only ask for a symbol's documentation comment once 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
+spelling_exclusion_path = SpellingExclusions.dic
 
 # Code files
 [*.{cs,csx,vb,vbx}]

--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,0 +1,1 @@
+﻿awaitable

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -11,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -39,11 +36,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
             public SymbolDescriptionBuilder(
                 SemanticModel semanticModel,
                 int position,
-                SolutionServices services,
-                IStructuralTypeDisplayService structuralTypeDisplayService,
+                Host.LanguageServices languageServices,
                 SymbolDescriptionOptions options,
                 CancellationToken cancellationToken)
-                : base(semanticModel, position, services, structuralTypeDisplayService, options, cancellationToken)
+                : base(semanticModel, position, languageServices, options, cancellationToken)
             {
             }
 
@@ -114,13 +110,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
             protected override ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(ISymbol symbol, SemanticModel semanticModel, int position, SymbolDisplayFormat format)
                 => CodeAnalysis.CSharp.SymbolDisplay.ToMinimalDisplayParts(symbol, semanticModel, position, format);
 
-            protected override string GetNavigationHint(ISymbol symbol)
+            protected override string? GetNavigationHint(ISymbol symbol)
                 => symbol == null ? null : CodeAnalysis.CSharp.SymbolDisplay.ToDisplayString(symbol, SymbolDisplayFormat.MinimallyQualifiedFormat);
 
             private async Task<ImmutableArray<SymbolDisplayPart>> GetInitializerSourcePartsAsync(
                 IFieldSymbol symbol)
             {
-                EqualsValueClauseSyntax initializer = null;
+                EqualsValueClauseSyntax? initializer = null;
 
                 var variableDeclarator = await GetFirstDeclarationAsync<VariableDeclaratorSyntax>(symbol).ConfigureAwait(false);
                 if (variableDeclarator != null)
@@ -169,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
                 return ImmutableArray<SymbolDisplayPart>.Empty;
             }
 
-            private async Task<T> GetFirstDeclarationAsync<T>(ISymbol symbol) where T : SyntaxNode
+            private async Task<T?> GetFirstDeclarationAsync<T>(ISymbol symbol) where T : SyntaxNode
             {
                 foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
                 {
@@ -184,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
             }
 
             private async Task<ImmutableArray<SymbolDisplayPart>> GetInitializerSourcePartsAsync(
-                EqualsValueClauseSyntax equalsValue)
+                EqualsValueClauseSyntax? equalsValue)
             {
                 if (equalsValue != null && equalsValue.Value != null)
                 {
@@ -192,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
                     if (semanticModel != null)
                     {
                         return await Classifier.GetClassifiedSymbolDisplayPartsAsync(
-                            Services, semanticModel, equalsValue.Value.Span,
+                            LanguageServices, semanticModel, equalsValue.Value.Span,
                             Options.ClassificationOptions, cancellationToken: CancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -4,13 +4,11 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host;

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
@@ -16,6 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
         }
 
         protected override AbstractSymbolDescriptionBuilder CreateDescriptionBuilder(SemanticModel semanticModel, int position, SymbolDescriptionOptions options, CancellationToken cancellationToken)
-            => new SymbolDescriptionBuilder(semanticModel, position, Services.SolutionServices, AnonymousTypeDisplayService, options, cancellationToken);
+            => new SymbolDescriptionBuilder(semanticModel, position, LanguageServices, options, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -11,12 +11,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
                 var compilation = _semanticModel.Compilation;
 
                 // Grab the doc comment once as computing it for each portion we're concatenating can be expensive for
-                // lsif (which does this for every symbol in an entire solution).
+                // LSIF (which does this for every symbol in an entire solution).
                 var documentationComment = original is IMethodSymbol method
                     ? ISymbolExtensions2.GetMethodDocumentation(method, compilation, CancellationToken)
                     : original.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: CancellationToken);

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
                 if (firstSymbol.IsAnonymousDelegateType())
                     directStructuralTypes = directStructuralTypes.Except(new[] { (INamedTypeSymbol)firstSymbol });
 
-                var info = _structuralTypeDisplayService.GetTypeDisplayInfo(
+                var info = LanguageServices.GetRequiredService<IStructuralTypeDisplayService>().GetTypeDisplayInfo(
                     firstSymbol, directStructuralTypes.ToImmutableArrayOrEmpty(), _semanticModel, _position);
 
                 if (info.TypesParts.Count > 0)

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -15,13 +13,11 @@ namespace Microsoft.CodeAnalysis.LanguageService
 {
     internal abstract partial class AbstractSymbolDisplayService : ISymbolDisplayService
     {
-        protected readonly LanguageServices Services;
-        protected readonly IStructuralTypeDisplayService AnonymousTypeDisplayService;
+        protected readonly LanguageServices LanguageServices;
 
         protected AbstractSymbolDisplayService(LanguageServices services)
         {
-            Services = services;
-            AnonymousTypeDisplayService = services.GetService<IStructuralTypeDisplayService>();
+            LanguageServices = services;
         }
 
         protected abstract AbstractSymbolDescriptionBuilder CreateDescriptionBuilder(SemanticModel semanticModel, int position, SymbolDescriptionOptions options, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
 

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
@@ -29,11 +29,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
 
             Public Sub New(semanticModel As SemanticModel,
                            position As Integer,
-                           services As SolutionServices,
-                           structuralTypeDisplayService As IStructuralTypeDisplayService,
+                           languageServices As Host.LanguageServices,
                            options As SymbolDescriptionOptions,
                            cancellationToken As CancellationToken)
-                MyBase.New(semanticModel, position, services, structuralTypeDisplayService, options, cancellationToken)
+                MyBase.New(semanticModel, position, languageServices, options, cancellationToken)
             End Sub
 
             Protected Overrides Sub AddDeprecatedPrefix()
@@ -159,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                     Dim semanticModel = GetSemanticModel(equalsValue.SyntaxTree)
                     If semanticModel IsNot Nothing Then
                         Return Await Classifier.GetClassifiedSymbolDisplayPartsAsync(
-                            Services, semanticModel, equalsValue.Value.Span, Options.ClassificationOptions, CancellationToken).ConfigureAwait(False)
+                            LanguageServices, semanticModel, equalsValue.Value.Span, Options.ClassificationOptions, CancellationToken).ConfigureAwait(False)
                     End If
                 End If
 

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                                                               position As Integer,
                                                               options As SymbolDescriptionOptions,
                                                               cancellationToken As CancellationToken) As AbstractSymbolDescriptionBuilder
-            Return New SymbolDescriptionBuilder(semanticModel, position, Services.SolutionServices, AnonymousTypeDisplayService, options, cancellationToken)
+            Return New SymbolDescriptionBuilder(semanticModel, position, LanguageServices, options, cancellationToken)
         End Function
     End Class
 End Namespace

--- a/src/Tools/ExternalAccess/Razor/RazorClassifierAccessor.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorClassifierAccessor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             return Classifier.GetClassifiedSpans(
-                document.Project.Solution.Services, document.Project, semanticModel, textSpan, options.UnderlyingObject, cancellationToken);
+                document.Project.Services, document.Project, semanticModel, textSpan, options.UnderlyingObject, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -14,7 +14,6 @@ using System.Threading;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Shared.Utilities;

--- a/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/DocumentationComment.cs
@@ -328,6 +328,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return text;
         }
 
+        public DocumentationComment? GetParameter(string parameterName)
+        {
+            if (!_parameterTexts.TryGetValue(parameterName, out var text))
+                return null;
+
+            return new DocumentationComment(text) { SummaryText = text };
+        }
+
         /// <summary>
         /// Returns the text for a given type parameter, or null if no documentation was given for the type parameter.
         /// </summary>
@@ -335,6 +343,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             _typeParameterTexts.TryGetValue(typeParameterName, out var text);
             return text;
+        }
+
+        public DocumentationComment? GetTypeParameter(string parameterName)
+        {
+            if (!_typeParameterTexts.TryGetValue(parameterName, out var text))
+                return null;
+
+            return new DocumentationComment(text) { SummaryText = text };
         }
 
         /// <summary>


### PR DESCRIPTION
Right now computing hover information is a fairly expensive portion of an LSIF dump. One small hotspot was we were fetching documentation comment information at least twice: once for the documentation itself and once for computing the exception info. This ensures we fetch it just once per generation.

This also generally cleans up the AbstractSymbolDescriptionBuilder:

1. Duplicate local functions for returns/value is unified.
2. Removes a bunch of specific logic in the builder which supported finding the correct documentation in favor of the helper we already had.

To support the second one, I added some methods to DocumentationComment to return a DocumentationComment with the contents of a <param> tag as the summary text for a specific parameter; this allows everything else to be able to operate as if that's a regular summary tag and removes some special cases in the code.

This by itself isn't the hugest speedup (maybe a couple of percent) but generally makes the code easier to follow and easier to see where the remaining expensive bits are in traces.