### PR TITLE
Improve collection literal parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -15,7 +15,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
-    using System.Text;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
     internal partial class LanguageParser : SyntaxParser

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -11685,6 +11685,14 @@ done:;
 
                 case ScanTypeFlags.GenericTypeOrExpression:
                 case ScanTypeFlags.NonGenericTypeOrExpression:
+                    // if we have `(A)[]` then treat that always as a cast of an empty collection literal.  `[]` is not
+                    // legal on the RHS in any other circumstances for a parenthesized expr.
+                    if (this.CurrentToken.Kind == SyntaxKind.OpenBracketToken &&
+                        this.PeekToken(1).Kind == SyntaxKind.CloseBracketToken)
+                    {
+                        return true;
+                    }
+
                     // check for ambiguous type or expression followed by disambiguating token.  i.e.
                     //
                     // "(A)b" is a cast.  But "(A)+b" is not a cast.  

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -15,6 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
+    using System.Text;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
     internal partial class LanguageParser : SyntaxParser
@@ -5881,6 +5882,14 @@ parse_member_name:;
 
                     case ScanTypeFlags.GenericTypeOrMethod:
                         result = ScanTypeFlags.GenericTypeOrMethod;
+                        break;
+
+                    case ScanTypeFlags.NonGenericTypeOrExpression:
+                        // Explicitly keeping this case in the switch for clarity.  We parsed out another portion of the
+                        // type argument list that looks like it's a non-generic-type-or-expr (the simplest case just
+                        // being "X").  That changes nothing here wrt determining what type of entity we have here, so
+                        // just fall through and see if we're followed by a "," (in which case keep going), or a ">", in
+                        // which case we're done.
                         break;
                 }
             }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
@@ -3928,10 +3928,12 @@ class C
     [Fact]
     public void CastVersusIndexAmbiguity24_D()
     {
-        // PROTOTYPE: No errors here syntactically.  But user will likely get one semantically.
+        // PROTOTYPE: No errors here syntactically.  But user will likely get one semantically.  Specifically, this
+        // could look like a case of a collection literal with a spread element in it, or as indexing into a
+        // parenthesized expression with a range expression.
         //
         // We may want a dedicated error to tell them to parenthesize the brackets if they're trying to cast this as a list.
-        UsingExpression("(A)[..NotARange]");
+        UsingExpression("(A)[..B]");
 
         N(SyntaxKind.ElementAccessExpression);
         {
@@ -3954,7 +3956,7 @@ class C
                         N(SyntaxKind.DotDotToken);
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "NotARange");
+                            N(SyntaxKind.IdentifierToken, "B");
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
@@ -3818,12 +3818,34 @@ class C
     }
 
     [Fact]
