### PR TITLE
Don't report CLS compliance warnings for attributes on inacessible types

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -449,6 +449,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         CheckMemberDistinctness((NamedTypeSymbol)symbol);
                     }
+
+                    CheckForAttributeWithArrayArgument(symbol);
                 }
                 else if (GetDeclaredOrInheritedCompliance(symbol.ContainingAssembly) == Compliance.DeclaredTrue && IsTrue(GetInheritedCompliance(symbol)))
                 {
@@ -459,12 +461,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 this.AddDiagnostic(ErrorCode.WRN_CLS_MeaninglessOnPrivateType, symbol.GetFirstLocation(), symbol);
                 return false; // Don't cascade from this failure.
-            }
-
-            if (isCompliant)
-            {
-                // Independent of accessibility.
-                CheckForAttributeWithArrayArgument(symbol);
             }
 
             // These checks are independent of accessibility and compliance.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -3267,10 +3267,7 @@ public class ArrayAttribute : Attribute
 class Test { }
 ";
 
-            CreateCompilation(source).VerifyDiagnostics(
-                // (11,2): warning CS3016: Arrays as attribute arguments is not CLS-compliant
-                // [Array(new int[] { 1 })]
-                Diagnostic(ErrorCode.WRN_CLS_ArrayArgumentToAttribute, "Array(new int[] { 1 })"));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3804,7 +3801,7 @@ class Test
         }
 
         [Fact]
-        [WorkItem(741718, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/741718")]
+        [WorkItem(68526, "https://github.com/dotnet/roslyn/issues/68526")]
         public void WRN_CLS_ArrayArgumentToAttribute_Inaccessible()
         {
             var source = @"
@@ -3826,10 +3823,7 @@ class MyAttribute : Attribute
 }
 
 ";
-            CreateCompilation(source).VerifyDiagnostics(
-                // (4,2): warning CS3016: Arrays as attribute arguments is not CLS-compliant
-                // [My(new int[] { 1, 2 })]
-                Diagnostic(ErrorCode.WRN_CLS_ArrayArgumentToAttribute, "My(new int[] { 1, 2 })"));
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68526

Interestingly, the initial issue that prompted this fix in 2013 (linked in the changed `[WorkItem]` attribute below, even asks why a diagnostic should be reported in this case anyway.