### PR TITLE
Remove CPD attribute on DiaSymReader dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,7 +28,7 @@
       <Sha>3f43bf1b2dead2cb51f20dc47f6dfd7981248820</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DiaSymReader" Version="2.0.0" CoherentParentDependency="Microsoft.Net.Compilers.Toolset">
+    <Dependency Name="Microsoft.DiaSymReader" Version="2.0.0">
       <Uri>https://github.com/dotnet/symreader</Uri>
       <Sha>27e584661980ee6d82c419a2a471ae505b7d122e</Sha>
     </Dependency>


### PR DESCRIPTION
This breaks coherency, because roslyn @ 5d10d428050c0d6afef30a072c4ae68776621877 does not have a dependency on DiaSymReader, so this coherency restriction is unresolvable.

I don't think this was intended.

Furthermore, even if roslyn did have such a dependency, it would freeze this version in place, because in order to update DiaSymReader, you would have to first make it incoherency (manually edit the version), then immediately flow roslyn to itself. Otherwise, Maestro would simply change things back.