### PR TITLE
Add PrivateAnalyzers helper assembly

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -547,6 +547,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.VisualStudio.ServiceHub.Setup.arm64", "src\VisualStudio\Setup.ServiceHub\arm64\Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj", "{09E88382-0D7B-4A15-B1AF-0B89A5B67227}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PrivateAnalyzers", "src\Tools\PrivateAnalyzers\Core\Microsoft.CodeAnalysis.PrivateAnalyzers.csproj", "{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PrivateAnalyzers", "PrivateAnalyzers", "{99490140-068D-46CC-A1D2-EBBFD19207E9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp", "src\Tools\PrivateAnalyzers\CSharp\Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp.csproj", "{8B383925-80D4-4B8C-90B4-3CB59CBCE177}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic", "src\Tools\PrivateAnalyzers\VisualBasic\Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic.csproj", "{258522B4-2D16-4627-B5FF-27F4BF80C442}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1345,6 +1353,18 @@ Global
 		{09E88382-0D7B-4A15-B1AF-0B89A5B67227}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09E88382-0D7B-4A15-B1AF-0B89A5B67227}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09E88382-0D7B-4A15-B1AF-0B89A5B67227}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B383925-80D4-4B8C-90B4-3CB59CBCE177}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B383925-80D4-4B8C-90B4-3CB59CBCE177}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B383925-80D4-4B8C-90B4-3CB59CBCE177}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B383925-80D4-4B8C-90B4-3CB59CBCE177}.Release|Any CPU.Build.0 = Release|Any CPU
+		{258522B4-2D16-4627-B5FF-27F4BF80C442}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{258522B4-2D16-4627-B5FF-27F4BF80C442}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{258522B4-2D16-4627-B5FF-27F4BF80C442}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{258522B4-2D16-4627-B5FF-27F4BF80C442}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1594,6 +1614,10 @@ Global
 		{3ABBDFF7-ED76-4EA3-840E-85E3274302B0} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{172F3A04-644B-492C-9632-B07B52A5C0C4} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{09E88382-0D7B-4A15-B1AF-0B89A5B67227} = {8DBA5174-B0AA-4561-82B1-A46607697753}
+		{AF658A9F-C4B2-4C3F-86DB-F78C85CF3880} = {99490140-068D-46CC-A1D2-EBBFD19207E9}
+		{99490140-068D-46CC-A1D2-EBBFD19207E9} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
+		{8B383925-80D4-4B8C-90B4-3CB59CBCE177} = {99490140-068D-46CC-A1D2-EBBFD19207E9}
+		{258522B4-2D16-4627-B5FF-27F4BF80C442} = {99490140-068D-46CC-A1D2-EBBFD19207E9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -18,6 +18,9 @@ dotnet_diagnostic.IDE0170.severity = suggestion
 # IDE0090: Simplify new expression
 dotnet_diagnostic.IDE0090.severity = none
 
+# RP0001: Avoid implicit object creation
+dotnet_diagnostic.RP0001.severity = warning
+
 # CSharp code style settings:
 [*.cs]
 csharp_style_var_for_built_in_types = false:none

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDeterministicKeyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDeterministicKeyBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed class CSharpDeterministicKeyBuilder : DeterministicKeyBuilder
     {
-        internal static readonly CSharpDeterministicKeyBuilder Instance = new();
+        internal static readonly CSharpDeterministicKeyBuilder Instance = new CSharpDeterministicKeyBuilder();
 
         private CSharpDeterministicKeyBuilder()
         {

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private abstract class MatchDefs
         {
             private readonly EmitContext _sourceContext;
-            private readonly ConcurrentDictionary<Cci.IDefinition, Cci.IDefinition?> _matches = new(ReferenceEqualityComparer.Instance);
+            private readonly ConcurrentDictionary<Cci.IDefinition, Cci.IDefinition?> _matches = new ConcurrentDictionary<Cci.IDefinition, Cci.IDefinition?>(ReferenceEqualityComparer.Instance);
             private IReadOnlyDictionary<string, Cci.INamespaceTypeDefinition>? _lazyTopLevelTypes;
 
             public MatchDefs(EmitContext sourceContext)
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             private readonly ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? _otherDeletedMembers;
 
             private readonly SymbolComparer _comparer;
-            private readonly ConcurrentDictionary<Symbol, Symbol?> _matches = new(ReferenceEqualityComparer.Instance);
+            private readonly ConcurrentDictionary<Symbol, Symbol?> _matches = new ConcurrentDictionary<Symbol, Symbol?>(ReferenceEqualityComparer.Instance);
 
             /// <summary>
             /// A cache of members per type, populated when the first member for a given
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             /// for caching, and indexing by name, is to avoid searching sequentially
             /// through all members of a given kind each time a member is matched.
             /// </summary>
-            private readonly ConcurrentDictionary<ISymbolInternal, IReadOnlyDictionary<string, ImmutableArray<ISymbolInternal>>> _otherMembers = new(ReferenceEqualityComparer.Instance);
+            private readonly ConcurrentDictionary<ISymbolInternal, IReadOnlyDictionary<string, ImmutableArray<ISymbolInternal>>> _otherMembers = new ConcurrentDictionary<ISymbolInternal, IReadOnlyDictionary<string, ImmutableArray<ISymbolInternal>>>(ReferenceEqualityComparer.Instance);
 
             public MatchSymbols(
                 IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DelegateCacheContainer.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/DelegateCacheContainer.cs
@@ -15,7 +15,7 @@ internal sealed class DelegateCacheContainer : SynthesizedContainer
 {
     private readonly Symbol _containingSymbol;
     private readonly NamedTypeSymbol? _constructedContainer;
-    private readonly Dictionary<(TypeSymbol?, TypeSymbol, MethodSymbol), FieldSymbol> _delegateFields = new(CLRSignatureComparer.Instance);
+    private readonly Dictionary<(TypeSymbol?, TypeSymbol, MethodSymbol), FieldSymbol> _delegateFields = new Dictionary<(TypeSymbol?, TypeSymbol, MethodSymbol), FieldSymbol>(CLRSignatureComparer.Instance);
 
     /// <summary>Creates a type-scope concrete delegate cache container.</summary>
     internal DelegateCacheContainer(TypeSymbol containingType, int generationOrdinal)
@@ -86,7 +86,7 @@ internal sealed class DelegateCacheContainer : SynthesizedContainer
 
     private sealed class CLRSignatureComparer : IEqualityComparer<(TypeSymbol? constrainedToTypeOpt, TypeSymbol delegateType, MethodSymbol targetMethod)>
     {
-        public static readonly CLRSignatureComparer Instance = new();
+        public static readonly CLRSignatureComparer Instance = new CLRSignatureComparer();
 
         public bool Equals((TypeSymbol? constrainedToTypeOpt, TypeSymbol delegateType, MethodSymbol targetMethod) x, (TypeSymbol? constrainedToTypeOpt, TypeSymbol delegateType, MethodSymbol targetMethod) y)
         {

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Note that there is a dispatch occurring at every try-finally statement, so this
         /// variable takes on a new set of values inside each try block.
         /// </summary>
-        private Dictionary<LabelSymbol, List<StateMachineState>> _dispatches = new();
+        private Dictionary<LabelSymbol, List<StateMachineState>> _dispatches = new Dictionary<LabelSymbol, List<StateMachineState>>();
 
         /// <summary>
         /// A pool of fields used to hoist locals. They appear in this set when not in scope,

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -992,7 +992,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SwitchSection(ImmutableArray.Create(value), statements);
 
         public SyntheticSwitchSection SwitchSection(ImmutableArray<int> values, params BoundStatement[] statements)
-            => new(values, ImmutableArray.Create(statements));
+            => new SyntheticSwitchSection(values, ImmutableArray.Create(statements));
 
         /// <summary>
         /// Produce an int switch.

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -644,7 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </returns>
         /// <remarks>The values are not affected by line mapping directives (<c>#line</c>).</remarks>
         public override FileLinePositionSpan GetLineSpan(TextSpan span, CancellationToken cancellationToken = default)
-            => new(FilePath, GetLinePosition(span.Start, cancellationToken), GetLinePosition(span.End, cancellationToken));
+            => new FileLinePositionSpan(FilePath, GetLinePosition(span.Start, cancellationToken), GetLinePosition(span.End, cancellationToken));
 
         /// <summary>
         /// Gets the location in terms of path, line and column after applying source line mapping directives (<c>#line</c>).

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -13483,9 +13483,9 @@ class C
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/generatedfilesout:" + generatedDir.Path, "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator }, analyzers: null);
 
             var generatorPrefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator);
-            ValidateWrittenSources(new()
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>()
             {
-                { Path.Combine(generatedDir.Path, generatorPrefix, expectedDir), new() { { expectedFileName, generatedSource } } }
+                { Path.Combine(generatedDir.Path, generatorPrefix, expectedDir), new Dictionary<string, string>() { { expectedFileName, generatedSource } } }
             });
 
             // Clean up temp files
@@ -13509,14 +13509,14 @@ class C
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/generatedfilesout:" + generatedDir.Path, "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator1 }, analyzers: null);
 
             var generatorPrefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator1);
-            ValidateWrittenSources(new() { { Path.Combine(generatedDir.Path, generatorPrefix), new() { { "generatedSource.cs", generatedSource1 } } } });
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>() { { Path.Combine(generatedDir.Path, generatorPrefix), new Dictionary<string, string>() { { "generatedSource.cs", generatedSource1 } } } });
 
             var generatedSource2 = "public class D { }";
             var generator2 = new SingleFileTestGenerator(generatedSource2, "generatedSource.cs");
 
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/generatedfilesout:" + generatedDir.Path, "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator2 }, analyzers: null);
 
