### PR TITLE
Use newer version of msbuild

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -82,7 +82,7 @@ stages:
   displayName: Build and Test
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals windows.vs2022.amd64
+    demands: ImageOverride -equals windows.vs2022preview.amd64
 
   jobs:
   - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.7') }}:

--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.100-preview.5.23303.2",
     "vs": {
-      "version": "17.4.1"
+      "version": "17.6.0"
     },
-    "xcopy-msbuild": "17.4.1"
+    "xcopy-msbuild": "17.6.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23314.1",


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/68573 updated us to net8p5, which requires 17.6.  This caused the signed build to fail here https://dnceng.visualstudio.com/internal/_build/results?buildId=2201829&view=results.  The signed build machines are on 17.5, so upgrading the queue as well

Validation - https://dnceng.visualstudio.com/internal/_build/results?buildId=2201854&view=results - passed the restore internal tools step where it failed before