### PR TITLE
Enhance the SARIF v2 log to report analyzer execution time

### DIFF
--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -29,6 +29,9 @@ Example `runs` section, with stripped off `results` and `rules` sections:
 {
   "results": [
   ],
+  "properties": {
+    "analyzerExecutionTime": "x.xxx"
+  },
   "tool": {
     "driver": {
       "name": "Microsoft (R) Visual C# Compiler",
@@ -131,6 +134,8 @@ Example `rule` entry:
   "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001",
   "properties": {
     "category": "Design",
+    "executionTimeInSeconds": "x.xxx",
+    "executionTimeInPercentage": "xx",
     "isEverSuppressed": "true",
     "suppressionKinds": [
       "external"

--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -16,10 +16,12 @@ This section provides a high level overview of the contents of the SARIF v2 erro
 "version": "2.1.0",
 ```
 
-2. `runs` information: The core entry in the error log file is the `runs` section with a single run entry within it for the build. The run entry has 3 main parts:
-  1. `results` section: This section contains an array of result entries, where each result corresponds to information about a reported compiler or analyzer `Diagnostic`. More details in [`Result` format for each compiler or analyzer `Diagnostic` instance](#result-format-for-each-compiler-or-analyzer-diagnostic-instance).
-  2. `tools` section: This section contains information about the compiler build and version. Additionally, it contains a `rules` array, where each rule entry corresponds to metadata or `DiagnosticDescriptor` information about each reported analyzer diagnostic. More details in [`Rule` format for each analyzer supported `DiagnosticDescriptor` instance](#rule-format-for-each-analyzer-supported-diagnosticdescriptor-instance)
-  3. `columnKind` section: This section contains information about the unit in which the tool measures columns. C# and Visual Basic compilers uses utf16 code units.
+2. `runs` information: The core entry in the error log file is the `runs` section with a single run entry within it for the build. The run entry has the following main parts:
+   1. `results` section: This section contains an array of result entries, where each result corresponds to information about a reported compiler or analyzer `Diagnostic`. More details in [`Result` format for each compiler or analyzer `Diagnostic` instance](#result-format-for-each-compiler-or-analyzer-diagnostic-instance).
+   2. `properties` section: This section contains custom key-value properties associated with the run. Following properties are currently emitted:
+      1. `analyzerExecutionTime`: Execution time in seconds for execution of all analyzers, as reported with the `/reportAnalyzer` compiler switch.
+   3. `tools` section: This section contains information about the compiler build and version. Additionally, it contains a `rules` array, where each rule entry corresponds to metadata or `DiagnosticDescriptor` information about each reported analyzer diagnostic. More details in [`Rule` format for each analyzer supported `DiagnosticDescriptor` instance](#rule-format-for-each-analyzer-supported-diagnosticdescriptor-instance)
+   4. `columnKind` section: This section contains information about the unit in which the tool measures columns. C# and Visual Basic compilers uses utf16 code units.
 
 Example `runs` section, with stripped off `results` and `rules` sections:
 ```json
@@ -51,9 +53,9 @@ The results section contains an array of result entries, where each result corre
 3. `level`: Severity level for the diagnostic, such as `error`, `warning`, `note`, etc.
 4. `message`: User facing message for the diagnostic.
 5. `suppressions`: For each diagnostic instance that is suppressed with a pragma directive, SuppressMessageAttribute or via a DiagnosticSuppressor, the result entry contains `suppressions` section with the following data:
-  1. `kind` information: C# and Visual Basic compilers support a single `inSource` suppression kind.
-  2. `justification` information: Justification pertaining to the suppression. Currently, this field is populated only for `SuppressMessageAttribute` based suppression, with a non-null justification argument.
-  3. `suppressionType` property with one of these three values: `Pramga Directive`, `SuppressMessageAttribute`, or `DiagnosticSuppressor`. This data helps analyze the preferred in-source suppression mechanisms in a code base.
+   1. `kind` information: C# and Visual Basic compilers support a single `inSource` suppression kind.
+   2. `justification` information: Justification pertaining to the suppression. Currently, this field is populated only for `SuppressMessageAttribute` based suppression, with a non-null justification argument.
+   3. `suppressionType` property with one of these three values: `Pramga Directive`, `SuppressMessageAttribute`, or `DiagnosticSuppressor`. This data helps analyze the preferred in-source suppression mechanisms in a code base.
 6. `locations`: One or more locations associated with the diagnostic.
 7. `properties`: One or more custom key-value string pairs associated with the diagnostic.
 
@@ -105,11 +107,13 @@ The `rules` section contains a rule entry that corresponds to metadata or `Diagn
 4. `defaultConfiguration`: Default severity level for the diagnostics reported for the descriptor, such as `error`, `warning`, `note`, etc.
 5. `helpUri`: Help uri for help information associated with the descriptor.
 6. `properties`: One or more custom properties associated with the descriptor. It includes the following:
-  1. `category`: `Category` associated with the descriptor, such as, `Design`, `Performance`, `Security`, etc.
-  2. `isEverSuppressed` and `suppressionKinds`: If a rule had either a source suppression or was disabled for part or whole of the compilation via options, the rule metadata contains a special flag `isEverSuppressed = true` and an array `suppressionKinds` with either or both of the below suppression kinds:
-    1. `inSource` suppression kind for one or more reported diagnostic(s) that were suppressed through pragma directive, SuppressMessageAttribute or a DiagnosticSuppressor.
-    2. `external` suppression kind for diagnostic ID that is disabled either for the entire compilation (via global options such as /nowarn, ruleset, globalconfig, etc.) or for certain files or folders in the compilation (via editorconfig options).
-  3. `tags`: An array of one of more `CustomTags` associated with the descriptor.
+   1. `category`: `Category` associated with the descriptor, such as, `Design`, `Performance`, `Security`, etc.
+   2. `executionTimeInSeconds`: Execution time in seconds associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `0.001` seconds are reported as `<0.001`.
+   3. `executionTimeInPercentage`: Execution time in percentage associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `1` are reported as `<1`.
+   4. `isEverSuppressed` and `suppressionKinds`: If a rule had either a source suppression or was disabled for part or whole of the compilation via options, the rule metadata contains a special flag `isEverSuppressed = true` and an array `suppressionKinds` with either or both of the below suppression kinds:
+      1. `inSource` suppression kind for one or more reported diagnostic(s) that were suppressed through pragma directive, SuppressMessageAttribute or a DiagnosticSuppressor.
+      2. `external` suppression kind for diagnostic ID that is disabled either for the entire compilation (via global options such as /nowarn, ruleset, globalconfig, etc.) or for certain files or folders in the compilation (via editorconfig options).
+   5. `tags`: An array of one of more `CustomTags` associated with the descriptor.
   
 Example `rule` entry:
 ```json

--- a/src/Compilers/CSharp/Test/CommandLine/SarifErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifErrorLoggerTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     public abstract class SarifErrorLoggerTests : CommandLineTestBase
     {
         protected abstract string ErrorLogQualifier { get; }
-        internal abstract string GetExpectedOutputForNoDiagnostics(CommonCompiler cmd);
-        internal abstract string GetExpectedOutputForSimpleCompilerDiagnostics(CommonCompiler cmd, string sourceFile);
-        internal abstract string GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(CommonCompiler cmd, string sourceFile, params string[] suppressionKinds);
+        internal abstract string GetExpectedOutputForNoDiagnostics(MockCSharpCompiler cmd);
+        internal abstract string GetExpectedOutputForSimpleCompilerDiagnostics(MockCSharpCompiler cmd, string sourceFile);
+        internal abstract string GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(MockCSharpCompiler cmd, string sourceFile, params string[] suppressionKinds);
         internal abstract string GetExpectedOutputForAnalyzerDiagnosticsWithAndWithoutLocation(MockCSharpCompiler cmd);
         internal abstract string GetExpectedOutputForAnalyzerDiagnosticsWithSuppression(MockCSharpCompiler cmd, string justification, string suppressionType, params string[] suppressionKinds);
 

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     {
         protected override string ErrorLogQualifier => string.Empty;
 
-        internal override string GetExpectedOutputForNoDiagnostics(CommonCompiler cmd)
+        internal override string GetExpectedOutputForNoDiagnostics(MockCSharpCompiler cmd)
         {
             var expectedHeader = GetExpectedErrorLogHeader(cmd);
             var expectedIssues = @"
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             NoDiagnosticsImpl();
         }
 
-        internal override string GetExpectedOutputForSimpleCompilerDiagnostics(CommonCompiler cmd, string sourceFile)
+        internal override string GetExpectedOutputForSimpleCompilerDiagnostics(MockCSharpCompiler cmd, string sourceFile)
         {
             var expectedHeader = GetExpectedErrorLogHeader(cmd);
             var expectedIssues = string.Format(@"
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             SimpleCompilerDiagnosticsImpl();
         }
 
-        internal override string GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(CommonCompiler cmd, string sourceFile, params string[] suppressionKinds)
+        internal override string GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(MockCSharpCompiler cmd, string sourceFile, params string[] suppressionKinds)
         {
             var expectedHeader = GetExpectedErrorLogHeader(cmd);
             var expectedIssues = string.Format(@"

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1109,7 +1109,7 @@ namespace Microsoft.CodeAnalysis
                         analyzerOptions,
                         new AnalyzerManager(analyzers),
                         analyzerExceptionDiagnostics.Add,
-                        Arguments.ReportAnalyzer,
+                        reportAnalyzer: Arguments.ReportAnalyzer || errorLogger != null,
                         severityFilter,
                         trackSuppressedDiagnosticIds: errorLogger != null,
                         out compilation,
@@ -1303,7 +1303,8 @@ namespace Microsoft.CodeAnalysis
 
                             if (errorLogger != null)
                             {
-                                errorLogger.AddAnalyzerDescriptors(analyzerDriver.GetAllDescriptors(cancellationToken));
+                                var descriptorsWithInfo = analyzerDriver.GetAllDiagnosticDescriptorsWithInfo(cancellationToken, out var totalAnalyzerExecutionTime);
+                                AddAnalyzerDescriptorsAndExecutionTime(errorLogger, descriptorsWithInfo, totalAnalyzerExecutionTime);
                             }
                         }
                     }
@@ -1405,6 +1406,8 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<AdditionalText> additionalTextFiles,
             AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
             => new Diagnostics.AnalyzerOptions(additionalTextFiles, analyzerConfigOptionsProvider);
+        protected virtual void AddAnalyzerDescriptorsAndExecutionTime(ErrorLogger errorLogger, ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptorsWithInfo, double totalAnalyzerExecutionTime)
+            => errorLogger.AddAnalyzerDescriptorsAndExecutionTime(descriptorsWithInfo, totalAnalyzerExecutionTime);
 
         private bool WriteTouchedFiles(DiagnosticBag diagnostics, TouchedFileLogger? touchedFilesLogger, string? finalXmlFilePath)
         {

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis
     ///      external non-source suppression from editorconfig, ruleset, command line options, etc.,
     ///      which disables the descriptor for either part of the compilation or the entire compilation.
     ///      Note that this flag doesn't account for source suppressions from pragma directives,
-    ///      SuppressMessageAttributes, DiagnosticSuppressors, etc. which suppresses individual instances
+    ///      SuppressMessageAttributes, DiagnosticSuppressors, etc. which suppress individual instances
     ///      of reported diagnostics.
     /// </summary>
     internal readonly record struct DiagnosticDescriptorErrorLoggerInfo(

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -13,6 +13,23 @@ namespace Microsoft.CodeAnalysis
     internal abstract class ErrorLogger
     {
         public abstract void LogDiagnostic(Diagnostic diagnostic, SuppressionInfo? suppressionInfo);
-        public abstract void AddAnalyzerDescriptors(ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> descriptors);
+        public abstract void AddAnalyzerDescriptorsAndExecutionTime(ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptors, double totalAnalyzerExecutionTime);
     }
+
+    /// <summary>
+    /// Contains information associated with a <see cref="DiagnosticDescriptor"/>
+    /// for the <see cref="ErrorLogger"/>. It contains the following:
+    ///   1. Analyzer execution time in seconds for the analyzer owning the descriptor.
+    ///   2. Analyzer execution time in percentage of the total analyzer execution time.
+    ///   3. A boolean value "HasAnyExternalSuppression" indicating if the diagnostic ID has any
+    ///      external non-source suppression from editorconfig, ruleset, command line options, etc.,
+    ///      which disables the descriptor for either part of the compilation or the entire compilation.
+    ///      Note that this flag doesn't account for source suppressions from pragma directives,
+    ///      SuppressMessageAttributes, DiagnosticSuppressors, etc. which suppresses individual instances
+    ///      of reported diagnostics.
+    /// </summary>
+    internal readonly record struct DiagnosticDescriptorErrorLoggerInfo(
+        double ExecutionTime,
+        int ExecutionPercentage,
+        bool HasAnyExternalSuppression);
 }

--- a/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ReportAnalyzerUtil.cs
@@ -39,9 +39,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static string GetFormattedTime(double d, CultureInfo culture) => d < 0.001 ?
+        public static string GetFormattedAnalyzerExecutionTime(double executionTime, CultureInfo culture) =>
+            executionTime < 0.001 ?
                 string.Format(culture, "{0,8:<0.000}", 0.001) :
-                string.Format(culture, "{0,8:##0.000}", d);
+                string.Format(culture, "{0,8:##0.000}", executionTime);
+
+        public static string GetFormattedAnalyzerExecutionPercentage(int percentage, CultureInfo culture) =>
+            string.Format("{0,5}", percentage < 1 ? "<1" : percentage.ToString(culture));
 
         private static string GetColumnHeader(string kind)
         {
@@ -52,8 +56,8 @@ namespace Microsoft.CodeAnalysis
 
         private static string GetColumnEntry(double totalSeconds, int percentage, string? name, CultureInfo culture)
         {
-            var time = GetFormattedTime(totalSeconds, culture);
-            var percent = string.Format("{0,5}", percentage < 1 ? "<1" : percentage.ToString(culture));
+            var time = GetFormattedAnalyzerExecutionTime(totalSeconds, culture);
+            var percent = GetFormattedAnalyzerExecutionPercentage(percentage, culture);
 
             return time + percent + "   " + name;
         }

--- a/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public override void AddAnalyzerDescriptors(ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> descriptors)
+        public override void AddAnalyzerDescriptorsAndExecutionTime(ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptors, double totalAnalyzerExecutionTime)
         {
             // We log all analyzer descriptors only in SARIF v2+ format.
         }

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -227,6 +227,7 @@ namespace Microsoft.CodeAnalysis
             {
                 _writer.WriteArrayStart("rules");
 
+                var reportAnalyzerExecutionTime = !string.IsNullOrEmpty(_totalAnalyzerExecutionTime);
                 foreach (var (_, descriptor, descriptorInfo) in _descriptors.ToSortedList())
                 {
                     _writer.WriteObjectStart(); // rule
@@ -264,7 +265,6 @@ namespace Microsoft.CodeAnalysis
                     var hasAnySourceSuppression = _diagnosticIdsWithAnySourceSuppressions.Contains(descriptor.Id);
                     var isEverSuppressed = descriptorInfo.HasAnyExternalSuppression || hasAnySourceSuppression;
 
-                    var reportAnalyzerExecutionTime = !string.IsNullOrEmpty(_totalAnalyzerExecutionTime);
                     Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionTime == 0);
                     Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionPercentage == 0);
 
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis
                 if (_distinctDescriptors.TryGetValue(descriptor, out var descriptorInfoWithIndex))
                 {
                     // Descriptor has already been seen.
-                    // Update 'HasAnyExternalSuppression' value if different from the saved one.
+                    // Update 'Info' value if different from the saved one.
                     if (info.HasValue && descriptorInfoWithIndex.Info != info)
                     {
                         descriptorInfoWithIndex = new(descriptorInfoWithIndex.Index, info.Value);

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -29,6 +29,8 @@ namespace Microsoft.CodeAnalysis
         private readonly string _toolFileVersion;
         private readonly Version _toolAssemblyVersion;
 
+        private string? _totalAnalyzerExecutionTime;
+
         public SarifV2ErrorLogger(Stream stream, string toolName, string toolFileVersion, Version toolAssemblyVersion, CultureInfo culture)
             : base(stream, culture)
         {
@@ -114,12 +116,14 @@ namespace Microsoft.CodeAnalysis
             _writer.WriteObjectEnd(); // result
         }
 
-        public override void AddAnalyzerDescriptors(ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> descriptors)
+        public override void AddAnalyzerDescriptorsAndExecutionTime(ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptors, double totalAnalyzerExecutionTime)
         {
-            foreach (var (descriptor, hasAnyExternalSuppression) in descriptors.OrderBy(d => d.Descriptor.Id))
+            foreach (var (descriptor, info) in descriptors.OrderBy(d => d.Descriptor.Id))
             {
-                _descriptors.Add(descriptor, hasAnyExternalSuppression);
+                _descriptors.Add(descriptor, info);
             }
+
+            _totalAnalyzerExecutionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(totalAnalyzerExecutionTime, _culture).Trim();
         }
 
         private void WriteLocations(Location location, IReadOnlyList<Location> additionalLocations)
@@ -183,6 +187,15 @@ namespace Microsoft.CodeAnalysis
         {
             _writer.WriteArrayEnd(); //results
 
+            if (!string.IsNullOrEmpty(_totalAnalyzerExecutionTime))
+            {
+                _writer.WriteObjectStart("properties");
+
+                _writer.Write("analyzerExecutionTime", _totalAnalyzerExecutionTime);
+
+                _writer.WriteObjectEnd(); // properties
+            }
+
             WriteTool();
 
             _writer.Write("columnKind", "utf16CodeUnits");
@@ -215,7 +228,7 @@ namespace Microsoft.CodeAnalysis
             {
                 _writer.WriteArrayStart("rules");
 
-                foreach (var (_, descriptor, hasAnyExternalSuppression) in _descriptors.ToSortedList())
+                foreach (var (_, descriptor, descriptorInfo) in _descriptors.ToSortedList())
                 {
                     _writer.WriteObjectStart(); // rule
                     _writer.Write("id", descriptor.Id);
@@ -250,9 +263,13 @@ namespace Microsoft.CodeAnalysis
                     // 2. If there is any source suppression for diagnostic(s) with the rule ID through pragma directive,
                     //    SuppressMessageAttribute, DiagnosticSuppressor, etc.
                     var hasAnySourceSuppression = _diagnosticIdsWithAnySourceSuppressions.Contains(descriptor.Id);
-                    var isEverSuppressed = hasAnyExternalSuppression || hasAnySourceSuppression;
+                    var isEverSuppressed = descriptorInfo.HasAnyExternalSuppression || hasAnySourceSuppression;
+                    
+                    var reportAnalyzerExecutionTime = !string.IsNullOrEmpty(_totalAnalyzerExecutionTime);
+                    Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionTime == 0);
+                    Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionPercentage == 0);
 
-                    if (!string.IsNullOrEmpty(descriptor.Category) || isEverSuppressed || descriptor.ImmutableCustomTags.Any())
+                    if (!string.IsNullOrEmpty(descriptor.Category) || isEverSuppressed || reportAnalyzerExecutionTime || descriptor.ImmutableCustomTags.Any())
                     {
                         _writer.WriteObjectStart("properties");
 
@@ -267,7 +284,7 @@ namespace Microsoft.CodeAnalysis
 
                             _writer.WriteArrayStart("suppressionKinds");
 
-                            if (hasAnyExternalSuppression)
+                            if (descriptorInfo.HasAnyExternalSuppression)
                             {
                                 _writer.Write("external");
                             }
@@ -278,6 +295,15 @@ namespace Microsoft.CodeAnalysis
                             }
 
                             _writer.WriteArrayEnd(); // suppressionKinds
+                        }
+
+                        if (reportAnalyzerExecutionTime)
+                        {
+                            var executionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(descriptorInfo.ExecutionTime, _culture).Trim();
+                            _writer.Write("executionTimeInSeconds", executionTime);
+
+                            var executionPercentage = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionPercentage(descriptorInfo.ExecutionPercentage, _culture).Trim();
+                            _writer.Write("executionTimeInPercentage", executionPercentage);
                         }
 
                         if (descriptor.ImmutableCustomTags.Any())
@@ -336,9 +362,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         private sealed class DiagnosticDescriptorSet
         {
-            private readonly record struct DescriptorInfo(int Index, bool HasAnyExternalSuppression);
+            private readonly record struct DescriptorInfoWithIndex(int Index, DiagnosticDescriptorErrorLoggerInfo Info);
             // DiagnosticDescriptor -> DescriptorInfo
-            private readonly Dictionary<DiagnosticDescriptor, DescriptorInfo> _distinctDescriptors = new(SarifDiagnosticComparer.Instance);
+            private readonly Dictionary<DiagnosticDescriptor, DescriptorInfoWithIndex> _distinctDescriptors = new(SarifDiagnosticComparer.Instance);
 
             /// <summary>
             /// The total number of descriptors in the set.
@@ -351,24 +377,23 @@ namespace Microsoft.CodeAnalysis
             /// <returns>
             /// The unique key assigned to the given descriptor.
             /// </returns>
-            public int Add(DiagnosticDescriptor descriptor, bool? hasAnyExternalSuppression = null)
+            public int Add(DiagnosticDescriptor descriptor, DiagnosticDescriptorErrorLoggerInfo? info = null)
             {
-                if (_distinctDescriptors.TryGetValue(descriptor, out var descriptorInfo))
+                if (_distinctDescriptors.TryGetValue(descriptor, out var descriptorInfoWithIndex))
                 {
                     // Descriptor has already been seen.
                     // Update 'HasAnyExternalSuppression' value if different from the saved one.
-                    if (hasAnyExternalSuppression.HasValue &&
-                        descriptorInfo.HasAnyExternalSuppression != hasAnyExternalSuppression.Value)
+                    if (info.HasValue && descriptorInfoWithIndex.Info != info)
                     {
-                        descriptorInfo = new(descriptorInfo.Index, hasAnyExternalSuppression.Value);
-                        _distinctDescriptors[descriptor] = descriptorInfo;
+                        descriptorInfoWithIndex = new(descriptorInfoWithIndex.Index, info.Value);
+                        _distinctDescriptors[descriptor] = descriptorInfoWithIndex;
                     }
 
-                    return descriptorInfo.Index;
+                    return descriptorInfoWithIndex.Index;
                 }
                 else
                 {
-                    _distinctDescriptors.Add(descriptor, new(Index: Count, hasAnyExternalSuppression ?? false));
+                    _distinctDescriptors.Add(descriptor, new(Index: Count, info ?? default));
                     return Count - 1;
                 }
             }
@@ -376,16 +401,16 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Converts the set to a list, sorted by index.
             /// </summary>
-            public List<(int Index, DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> ToSortedList()
+            public List<(int Index, DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> ToSortedList()
             {
                 Debug.Assert(Count > 0);
 
-                var list = new List<(int Index, DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)>(Count);
+                var list = new List<(int Index, DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)>(Count);
 
                 foreach (var pair in _distinctDescriptors)
                 {
                     Debug.Assert(list.Capacity > list.Count);
-                    list.Add((pair.Value.Index, pair.Key, pair.Value.HasAnyExternalSuppression));
+                    list.Add((pair.Value.Index, pair.Key, pair.Value.Info));
                 }
 
                 Debug.Assert(list.Capacity == list.Count);

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
 
@@ -264,7 +263,7 @@ namespace Microsoft.CodeAnalysis
                     //    SuppressMessageAttribute, DiagnosticSuppressor, etc.
                     var hasAnySourceSuppression = _diagnosticIdsWithAnySourceSuppressions.Contains(descriptor.Id);
                     var isEverSuppressed = descriptorInfo.HasAnyExternalSuppression || hasAnySourceSuppression;
-                    
+
                     var reportAnalyzerExecutionTime = !string.IsNullOrEmpty(_totalAnalyzerExecutionTime);
                     Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionTime == 0);
                     Debug.Assert(reportAnalyzerExecutionTime || descriptorInfo.ExecutionPercentage == 0);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -888,20 +888,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
-        /// Returns an array of all <see cref="DiagnosticDescriptor"/>s for all <see cref="Analyzers"/> along
-        /// with a boolean value "HasAnyExternalSuppression" indicating if the diagnostic ID has any
-        /// external non-source suppression from editorconfig, ruleset, command line options, etc.,
-        /// which disables the descriptor for either part of the compilation or the entire compilation.
-        /// Note that this flag doesn't account for source suppressions from pragma directives,
-        /// SuppressMessageAttributes, DiagnosticSuppressors, etc. which suppresses individual instances
-        /// of reported diagnostics.
+        /// Returns an array of  <see cref="DiagnosticDescriptor"/>s for all <see cref="Analyzers"/>
+        /// along with <see cref="DiagnosticDescriptorErrorLoggerInfo"/> to be logged by the <see cref="ErrorLogger"/>.
         /// </summary>
-        public ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> GetAllDescriptors(CancellationToken cancellationToken)
+        public ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> GetAllDiagnosticDescriptorsWithInfo(CancellationToken cancellationToken, out double totalAnalyzerExecutionTime)
         {
             var uniqueDiagnosticIds = PooledHashSet<string>.GetInstance();
             var analyzersSuppressedForSomeTree = SuppressedAnalyzersForTreeMap.SelectMany(kvp => kvp.Value).ToImmutableHashSet();
+            totalAnalyzerExecutionTime = AnalyzerExecutionTimes.Sum(kvp => kvp.Value.TotalSeconds);
 
-            var builder = ArrayBuilder<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)>.GetInstance();
+            var builder = ArrayBuilder<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)>.GetInstance();
             foreach (var analyzer in Analyzers)
             {
                 var descriptors = AnalyzerManager.GetSupportedDiagnosticDescriptors(analyzer, AnalyzerExecutor, cancellationToken);
@@ -910,6 +906,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // or for one or more syntax trees via editorconfig.
                 bool isAnalyzerEverSuppressed = !UnsuppressedAnalyzers.Contains(analyzer) ||
                     analyzersSuppressedForSomeTree.Contains(analyzer);
+
+                double analyzerExecutionTime = 0;
+                if (AnalyzerExecutionTimes.TryGetValue(analyzer, out var analyzerExecutionTimeSpan))
+                {
+                    analyzerExecutionTime = analyzerExecutionTimeSpan.TotalSeconds;
+                }
+
+                var executionPercentage = (int)(analyzerExecutionTime * 100 / totalAnalyzerExecutionTime);
+
                 foreach (var descriptor in descriptors)
                 {
                     if (!uniqueDiagnosticIds.Add(descriptor.Id))
@@ -922,7 +927,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var isDiagnosticIdEverSuppressed = isAnalyzerEverSuppressed ||
                         SuppressedDiagnosticIdsForUnsuppressedAnalyzers.Contains(descriptor.Id);
 
-                    builder.Add((descriptor, isDiagnosticIdEverSuppressed));
+                    var info = new DiagnosticDescriptorErrorLoggerInfo(analyzerExecutionTime, executionPercentage, isDiagnosticIdEverSuppressed);
+                    builder.Add((descriptor, info));
                 }
             }
 

--- a/src/Compilers/Test/Core/Compilation/DiagnosticBagErrorLogger.cs
+++ b/src/Compilers/Test/Core/Compilation/DiagnosticBagErrorLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Diagnostics.Add(diagnostic);
         }
 
-        public override void AddAnalyzerDescriptors(ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> descriptors)
+        public override void AddAnalyzerDescriptorsAndExecutionTime(ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptors, double totalAnalyzerExecutionTime)
         {
         }
     }

--- a/src/Compilers/Test/Core/Compilation/NullErrorLogger.cs
+++ b/src/Compilers/Test/Core/Compilation/NullErrorLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
         }
 
-        public override void AddAnalyzerDescriptors(ImmutableArray<(DiagnosticDescriptor Descriptor, bool HasAnyExternalSuppression)> descriptors)
+        public override void AddAnalyzerDescriptorsAndExecutionTime(ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptors, double totalAnalyzerExecutionTime)
         {
         }
     }

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis
                 var descriptor1Info = descriptorsWithInfo.Single(d => d.Descriptor.Id == Descriptor1.Id).Info;
                 var descriptor1ExecutionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(descriptor1Info.ExecutionTime, culture).Trim();
                 var descriptor1ExecutionPercentage = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionPercentage(descriptor1Info.ExecutionPercentage, culture).Trim();
-                
+
                 var descriptor2Info = descriptorsWithInfo.Single(d => d.Descriptor.Id == Descriptor2.Id).Info;
                 var descriptor2ExecutionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(descriptor2Info.ExecutionTime, culture).Trim();
                 var descriptor2ExecutionPercentage = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionPercentage(descriptor2Info.ExecutionPercentage, culture).Trim();

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -371,8 +372,20 @@ namespace Microsoft.CodeAnalysis
                 return string.Empty;
             }
 
-            public static string GetExpectedV2ErrorLogRulesText(string[] suppressionKinds1 = null, string[] suppressionKinds2 = null)
+            internal static string GetExpectedV2ErrorLogRulesText(
+                ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptorsWithInfo,
+                CultureInfo culture,
+                string[] suppressionKinds1 = null,
+                string[] suppressionKinds2 = null)
             {
+                var descriptor1Info = descriptorsWithInfo.Single(d => d.Descriptor.Id == Descriptor1.Id).Info;
+                var descriptor1ExecutionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(descriptor1Info.ExecutionTime, culture).Trim();
+                var descriptor1ExecutionPercentage = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionPercentage(descriptor1Info.ExecutionPercentage, culture).Trim();
+                
+                var descriptor2Info = descriptorsWithInfo.Single(d => d.Descriptor.Id == Descriptor2.Id).Info;
+                var descriptor2ExecutionTime = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(descriptor2Info.ExecutionTime, culture).Trim();
+                var descriptor2ExecutionPercentage = ReportAnalyzerUtil.GetFormattedAnalyzerExecutionPercentage(descriptor2Info.ExecutionPercentage, culture).Trim();
+
                 return
 @"          ""rules"": [
             {
@@ -386,6 +399,8 @@ namespace Microsoft.CodeAnalysis
               ""helpUri"": """ + Descriptor1.HelpLinkUri + @""",
               ""properties"": {
                 ""category"": """ + Descriptor1.Category + @"""" + GetExpectedV2SuppressionTextForRulesSection(suppressionKinds1) + @",
+                ""executionTimeInSeconds"": """ + descriptor1ExecutionTime + @""",
+                ""executionTimeInPercentage"": """ + descriptor1ExecutionPercentage + @""",
                 ""tags"": [
                   " + string.Join("," + Environment.NewLine + "                  ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
                 ]
@@ -405,6 +420,8 @@ namespace Microsoft.CodeAnalysis
               ""helpUri"": """ + Descriptor2.HelpLinkUri + @""",
               ""properties"": {
                 ""category"": """ + Descriptor2.Category + @"""" + GetExpectedV2SuppressionTextForRulesSection(suppressionKinds2) + @",
+                ""executionTimeInSeconds"": """ + descriptor2ExecutionTime + @""",
+                ""executionTimeInPercentage"": """ + descriptor2ExecutionPercentage + @""",
                 ""tags"": [
                   " + String.Join("," + Environment.NewLine + "                  ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
                 ]

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         private readonly ImmutableArray<ISourceGenerator> _generators;
         internal Compilation Compilation;
         internal AnalyzerOptions AnalyzerOptions;
+        internal ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> DescriptorsWithInfo;
+        internal double TotalAnalyzerExecutionTime;
 
         public MockCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
             : this(responseFile, CreateBuildPaths(workingDirectory), args, analyzers, generators, loader)
@@ -88,5 +90,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             AnalyzerOptions = base.CreateAnalyzerOptions(additionalTextFiles, analyzerConfigOptionsProvider);
             return AnalyzerOptions;
         }
+
+        protected override void AddAnalyzerDescriptorsAndExecutionTime(ErrorLogger errorLogger, ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptorsWithInfo, double totalAnalyzerExecutionTime)
+        {
+            DescriptorsWithInfo = descriptorsWithInfo;
+            TotalAnalyzerExecutionTime = totalAnalyzerExecutionTime;
+
+            base.AddAnalyzerDescriptorsAndExecutionTime(errorLogger, descriptorsWithInfo, totalAnalyzerExecutionTime);
+        }
+
+        public string GetAnalyzerExecutionTimeFormattedString()
+            => ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(TotalAnalyzerExecutionTime, Culture).Trim();
     }
 }

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports System.IO
+Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Test.Utilities
@@ -15,6 +16,8 @@ Friend Class MockVisualBasicCompiler
     Private ReadOnly _generators As ImmutableArray(Of ISourceGenerator)
     Public Compilation As Compilation
     Public AnalyzerOptions As AnalyzerOptions
+    Public DescriptorsWithInfo As ImmutableArray(Of (Descriptor As DiagnosticDescriptor, Info As DiagnosticDescriptorErrorLoggerInfo))
+    Public TotalAnalyzerExecutionTime As Double
 
     Public Sub New(baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
         MyClass.New(Nothing, baseDirectory, args, analyzer)
@@ -75,5 +78,16 @@ Friend Class MockVisualBasicCompiler
         analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider) As AnalyzerOptions
         AnalyzerOptions = MyBase.CreateAnalyzerOptions(additionalTextFiles, analyzerConfigOptionsProvider)
         Return AnalyzerOptions
+    End Function
+
+    Protected Overrides Sub AddAnalyzerDescriptorsAndExecutionTime(errorLogger As ErrorLogger, descriptorsWithInfo As ImmutableArray(Of (Descriptor As DiagnosticDescriptor, Info As DiagnosticDescriptorErrorLoggerInfo)), totalAnalyzerExecutionTime As Double)
+        Me.DescriptorsWithInfo = descriptorsWithInfo
+        Me.TotalAnalyzerExecutionTime = totalAnalyzerExecutionTime
+
+        MyBase.AddAnalyzerDescriptorsAndExecutionTime(errorLogger, descriptorsWithInfo, totalAnalyzerExecutionTime)
+    End Sub
+
+    Public Function GetAnalyzerExecutionTimeFormattedString() As String
+        Return ReportAnalyzerUtil.GetFormattedAnalyzerExecutionTime(TotalAnalyzerExecutionTime, Culture).Trim()
     End Function
 End Class

--- a/src/Compilers/VisualBasic/Test/CommandLine/SarifErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/SarifErrorLoggerTests.vb
@@ -20,14 +20,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
         Protected MustOverride ReadOnly Property ErrorLogQualifier As String
 
         Friend MustOverride Function GetExpectedOutputForNoDiagnostics(
-            cmd As CommonCompiler) As String
+            cmd As MockVisualBasicCompiler) As String
 
         Friend MustOverride Function GetExpectedOutputForSimpleCompilerDiagnostics(
-            cmd As CommonCompiler,
+            cmd As MockVisualBasicCompiler,
             sourceFilePath As String) As String
 
         Friend MustOverride Function GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(
-            cmd As CommonCompiler,
+            cmd As MockVisualBasicCompiler,
             sourceFilePath As String,
             ParamArray suppressionKinds As String()) As String
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/SarifV1ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/SarifV1ErrorLoggerTests.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
         End Property
 
         Friend Overrides Function GetExpectedOutputForNoDiagnostics(
-            cmd As CommonCompiler) As String
+            cmd As MockVisualBasicCompiler) As String
 
             Dim expectedHeader = GetExpectedErrorLogHeader(cmd)
             Dim expectedIssues = "
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
         End Sub
 
         Friend Overrides Function GetExpectedOutputForSimpleCompilerDiagnostics(
-            cmd As CommonCompiler,
+            cmd As MockVisualBasicCompiler,
             sourceFilePath As String) As String
 
             Dim expectedHeader = GetExpectedErrorLogHeader(cmd)
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
         End Sub
 
         Friend Overrides Function GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(
-            cmd As CommonCompiler,
+            cmd As MockVisualBasicCompiler,
             sourceFilePath As String,
             ParamArray suppressionKinds As String()) As String
 


### PR DESCRIPTION
Closes #68476

We now report analyzer performance data in the SARIF v2 log. This is the same data that is reported on the command line with compiler switch `/reportanalyzer`. We report the following additional info:

1. `runs` section now contains an `analyzerExecutionTime` property within a custom `properties` section: Execution time in seconds for execution of all analyzers, as reported with the `/reportAnalyzer` compiler switch.
2. Two additional properties are emitted per-rule in the `rules` section:
   1. `executionTimeInSeconds`: Execution time in seconds associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch.  Values less than `0.001` seconds are reported as `<0.001`.
   2. `executionTimeInPercentage`: Execution time in percentage associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `1` are reported as `<1`.

**Samples**:
   1. Sample error log file with these enhancements: 
[errorlog.log](https://github.com/dotnet/roslyn/files/11743307/errorlog.log)
   2. Corresponding `/reportanalyzer` output: 
[reportanalyzer.log](https://github.com/dotnet/roslyn/files/11743310/reportanalyzer.log)

**Report analyzer format**: https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Report%20Analyzer%20Format.md