### PR TITLE
Use GetContainingLineNumber() to reduce allocations

### DIFF
--- a/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
@@ -362,8 +362,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             var visibleEnd = visibleSpansInBuffer.Last().End;
 
             var snapshot = subjectBuffer.CurrentSnapshot;
-            var startLine = visibleStart.GetContainingLine().LineNumber;
-            var endLine = visibleEnd.GetContainingLine().LineNumber;
+            var startLine = visibleStart.GetContainingLineNumber();
+            var endLine = visibleEnd.GetContainingLineNumber();
 
             startLine = Math.Max(startLine - extraLines, 0);
             endLine = Math.Min(endLine + extraLines, snapshot.LineCount - 1);

--- a/src/EditorFeatures/Core/Shared/Extensions/SnapshotPointExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/SnapshotPointExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             => point.Snapshot.GetLineAndCharacter(point.Position, out lineNumber, out characterIndex);
 
         public static int GetContainingLineNumber(this SnapshotPoint point)
-            => point.GetContainingLine().LineNumber;
+            => point.GetContainingLineNumber();
 
         public static ITrackingPoint CreateTrackingPoint(this SnapshotPoint point, PointTrackingMode trackingMode)
             => point.Snapshot.CreateTrackingPoint(point, trackingMode);

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -255,7 +255,7 @@ End Class
                                               Sub() AssertEx.Fail("Tab should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
 
-                Assert.Equal(3, view.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
+                Assert.Equal(3, view.Caret.Position.BufferPosition.GetContainingLineNumber())
 
                 session.Cancel()
             End Using

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -222,7 +222,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
         Public Shared Function IsMovementBetweenStatements(oldPoint As SnapshotPoint, newPoint As SnapshotPoint, cancellationToken As CancellationToken) As Boolean
             ' If they are the same line, then definitely no
-            If oldPoint.GetContainingLine().LineNumber = newPoint.GetContainingLine().LineNumber Then
+            If oldPoint.GetContainingLineNumber() = newPoint.GetContainingLineNumber() Then
                 Return False
             End If
 

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
@@ -462,7 +462,7 @@ End Class
                  End Sub,
                  Sub(expected, actual, view)
                      AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, actual)
-                     Assert.Equal(4, view.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
+                     Assert.Equal(4, view.Caret.Position.BufferPosition.GetContainingLineNumber())
                      Assert.Equal(4, view.Caret.Position.VirtualSpaces)
                  End Sub)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -253,7 +253,7 @@ rem Hello World$$|]
                 testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine(), TestCommandExecutionContext.Create())
                 testData.UndoHistory.Undo(count:=1)
 
-                Assert.Equal(0, testData.View.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
+                Assert.Equal(0, testData.View.Caret.Position.BufferPosition.GetContainingLineNumber())
             End Using
         End Sub
 
@@ -342,14 +342,14 @@ End Module
 
         Private Shared Sub AssertCommitsStatement(test As XElement, expectCommit As Boolean, Optional usedSemantics As Boolean = True)
             Using testData = CommitTestData.Create(test)
-                Dim lineNumber = testData.View.Caret.Position.BufferPosition.GetContainingLine().LineNumber
+                Dim lineNumber = testData.View.Caret.Position.BufferPosition.GetContainingLineNumber()
                 testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine(), TestCommandExecutionContext.Create())
                 testData.AssertHadCommit(expectCommit)
                 If expectCommit Then
                     testData.AssertUsedSemantics(usedSemantics)
                 End If
 
-                Assert.Equal(lineNumber + 1, testData.View.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
+                Assert.Equal(lineNumber + 1, testData.View.Caret.Position.BufferPosition.GetContainingLineNumber())
             End Using
         End Sub
     End Class


### PR DESCRIPTION
Calling `GetContainingLine().LineNumber` causes `TextSnapshotLine` allocations. The `GetContainingLineNumber()` method avoids these.