### PR TITLE
Reduce allocations in outlining in pathlogical files

### DIFF
--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BraceCompletion;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.BraceCompletion;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal readonly struct BlockStructureContext : IDisposable
+    internal readonly ref struct BlockStructureContext
     {
         public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
 

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -6,10 +6,12 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal readonly ref struct BlockStructureContext
+    [NonCopyable]
+    internal readonly struct BlockStructureContext : IDisposable
     {
         public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
 

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal sealed class BlockStructureContext : IDisposable
+    internal readonly struct BlockStructureContext : IDisposable
     {
         public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
 
@@ -25,8 +25,6 @@ namespace Microsoft.CodeAnalysis.Structure
         }
 
         public void Dispose()
-        {
-            Spans.Free();
-        }
+            => Spans.Free();
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal sealed class BlockStructureContext
+    internal sealed class BlockStructureContext : IDisposable
     {
-        private readonly ImmutableArray<BlockSpan>.Builder _spans = ImmutableArray.CreateBuilder<BlockSpan>();
+        public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
 
-        public SyntaxTree SyntaxTree { get; }
-        public BlockStructureOptions Options { get; }
-        public CancellationToken CancellationToken { get; }
-
-        internal ImmutableArray<BlockSpan> Spans => _spans.ToImmutable();
+        public readonly SyntaxTree SyntaxTree;
+        public readonly BlockStructureOptions Options;
+        public readonly CancellationToken CancellationToken;
 
         public BlockStructureContext(SyntaxTree syntaxTree, BlockStructureOptions options, CancellationToken cancellationToken)
         {
@@ -24,7 +24,9 @@ namespace Microsoft.CodeAnalysis.Structure
             CancellationToken = cancellationToken;
         }
 
-        public void AddBlockSpan(BlockSpan span)
-            => _spans.Add(span);
+        public void Dispose()
+        {
+            Spans.Free();
+        }
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureProvider.cs
@@ -6,6 +6,6 @@ namespace Microsoft.CodeAnalysis.Structure
 {
     internal abstract class BlockStructureProvider
     {
-        public abstract void ProvideBlockStructure(BlockStructureContext context);
+        public abstract void ProvideBlockStructure(in BlockStructureContext context);
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -50,13 +50,8 @@ namespace Microsoft.CodeAnalysis.Structure
             CancellationToken cancellationToken)
         {
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            return GetBlockStructureWorker();
-
-            BlockStructure GetBlockStructureWorker()
-            {
-                using var context = CreateContext(syntaxTree, options, cancellationToken);
-                return GetBlockStructure(context, _providers);
-            }
+            using var context = CreateContext(syntaxTree, options, cancellationToken);
+            return GetBlockStructure(context, _providers);
         }
 
         private static BlockStructureContext CreateContext(
@@ -68,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Structure
         }
 
         private static BlockStructure GetBlockStructure(
-            BlockStructureContext context,
+            in BlockStructureContext context,
             ImmutableArray<BlockStructureProvider> providers)
         {
             foreach (var provider in providers)
@@ -77,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Structure
             return CreateBlockStructure(context);
         }
 
-        private static BlockStructure CreateBlockStructure(BlockStructureContext context)
+        private static BlockStructure CreateBlockStructure(in BlockStructureContext context)
         {
             using var _ = ArrayBuilder<BlockSpan>.GetInstance(context.Spans.Count, out var updatedSpans);
             foreach (var span in context.Spans)

--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -50,8 +50,13 @@ namespace Microsoft.CodeAnalysis.Structure
             CancellationToken cancellationToken)
         {
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            using var context = CreateContext(syntaxTree, options, cancellationToken);
-            return GetBlockStructure(context, _providers);
+            return GetBlockStructureWorker();
+
+            BlockStructure GetBlockStructureWorker()
+            {
+                using var context = CreateContext(syntaxTree, options, cancellationToken);
+                return GetBlockStructure(context, _providers);
+            }
         }
 
         private static BlockStructureContext CreateContext(

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -39,8 +37,9 @@ namespace Microsoft.CodeAnalysis.Structure
                 BlockSpanCollector.CollectBlockSpans(
                     syntaxRoot, context.Options, _nodeProviderMap, _triviaProviderMap, ref spans.AsRef(), context.CancellationToken);
 
+                context.Spans.EnsureCapacity(context.Spans.Count + spans.Count);
                 foreach (var span in spans)
-                    context.AddBlockSpan(span);
+                    context.Spans.Add(span);
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
             {

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Structure
             _triviaProviderMap = defaultTriviaOutlinerMap;
         }
 
-        public override void ProvideBlockStructure(BlockStructureContext context)
+        public override void ProvideBlockStructure(in BlockStructureContext context)
         {
             try
             {


### PR DESCRIPTION
We're seeing traces where the allocations here show up.  This would happen in files that have a massive amount of string literals in them.  Mitigating cases where we could not need code folding here.