### PR TITLE
Fix LSP completion edit span computation

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             // covers the span ends at the cursor location, e.g. "pub" in the example above. Here we detect when that occurs and
             // adjust the span accordingly.
             var defaultSpan = !capabilityHelper.SupportVSInternalClientCapabilities && position < list.Span.End
-                ? new(list.Span.Start, position)
+                ? new(list.Span.Start, length: position - list.Span.Start)
                 : list.Span;
 
             var typedText = documentText.GetSubText(defaultSpan).ToString();

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -25,6 +25,7 @@ using Xunit.Abstractions;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion;
+
 public class CompletionFeaturesTests : AbstractLanguageServerProtocolTests
 {
     protected override TestComposition Composition => FeaturesLspComposition;
@@ -467,7 +468,9 @@ class A
     public async Task EditRangeShouldEndAtCursorPosition(bool mutatingLspWorkspace)
     {
         var markup =
-@"pub{|caret:|}class";
+@"public class C1 {}
+
+pub{|caret:|}class";
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, DefaultClientCapabilities);
         var caret = testLspServer.GetLocations("caret").Single();
         var completionParams = new LSP.CompletionParams()
@@ -485,6 +488,6 @@ class A
         var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
         AssertEx.NotNull(results);
         Assert.NotEmpty(results.Items);
-        Assert.Equal(new() { Start = new(0, 0), End = caret.Range.Start }, results.ItemDefaults.EditRange.Value.First);
+        Assert.Equal(new() { Start = new(2, 0), End = caret.Range.Start }, results.ItemDefaults.EditRange.Value.First);
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -1450,7 +1450,10 @@ class A
         [Theory, CombinatorialData]
         public async Task EditRangeShouldNotEndAtCursorPosition(bool mutatingLspWorkspace)
         {
-            var markup = @"pub{|caret:|}class";
+            var markup =
+@"public class C1 {}
+
+pub{|caret:|}class";
 
             await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, s_vsCompletionCapabilities);
             var caret = testLspServer.GetLocations("caret").Single();
@@ -1465,7 +1468,7 @@ class A
             var results = await RunGetCompletionsAsync(testLspServer, completionParams);
             AssertEx.NotNull(results);
             Assert.NotEmpty(results.Items);
-            Assert.Equal(new() { Start = new(0, 0), End = new(0, 8) }, results.ItemDefaults.EditRange.Value.First);
+            Assert.Equal(new() { Start = new(2, 0), End = new(2, 8) }, results.ItemDefaults.EditRange.Value.First);
         }
 
         internal static Task<LSP.CompletionList> RunGetCompletionsAsync(TestLspServer testLspServer, LSP.CompletionParams completionParams)


### PR DESCRIPTION
I've made a dumb mistake in [this PR](https://github.com/dotnet/roslyn/pull/68624), which wasn't not caught by the test because the test code happens to hit the only case the result would be correct. 🤣