### PR TITLE
Prevent Uri/char[] allocs in RoslynErrorTag.Equals

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsAdornmentTaggerProvider.RoslynErrorTag.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsAdornmentTaggerProvider.RoslynErrorTag.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 return other != null &&
                     this.ErrorType == other.ErrorType &&
-                    this._data.GetValidHelpLinkUri() == other._data.GetValidHelpLinkUri() &&
+                    this._data.HelpLink == other._data.HelpLink &&
                     this._data.Id == other._data.Id &&
                     this._data.Message == other._data.Message;
             }


### PR DESCRIPTION
For the equality check, comparing the underlying HelpLink should be sufficient.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824219