### PR TITLE
fix index out of range in generator driver

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -262,6 +262,12 @@ namespace Microsoft.CodeAnalysis
                     return false;
                 }
 
+                if (previousEntry.Count == 0)
+                {
+                    // it's possible that the previous execution removed this item, but we left in an empty entry as a placeholder. In which case, we can't modify it
+                    return false;
+                }
+
                 Debug.Assert(previousEntry.Count == 1);
                 var (chosen, state, _) = GetModifiedItemAndState(previousEntry.GetItem(0), value, comparer);
                 _states.Add(new TableEntry(OneOrMany.Create(chosen), state));


### PR DESCRIPTION
In certain cases when combining, we end up with an empty entry in the previous table, but a modified entry in the new one. When we try and re-use the previous entry, we throw an exception (because it wasn't there and is empty).

I've yet to come up with a unit test that demonstrates this, but there is a fairly long repro involving razor and hot reload, and can confirm that this fixes that. 