### PR TITLE
Small perf improvement during code action computation.

### DIFF
--- a/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
 
 namespace Microsoft.CodeAnalysis.Wrapping
 {
@@ -88,9 +87,8 @@ namespace Microsoft.CodeAnalysis.Wrapping
             protected string GetIndentationAfter(SyntaxNodeOrToken nodeOrToken, FormattingOptions2.IndentStyle indentStyle)
             {
                 var newLine = Options.FormattingOptions.NewLine;
-                var newSourceText = OriginalSourceText.WithChanges(new TextChange(new TextSpan(nodeOrToken.Span.End, 0), newLine));
-                newSourceText = newSourceText.WithChanges(
-                    new TextChange(TextSpan.FromBounds(nodeOrToken.Span.End + newLine.Length, newSourceText.Length), ""));
+                var newSourceText = OriginalSourceText.WithChanges(
+                    new TextChange(TextSpan.FromBounds(nodeOrToken.Span.End, OriginalSourceText.Length), newLine));
 
                 var newDocument = OriginalDocument.WithText(newSourceText);
 


### PR DESCRIPTION
1) Changed AbstractCodeActionComputer.GetIndentationAfter to only create two snapshots per invocation. 

2) Slight optimization around codeaction computation in parameter list context as there are scenarios I was hitting where neither  _singleIndentationTrivia nor _braceIndentationTrivia were used during ComputeWrappingGroupsAsync.