-            ValidateWrittenSources(new() { { Path.Combine(generatedDir.Path, generatorPrefix), new() { { "generatedSource.cs", generatedSource2 } } } });
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>() { { Path.Combine(generatedDir.Path, generatorPrefix), new Dictionary<string, string>() { { "generatedSource.cs", generatedSource2 } } } });
 
             // Clean up temp files
             CleanupAllGeneratedFiles(src.Path);
@@ -13546,10 +13546,10 @@ class C
             var generator1Prefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator);
             var generator2Prefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator2);
 
-            ValidateWrittenSources(new()
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>()
             {
-                { Path.Combine(generatedDir.Path, generator1Prefix), new() { { source1Name, source1 } } },
-                { Path.Combine(generatedDir.Path, generator2Prefix), new() { { source2Name, source2 } } }
+                { Path.Combine(generatedDir.Path, generator1Prefix), new Dictionary<string, string>() { { source1Name, source1 } } },
+                { Path.Combine(generatedDir.Path, generator2Prefix), new Dictionary<string, string>() { { source2Name, source2 } } }
             });
 
             // Clean up temp files
@@ -13585,9 +13585,9 @@ class C
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/generatedfilesout:" + generatedDir.Path, "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator }, analyzers: null);
 
             var generatorPrefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator);
-            ValidateWrittenSources(new()
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>()
             {
-                { Path.Combine(generatedDir.Path, generatorPrefix, expectedDir), new() { { generatedFileName, generatedSource } } }
+                { Path.Combine(generatedDir.Path, generatorPrefix, expectedDir), new Dictionary<string, string>() { { generatedFileName, generatedSource } } }
             });
 
             // Clean up temp files
@@ -13637,10 +13637,10 @@ public class TestGenerator : ISourceGenerator
 
             // This is wrong! Both generators are writing the same file out, over the top of each other
             // See https://github.com/dotnet/roslyn/issues/47990
-            ValidateWrittenSources(new()
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>()
             {
                 //  { Path.Combine(generatedDir.Path,  "generator", "TestGenerator"), new() { { "generatedSource.cs", "//from version 1.0.0.0" } } },
-                { Path.Combine(generatedDir.Path, "generator", "TestGenerator"), new() { { "generatedSource.cs", "//from version 2.0.0.0" } } }
+                { Path.Combine(generatedDir.Path, "generator", "TestGenerator"), new Dictionary<string, string>() { { "generatedSource.cs", "//from version 2.0.0.0" } } }
             });
         }
 
@@ -13658,7 +13658,7 @@ class C
             var generator = new SingleFileTestGenerator(generatedSource, "generatedSource.cs");
 
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator }, analyzers: null);
-            ValidateWrittenSources(new() { { generatedDir.Path, new() } });
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>() { { generatedDir.Path, new Dictionary<string, string>() } });
 
             // Clean up temp files
             CleanupAllGeneratedFiles(src.Path);
@@ -13702,7 +13702,7 @@ class C
             VerifyOutput(dir, src, includeCurrentAssemblyAsAnalyzerReference: false, additionalFlags: new[] { "/generatedfilesout:" + generatedDir.Path, "/langversion:preview", "/out:embed.exe" }, generators: new[] { generator }, analyzers: null);
 
             var generatorPrefix = GeneratorDriver.GetFilePathPrefixForGenerator(generator);
-            ValidateWrittenSources(new() { { Path.Combine(generatedDir.Path, generatorPrefix), new() { { "generatedSource.cs", generatedSource } } } });
+            ValidateWrittenSources(new Dictionary<string, Dictionary<string, string>>() { { Path.Combine(generatedDir.Path, generatorPrefix), new Dictionary<string, string>() { { "generatedSource.cs", generatedSource } } } });
 
             // Clean up temp files
             CleanupAllGeneratedFiles(src.Path);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -10546,7 +10546,7 @@ public unsafe class C
 }}
 ");
 
