### PR TITLE
Do not lower priority for refactorings

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -687,19 +687,13 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             }
             else
             {
-                // No selection.  Treat all medium and low pri refactorings as low priority, and
-                // place after fixes.  Even a low pri fixes will be above what was *originally*
-                // a medium pri refactoring.
-                //
-                // Note: we do not do this for *high* pri refactorings (like 'rename').  These
-                // are still very important and need to stay at the top (though still after high
-                // pri fixes).
-                var highPriRefactorings = refactorings.WhereAsArray(
-                    s => s.Priority == CodeActionPriority.High);
-                var nonHighPriRefactorings = refactorings.WhereAsArray(
-                    s => s.Priority != CodeActionPriority.High)
-                        .SelectAsArray(s => WithPriority(s, CodeActionPriority.Low));
-
+                // No selection.  Order the actions as per follows:
+                //   - HighPri fixes
+                //   - HighPri refactorings
+                //   - Rest of the fixes
+                //   - Rest of the refactorings
+                var highPriRefactorings = refactorings.WhereAsArray(s => s.Priority == CodeActionPriority.High);
+                var nonHighPriRefactorings = refactorings.WhereAsArray(s => s.Priority != CodeActionPriority.High);
                 var highPriFixes = fixes.WhereAsArray(s => s.Priority == CodeActionPriority.High);
                 var nonHighPriFixes = fixes.WhereAsArray(s => s.Priority != CodeActionPriority.High);
 

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -709,10 +709,6 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                              .ToImmutableArray();
         }
 
-        private static UnifiedSuggestedActionSet WithPriority(
-            UnifiedSuggestedActionSet set, CodeActionPriority priority)
-            => new(set.OriginalSolution, set.CategoryName, set.Actions, set.Title, priority, set.ApplicableToSpan);
-
         private static ImmutableArray<UnifiedSuggestedActionSet> InlineActionSetsIfDesirable(
             ImmutableArray<UnifiedSuggestedActionSet> actionSets,
             int currentActionCount)

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
                     CSharpAnalyzersResources.Use_implicit_type,
                     caretLocation,
                     customTags: new[] { PredefinedCodeRefactoringProviderNames.UseImplicitType }),
-                priority: VSInternalPriorityLevel.Low,
+                priority: VSInternalPriorityLevel.Normal,
                 groupName: "Roslyn1",
                 applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 8 }, End = new Position { Line = 4, Character = 11 } },
                 diagnostics: null);
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
                     FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
                     caretLocation),
                 priority: VSInternalPriorityLevel.Normal,
-                groupName: "Roslyn3",
+                groupName: "Roslyn2",
                 applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 12 }, End = new Position { Line = 4, Character = 12 } },
                 diagnostics: null);
 


### PR DESCRIPTION
We lowered all non-highpri refactorings to Low priority, with the assumption that we want to place even the medium priority refactorings after low priority fixes. This is no longer true as we explicitly push slower analyzers/fixers to low priority.