### PR TITLE
Adjust edit span for LSP completion when triggered in the middle of a word

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
 
         public async Task<LSP.CompletionList> ConvertToLspCompletionListAsync(
             Document document,
+            int position,
             CompletionCapabilityHelper capabilityHelper,
             CompletionList list, bool isIncomplete, long resultId,
             CancellationToken cancellationToken)
@@ -50,8 +51,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             var lspVSClientCapability = capabilityHelper.SupportVSInternalClientCapabilities;
             var defaultEditRangeSupported = capabilityHelper.SupportDefaultEditRange;
 
-            // We use the default completion list span as our comparison point for optimization when generating the TextEdits later on.
-            var defaultSpan = list.Span;
             var documentText = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Set resolve data on list if the client supports it, otherwise set it on each item.
@@ -65,9 +64,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             var creationService = document.Project.Solution.Services.GetRequiredService<ILspCompletionResultCreationService>();
             var completionService = document.GetRequiredLanguageService<CompletionService>();
 
+            // By default, Roslyn would treat continuous alphabetical text as a single word for completion purpose.
+            // e.g. when user triggers completion at the location of {$} in "pub{$}class", the span would cover "pubclass",
+            // which is used for subsequent matching and commit.
+            // This works fine for VS async-completion, where we have full control of entire completion process.
+            // However, the insert mode in VSCode (i.e. the mode our LSP server supports) expects us to return TextEdit that only
+            // covers the span ends at the cursor location, e.g. "pub" in the example above. Here we detect when that occurs and
+            // adjust the span accordingly.
+            var defaultSpan = !capabilityHelper.SupportVSInternalClientCapabilities && position < list.Span.End
+                ? new(list.Span.Start, position)
+                : list.Span;
+
             var typedText = documentText.GetSubText(defaultSpan).ToString();
             foreach (var item in list.ItemsList)
+            {
+                item.Span = defaultSpan;    // item.Span will be used to generate change, adjust it if needed
                 lspCompletionItems.Add(await CreateLSPCompletionItemAsync(item, typedText).ConfigureAwait(false));
+            }
 
             var completionList = new LSP.VSInternalCompletionList
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var (list, isIncomplete, resultId) = completionListResult.Value;
 
             var creationService = document.Project.Solution.Services.GetRequiredService<ILspCompletionResultCreationService>();
-            return await creationService.ConvertToLspCompletionListAsync(document, capabilityHelper, list, isIncomplete, resultId, cancellationToken)
+            return await creationService.ConvertToLspCompletionListAsync(document, position, capabilityHelper, list, isIncomplete, resultId, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/ILspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/ILspCompletionResultCreationService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
     {
         Task<LSP.CompletionList> ConvertToLspCompletionListAsync(
             Document document,
+            int position,
             CompletionCapabilityHelper capabilityHelper,
             CompletionList list, bool isIncomplete, long resultId,
             CancellationToken cancellationToken);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -1447,6 +1447,27 @@ class A
             Assert.True(list.SuggestionMode);
         }
 
+        [Theory, CombinatorialData]
+        public async Task EditRangeShouldNotEndAtCursorPosition(bool mutatingLspWorkspace)
+        {
+            var markup = @"pub{|caret:|}class";
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
+            var caret = testLspServer.GetLocations("caret").Single();
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.NeverInclude);
+
+            var completionParams = CreateCompletionParams(
+                caret,
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams);
+            AssertEx.NotNull(results);
+            Assert.NotEmpty(results.Items);
+            Assert.Equal(new() { Start = new(0, 0), End = new(0, 8) }, results.ItemDefaults.EditRange.Value.First);
+        }
+
         internal static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)
         {
             return testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName,


### PR DESCRIPTION
Fix https://github.com/dotnet/vscode-csharp/issues/5777

![typing](https://github.com/dotnet/roslyn/assets/788783/df0d7dae-83f2-4605-abda-4107e7c04450)
