### PR TITLE
Convert xml references when moving to primary constructors

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -151,9 +151,6 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
         var constructorDocumentEditor = await solutionEditor.GetDocumentEditorAsync(document.Id, cancellationToken).ConfigureAwait(false);
         constructorDocumentEditor.RemoveNode(constructorDeclaration);
 
-        var finalTrivia = CreateFinalTypeDeclarationLeadingTrivia(
-            typeDeclaration, constructorDeclaration, constructor, properties, removedMembers);
-
         // Finally move the constructors parameter list to the type declaration.
         constructorDocumentEditor.ReplaceNode(
             typeDeclaration,
@@ -181,6 +178,9 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
                     static list => list.Parameters);
 
                 parameterList = RemoveInModifierIfMemberIsRemoved(parameterList);
+
+                var finalTrivia = CreateFinalTypeDeclarationLeadingTrivia(
+                    currentTypeDeclaration, constructorDeclaration, constructor, properties, removedMembers);
 
                 return currentTypeDeclaration
                     .WithLeadingTrivia(finalTrivia)
@@ -401,7 +401,8 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
             var references = await SymbolFinder.FindReferencesAsync(
                 member, solution, namedTypeDocuments, cancellationToken).ConfigureAwait(false);
 
-            using var _ = PooledHashSet<SyntaxNode>.GetInstance(out var nodesToReplace);
+            using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var nodesToReplace);
+            using var _2 = PooledHashSet<XmlEmptyElementSyntax>.GetInstance(out var seeTagsToReplace);
             foreach (var reference in references)
             {
                 foreach (var location in reference.Locations)
@@ -409,10 +410,16 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
                     if (location.IsImplicit)
                         continue;
 
-                    if (location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken) is not IdentifierNameSyntax identifier)
+                    if (location.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken) is not IdentifierNameSyntax identifier)
                         continue;
 
-                    if (identifier.IsRightSideOfDot())
+                    var xmlElement = identifier.AncestorsAndSelf().OfType<XmlEmptyElementSyntax>().FirstOrDefault();
+                    if (xmlElement is { Name.LocalName.ValueText: "see" })
+                    {
+                        // reference to member in a `<see cref="name"/>` tag.  Switch to a paramref tag instead.
+                        seeTagsToReplace.Add(xmlElement);
+                    }
+                    else if (identifier.IsRightSideOfDot())
                     {
                         if (identifier.GetRequiredParent() is ExpressionSyntax expression)
                             nodesToReplace.Add(expression);
@@ -437,6 +444,24 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
                     documentEditor.ReplaceNode(
                         nodeToReplace,
                         parameterNameNode.WithTriviaFrom(nodeToReplace));
+                }
+            }
+
+            foreach (var group in seeTagsToReplace.GroupBy(n => n.SyntaxTree))
+            {
+                var document = solution.GetDocument(group.Key);
+                if (document is null)
+                    continue;
+
+                var documentEditor = await solutionEditor.GetDocumentEditorAsync(document.Id, cancellationToken).ConfigureAwait(false);
+
+                foreach (var seeTag in group)
+                {
+                    var paramRefTag = seeTag
+                        .ReplaceToken(seeTag.Name.LocalName, Identifier("paramref").WithTriviaFrom(seeTag.Name.LocalName))
+                        .WithAttributes(SingletonList<XmlAttributeSyntax>(XmlNameAttribute(parameterName)));
+
+                    documentEditor.ReplaceNode(seeTag, paramRefTag);
                 }
             }
         }

--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider_DocComments.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider_DocComments.cs
@@ -66,7 +66,7 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
         ConstructorDeclarationSyntax constructorDeclaration,
         IMethodSymbol constructor,
         ImmutableDictionary<string, string?> properties,
-        Dictionary<ISymbol, SyntaxNode> removedMembers)
+        ImmutableDictionary<ISymbol, SyntaxNode> removedMembers)
     {
         // First, take the constructor doc comments and merge those into the type's doc comments.
         // Then, take any removed fields/properties and merge their comments into the type's doc comments.
@@ -164,7 +164,7 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
         static SyntaxTriviaList MergeTypeDeclarationAndRemovedMembersDocComments(
             IMethodSymbol constructor,
             ImmutableDictionary<string, string?> properties,
-            Dictionary<ISymbol, SyntaxNode> removedMembers,
+            ImmutableDictionary<ISymbol, SyntaxNode> removedMembers,
             SyntaxTriviaList typeDeclarationLeadingTrivia)
         {
             // now, if we're removing any members, and they had doc comments, and we don't already have doc comments for

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -2894,12 +2894,45 @@ public partial class UsePrimaryConstructorTests
                 """,
             FixedCode = """
                 /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C(int i)
+                {
+                    private int _i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.Preview,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSeeTag2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C
+                {
+                    private int _i;
+
+                    public [|C|](int i)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary>
                 /// Provides strongly typed wrapper around <paramref name="i"/>.
                 /// </summary>
                 class C(int i)
                 {
                 }
                 """,
+            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.Preview,
         }.RunAsync();
     }

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -2872,4 +2872,35 @@ public partial class UsePrimaryConstructorTests
             LanguageVersion = LanguageVersion.Preview,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestSeeTag1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C
+                {
+                    private int _i;
+
+                    public [|C|](int i)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <paramref name="i"/>.
+                /// </summary>
+                class C(int i)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.Preview,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
Converts `<see cref="memberName"/>` to `<paramref name="parameterName"/>`.