### PR TITLE
update System.CommandLine to the latest version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,7 @@
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vssdk-archived" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk-archived/nuget/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -238,9 +238,7 @@
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCompositionVersion>7.0.0</SystemCompositionVersion>
     <SystemCodeDomVersion>7.0.0</SystemCodeDomVersion>
-    <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
-    <SystemCommandLineExperimentalVersion>0.3.0-alpha.19577.1</SystemCommandLineExperimentalVersion>
-    <SystemCommandLineNamingConventionBinderVersion>$(SystemCommandLineVersion)</SystemCommandLineNamingConventionBinderVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
     <SystemComponentModelCompositionVersion>7.0.0</SystemComponentModelCompositionVersion>
     <SystemConfigurationConfigurationManagerVersion>7.0.0</SystemConfigurationConfigurationManagerVersion>
     <SystemDrawingCommonVersion>7.0.0</SystemDrawingCommonVersion>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
@@ -32,7 +30,7 @@ catch (IOException)
 WindowsErrorReporting.SetErrorModeOnWindows();
 
 var parser = CreateCommandLineParser();
-return await parser.InvokeAsync(args);
+return await parser.Parse(args).InvokeAsync(CancellationToken.None);
 
 static async Task RunAsync(
     bool launchDebugger,
@@ -121,60 +119,56 @@ static async Task RunAsync(
     }
 }
 
