### PR TITLE
Revert "Switch to new lower-overhead spell checking protocol"

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SpellCheck
         public override TextDocumentIdentifier GetTextDocumentIdentifier(VSInternalDocumentSpellCheckableParams requestParams)
             => requestParams.TextDocument;
 
-        protected override VSInternalSpellCheckableRangeReport CreateReport(TextDocumentIdentifier identifier, int[]? ranges, string? resultId)
+        protected override VSInternalSpellCheckableRangeReport CreateReport(TextDocumentIdentifier identifier, VSInternalSpellCheckableRange[]? ranges, string? resultId)
             => new()
             {
-                Ranges = ranges,
+                Ranges = ranges!,
                 ResultId = resultId,
             };
 

--- a/src/Features/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SpellCheck
     [Method(VSInternalMethods.WorkspaceSpellCheckableRangesName)]
     internal class WorkspaceSpellCheckHandler : AbstractSpellCheckHandler<VSInternalWorkspaceSpellCheckableParams, VSInternalWorkspaceSpellCheckableReport>
     {
-        protected override VSInternalWorkspaceSpellCheckableReport CreateReport(TextDocumentIdentifier identifier, int[]? ranges, string? resultId)
+        protected override VSInternalWorkspaceSpellCheckableReport CreateReport(TextDocumentIdentifier identifier, VSInternalSpellCheckableRange[]? ranges, string? resultId)
             => new()
             {
                 TextDocument = identifier,
-                Ranges = ranges,
+                Ranges = ranges!,
                 ResultId = resultId,
             };
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -116,7 +116,7 @@ class B : A
             Assert.Equal(@"public override void M()
     {
         throw new System.NotImplementedException();
-    }", results.TextEdit.Value.First.NewText);
+    }", results.TextEdit.NewText);
         }
 
         [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/51125")]
@@ -161,7 +161,7 @@ class B : A
             Assert.Equal(@"public override void M()
     {
         throw new System.NotImplementedException();$0
-    }", results.TextEdit.Value.First.NewText);
+    }", results.TextEdit.NewText);
         }
 
         [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/51125")]


### PR DESCRIPTION
#68426 is suspected of introducing RPS regressions.

Last known good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/477008
First known bad: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/477037
Revert validation: TODO

Please advise whether the failures are plausibly connected with this PR, and if so, whether we should revert, or take a follow-up PR to fix, or seek an exception. @genlu @CyrusNajmabadi @dibarbet.

It looks like this PR is improving perf, so most likely we want to be seeking an exception. In that case, this PR tracks the status of getting that exception.

<details>
    <summary>Regressed counters</summary>

❌ Test Run FAILED
There were 10 regressions, please review the results below.

🕳 View Performance Details on PIT 
PR build 33807.538.dn-bot.230608.055657.477037 VS. Baseline CI build main-33807.538

Performance results from Target run and Baseline run

🚩 Regressions
Check if there is a known noise issue in these counters 

Found in	Details	Next steps
BuildInfoVS64.Test
0001.BuildInfo
Build_Ngen_InvalidAssemblyCount
Regressed: 6 Count (35.29%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
WinformsVS64.Designer
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 6 Count (17.71%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
ManagedLangsVS64.SolutionManagement
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 5 Count (5.22%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
ManagedLangsVS64.Typing
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 6 Count (6.01%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
ManagedLangsVS64.RebuildSolution
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 5 Count (5.09%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
WebToolsVS64.SolutionManagement
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 6 Count (22.9%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
UWP64.ProjectManagement
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 5 Count (1.28%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
CPlusPlusVS64.SolutionManagement
9990.Totals
CLR_AdjustedExceptions_Count_Total_devenv
Regressed: 6 Count (11.63%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
CPlusPlusVS64.Debugging
0400.Stop Debugging
CLR_BytesAllocatedLOH_Total_devenv
Regressed: 695,168 Bytes (6.71%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 
CPlusPlusVS64.Coding
0400.MemberList
CLR_BytesAllocatedLOH_Total_devenv
Regressed: 611,187 Bytes (6.38%)	🕳 View it in PIT 
📂 Open test outputs 
📈 Compare in PerfView 

✅ 14 Improvements found
Found in	Details	Links
ManagedLangsVS64.Debugging
0200.Start Debugging
CLR_BytesAllocated_devenv
Improved: -3,881,378 Bytes (-23.06%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
WinformsVS64.Designer
9990.Totals
CLR_MethodsJitted_Total_devenv
Improved: -514 Count (-10.66%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.SolutionManagement
9990.Totals
CLR_MethodsJitted_Total_devenv
Improved: -491 Count (-11.62%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.RebuildSolution
9990.Totals
CLR_MethodsJitted_Total_devenv
Improved: -510 Count (-10.9%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
UWP64.ProjectManagement
9990.Totals
CLR_MethodsJitted_Total_devenv
Improved: -865 Count (-11.43%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
CPlusPlusVS64.SolutionManagement
0400.Change Solution Configuration - Warm
Duration_TotalElapsedTime
Improved: -615 ms (-20.72%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.SolutionManagement
0100.Open Solution
RefSet_Image_Delta_devenv
Improved: -3,178,496 Bytes (-3.12%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.SolutionManagement
0200.Close Solution
VM_AdjustedImagesInMemory_Total_devenv
Improved: -2 Count (-0.59%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.AddNewProject
0100.Add New Project
VM_AdjustedImagesInMemory_Total_devenv
Improved: -2 Count (-0.56%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.Debugging
0600.Stop Debugging
VM_AdjustedImagesInMemory_Total_devenv
Improved: -1 Count (-0.24%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
ManagedLangsVS64.Typing
0200.Typing
VM_AdjustedImagesInMemory_Total_devenv
Improved: -1 Count (-0.28%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
WebToolsVS64.TypingInWebforms
0200.Typing CSharp in Webforms
VM_AdjustedImagesInMemory_Total_devenv
Improved: -2 Count (-0.39%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
WebToolsVS64.Debugging
0300.Stop Debugging
VM_AdjustedImagesInMemory_Total_devenv
Improved: -1 Count (-0.18%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView
UWP64.ProjectManagement
0200.Xaml Designer Load
VM_AdjustedImagesInMemory_Total_devenv
Improved: -1 Count (-0.22%)	🕳 View it in PIT
📂 Open test outputs
📈 Compare in PerfView

</details>
