### PR TITLE
Correctly handle trivia in inline statement snippets

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
@@ -468,15 +468,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
 
-        [WpfFact]
-        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetTest()
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        [InlineData("#region test")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest1(string trivia)
         {
-            var markupBeforeCommit = """
+            var markupBeforeCommit = $$"""
                 class Program
                 {
                     void M(bool arg)
                     {
-                        // comment
+                        {{trivia}}
                         arg.$$
                     }
                 }
@@ -487,12 +490,91 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 {
                     void M(bool arg)
                     {
-                        // comment
+                        {{trivia}}
                         {{ItemToCommit}} (arg)
                         {
                             $$
                         }
                     }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                {{trivia}}
+                        arg.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                {{trivia}}
+                        {{ItemToCommit}} (arg)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                true.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{trivia}}
+                {{ItemToCommit}} (true)
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#region test")]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                true.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+
+                {{trivia}}
+                {{ItemToCommit}} (true)
+                {
+                    $$
                 }
                 """;
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
@@ -467,5 +467,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
+
+        [WpfFact]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetTest()
+        {
+            var markupBeforeCommit = """
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                        // comment
+                        arg.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(bool arg)
+                    {
+                        // comment
+                        {{ItemToCommit}} (arg)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -315,5 +315,118 @@ static void Main(string[] args)
 
             await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        [InlineData("#region test")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int[] arr)
+                    {
+                        {{trivia}}
+                        arr.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int[] arr)
+                    {
+                        {{trivia}}
+                        foreach (var item in arr)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int[] arr)
+                    {
+                {{trivia}}
+                        arr.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int[] arr)
+                    {
+                {{trivia}}
+                        foreach (var item in arr)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                (new int[10]).$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{trivia}}
+                foreach (var item in new int[10])
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#region test")]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                (new int[10]).$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+
+                {{trivia}}
+                foreach (var item in new int[10])
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForSnippetCompletionProviderTests.cs
@@ -407,5 +407,118 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyItemIsAbsentAsync(markup, ItemToCommit);
         }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        [InlineData("#region test")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                        {{trivia}}
+                        len.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                        {{trivia}}
+                        for (int i = 0; i < len; i++)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                {{trivia}}
+                        len.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                {{trivia}}
+                        for (int i = 0; i < len; i++)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                10.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{trivia}}
+                for (int i = 0; i < 10; i++)
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#region test")]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                10.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+
+                {{trivia}}
+                for (int i = 0; i < 10; i++)
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForrSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForrSnippetCompletionProviderTests.cs
@@ -409,5 +409,118 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             await VerifyItemIsAbsentAsync(markup, ItemToCommit);
         }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        [InlineData("#region test")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                        {{trivia}}
+                        len.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                        {{trivia}}
+                        for (int i = len - 1; i >= 0; i--)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInMethodTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                {{trivia}}
+                        len.$$
+                    }
+                }
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                class Program
+                {
+                    void M(int len)
+                    {
+                {{trivia}}
+                        for (int i = len - 1; i >= 0; i--)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("// comment")]
+        [InlineData("/* comment */")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest1(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                10.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{trivia}}
+                for (int i = 10 - 1; i >= 0; i--)
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("#region test")]
+        [InlineData("#if true")]
+        [InlineData("#pragma warning disable CS0108")]
+        [InlineData("#nullable enable")]
+        public async Task CorrectlyDealWithLeadingTriviaInInlineSnippetInGlobalStatementTest2(string trivia)
+        {
+            var markupBeforeCommit = $$"""
+                {{trivia}}
+                10.$$
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+
+                {{trivia}}
+                for (int i = 10 - 1; i >= 0; i--)
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
                 iteratorTypeSyntax = inlineExpressionType.GenerateTypeSyntax();
             }
 
+            inlineExpression = inlineExpression?.WithoutLeadingTrivia();
+
             var variableDeclaration = SyntaxFactory.VariableDeclaration(
                 iteratorTypeSyntax,
                 variables: SyntaxFactory.SingletonSeparatedList(

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             }
             else
             {
-                var inlineExpressionType = semanticModel.GetTypeInfo(OriginalInlineExpression!).Type;
+                var inlineExpressionType = semanticModel.GetTypeInfo(inlineExpression).Type;
                 Debug.Assert(inlineExpressionType is not null && (inlineExpressionType.IsIntegralType() || inlineExpressionType.IsNativeIntegerType));
                 iteratorTypeSyntax = inlineExpressionType.GenerateTypeSyntax();
             }

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             }
             else
             {
-                var inlineExpressionType = semanticModel.GetTypeInfo(inlineExpression).Type;
+                var inlineExpressionType = semanticModel.GetTypeInfo(OriginalInlineExpression!).Type;
                 Debug.Assert(inlineExpressionType is not null && (inlineExpressionType.IsIntegralType() || inlineExpressionType.IsNativeIntegerType));
                 iteratorTypeSyntax = inlineExpressionType.GenerateTypeSyntax();
             }

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var itemString = NameGenerator.GenerateUniqueName(
                 "item", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
 
-            return SyntaxFactory.ForEachStatement(varIdentifier, itemString, collectionIdentifier, SyntaxFactory.Block()).NormalizeWhitespace();
+            return SyntaxFactory.ForEachStatement(varIdentifier, itemString, collectionIdentifier.WithoutLeadingTrivia(), SyntaxFactory.Block()).NormalizeWhitespace();
         }
 
         /// <summary>

--- a/src/Features/CSharp/Portable/Snippets/CSharpReversedForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpReversedForLoopSnippetProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override ExpressionSyntax GenerateInitializerValue(SyntaxGenerator generator, SyntaxNode? inlineExpression)
         {
-            var subtractFrom = inlineExpression ?? generator.IdentifierName("length");
+            var subtractFrom = inlineExpression?.WithoutLeadingTrivia() ?? generator.IdentifierName("length");
             return (ExpressionSyntax)generator.SubtractExpression(subtractFrom, generator.LiteralExpression(1));
         }
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -22,6 +22,6 @@ namespace Microsoft.CodeAnalysis.Snippets
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsIfStatement;
 
         protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
-            => generator.IfStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
+            => generator.IfStatement(inlineExpression?.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -66,36 +66,9 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             _ = TryGetInlineExpression(targetToken, syntaxFacts, out var inlineExpression);
 
             var statement = GenerateStatement(SyntaxGenerator.GetGenerator(document), syntaxContext, inlineExpression);
-
-            if (inlineExpression is not null)
-            {
-                ConstructedFromInlineExpression = true;
-
-                // We need to trim leading trivia of `inlineExpression` to remove unwanted comments and so on.
-                // Need to do it after the statement was generated, so snippet can ask semantic questions about given `inlineExpression`.
-                // But we cannot just use `ReplaceNode` with `inlineExpression` as argument, since corresponding node now belongs to a different syntax tree.
-                // So we manually walk statement's descendant nodes to find equivalent one to `inlineExpression` we have
-                var inlineExpressionInStatement = FindInlineExpressionInGeneratedStatement(statement, inlineExpression);
-                if (inlineExpressionInStatement is not null)
-                    statement = statement.ReplaceNode(inlineExpressionInStatement, inlineExpressionInStatement.WithoutLeadingTrivia());
-            }
+            ConstructedFromInlineExpression = inlineExpression is not null;
 
             return new TextChange(inlineExpression?.Parent?.Span ?? TextSpan.FromBounds(position, position), statement.ToFullString());
-
-            static SyntaxNode? FindInlineExpressionInGeneratedStatement(SyntaxNode statement, SyntaxNode inlineExpression)
-            {
-                foreach (var node in statement.DescendantNodes())
-                {
-                    if (node.IsEquivalentTo(inlineExpression))
-                        return node;
-                }
-
-                // Generally we shouldn't appear here in a normal flow.
-                // But it is theoretically possible if:
-                // 1. Snippet didn't use `inlineExpression`. Most likely something it wrong with its implementation. Or it is WIP and not everything is wired up at this point
-                // 2. Snippet modified `inlineExpression` when used it. In this case responsibility of handling trivia lies on the snippet, since we don't have any means to find it
-                return null;
-            }
         }
 
         protected sealed override SyntaxNode? FindAddedSnippetSyntaxNode(SyntaxNode root, int position, Func<SyntaxNode?, bool> isCorrectContainer)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractWhileLoopSnippetProvider.cs
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts) => syntaxFacts.IsWhileStatement;
 
         protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
-            => generator.WhileStatement(inlineExpression ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
+            => generator.WhileStatement(inlineExpression?.WithoutLeadingTrivia() ?? generator.TrueLiteralExpression(), Array.Empty<SyntaxNode>());
     }
 }


### PR DESCRIPTION
Behaviour before this PR:
![devenv_DwVmRJYICt](https://github.com/dotnet/roslyn/assets/70431552/1d863648-582d-4aff-9109-6937ddf6d422)

Fixed behaviour after this PR:
![devenv_v30kCnuebX](https://github.com/dotnet/roslyn/assets/70431552/bdaf9cfd-0263-4031-b65c-6d5877d5e274)

Didn't create an issue upfront because the core fix is 1 line change.