### PR TITLE
Validate diagnostics reported by source generators

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3567,7 +3567,7 @@ class D {  (int, bool) _field; }";
             {
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (ctx, _) =>
                 {
-                    var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+                    var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "/detached");
                     ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                         "TEST0001",
                         "Test",
@@ -3583,7 +3583,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3601,7 +3601,7 @@ class D {  (int, bool) _field; }";
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (ctx, comp) =>
                 {
                     var validSyntaxTree = comp.SyntaxTrees.Single();
-                    var invalidSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+                    var invalidSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "/detached");
                     ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                         "TEST0001",
                         "Test",
@@ -3618,7 +3618,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3633,7 +3633,7 @@ class D {  (int, bool) _field; }";
 
             var generator = new CallbackGenerator(ctx => { }, ctx =>
             {
-                var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+                var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "/detached");
                 ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                     "TEST0001",
                     "Test",
@@ -3648,7 +3648,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3664,7 +3664,7 @@ class D {  (int, bool) _field; }";
             var generator = new CallbackGenerator(ctx => { }, ctx =>
             {
                 var validSyntaxTree = ctx.Compilation.SyntaxTrees.Single();
-                var invalidSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+                var invalidSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "/detached");
                 ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                     "TEST0001",
                     "Test",
@@ -3680,7 +3680,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3690,7 +3690,7 @@ class D {  (int, bool) _field; }";
         {
             var source = "class C {}";
             var parseOptions = TestOptions.RegularPreview;
-            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions, sourceFileName: "/original");
             compilation.VerifyDiagnostics();
 
             var generator = new PipelineCallbackGenerator(ctx =>
@@ -3713,7 +3713,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3723,7 +3723,7 @@ class D {  (int, bool) _field; }";
         {
             var source = "class C {}";
             var parseOptions = TestOptions.RegularPreview;
-            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions, sourceFileName: "/original");
             compilation.VerifyDiagnostics();
 
             var generator = new PipelineCallbackGenerator(ctx =>
@@ -3747,7 +3747,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3757,7 +3757,7 @@ class D {  (int, bool) _field; }";
         {
             var source = "class C {}";
             var parseOptions = TestOptions.RegularPreview;
-            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions, sourceFileName: "/original");
             compilation.VerifyDiagnostics();
 
             var generator = new CallbackGenerator(ctx => { }, ctx =>
@@ -3777,7 +3777,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3787,7 +3787,7 @@ class D {  (int, bool) _field; }";
         {
             var source = "class C {}";
             var parseOptions = TestOptions.RegularPreview;
-            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions, sourceFileName: "/original");
             compilation.VerifyDiagnostics();
 
             var generator = new CallbackGenerator(ctx => { }, ctx =>
@@ -3808,7 +3808,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -485,7 +485,7 @@ class C { }
             Assert.Equal(2, outputCompilation.SyntaxTrees.Count());
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         public void Generator_HintName_MustBe_Unique_Across_Outputs()
         {
             var source = @"
@@ -521,7 +521,7 @@ class C { }
             driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
             outputCompilation.VerifyDiagnostics();
             generatorDiagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "The hintName 'test.cs' of the added source file must be unique within a generator. (Parameter 'hintName')").WithLocation(1, 1)
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "The hintName 'test.cs' of the added source file must be unique within a generator.", "hintName").WithLocation(1, 1)
                 );
             Assert.Equal(1, outputCompilation.SyntaxTrees.Count());
         }
@@ -758,7 +758,7 @@ class C
             Assert.Same(oldDriver, driver);
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         public void Adding_A_Source_Text_Without_Encoding_Fails_Generation()
         {
             var source = @"
@@ -776,7 +776,7 @@ class C { }
 
             Assert.Single(outputDiagnostics);
             outputDiagnostics.Verify(
-                Diagnostic("CS" + (int)ErrorCode.WRN_GeneratorFailedDuringGeneration).WithArguments("CallbackGenerator", "ArgumentException", "The SourceText with hintName 'a.cs' must have an explicit encoding set. (Parameter 'source')").WithLocation(1, 1)
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "The SourceText with hintName 'a.cs' must have an explicit encoding set.", "source").WithLocation(1, 1)
                 );
         }
 
@@ -3554,7 +3554,7 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Incremental()
         {
@@ -3583,11 +3583,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Incremental_AdditionalLocations()
         {
@@ -3618,11 +3618,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Execute()
         {
@@ -3648,11 +3648,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Execute_AdditionalLocations()
         {
@@ -3680,11 +3680,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Incremental()
         {
@@ -3713,11 +3713,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Incremental_AdditionalLocations()
         {
@@ -3747,11 +3747,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Execute()
         {
@@ -3777,11 +3777,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Execute_AdditionalLocations()
         {
@@ -3808,11 +3808,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpaceInIdentifier_Incremental()
         {
@@ -3841,11 +3841,11 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(PipelineCallbackGenerator), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
         [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpaceInIdentifier_Execute()
         {
@@ -3871,7 +3871,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
+                ArgumentExceptionDiagnostic(nameof(CallbackGenerator), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier.", "diagnostic").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -4066,6 +4066,17 @@ class C { }
                 var tree = compilation.GetMember(className).DeclaringSyntaxReferences.Single().SyntaxTree;
                 compilation = compilation.ReplaceSyntaxTree(tree, CSharpSyntaxTree.ParseText(source, parseOptions));
             }
+        }
+
+        private static DiagnosticDescription ArgumentExceptionDiagnostic(string generatorName, string message, string parameterName)
+        {
+            return Diagnostic("CS8785").WithArguments(generatorName, nameof(ArgumentException),
+#if NETCOREAPP
+                $"{message} (Parameter '{parameterName}')"
+#else
+                $"{message}{Environment.NewLine}Parameter name: {parameterName}"
+#endif
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3583,7 +3583,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3618,7 +3618,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3648,7 +3648,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3680,7 +3680,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3713,7 +3713,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3747,7 +3747,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3777,7 +3777,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3808,7 +3808,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '/original', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3841,7 +3841,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(PipelineCallbackGenerator), nameof(ArgumentException), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3871,7 +3871,7 @@ class D {  (int, bool) _field; }";
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
             diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
+                Diagnostic("CS8785").WithArguments(nameof(CallbackGenerator), nameof(ArgumentException), "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3581,7 +3581,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify();
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3614,7 +3615,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3642,7 +3644,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify();
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3672,7 +3675,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3703,7 +3707,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify();
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3735,7 +3740,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3763,7 +3769,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify();
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3792,7 +3799,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[0..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3823,7 +3831,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST 0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 
@@ -3851,7 +3860,8 @@ class D {  (int, bool) _field; }";
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out var diagnostics);
-            diagnostics.Verify(Diagnostic("TEST 0001", "cl").WithLocation(1, 1));
+            diagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1));
             compilation.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3554,7 +3554,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Incremental()
         {
             var source = "class C {}";
@@ -3586,7 +3587,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Incremental_AdditionalLocations()
         {
             var source = "class C {}";
@@ -3620,7 +3622,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Execute()
         {
             var source = "class C {}";
@@ -3649,7 +3652,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_DetachedSyntaxTree_Execute_AdditionalLocations()
         {
             var source = "class C {}";
@@ -3680,7 +3684,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Incremental()
         {
             var source = "class C {}";
@@ -3712,7 +3717,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Incremental_AdditionalLocations()
         {
             var source = "class C {}";
@@ -3745,7 +3751,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Execute()
         {
             var source = "class C {}";
@@ -3774,7 +3781,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpanOutsideRange_Execute_AdditionalLocations()
         {
             var source = "class C {}";
@@ -3804,7 +3812,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpaceInIdentifier_Incremental()
         {
             var source = "class C {}";
@@ -3836,7 +3845,8 @@ class D {  (int, bool) _field; }";
             compilation.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
+        [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")]
         public void Diagnostic_SpaceInIdentifier_Execute()
         {
             var source = "class C {}";

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis
         /// </exception>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, static (_, _) => true, CancellationToken);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, isSupportedDiagnostic: static (_, _) => true, CancellationToken);
             _diagnostics.Add(diagnostic);
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorContexts.cs
@@ -98,7 +98,15 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The severity of the diagnostic may cause the compilation to fail, depending on the <see cref="Compilation"/> settings.
         /// </remarks>
-        public void ReportDiagnostic(Diagnostic diagnostic) => _diagnostics.Add(diagnostic);
+        /// <exception cref="ArgumentException">
+        /// <paramref name="diagnostic"/> is located in a syntax tree which is not part of the compilation,
+        /// its location span is outside of the given file, or its identifier is not valid.
+        /// </exception>
+        public void ReportDiagnostic(Diagnostic diagnostic)
+        {
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, static (_, _) => true, CancellationToken);
+            _diagnostics.Add(diagnostic);
+        }
 
         internal (ImmutableArray<GeneratedSourceText> sources, ImmutableArray<Diagnostic> diagnostics) ToImmutableAndFree()
             => (_additionalSources.ToImmutableAndFree(), _diagnostics.ToReadOnlyAndFree());

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis
         /// </exception>
         public void ReportDiagnostic(Diagnostic diagnostic)
         {
-            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, static (_, _) => true, CancellationToken);
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, isSupportedDiagnostic: static (_, _) => true, CancellationToken);
             Diagnostics.Add(diagnostic);
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -126,12 +126,14 @@ namespace Microsoft.CodeAnalysis
     {
         internal readonly AdditionalSourcesCollection Sources;
         internal readonly DiagnosticBag Diagnostics;
+        internal readonly Compilation Compilation;
 
-        internal SourceProductionContext(AdditionalSourcesCollection sources, DiagnosticBag diagnostics, CancellationToken cancellationToken)
+        internal SourceProductionContext(AdditionalSourcesCollection sources, DiagnosticBag diagnostics, Compilation compilation, CancellationToken cancellationToken)
         {
             CancellationToken = cancellationToken;
             Sources = sources;
             Diagnostics = diagnostics;
+            Compilation = compilation;
         }
 
         public CancellationToken CancellationToken { get; }
@@ -160,7 +162,15 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// The severity of the diagnostic may cause the compilation to fail, depending on the <see cref="Compilation"/> settings.
         /// </remarks>
-        public void ReportDiagnostic(Diagnostic diagnostic) => Diagnostics.Add(diagnostic);
+        /// <exception cref="ArgumentException">
+        /// <paramref name="diagnostic"/> is located in a syntax tree which is not part of the compilation,
+        /// its location span is outside of the given file, or its identifier is not valid.
+        /// </exception>
+        public void ReportDiagnostic(Diagnostic diagnostic)
+        {
+            DiagnosticAnalysisContextHelpers.VerifyArguments(diagnostic, Compilation, static (_, _) => true, CancellationToken);
+            Diagnostics.Add(diagnostic);
+        }
     }
 
     // https://github.com/dotnet/roslyn/issues/53608 right now we only support generating source + diagnostics, but actively want to support generation of other things

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
                     var sourcesBuilder = new AdditionalSourcesCollection(_sourceExtension);
                     var diagnostics = DiagnosticBag.GetInstance();
 
-                    SourceProductionContext context = new SourceProductionContext(sourcesBuilder, diagnostics, cancellationToken);
+                    SourceProductionContext context = new SourceProductionContext(sourcesBuilder, diagnostics, graphState.Compilation, cancellationToken);
                     try
                     {
                         var stopwatch = SharedStopwatch.StartNew();

--- a/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
@@ -296,7 +296,7 @@ End Class",
                                           Diagnostic("GEN001", "ano").WithLocation(5, 6))
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Incremental()
             Dim parseOptions = TestOptions.Regular
@@ -306,7 +306,7 @@ End Class",
                 Sub(ctx)
                     ctx.RegisterSourceOutput(ctx.CompilationProvider,
                         Sub(ctx2, comp)
-                            Dim syntaxTree = VisualBasicSyntaxTree.ParseText(comp.SyntaxTrees.Single().GetText(), parseOptions)
+                            Dim syntaxTree = VisualBasicSyntaxTree.ParseText(comp.SyntaxTrees.Single().GetText(), parseOptions, path:="/detached")
                             ctx2.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                                 "TEST0001",
                                 "Test",
@@ -323,11 +323,11 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, Diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("PipelineCallbackGenerator", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Incremental_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
@@ -338,7 +338,7 @@ End Class",
                     ctx.RegisterSourceOutput(ctx.CompilationProvider,
                         Sub(ctx2, comp)
                             Dim validSyntaxTree = comp.SyntaxTrees.Single()
-                            Dim invalidSyntaxTree = VisualBasicSyntaxTree.ParseText(validSyntaxTree.GetText(), parseOptions)
+                            Dim invalidSyntaxTree = VisualBasicSyntaxTree.ParseText(validSyntaxTree.GetText(), parseOptions, path:="/detached")
                             ctx2.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                                 "TEST0001",
                                 "Test",
@@ -356,11 +356,11 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("PipelineCallbackGenerator", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Execute()
             Dim parseOptions = TestOptions.Regular
@@ -370,7 +370,7 @@ End Class",
                 Sub(ctx)
                 End Sub,
                 Sub(ctx)
-                    Dim syntaxTree = VisualBasicSyntaxTree.ParseText(ctx.Compilation.SyntaxTrees.Single().GetText(), parseOptions)
+                    Dim syntaxTree = VisualBasicSyntaxTree.ParseText(ctx.Compilation.SyntaxTrees.Single().GetText(), parseOptions, path:="/detached")
                     ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                         "TEST0001",
                         "Test",
@@ -386,11 +386,11 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("CallbackGenerator", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Execute_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
@@ -401,7 +401,7 @@ End Class",
                 End Sub,
                 Sub(ctx)
                     Dim validSyntaxTree = ctx.Compilation.SyntaxTrees.Single()
-                    Dim invalidSyntaxTree = VisualBasicSyntaxTree.ParseText(validSyntaxTree.GetText(), parseOptions)
+                    Dim invalidSyntaxTree = VisualBasicSyntaxTree.ParseText(validSyntaxTree.GetText(), parseOptions, path:="/detached")
                     ctx.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(
                         "TEST0001",
                         "Test",
@@ -418,15 +418,15 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("CallbackGenerator", "Reported diagnostic 'TEST0001' has a source location in file '/detached', which is not part of the compilation being analyzed.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Incremental()
             Dim parseOptions = TestOptions.Regular
-            Dim compilation As Compilation = GetCompilation(parseOptions)
+            Dim compilation As Compilation = GetCompilation(parseOptions, sourcePath:="/original")
 
             Dim generator = New PipelineCallbackGenerator(
                 Sub(ctx)
@@ -449,15 +449,15 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("PipelineCallbackGenerator", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Incremental_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
-            Dim compilation As Compilation = GetCompilation(parseOptions)
+            Dim compilation As Compilation = GetCompilation(parseOptions, sourcePath:="/original")
 
             Dim generator = New PipelineCallbackGenerator(
                 Sub(ctx)
@@ -481,15 +481,15 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("PipelineCallbackGenerator", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Execute()
             Dim parseOptions = TestOptions.Regular
-            Dim compilation As Compilation = GetCompilation(parseOptions)
+            Dim compilation As Compilation = GetCompilation(parseOptions, sourcePath:="/original")
 
             Dim generator As ISourceGenerator = New CallbackGenerator(
                 Sub(ctx)
@@ -511,15 +511,15 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("CallbackGenerator", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Execute_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
-            Dim compilation As Compilation = GetCompilation(parseOptions)
+            Dim compilation As Compilation = GetCompilation(parseOptions, sourcePath:="/original")
 
             Dim generator As ISourceGenerator = New CallbackGenerator(
                 Sub(ctx)
@@ -542,11 +542,11 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("CallbackGenerator", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '/original', which is outside of the given file.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpaceInIdentifier_Incremental()
             Dim parseOptions = TestOptions.Regular
@@ -573,11 +573,11 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("PipelineCallbackGenerator", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
-        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
         <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpaceInIdentifier_Execute()
             Dim parseOptions = TestOptions.Regular
@@ -603,7 +603,7 @@ End Class",
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
             diagnostics.Verify(
-                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1))
+                ArgumentExceptionDiagnostic("CallbackGenerator", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier.", "diagnostic").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -645,7 +645,7 @@ End Class",
             Assert.False(testGenerator._sourceExecuted)
         End Sub
 
-        Shared Function GetCompilation(parseOptions As VisualBasicParseOptions, Optional source As String = "") As Compilation
+        Shared Function GetCompilation(parseOptions As VisualBasicParseOptions, Optional source As String = "", Optional sourcePath As String = "") As Compilation
             If (String.IsNullOrWhiteSpace(source)) Then
                 source = "
 Public Class C
@@ -653,7 +653,7 @@ End Class
 "
             End If
 
-            Dim compilation As Compilation = CreateCompilation(source, options:=TestOptions.DebugDll, parseOptions:=parseOptions)
+            Dim compilation As Compilation = CreateCompilation(BasicTestSource.Parse(source, sourcePath, parseOptions), options:=TestOptions.DebugDll)
             compilation.VerifyDiagnostics()
             Assert.Single(compilation.SyntaxTrees)
 
@@ -735,6 +735,15 @@ End Class
             outputCompilation.VerifyDiagnostics()
             diagnostics.Verify(expected)
         End Sub
+
+        Shared Function ArgumentExceptionDiagnostic(generatorName As String, message As String, parameterName As String) As DiagnosticDescription
+#If NETCOREAPP Then
+            Dim fullMessage = $"{message} (Parameter '{parameterName}')"
+#Else
+            Dim fullMessage = $"{message}{Environment.NewLine}Parameter name: {parameterName}"
+#End If
+            Return Diagnostic("BC42502").WithArguments(generatorName, NameOf(ArgumentException), fullMessage)
+        End Function
     End Class
 
     <Generator(LanguageNames.VisualBasic)>

--- a/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
@@ -321,7 +321,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, Diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -352,7 +353,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -380,7 +382,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -410,7 +413,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location in file '', which is not part of the compilation being analyzed. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -439,7 +443,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -469,7 +474,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -497,7 +503,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -526,7 +533,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic 'TEST0001' has a source location '[2..100)' in file '', which is outside of the given file. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -555,7 +563,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST 0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("PipelineCallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 
@@ -583,7 +592,8 @@ End Class",
             Dim driver As GeneratorDriver = VisualBasicGeneratorDriver.Create(ImmutableArray.Create(generator), parseOptions:=parseOptions)
             Dim diagnostics As ImmutableArray(Of Diagnostic) = Nothing
             driver.RunGeneratorsAndUpdateCompilation(compilation, compilation, diagnostics)
-            diagnostics.Verify(Diagnostic("TEST 0001", "Pu").WithLocation(2, 1))
+            diagnostics.Verify(
+                Diagnostic("BC42502").WithArguments("CallbackGenerator", "ArgumentException", "Reported diagnostic has an ID 'TEST 0001', which is not a valid identifier. (Parameter 'diagnostic')").WithLocation(1, 1))
             compilation.VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/SourceGeneration/GeneratorDriverTests.vb
@@ -296,7 +296,8 @@ End Class",
                                           Diagnostic("GEN001", "ano").WithLocation(5, 6))
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Incremental()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -326,7 +327,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Incremental_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -358,7 +360,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Execute()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -387,7 +390,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_DetachedSyntaxTree_Execute_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -418,7 +422,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Incremental()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -448,7 +453,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Incremental_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -479,7 +485,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Execute()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -508,7 +515,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpanOutsideRange_Execute_AdditionalLocations()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -538,7 +546,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpaceInIdentifier_Incremental()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)
@@ -568,7 +577,8 @@ End Class",
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
+        <ConditionalFact(GetType(MonoOrCoreClrOnly), Reason:="Desktop CLR displays argument exceptions differently")>
+        <WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836")>
         Public Sub Diagnostic_SpaceInIdentifier_Execute()
             Dim parseOptions = TestOptions.Regular
             Dim compilation As Compilation = GetCompilation(parseOptions)


### PR DESCRIPTION
Fixes [AB#1805836](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1805836) (assuming the cause of the error is a misbehaving source generator; if it's instead a bug in the generator driver, one of Chris's PRs should fix that).

If a source generator reports invalid diagnostic, an exception is thrown early (similarly to an exception thrown if a hint name is not unique, for example).

Note that not all diagnostics that now fail validation crashed the generator driver previously, but validating the same way as `DiagnosticAnalyzer` seems most consistent. Specifically, only these tests crashed the generator driver without the validation:

![image](https://github.com/dotnet/roslyn/assets/3669664/6eccf3c8-5fac-431f-a429-62ae0d54da6f)
