### PR TITLE
Reduce allocations in MergedNamespaceSymbol.SlowGetChildNames

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -196,7 +196,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
 #if NETSTANDARD2_0
-            return new HashSet<ReadOnlyMemory<char>>(childNames.ToArrayAndFree(), comparer);
+            var asHashSet = new HashSet<ReadOnlyMemory<char>>(childNames, comparer);
+            childNames.Free();
+
+            return asHashSet;
 #else
             return childNames;
 #endif

--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private HashSet<ReadOnlyMemory<char>> SlowGetChildNames(IEqualityComparer<ReadOnlyMemory<char>> comparer)
         {
-            // compute the final capacity of the set we'll return, to reduce heap churn
+            // compute a reasonable estimate for the capacity of the set we'll return, to reduce heap churn
             int childCount = 0;
 
             foreach (var ns in _namespacesToMerge)

--- a/src/Compilers/Core/CodeAnalysisTest/CachingLookupTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CachingLookupTests.cs
@@ -35,9 +35,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return result;
         }
 
-        private HashSet<string> Keys(int[] numbers, bool randomCase, IEqualityComparer<string> comparer)
+        private SegmentedHashSet<string> Keys(int[] numbers, bool randomCase, IEqualityComparer<string> comparer)
         {
-            var keys = new HashSet<string>(comparer);
+            var keys = new SegmentedHashSet<string>(comparer);
             foreach (var n in numbers)
             {
                 keys.Add(GetKey(n, randomCase));
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        private void CompareLookups1(ILookup<string, int> look1, CachingDictionary<string, int> look2, HashSet<string> keys)
+        private void CompareLookups1(ILookup<string, int> look1, CachingDictionary<string, int> look2, SegmentedHashSet<string> keys)
         {
             foreach (string k in keys)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        private void CompareLookups2(ILookup<string, int> look1, CachingDictionary<string, int> look2, HashSet<string> keys)
+        private void CompareLookups2(ILookup<string, int> look1, CachingDictionary<string, int> look2, SegmentedHashSet<string> keys)
         {
             foreach (string k in look1.Select(g => g.Key))
             {
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(look1.Count, look2.Count);
         }
 
-        private void CompareLookups2(CachingDictionary<string, int> look1, ILookup<string, int> look2, HashSet<string> keys)
+        private void CompareLookups2(CachingDictionary<string, int> look1, ILookup<string, int> look2, SegmentedHashSet<string> keys)
         {
             foreach (string k in look1.Keys)
             {
@@ -313,9 +313,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 return ImmutableArray.Create<FullyPopulateRaceHelper>(new FullyPopulateRaceHelper());
             }
 
-            HashSet<int> getKeys(IEqualityComparer<int> comparer)
+            SegmentedHashSet<int> getKeys(IEqualityComparer<int> comparer)
             {
-                return new HashSet<int>(new[] { 1 }, comparer);
+                return new SegmentedHashSet<int>(new[] { 1 }, comparer);
             }
 
             FullyPopulateRaceHelper getItem()
@@ -356,9 +356,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 return ImmutableArray.Create<FullyPopulateRaceHelper>(new FullyPopulateRaceHelper());
             }
 
-            HashSet<int> getKeys(IEqualityComparer<int> comparer)
+            SegmentedHashSet<int> getKeys(IEqualityComparer<int> comparer)
             {
-                return new HashSet<int>(new[] { 1 }, comparer);
+                return new SegmentedHashSet<int>(new[] { 1 }, comparer);
             }
 
             FullyPopulateRaceHelper getItem()

--- a/src/Compilers/Core/Portable/Collections/CachingDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/CachingDictionary.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Collections
         where TKey : notnull
     {
         private readonly Func<TKey, ImmutableArray<TElement>> _getElementsOfKey;
-        private readonly Func<IEqualityComparer<TKey>, HashSet<TKey>> _getKeys;
+        private readonly Func<IEqualityComparer<TKey>, SegmentedHashSet<TKey>> _getKeys;
         private readonly IEqualityComparer<TKey> _comparer;
 
         // The underlying dictionary. It may be null (indicating that nothing is cached), a ConcurrentDictionary
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <param name="comparer">A IEqualityComparer used to compare keys.</param>
         public CachingDictionary(
             Func<TKey, ImmutableArray<TElement>> getElementsOfKey,
-            Func<IEqualityComparer<TKey>, HashSet<TKey>> getKeys,
+            Func<IEqualityComparer<TKey>, SegmentedHashSet<TKey>> getKeys,
             IEqualityComparer<TKey> comparer)
         {
             _getElementsOfKey = getElementsOfKey;

--- a/src/Compilers/VisualBasic/Portable/Symbols/MergedNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MergedNamespaceSymbol.vb
@@ -251,7 +251,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' HashSet And then initialzing the HashSet from the array.
             Dim childNames As ArrayBuilder(Of String) = ArrayBuilder(Of String).GetInstance(childCount)
 #Else
-            Dim childNames As New HashSet(Of String)(comparer)
+            Dim childNames As New HashSet(Of String)(childCount, comparer)
 #End If
 
             For Each nsSym As NamespaceSymbol In _namespacesToMerge

--- a/src/Compilers/VisualBasic/Portable/Symbols/MergedNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MergedNamespaceSymbol.vb
@@ -261,7 +261,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
 
 #If NETSTANDARD2_0 Then
-            Dim asHashSet As New HashSet(Of String)(childNames.ToArrayAndFree(), comparer)
+            Dim asHashSet As New HashSet(Of String)(childNames, comparer)
+            childNames.Free()
+
             Return asHashSet
 #Else
             Return childNames


### PR DESCRIPTION
Create the returned `HashSet<T>` with a capacity parameter so it doesn't need to resize while it's being built.

On .NET Standard 2.0, `HashSet<T>` doesn't have a constructor that accepts a capacity parameter.  ~~In that case, we'll allocate a `List<T>` with the computed capacity and then create the `HashSet<T>` from the list.  Since `List<T>` implements `ICollection<T>`, the `HashSet<T>` constructor can optimize the allocation.~~ Since `SegmentedHashSet<T>` was implemented using the source code for a newer implementation of `HashSet<T>`, it provides the desired constructor even in .NET Standard 2.0 builds. Use of `HashSet<T>` was drop-in replaced with `SegmentedHashSet<T>` to avoid the need to conditionally include this optimization.