### PR TITLE
Point manual publishing to public feed

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -317,8 +317,9 @@ stages:
         command: push
         packagesToPush: '$(Build.SourcesDirectory)\artifacts\LanguageServer\*.nupkg'
         allowPackageConflicts: false
+        feedsToUse: select
         nuGetFeedType: external
-        publishFeedCredentials: 'DevDiv - VS package feed'
+        publishFeedCredentials: 'azure-public/vs-impl'
       condition: succeeded()
 
     # Publish language server package


### PR DESCRIPTION
I'm working on enabling our normal publishing flow for this package (see https://github.com/dotnet/roslyn/pull/68504), but there are some issues around signing.  I'm working with dnceng to get those resolved, but in the meantime this should unblock consumption of the packages in vscode-csharp.

Test build - https://dnceng.visualstudio.com/internal/_build/results?buildId=2198741&view=results