-static Parser CreateCommandLineParser()
+static CliRootCommand CreateCommandLineParser()
 {
-    var debugOption = new Option<bool>("--debug", getDefaultValue: () => false)
+    var debugOption = new CliOption<bool>("--debug")
     {
         Description = "Flag indicating if the debugger should be launched on startup.",
-        IsRequired = false,
+        Required = false,
+        DefaultValueFactory = _ => false,
     };
-    var brokeredServicePipeNameOption = new Option<string?>("--brokeredServicePipeName")
+    var brokeredServicePipeNameOption = new CliOption<string?>("--brokeredServicePipeName")
     {
         Description = "The name of the pipe used to connect to a remote process (if one exists).",
-        IsRequired = false,
+        Required = false,
     };
 
-    var logLevelOption = new Option<LogLevel>("--logLevel", description: "The minimum log verbosity.", parseArgument: result =>
+    var logLevelOption = new CliOption<LogLevel>("--logLevel")
     {
-        var value = result.Tokens.Single().Value;
-        return !Enum.TryParse<LogLevel>(value, out var logLevel)
-            ? throw new InvalidOperationException($"Unexpected logLevel argument {result}")
-            : logLevel;
-    })
-    {
-        IsRequired = true,
+        Description = "The minimum log verbosity.",
+        Required = true,
     };
-    var starredCompletionsPathOption = new Option<string?>("--starredCompletionComponentPath")
+    var starredCompletionsPathOption = new CliOption<string?>("--starredCompletionComponentPath")
     {
         Description = "The location of the starred completion component (if one exists).",
-        IsRequired = false,
+        Required = false,
     };
 
-    var telemetryLevelOption = new Option<string?>("--telemetryLevel")
+    var telemetryLevelOption = new CliOption<string?>("--telemetryLevel")
     {
         Description = "Telemetry level, Defaults to 'off'. Example values: 'all', 'crash', 'error', or 'off'.",
-        IsRequired = false,
+        Required = false,
     };
 
-    var sessionIdOption = new Option<string?>("--sessionId")
+    var sessionIdOption = new CliOption<string?>("--sessionId")
     {
         Description = "Session Id to use for telemetry",
-        IsRequired = false
+        Required = false
     };
 
-    var sharedDependenciesOption = new Option<string?>("--sharedDependencies")
+    var sharedDependenciesOption = new CliOption<string?>("--sharedDependencies")
     {
         Description = "Full path of the directory containing shared assemblies (optional).",
-        IsRequired = false
+        Required = false
     };
 
-    var extensionAssemblyPathsOption = new Option<string[]?>(new string[] { "--extension", "--extensions" }) // TODO: remove plural form
+    var extensionAssemblyPathsOption = new CliOption<string[]?>("--extension", "--extensions") // TODO: remove plural form
     {
         Description = "Full paths of extension assemblies to load (optional).",
-        IsRequired = false
+        Required = false
     };
 
-    var rootCommand = new RootCommand()
+    var rootCommand = new CliRootCommand()
     {
         debugOption,
         brokeredServicePipeNameOption,
@@ -185,20 +179,19 @@ static Parser CreateCommandLineParser()
         sharedDependenciesOption,
         extensionAssemblyPathsOption,
     };
-    rootCommand.SetHandler(context =>
+    rootCommand.SetAction((parseResult, cancellationToken) =>
     {
-        var cancellationToken = context.GetCancellationToken();
-        var launchDebugger = context.ParseResult.GetValueForOption(debugOption);
-        var logLevel = context.ParseResult.GetValueForOption(logLevelOption);
-        var starredCompletionsPath = context.ParseResult.GetValueForOption(starredCompletionsPathOption);
-        var telemetryLevel = context.ParseResult.GetValueForOption(telemetryLevelOption);
-        var sessionId = context.ParseResult.GetValueForOption(sessionIdOption);
-        var sharedDependenciesPath = context.ParseResult.GetValueForOption(sharedDependenciesOption);
-        var extensionAssemblyPaths = context.ParseResult.GetValueForOption(extensionAssemblyPathsOption) ?? Array.Empty<string>();
+        var launchDebugger = parseResult.GetValue(debugOption);
+        var logLevel = parseResult.GetValue(logLevelOption);
+        var starredCompletionsPath = parseResult.GetValue(starredCompletionsPathOption);
+        var telemetryLevel = parseResult.GetValue(telemetryLevelOption);
+        var sessionId = parseResult.GetValue(sessionIdOption);
+        var sharedDependenciesPath = parseResult.GetValue(sharedDependenciesOption);
+        var extensionAssemblyPaths = parseResult.GetValue(extensionAssemblyPathsOption) ?? Array.Empty<string>();
 
         return RunAsync(launchDebugger, logLevel, starredCompletionsPath, telemetryLevel, sessionId, sharedDependenciesPath, extensionAssemblyPaths, cancellationToken);
     });
 
-    return new CommandLineBuilder(rootCommand).UseDefaults().Build();
+    return rootCommand;
 }
 

--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
 
     <!-- Since we're using Microsoft.Build.Locator, it's important to ensure that absolutely no MSBuild binaries are deployed alongside our application,
          or else those can get picked up first and break things. Since we're referencing MSBuild.StructuredLogger, it'll bring along extra dependencies by default. -->

--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Microsoft.DiaSymReader.Converter.Xml" Version="$(MicrosoftDiaSymReaderConverterXmlVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="$(SystemCommandLineNamingConventionBinderVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
@@ -31,35 +30,71 @@ namespace BuildValidator
         static int Main(string[] args)
         {
             System.Diagnostics.Trace.Listeners.Clear();
-            var rootCommand = new RootCommand
+
+            var assembliesPath = new CliOption<string[]>("--assembliesPath")
             {
-                new Option<string[]>(
-                    "--assembliesPath", BuildValidatorResources.Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times
-                ) { IsRequired = true, Arity = ArgumentArity.OneOrMore },
-                new Option<string[]>(
-                    "--exclude", BuildValidatorResources.Assemblies_to_be_excluded_substring_match
-                ) { Arity = ArgumentArity.ZeroOrMore },
-                new Option<string>(
-                    "--sourcePath", BuildValidatorResources.Path_to_sources_to_use_in_rebuild
-                ) { IsRequired = true },
-                new Option<string[]>(
-                    "--referencesPath", BuildValidatorResources.Path_to_referenced_assemblies_can_be_specified_zero_or_more_times
-                ) { Arity = ArgumentArity.ZeroOrMore },
-                new Option<bool>(
-                    "--verbose", BuildValidatorResources.Output_verbose_log_information
-                ),
-                new Option<bool>(
-                    "--quiet", BuildValidatorResources.Do_not_output_log_information_to_console
-                ),
-                new Option<bool>(
-                    "--debug", BuildValidatorResources.Output_debug_info_when_rebuild_is_not_equal_to_the_original
-                ),
-                new Option<string?>(
-                    "--debugPath", BuildValidatorResources.Path_to_output_debug_info
-                )
+                Description = BuildValidatorResources.Path_to_assemblies_to_rebuild_can_be_specified_one_or_more_times,
+                Required = true,
+                Arity = ArgumentArity.OneOrMore,
             };
-            rootCommand.Handler = CommandHandler.Create(new Func<string[], string[]?, string, string[]?, bool, bool, bool, string, int>(HandleCommand));
-            return rootCommand.Invoke(args);
+            var exclude = new CliOption<string[]>("--exclude")
+            {
+                Description = BuildValidatorResources.Assemblies_to_be_excluded_substring_match,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
+            var source = new CliOption<string>("--sourcePath")
+            {
+                Description = BuildValidatorResources.Path_to_sources_to_use_in_rebuild,
+                Required = true,
+            };
+            var referencesPath = new CliOption<string[]>("--referencesPath")
+            {
+                Description = BuildValidatorResources.Path_to_referenced_assemblies_can_be_specified_zero_or_more_times,
+                Arity = ArgumentArity.ZeroOrMore,
+            };
+            var verbose = new CliOption<bool>("--verbose")
+            {
+                Description = BuildValidatorResources.Output_verbose_log_information
+            };
+            var quiet = new CliOption<bool>("--quiet")
+            {
+                Description = BuildValidatorResources.Do_not_output_log_information_to_console
+            };
+            var debug = new CliOption<bool>("--debug")
+            {
+                Description = BuildValidatorResources.Output_debug_info_when_rebuild_is_not_equal_to_the_original
+            };
+            var debugPath = new CliOption<string?>("--debugPath")
+            {
+                Description = BuildValidatorResources.Path_to_output_debug_info
+            };
+
+            var rootCommand = new CliRootCommand
+            {
+                assembliesPath,
+                exclude,
+                source,
+                referencesPath,
+                verbose,
+                quiet,
+                debug,
+                debugPath,
+            };
+
+            rootCommand.SetAction(parseResult =>
+            {
+                return HandleCommand(
+                    assembliesPath: parseResult.GetValue(assembliesPath),
+                    exclude: parseResult.GetValue(exclude),
+                    sourcePath: parseResult.GetValue(source),
+                    referencesPath: parseResult.GetValue(referencesPath),
+                    verbose: parseResult.GetValue(verbose),
+                    quiet: parseResult.GetValue(quiet),
+                    debug: parseResult.GetValue(debug),
+                    debugPath: parseResult.GetValue(debugPath));
+            });
+
+            return rootCommand.Parse(args).Invoke();
         }
 
         static int HandleCommand(string[] assembliesPath, string[]? exclude, string sourcePath, string[]? referencesPath, bool verbose, bool quiet, bool debug, string? debugPath)

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -84,9 +84,9 @@ namespace BuildValidator
             rootCommand.SetAction(parseResult =>
             {
                 return HandleCommand(
-                    assembliesPath: parseResult.GetValue(assembliesPath),
+                    assembliesPath: parseResult.GetValue(assembliesPath)!,
                     exclude: parseResult.GetValue(exclude),
-                    sourcePath: parseResult.GetValue(source),
+                    sourcePath: parseResult.GetValue(source)!,
                     referencesPath: parseResult.GetValue(referencesPath),
                     verbose: parseResult.GetValue(verbose),
                     quiet: parseResult.GetValue(quiet),


### PR DESCRIPTION
- stop using System.CommandLine.NamingConventionBinder as it's reflection based and won't be supported in the long term

- stop using ancient System.CommandLine.Experimental

Contributes to https://github.com/dotnet/sdk/pull/33157