-    public void CastVersusIndexAmbiguity24()
+    public void CastVersusIndexAmbiguity24_A()
     {
-        UsingExpression("(A)[]",
-            // (1,5): error CS0443: Syntax error; value expected
-            // (A)[]
-            Diagnostic(ErrorCode.ERR_ValueExpected, "]").WithLocation(1, 5));
+        UsingExpression("(A)[]");
+
+        N(SyntaxKind.CastExpression);
+        {
+            N(SyntaxKind.OpenParenToken);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "A");
+            }
+            N(SyntaxKind.CloseParenToken);
+            N(SyntaxKind.CollectionCreationExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CastVersusIndexAmbiguity24_B()
+    {
+        // PROTOTYPE: No errors here syntactically.  But user will likely get one semantically.
+        //
+        // We may want a dedicated error to tell them to parenthesize the brackets if they're trying to cast this as a list.
+        UsingExpression("(A)[1]");
 
         N(SyntaxKind.ElementAccessExpression);
         {
@@ -3839,11 +3861,101 @@ class C
             N(SyntaxKind.BracketedArgumentList);
             {
                 N(SyntaxKind.OpenBracketToken);
-                M(SyntaxKind.Argument);
+                N(SyntaxKind.Argument);
                 {
-                    M(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.NumericLiteralExpression);
                     {
-                        M(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CastVersusIndexAmbiguity24_C()
+    {
+        // PROTOTYPE: This is not a great diagnostic.  Users could easily run into this and be confused.  Can we do
+        // better.  For example:
+        //
+        // 1. tell them we think this is an indexer, and `1:2` isn't a valid argument.
+        // 2. tell them to parenthesize the brackets if they're trying to cast this as a list.
+        UsingExpression("(A)[1:2]",
+            // (1,6): error CS1003: Syntax error, ',' expected
+            // (A)[1:2]
+            Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",").WithLocation(1, 6),
+            // (1,7): error CS1003: Syntax error, ',' expected
+            // (A)[1:2]
+            Diagnostic(ErrorCode.ERR_SyntaxError, "2").WithArguments(",").WithLocation(1, 7));
+
+        N(SyntaxKind.ElementAccessExpression);
+        {
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.BracketedArgumentList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                    }
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CastVersusIndexAmbiguity24_D()
+    {
+        // PROTOTYPE: No errors here syntactically.  But user will likely get one semantically.
+        //
+        // We may want a dedicated error to tell them to parenthesize the brackets if they're trying to cast this as a list.
+        UsingExpression("(A)[..NotARange]");
+
+        N(SyntaxKind.ElementAccessExpression);
+        {
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.BracketedArgumentList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Argument);
+                {
+                    N(SyntaxKind.RangeExpression);
+                    {
+                        N(SyntaxKind.DotDotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "NotARange");
+                        }
                     }
                 }
                 N(SyntaxKind.CloseBracketToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
@@ -4169,6 +4169,61 @@ class C
     }
 
     [Fact]
+    public void CastVersusIndexAmbiguity30()
+    {
+        UsingExpression("(ImmutableArray<List<Int32>>)[[1]]");
+
+        N(SyntaxKind.CastExpression);
+        {
+            N(SyntaxKind.OpenParenToken);
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "ImmutableArray");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.GenericName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "List");
+                        N(SyntaxKind.TypeArgumentList);
+                        {
+                            N(SyntaxKind.LessThanToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Int32");
+                            }
+                            N(SyntaxKind.GreaterThanToken);
+                        }
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.CloseParenToken);
+            N(SyntaxKind.CollectionCreationExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.ExpressionElement);
+                {
+                    N(SyntaxKind.CollectionCreationExpression);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.ExpressionElement);
+                        {
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "1");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
     public void SpreadOfQuery()
     {
         UsingExpression("[.. from x in y select x]");

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CollectionLiteralParsingTests.cs
@@ -4102,6 +4102,73 @@ class C
     }
 
     [Fact]
+    public void CastVersusIndexAmbiguity28()
+    {
+        UsingExpression("(A<>)[]");
+
+        N(SyntaxKind.CastExpression);
+        {
+            N(SyntaxKind.OpenParenToken);
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "A");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.OmittedTypeArgument);
+                    {
+                        N(SyntaxKind.OmittedTypeArgumentToken);
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.CloseParenToken);
+            N(SyntaxKind.CollectionCreationExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void CastVersusIndexAmbiguity29()
+    {
+        UsingExpression("(A<,>)[]");
+
+        N(SyntaxKind.CastExpression);
+        {
+            N(SyntaxKind.OpenParenToken);
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "A");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.OmittedTypeArgument);
+                    {
+                        N(SyntaxKind.OmittedTypeArgumentToken);
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.OmittedTypeArgument);
+                    {
+                        N(SyntaxKind.OmittedTypeArgumentToken);
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.CloseParenToken);
+            N(SyntaxKind.CollectionCreationExpression);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.CloseBracketToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
     public void SpreadOfQuery()
     {
         UsingExpression("[.. from x in y select x]");


### PR DESCRIPTION
I realized that if you have `(A)[]` that that should not be an indexing expression as `[]` is not a legal indexer.  