### PR TITLE
Update to Nerdbank.Streams 2.9.116

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,7 +207,7 @@
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>
     <MoqVersion>4.10.1</MoqVersion>
-    <NerdbankStreamsVersion>2.9.112</NerdbankStreamsVersion>
+    <NerdbankStreamsVersion>2.9.116</NerdbankStreamsVersion>
     <NuGetVisualStudioVersion>6.0.0-preview.0.15</NuGetVisualStudioVersion>
     <NuGetSolutionRestoreManagerInteropVersion>4.8.0</NuGetSolutionRestoreManagerInteropVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>


### PR DESCRIPTION
Fixes random test failures involving cancellation of ServiceHub requests.

There are no API changes here, so this change only impacts our testing. Deployment scenarios will continue to use host-provided versions of this binary.