### PR TITLE
Reduce allocations in ArrayBuilder.AddMany

### DIFF
--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -590,6 +590,8 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public void AddMany(T item, int count)
         {
+            EnsureCapacity(Count + count);
+
             for (var i = 0; i < count; i++)
             {
                 Add(item);


### PR DESCRIPTION
Call `EnsureCapacity` in `ArrayBuilder.AddMany` so we have at most one array reallocation.

Fixes [AB#1830263](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1830263)