### PR TITLE
Prevent `EditAndContinueFeedbackDiagnosticFileProvider` from throwing an exception in Razor scenarios

### DIFF
--- a/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
+++ b/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
@@ -99,7 +99,9 @@ internal sealed class EditAndContinueFeedbackDiagnosticFileProvider : IFeedbackD
         => Path.Combine(Path.Combine(_tempDir, $"EnC_{_vsProcessId}", ZipFileName));
 
     public IReadOnlyCollection<string> GetFiles()
-        => new[] { GetZipFilePath() };
+        => _vsFeedbackSemaphoreFullPath is null
+           ? Array.Empty<string>()
+           : (IReadOnlyCollection<string>)(new[] { GetZipFilePath() });
 
     private void OnFeedbackSemaphoreCreatedOrChanged()
     {

--- a/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
+++ b/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
@@ -39,7 +39,7 @@ internal sealed class EditAndContinueFeedbackDiagnosticFileProvider : IFeedbackD
     /// Watching the file is currently the only way to detect the feedback session.
     /// </summary>
     private readonly string _vsFeedbackSemaphoreFullPath;
-    private readonly FileSystemWatcher _vsFeedbackSemaphoreFileWatcher;
+    private readonly FileSystemWatcher? _vsFeedbackSemaphoreFileWatcher;
 
     private readonly int _vsProcessId;
     private readonly DateTime _vsProcessStartTime;
@@ -64,6 +64,12 @@ internal sealed class EditAndContinueFeedbackDiagnosticFileProvider : IFeedbackD
         _tempDir = Path.GetTempPath();
         var vsFeedbackTempDir = Path.Combine(_tempDir, VSFeedbackSemaphoreDir);
         _vsFeedbackSemaphoreFullPath = Path.Combine(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+
+        // Directory may not exist in scenarios such as Razor integration tests
+        if (!Directory.Exists(vsFeedbackTempDir))
+        {
+            return;
+        }
 
         _vsFeedbackSemaphoreFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
         _vsFeedbackSemaphoreFileWatcher.Created += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();

--- a/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
+++ b/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
@@ -99,7 +99,7 @@ internal sealed class EditAndContinueFeedbackDiagnosticFileProvider : IFeedbackD
         => Path.Combine(Path.Combine(_tempDir, $"EnC_{_vsProcessId}", ZipFileName));
 
     public IReadOnlyCollection<string> GetFiles()
-        => _vsFeedbackSemaphoreFullPath is null
+        => _vsFeedbackSemaphoreFileWatcher is null
            ? Array.Empty<string>()
            : (IReadOnlyCollection<string>)(new[] { GetZipFilePath() });
 


### PR DESCRIPTION
[This line](https://github.com/dotnet/razor/blob/cba27feaa6097cdc1e214b4f9d9ed03059eea5cc/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs#L86) in Razor's integration test logic throws an exception since one of the found providers is `EditAndContinueFeedbackDiagnosticFileProvider`, which seems to only account for Roslyn scenarios. This PR mitigates the issue by ensuring that we don't initialize a `FileSystemWatcher` (which threw the original exception) unless the provided directory is valid.