-            List<DiagnosticDescription> diagnostics = new()
+            List<DiagnosticDescription> diagnostics = new List<DiagnosticDescription>()
             {
                 // (10,39): error CS8786: Calling convention of 'C.M()' is not compatible with 'Default'.
                 //         delegate*<void> ptrManaged = &M;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -27,9 +27,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         private readonly CSharpParseOptions? _parseOptions;
         private readonly TargetFramework _targetFramework;
 
-        private readonly List<IDisposable> _disposables = new();
-        private readonly List<GenerationInfo> _generations = new();
-        private readonly List<SourceWithMarkedNodes> _sources = new();
+        private readonly List<IDisposable> _disposables = new List<IDisposable>();
+        private readonly List<GenerationInfo> _generations = new List<GenerationInfo>();
+        private readonly List<SourceWithMarkedNodes> _sources = new List<SourceWithMarkedNodes>();
 
         private bool _hasVerified;
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             Func<Compilation, ISymbol> symbolProvider,
             Func<Compilation, ISymbol> newSymbolProvider = null,
             bool preserveLocalVariables = false)
-            => new(kind, symbolProvider, newSymbolProvider, preserveLocalVariables);
+            => new SemanticEditDescription(kind, symbolProvider, newSymbolProvider, preserveLocalVariables);
 
         internal static EditAndContinueLogEntry Row(int rowNumber, TableIndex table, EditAndContinueOperation operation)
         {

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3746,7 +3746,7 @@ public class C
                 _testSyntaxNodeAction = testSyntaxNodeAction;
             }
 
-            internal static DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
@@ -1409,7 +1409,7 @@ internal class TestAttribute : Attribute
         private sealed class DiagnosticSuppressorForCS0657 : DiagnosticSuppressor
         {
             internal const string SuppressionId = "SPR0001";
-            private readonly SuppressionDescriptor _descriptor = new(SuppressionId, "CS0657", "Justification");
+            private readonly SuppressionDescriptor _descriptor = new SuppressionDescriptor(SuppressionId, "CS0657", "Justification");
             public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(_descriptor);
 
             public override void ReportSuppressions(SuppressionAnalysisContext context)

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -927,7 +927,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             dstBuilder = GetBuilder(dstBuilder.ToImmutable());
             var table = dstBuilder.GetLatestStateTableForNode(inputNode);
 
-            AssertTableEntries(table, new[] { (1, EntryState.Cached, 0), new(2, EntryState.Cached, 0), new(3, EntryState.Cached, 0) });
+            AssertTableEntries(table, new[] { (1, EntryState.Cached, 0), (2, EntryState.Cached, 0), (3, EntryState.Cached, 0) });
         }
 
         [Fact]
@@ -943,7 +943,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty, trackIncrementalGeneratorSteps: true);
 
-            List<IncrementalGeneratorRunStep> steps = new();
+            List<IncrementalGeneratorRunStep> steps = new List<IncrementalGeneratorRunStep>();
 
             _ = dstBuilder.GetLatestStateTableForNode(addOneNode);
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -943,7 +943,7 @@ class C
             Compilation compilation = CreateCompilation(source1, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
 
-            List<string> syntaxFilterVisited = new();
+            List<string> syntaxFilterVisited = new List<string>();
             var testGenerator = new PipelineCallbackGenerator(context =>
             {
                 var source = context.SyntaxProvider.CreateSyntaxProvider((c, _) =>

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SymbolVisitorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SymbolVisitorTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private class LoggingSymbolVisitor : SymbolVisitor
         {
-            private readonly StringBuilder _output = new();
+            private readonly StringBuilder _output = new StringBuilder();
             private int _indent;
 
             public override string ToString() => _output.ToString();
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private class LoggingSymbolVisitorWithReturnValue : SymbolVisitor<string>
         {
-            private readonly StringBuilder _output = new();
+            private readonly StringBuilder _output = new StringBuilder();
             private int _indent;
 
             public override string ToString() => _output.ToString();

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/EverythingEqual.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/EverythingEqual.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
     /// <typeparam name="T"></typeparam>
     internal class EverythingEqual<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        private static readonly EverythingEqual<T> s_singleton = new();
+        private static readonly EverythingEqual<T> s_singleton = new EverythingEqual<T>();
 
         private EverythingEqual() { }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         public void HashSet_Generic_RemoveWhere_NewObject() // Regression Dev10_624201
         {
             object[] array = new object[2];
-            object obj = new();
+            object obj = new object();
             SegmentedHashSet<object> set = new SegmentedHashSet<object>();
 
             set.Add(obj);

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
     public class CompilationWithAnalyzersTests : TestBase
     {
-        private static readonly CSharpCompilationOptions s_dllWithMaxWarningLevel = new(OutputKind.DynamicallyLinkedLibrary, warningLevel: CodeAnalysis.Diagnostic.MaxWarningLevel);
+        private static readonly CSharpCompilationOptions s_dllWithMaxWarningLevel = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, warningLevel: CodeAnalysis.Diagnostic.MaxWarningLevel);
 
         [Fact]
         public void GetEffectiveDiagnostics_Errors()

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -925,7 +925,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             proj.Xml.AddTarget("PrepareForBuild");
 
             // create a dummy WriteLinesToFile task
-            addTask(proj, "WriteLinesToFile", new()
+            addTask(proj, "WriteLinesToFile", new Dictionary<string, string>()
             {
                 { "Lines", "System.String[]" },
                 { "File", "System.String" },
@@ -934,13 +934,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             });
 
             // dummy makeDir task
-            addTask(proj, "MakeDir", new()
+            addTask(proj, "MakeDir", new Dictionary<string, string>()
             {
                 { "Directories", "System.String[]" }
             });
 
             // dummy Message task
-            addTask(proj, "Message", new()
+            addTask(proj, "Message", new Dictionary<string, string>()
             {
                 { "Text", "System.String" },
                 { "Importance", "System.String" }

--- a/src/Compilers/Core/Portable/CodeGen/TokenMap.cs
+++ b/src/Compilers/Core/Portable/CodeGen/TokenMap.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
     /// </summary>
     internal sealed class TokenMap
     {
-        private readonly ConcurrentDictionary<IReferenceOrISignature, uint> _itemIdentityToToken = new();
+        private readonly ConcurrentDictionary<IReferenceOrISignature, uint> _itemIdentityToToken = new ConcurrentDictionary<IReferenceOrISignature, uint>();
         private object[] _items = Array.Empty<object>();
         private int _count = 0;
 

--- a/src/Compilers/Core/Portable/Collections/BitVector.cs
+++ b/src/Compilers/Core/Portable/Collections/BitVector.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
         // and might become not null/empty, unless we restrict access to it.
         private static Word[] s_emptyArray => Array.Empty<Word>();
         private static readonly BitVector s_nullValue = default;
-        private static readonly BitVector s_emptyValue = new(0, s_emptyArray, 0);
+        private static readonly BitVector s_emptyValue = new BitVector(0, s_emptyArray, 0);
 
         private Word _bits0;
         private Word[] _bits;

--- a/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
         // An empty dictionary we keep around to simplify certain operations (like "Keys")
         // when we don't have an underlying dictionary of our own.
-        private static readonly Dictionary<K, ValueSet> s_emptyDictionary = new();
+        private static readonly Dictionary<K, ValueSet> s_emptyDictionary = new Dictionary<K, ValueSet>();
 
         // The underlying dictionary we store our data in.  null if we are empty.
         private PooledDictionary<K, ValueSet>? _dictionary;

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly record struct DescriptorInfo(int Index, bool HasAnyExternalSuppression);
             // DiagnosticDescriptor -> DescriptorInfo
-            private readonly Dictionary<DiagnosticDescriptor, DescriptorInfo> _distinctDescriptors = new(SarifDiagnosticComparer.Instance);
+            private readonly Dictionary<DiagnosticDescriptor, DescriptorInfo> _distinctDescriptors = new Dictionary<DiagnosticDescriptor, DescriptorInfo>(SarifDiagnosticComparer.Instance);
 
             /// <summary>
             /// The total number of descriptors in the set.
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis
                     if (hasAnyExternalSuppression.HasValue &&
                         descriptorInfo.HasAnyExternalSuppression != hasAnyExternalSuppression.Value)
                     {
-                        descriptorInfo = new(descriptorInfo.Index, hasAnyExternalSuppression.Value);
+                        descriptorInfo = new DescriptorInfo(descriptorInfo.Index, hasAnyExternalSuppression.Value);
                         _distinctDescriptors[descriptor] = descriptorInfo;
                     }
 
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    _distinctDescriptors.Add(descriptor, new(Index: Count, hasAnyExternalSuppression ?? false));
+                    _distinctDescriptors.Add(descriptor, new DescriptorInfo(Index: Count, hasAnyExternalSuppression ?? false));
                     return Count - 1;
                 }
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
     /// </remarks>
     internal abstract partial class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
     {
-        private readonly object _guard = new();
+        private readonly object _guard = new object();
 
         /// <summary>
         /// Set of analyzer dependencies original full paths to the data calculated for that path
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Access must be guarded by <see cref="_guard"/>
         /// </remarks>
-        private readonly Dictionary<string, (AssemblyName? AssemblyName, string RealAssemblyPath)?> _analyzerAssemblyInfoMap = new();
+        private readonly Dictionary<string, (AssemblyName? AssemblyName, string RealAssemblyPath)?> _analyzerAssemblyInfoMap = new Dictionary<string, (AssemblyName? AssemblyName, string RealAssemblyPath)?>();
 
         /// <summary>
         /// Maps analyzer dependency simple names to the set of original full paths it was loaded from. This _only_ 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Access must be guarded by <see cref="_guard"/>
         /// </remarks>
-        private readonly Dictionary<string, ImmutableHashSet<string>> _knownAssemblyPathsBySimpleName = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ImmutableHashSet<string>> _knownAssemblyPathsBySimpleName = new Dictionary<string, ImmutableHashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// The implementation needs to load an <see cref="Assembly"/> with the specified <see cref="AssemblyName"/>. The

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             FullPath = fullPath;
             _assemblyLoader = assemblyLoader ?? throw new ArgumentNullException(nameof(assemblyLoader));
 
-            _diagnosticAnalyzers = new(this, typeof(DiagnosticAnalyzerAttribute), GetDiagnosticsAnalyzerSupportedLanguages, allowNetFramework: true);
-            _generators = new(this, typeof(GeneratorAttribute), GetGeneratorSupportedLanguages, allowNetFramework: false, coerceFunction: CoerceGeneratorType);
+            _diagnosticAnalyzers = new Extensions<DiagnosticAnalyzer>(this, typeof(DiagnosticAnalyzerAttribute), GetDiagnosticsAnalyzerSupportedLanguages, allowNetFramework: true);
+            _generators = new Extensions<ISourceGenerator>(this, typeof(GeneratorAttribute), GetGeneratorSupportedLanguages, allowNetFramework: false, coerceFunction: CoerceGeneratorType);
 
             // Note this analyzer full path as a dependency location, so that the analyzer loader
             // can correctly load analyzer dependencies.
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private class ExtTypeComparer : IEqualityComparer<TExtension>
             {
-                public static readonly ExtTypeComparer Instance = new();
+                public static readonly ExtTypeComparer Instance = new ExtTypeComparer();
 
                 public bool Equals(TExtension? x, TExtension? y) => object.Equals(x?.GetType(), y?.GetType());
 

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -35,9 +35,9 @@ namespace Microsoft.CodeAnalysis.Emit
         internal Cci.IMethodReference? DebugEntryPoint;
 
         private readonly ConcurrentDictionary<IMethodSymbolInternal, Cci.IMethodBody> _methodBodyMap;
-        private readonly TokenMap _referencesInILMap = new();
-        private readonly ItemTokenMap<string> _stringsInILMap = new();
-        private readonly ItemTokenMap<Cci.DebugSourceDocument> _sourceDocumentsInILMap = new();
+        private readonly TokenMap _referencesInILMap = new TokenMap();
+        private readonly ItemTokenMap<string> _stringsInILMap = new ItemTokenMap<string>();
+        private readonly ItemTokenMap<Cci.DebugSourceDocument> _sourceDocumentsInILMap = new ItemTokenMap<Cci.DebugSourceDocument>();
 
         private ImmutableArray<Cci.AssemblyReferenceAlias> _lazyAssemblyReferenceAliases;
         private ImmutableArray<Cci.ManagedResource> _lazyManagedResources;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.Emit
                         if (edit.OldSymbol is IMethodSymbol && edit.NewSymbol is { } newContainingSymbol)
                         {
                             Debug.Assert(edit.OldSymbol != null);
-                            lazyDeletedMembersBuilder ??= new();
+                            lazyDeletedMembersBuilder ??= new Dictionary<ISymbol, ISet<ISymbol>>();
                             if (!lazyDeletedMembersBuilder.TryGetValue(newContainingSymbol, out var set))
                             {
                                 set = new HashSet<ISymbol>();

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         private static readonly Encoding s_utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-        private static readonly Lazy<Encoding> s_fallbackEncoding = new(CreateFallbackEncoding);
+        private static readonly Lazy<Encoding> s_fallbackEncoding = new Lazy<Encoding>(CreateFallbackEncoding);
 
         /// <summary>
         /// Encoding to use when UTF-8 fails. We try to find the following, in order, if available:

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -25,7 +25,7 @@ namespace Roslyn.Utilities
         internal const char AltDirectorySeparatorChar = '/';
         internal const string ParentRelativeDirectory = "..";
         internal const string ThisDirectory = ".";
-        internal static readonly string DirectorySeparatorStr = new(DirectorySeparatorChar, 1);
+        internal static readonly string DirectorySeparatorStr = new string(DirectorySeparatorChar, 1);
         internal const char VolumeSeparatorChar = ':';
         internal static bool IsUnixLikePlatform => PlatformInformation.IsUnix;
 

--- a/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
+++ b/src/Compilers/Core/Portable/FileSystem/RelativePathResolver.cs
@@ -54,10 +54,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         public RelativePathResolver WithSearchPaths(ImmutableArray<string> searchPaths) =>
-            new(searchPaths, BaseDirectory);
+            new RelativePathResolver(searchPaths, BaseDirectory);
 
         public RelativePathResolver WithBaseDirectory(string baseDirectory) =>
-            new(SearchPaths, baseDirectory);
+            new RelativePathResolver(SearchPaths, baseDirectory);
 
         public bool Equals(RelativePathResolver other) =>
             BaseDirectory == other.BaseDirectory && SearchPaths.SequenceEqual(other.SearchPaths);

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.InternalUtilities
         private readonly Dictionary<K, CacheValue> _cache;
         private readonly LinkedList<K> _nodeList;
         // This is a naive course-grained lock, it can probably be optimized
-        private readonly object _lockObject = new();
+        private readonly object _lockObject = new object();
 
         public ConcurrentLruCache(int capacity)
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/ConsList`1.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConsList`1.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
     /// </summary>
     internal class ConsList<T> : IEnumerable<T>
     {
-        public static readonly ConsList<T> Empty = new();
+        public static readonly ConsList<T> Empty = new ConsList<T>();
 
         private readonly T? _head;
         private readonly ConsList<T>? _tail;

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
 #endif
 
-        private static readonly object s_reportedMarker = new();
+        private static readonly object s_reportedMarker = new object();
 
         // Do not allow this method to be inlined.  That way when we have a dump we can see this frame in the stack and
         // can examine things like s_reportedExceptionMessage.  Without this, it's a lot tricker as FatalError is linked

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -215,7 +215,7 @@ namespace Roslyn.Utilities
 
         public Dictionary<K, ValueSet>.ValueCollection Values => _dictionary.Values;
 
-        private readonly ValueSet _emptySet = new(null, null);
+        private readonly ValueSet _emptySet = new ValueSet(null, null);
 
         // Returns an empty set if there is no such key in the dictionary.
         public ValueSet this[K k]

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -230,7 +230,7 @@ namespace Roslyn.Utilities
             => this.HasOne ? ImmutableArray.Create(_one) : _many;
 
         public Enumerator GetEnumerator()
-            => new(this);
+            => new Enumerator(this);
 
         internal struct Enumerator
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
@@ -12,7 +12,7 @@ namespace Roslyn.Utilities
     /// </summary>
     internal class ReferenceEqualityComparer : IEqualityComparer<object?>
     {
-        public static readonly ReferenceEqualityComparer Instance = new();
+        public static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
 
         private ReferenceEqualityComparer()
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Dictionary.cs
@@ -20,7 +20,7 @@ namespace Roslyn.Utilities
 #nullable enable
                 where TKey : notnull
             {
-                public static new readonly Dictionary<TKey, TValue> Instance = new();
+                public static new readonly Dictionary<TKey, TValue> Instance = new Dictionary<TKey, TValue>();
 
                 private Dictionary()
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
@@ -20,7 +20,7 @@ namespace Roslyn.Utilities
 
             internal class List<T> : Collection<T>, IList<T>, IReadOnlyList<T>
             {
-                public static new readonly List<T> Instance = new();
+                public static new readonly List<T> Instance = new List<T>();
 
                 protected List()
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
@@ -13,7 +13,7 @@ namespace Roslyn.Utilities
         {
             internal class Set<T> : Collection<T>, ISet<T>, IReadOnlySet<T>
             {
-                public static new readonly Set<T> Instance = new();
+                public static new readonly Set<T> Instance = new Set<T>();
 
                 protected Set()
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ValueTaskFactory.cs
@@ -14,9 +14,9 @@ namespace Roslyn.Utilities
     {
         [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "This is a ValueTask wrapper, not an asynchronous method.")]
         public static ValueTask<T> FromResult<T>(T result)
-            => new(result);
+            => new ValueTask<T>(result);
 
         public static ValueTask CompletedTask
-            => new();
+            => new ValueTask();
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Cci
 {
     internal abstract class ReferenceIndexerBase : MetadataVisitor
     {
-        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new();
-        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new();
+        private readonly HashSet<IReferenceOrISignature> _alreadySeen = new HashSet<IReferenceOrISignature>();
+        private readonly HashSet<IReferenceOrISignature> _alreadyHasToken = new HashSet<IReferenceOrISignature>();
         protected bool typeReferenceNeedsToken;
 
         internal ReferenceIndexerBase(EmitContext context)

--- a/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectBinder.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Lock for all data in this type.
         /// </summary>
-        private static readonly object s_gate = new();
+        private static readonly object s_gate = new object();
 
         /// <summary>
         /// Last created snapshot of our data.  We hand this out instead of exposing our raw
@@ -34,9 +34,9 @@ namespace Roslyn.Utilities
         /// the stream, and <see cref="ObjectReader"/> will use that index to get the reader used
         /// for deserialization.
         /// </summary>
-        private static readonly Dictionary<Type, int> s_typeToIndex = new();
-        private static readonly List<Type> s_types = new();
-        private static readonly List<Func<ObjectReader, IObjectWritable>> s_typeReaders = new();
+        private static readonly Dictionary<Type, int> s_typeToIndex = new Dictionary<Type, int>();
+        private static readonly List<Type> s_types = new List<Type>();
+        private static readonly List<Func<ObjectReader, IObjectWritable>> s_typeReaders = new List<Func<ObjectReader, IObjectWritable>>();
 
         /// <summary>
         /// Gets an immutable copy of the state of this binder.  This copy does not need to be

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -319,13 +319,13 @@ namespace Roslyn.Utilities
             private readonly SegmentedList<T> _values;
 
             private static readonly ObjectPool<SegmentedList<T>> s_objectListPool
-                = new(() => new SegmentedList<T>(20));
+                = new ObjectPool<SegmentedList<T>>(() => new SegmentedList<T>(20));
 
             private ReaderReferenceMap(SegmentedList<T> values)
                 => _values = values;
 
             public static ReaderReferenceMap<T> Create()
-                => new(s_objectListPool.Allocate());
+                => new ReaderReferenceMap<T>(s_objectListPool.Allocate());
 
             public void Dispose()
             {

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -390,10 +390,10 @@ namespace Roslyn.Utilities
             private int _nextId;
 
             private static readonly ObjectPool<SegmentedDictionary<object, int>> s_referenceDictionaryPool =
-                new(() => new SegmentedDictionary<object, int>(128, ReferenceEqualityComparer.Instance));
+                new ObjectPool<SegmentedDictionary<object, int>>(() => new SegmentedDictionary<object, int>(128, ReferenceEqualityComparer.Instance));
 
             private static readonly ObjectPool<SegmentedDictionary<object, int>> s_valueDictionaryPool =
-                new(() => new SegmentedDictionary<object, int>(128));
+                new ObjectPool<SegmentedDictionary<object, int>>(() => new SegmentedDictionary<object, int>(128));
 
             public WriterReferenceMap(bool valueEquality)
             {

--- a/src/Compilers/Core/Portable/Serialization/SerializationThreadPool.cs
+++ b/src/Compilers/Core/Portable/Serialization/SerializationThreadPool.cs
@@ -32,7 +32,7 @@ namespace Roslyn.Utilities
             private static readonly TimeSpan s_idleTimeout = TimeSpan.FromSeconds(1);
 
             /// <summary>The queue of work items. Also used as a lock to protect all relevant state.</summary>
-            private static readonly Queue<(Delegate function, object? state, TaskCompletionSource<object?> tcs)> s_queue = new();
+            private static readonly Queue<(Delegate function, object? state, TaskCompletionSource<object?> tcs)> s_queue = new Queue<(Delegate function, object? state, TaskCompletionSource<object?> tcs)>();
 
             /// <summary>The number of threads currently waiting in <c>tryDequeue</c> for work to arrive.</summary>
             private static int s_availableThreads = 0;

--- a/src/Compilers/Core/Portable/SourceGeneration/GlobalAliases.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GlobalAliases.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration;
 /// </summary>
 internal sealed class GlobalAliases : IEquatable<GlobalAliases>
 {
-    public static readonly GlobalAliases Empty = new(ImmutableArray<(string aliasName, string symbolName)>.Empty);
+    public static readonly GlobalAliases Empty = new GlobalAliases(ImmutableArray<(string aliasName, string symbolName)>.Empty);
 
     public readonly ImmutableArray<(string aliasName, string symbolName)> AliasAndSymbolNames;
 
@@ -55,7 +55,7 @@ internal sealed class GlobalAliases : IEquatable<GlobalAliases>
         if (ga2.AliasAndSymbolNames.Length == 0)
             return ga1;
 
-        return new(ga1.AliasAndSymbolNames.Concat(ga2.AliasAndSymbolNames));
+        return new GlobalAliases(ga1.AliasAndSymbolNames.Concat(ga2.AliasAndSymbolNames));
     }
 
     public override int GetHashCode()

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
             _sourceExtension = sourceExtension;
         }
 
-        public SyntaxValueProvider SyntaxProvider => new(this, _syntaxInputBuilder, RegisterOutput, SyntaxHelper);
+        public SyntaxValueProvider SyntaxProvider => new SyntaxValueProvider(this, _syntaxInputBuilder, RegisterOutput, SyntaxHelper);
 
         public IncrementalValueProvider<Compilation> CompilationProvider => new IncrementalValueProvider<Compilation>(SharedInputNodes.Compilation.WithRegisterOutput(RegisterOutput).WithTrackingName(WellKnownGeneratorInputs.Compilation));
 
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis
         // (e.g. we don't care if it has the same conceptual value, we're ok rerunning as long as the actual instance
         // changes).
         internal IncrementalValueProvider<CompilationOptions> CompilationOptionsProvider
-            => new(SharedInputNodes.CompilationOptions.WithRegisterOutput(RegisterOutput)
+            => new IncrementalValueProvider<CompilationOptions>(SharedInputNodes.CompilationOptions.WithRegisterOutput(RegisterOutput)
                 .WithComparer(ReferenceEqualityComparer.Instance)
                 .WithTrackingName(WellKnownGeneratorInputs.CompilationOptions));
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         public Builder ToBuilder(string? stepName, bool stepTrackingEnabled, IEqualityComparer<T>? equalityComparer = null, int? tableCapacity = null)
-            => new(this, stepName, stepTrackingEnabled, equalityComparer, tableCapacity);
+            => new Builder(this, stepName, stepTrackingEnabled, equalityComparer, tableCapacity);
 
         public NodeStateTable<T> CreateCachedTableWithUpdatedSteps<TInput>(NodeStateTable<TInput> inputTable, string? stepName, IEqualityComparer<T> equalityComparer)
         {
@@ -564,7 +564,7 @@ namespace Microsoft.CodeAnalysis
                 return new TableEntry(OneOrMany.Create(itemBuilder.ToImmutableArray()), s_allCachedEntries, anyRemoved: false);
             }
 
-            public TableEntry AsRemovedDueToInputRemoval() => new(_items, s_allRemovedDueToInputRemoval, anyRemoved: true);
+            public TableEntry AsRemovedDueToInputRemoval() => new TableEntry(_items, s_allRemovedDueToInputRemoval, anyRemoved: true);
 
             private static ImmutableArray<EntryState> GetSingleArray(EntryState state) => state switch
             {
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis
             };
 
             public Enumerator GetEnumerator()
-                => new(this);
+                => new Enumerator(this);
 
             public struct Enumerator
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly InputNode<Compilation> Compilation = new InputNode<Compilation>(b => ImmutableArray.Create(b.Compilation));
 
-        public static readonly InputNode<CompilationOptions> CompilationOptions = new(b => ImmutableArray.Create(b.Compilation.Options), ReferenceEqualityComparer.Instance);
+        public static readonly InputNode<CompilationOptions> CompilationOptions = new InputNode<CompilationOptions>(b => ImmutableArray.Create(b.Compilation.Options), ReferenceEqualityComparer.Instance);
 
         public static readonly InputNode<ParseOptions> ParseOptions = new InputNode<ParseOptions>(b => ImmutableArray.Create(b.DriverState.ParseOptions));
 

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
     {
         private static readonly char[] s_trimChars = { ' ', '\n', '\r' };
 
-        public static EmitOptions EmitOptions { get; } = new();
+        public static EmitOptions EmitOptions { get; } = new EmitOptions();
         public static SourceHashAlgorithm HashAlgorithm { get; } = SourceHashAlgorithm.Sha256;
         public static SourceHashAlgorithm[] HashAlgorithms { get; } = new[]
         {

--- a/src/Compilers/Directory.Build.props
+++ b/src/Compilers/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\Tools\PrivateAnalyzers\Core\Microsoft.CodeAnalysis.PrivateAnalyzers.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Condition="'$(Language)' == 'C#'" Include="$(MSBuildThisFileDirectory)..\Tools\PrivateAnalyzers\CSharp\Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Condition="'$(Language)' == 'VB'" Include="$(MSBuildThisFileDirectory)..\Tools\PrivateAnalyzers\VisualBasic\Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -458,7 +458,7 @@ public class Analyzer : DiagnosticAnalyzer
 
         private static string GenerateDll(string assemblyName, TempDirectory directory, string csSource, ImmutableArray<byte> publicKeyOpt, params MetadataReference[] additionalReferences)
         {
-            CSharpCompilationOptions options = new(OutputKind.DynamicallyLinkedLibrary, warningLevel: Diagnostic.MaxWarningLevel);
+            CSharpCompilationOptions options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, warningLevel: Diagnostic.MaxWarningLevel);
 
             if (!publicKeyOpt.IsDefault)
             {

--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -926,7 +926,7 @@ namespace Roslyn.Test.Utilities
                 }
                 catch (Exception ex)
                 {
-                    (exceptions ??= new()).Add((index, ex));
+                    (exceptions ??= new List<(int, Exception)>()).Add((index, ex));
                 }
             }
 

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -51,12 +51,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// </summary>
         public bool IncludeTokensAndModuleIds { get; init; }
 
-        public static readonly Verification Skipped = new() { Status = VerificationStatus.Skipped };
-        public static readonly Verification Passes = new() { Status = VerificationStatus.Passes };
-        public static readonly Verification FailsPEVerify = new() { Status = VerificationStatus.FailsPEVerify };
-        public static readonly Verification FailsILVerify = new() { Status = VerificationStatus.FailsILVerify };
-        public static readonly Verification Fails = new() { Status = VerificationStatus.Fails };
-        public static readonly Verification PassesOrFailFast = new() { Status = VerificationStatus.PassesOrFailFast };
+        public static readonly Verification Skipped = new Verification() { Status = VerificationStatus.Skipped };
+        public static readonly Verification Passes = new Verification() { Status = VerificationStatus.Passes };
+        public static readonly Verification FailsPEVerify = new Verification() { Status = VerificationStatus.FailsPEVerify };
+        public static readonly Verification FailsILVerify = new Verification() { Status = VerificationStatus.FailsILVerify };
+        public static readonly Verification Fails = new Verification() { Status = VerificationStatus.Fails };
+        public static readonly Verification PassesOrFailFast = new Verification() { Status = VerificationStatus.PassesOrFailFast };
     }
 
 #nullable disable

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -425,8 +425,8 @@ namespace Microsoft.CodeAnalysis
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         public class SuppressorForErrorLogTest : DiagnosticSuppressor
         {
-            public static readonly SuppressionDescriptor Descriptor1 = new("SPR0001", AnalyzerForErrorLogTest.Descriptor1.Id, "SuppressorJustification1");
-            public static readonly SuppressionDescriptor Descriptor2 = new("SPR0002", AnalyzerForErrorLogTest.Descriptor2.Id, "SuppressorJustification2");
+            public static readonly SuppressionDescriptor Descriptor1 = new SuppressionDescriptor("SPR0001", AnalyzerForErrorLogTest.Descriptor1.Id, "SuppressorJustification1");
+            public static readonly SuppressionDescriptor Descriptor2 = new SuppressionDescriptor("SPR0002", AnalyzerForErrorLogTest.Descriptor2.Id, "SuppressorJustification2");
 
             public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
                 => ImmutableArray.Create(Descriptor1, Descriptor2);
@@ -669,7 +669,7 @@ namespace Microsoft.CodeAnalysis
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: false);
 
-            internal readonly ConcurrentSet<ISymbol> CallbackSymbols = new();
+            internal readonly ConcurrentSet<ISymbol> CallbackSymbols = new ConcurrentSet<ISymbol>();
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
             public override void Initialize(AnalysisContext context)
@@ -2591,7 +2591,7 @@ namespace Microsoft.CodeAnalysis
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         public sealed class LocalNonLocalDiagnosticsAnalyzer : DiagnosticAnalyzer
         {
-            private static readonly DiagnosticDescriptor s_descriptor = new("ID0001", "Title", "{0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor("ID0001", "Title", "{0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
             private readonly ActionKind _actionKind;
 
             public enum ActionKind
@@ -2797,7 +2797,7 @@ namespace Microsoft.CodeAnalysis
                 new DiagnosticDescriptor(DiagnosticId, "test", "test", "test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
             private readonly AnalyzerRegisterActionKind _actionKind;
-            private readonly CancellationTokenSource _cancellationTokenSource = new();
+            private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
             public CancellationTestAnalyzer(AnalyzerRegisterActionKind actionKind)
             {
@@ -2861,28 +2861,28 @@ namespace Microsoft.CodeAnalysis
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         public sealed class AllActionsAnalyzer : DiagnosticAnalyzer
         {
-            private static readonly DiagnosticDescriptor s_descriptor = new("ID0001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor("ID0001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
             private readonly bool _testSyntaxTreeAction;
             private readonly bool _testSemanticModelAction;
             private readonly bool _testSymbolStartAction;
             private readonly bool _testBlockActions;
 
-            public readonly List<SyntaxTree> AnalyzedTrees = new();
-            public readonly List<SemanticModel> AnalyzedSemanticModels = new();
-            public readonly List<ISymbol> AnalyzedSymbols = new();
-            public readonly List<ISymbol> AnalyzedSymbolStartSymbols = new();
-            public readonly List<ISymbol> AnalyzedSymbolEndSymbols = new();
-            public readonly List<IOperation> AnalyzedOperations = new();
-            public readonly List<ISymbol> AnalyzedOperationBlockSymbols = new();
-            public readonly List<IOperation> AnalyzedOperationsInsideOperationBlock = new();
-            public readonly List<ISymbol> AnalyzedOperationBlockStartSymbols = new();
-            public readonly List<ISymbol> AnalyzedOperationBlockEndSymbols = new();
-            public readonly List<SyntaxNode> AnalyzedSyntaxNodes = new();
-            public readonly List<ISymbol> AnalyzedCodeBlockSymbols = new();
-            public readonly List<SyntaxNode> AnalyzedSyntaxNodesInsideCodeBlock = new();
-            public readonly List<ISymbol> AnalyzedCodeBlockStartSymbols = new();
-            public readonly List<ISymbol> AnalyzedCodeBlockEndSymbols = new();
+            public readonly List<SyntaxTree> AnalyzedTrees = new List<SyntaxTree>();
+            public readonly List<SemanticModel> AnalyzedSemanticModels = new List<SemanticModel>();
+            public readonly List<ISymbol> AnalyzedSymbols = new List<ISymbol>();
+            public readonly List<ISymbol> AnalyzedSymbolStartSymbols = new List<ISymbol>();
+            public readonly List<ISymbol> AnalyzedSymbolEndSymbols = new List<ISymbol>();
+            public readonly List<IOperation> AnalyzedOperations = new List<IOperation>();
+            public readonly List<ISymbol> AnalyzedOperationBlockSymbols = new List<ISymbol>();
+            public readonly List<IOperation> AnalyzedOperationsInsideOperationBlock = new List<IOperation>();
+            public readonly List<ISymbol> AnalyzedOperationBlockStartSymbols = new List<ISymbol>();
+            public readonly List<ISymbol> AnalyzedOperationBlockEndSymbols = new List<ISymbol>();
+            public readonly List<SyntaxNode> AnalyzedSyntaxNodes = new List<SyntaxNode>();
+            public readonly List<ISymbol> AnalyzedCodeBlockSymbols = new List<ISymbol>();
+            public readonly List<SyntaxNode> AnalyzedSyntaxNodesInsideCodeBlock = new List<SyntaxNode>();
+            public readonly List<ISymbol> AnalyzedCodeBlockStartSymbols = new List<ISymbol>();
+            public readonly List<ISymbol> AnalyzedCodeBlockEndSymbols = new List<ISymbol>();
 
             public AllActionsAnalyzer(bool testSyntaxTreeAction, bool testSemanticModelAction, bool testSymbolStartAction, bool testBlockActions)
             {

--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Test.Utilities.TestGenerators
 {
     internal class SingleFileTestGenerator : ISourceGenerator
     {
-        private readonly List<(string content, string hintName)> _sources = new();
+        private readonly List<(string content, string hintName)> _sources = new List<(string content, string hintName)>();
 
         public SingleFileTestGenerator()
         {

--- a/src/Compilers/Test/Core/TestableFileSystem.cs
+++ b/src/Compilers/Test/Core/TestableFileSystem.cs
@@ -69,7 +69,7 @@ namespace Roslyn.Test.Utilities
             return CreateForMap(map);
         }
 
-        public static TestableFileSystem CreateForMap() => CreateForMap(new());
+        public static TestableFileSystem CreateForMap() => CreateForMap(new Dictionary<string, TestableFile>());
 
         public static TestableFileSystem CreateForMap(Dictionary<string, TestableFile> map)
             => new TestableFileSystem(map)

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -148,7 +148,8 @@ namespace BuildBoss
             // version, so that way the source generator can actually be loaded by the toolset. We don't apply this rule to
             // any other project, as any other project having a reason to reference a version of Roslyn via a PackageReference
             // probably doesn't fall under this rule.
-            if (ProjectFilePath.Contains("CompilerGeneratorTools") && packageReference.Name == "Microsoft.CodeAnalysis.Common")
+            if ((ProjectFilePath.Contains("CompilerGeneratorTools") && packageReference.Name == "Microsoft.CodeAnalysis.Common")
+                || (ProjectFilePath.Contains("PrivateAnalyzers") && packageReference.Name is "Microsoft.CodeAnalysis.Common" or "Microsoft.CodeAnalysis.CSharp" or "Microsoft.CodeAnalysis.VisualBasic"))
             {
                 yield return "$(SourceGeneratorMicrosoftCodeAnalysisVersion)";
             }

--- a/src/Tools/PrivateAnalyzers/CSharp/CSharpAvoidImplicitObjectCreationDiagnosticAnalyzer.cs
+++ b/src/Tools/PrivateAnalyzers/CSharp/CSharpAvoidImplicitObjectCreationDiagnosticAnalyzer.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.PrivateAnalyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CSharpAvoidImplicitObjectCreationDiagnosticAnalyzer : DiagnosticAnalyzer
+{
+    internal static readonly DiagnosticDescriptor Descriptor = new(PrivateDiagnosticIds.AvoidImplicitObjectCreation, "Avoid new(...)", "Target-typed new is not allowed at this location", "Style", DiagnosticSeverity.Warning, isEnabledByDefault: false);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.ImplicitObjectCreationExpression);
+    }
+
+    private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+    {
+        var implicitObjectCreation = (ImplicitObjectCreationExpressionSyntax)context.Node;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor,
+            implicitObjectCreation.NewKeyword.GetLocation()));
+    }
+}

--- a/src/Tools/PrivateAnalyzers/CSharp/Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp.csproj
+++ b/src/Tools/PrivateAnalyzers/CSharp/Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.CodeAnalysis.PrivateAnalyzers</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Make sure to reference the same version of Microsoft.CodeAnalysis.Analyzers as the rest of the build -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(SourceGeneratorMicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(SourceGeneratorMicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Microsoft.CodeAnalysis.PrivateAnalyzers.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Tools/PrivateAnalyzers/Core/Microsoft.CodeAnalysis.PrivateAnalyzers.csproj
+++ b/src/Tools/PrivateAnalyzers/Core/Microsoft.CodeAnalysis.PrivateAnalyzers.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.CodeAnalysis.PrivateAnalyzers</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Make sure to reference the same version of Microsoft.CodeAnalysis.Analyzers as the rest of the build -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(SourceGeneratorMicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.PrivateAnalyzers.CSharp" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Hash.cs" Link="Hash.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Index.cs" Link="Index.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="IsExternalInit.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs" Link="NullableAttributes.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Range.cs" Link="Range.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Tools/PrivateAnalyzers/Core/PrivateDiagnosticIds.cs
+++ b/src/Tools/PrivateAnalyzers/Core/PrivateDiagnosticIds.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.PrivateAnalyzers;
+
+internal static class PrivateDiagnosticIds
+{
+    /// <summary>
+    /// Target-typed new is not allowed by code style policy in the compiler layer.
+    /// </summary>
+    public const string AvoidImplicitObjectCreation = "RP0001";
+}

--- a/src/Tools/PrivateAnalyzers/VisualBasic/Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic.csproj
+++ b/src/Tools/PrivateAnalyzers/VisualBasic/Microsoft.CodeAnalysis.PrivateAnalyzers.VisualBasic.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.CodeAnalysis.PrivateAnalyzers</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Make sure to reference the same version of Microsoft.CodeAnalysis.Analyzers as the rest of the build -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(SourceGeneratorMicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Microsoft.CodeAnalysis.PrivateAnalyzers.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
* Define a new project for analyzers used only for enforcing Roslyn private code style policy
* Implement RP0001 to enforce compiler code style policy to not use target-typed new
    ![image](https://github.com/dotnet/roslyn/assets/1408396/d6dd4f7b-81f5-4a78-b132-fa29293a2bc8)
