### PR TITLE
Enable spell checking for Razor

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             if (capabilities is VSInternalServerCapabilities vsServerCapabilities)
             {
                 vsServerCapabilities.SupportsDiagnosticRequests = true;
+                vsServerCapabilities.SpellCheckingProvider = true;
 
                 var regexExpression = string.Join("|", InlineCompletionsHandler.BuiltInSnippets);
                 var regex = new Regex(regexExpression, RegexOptions.Compiled | RegexOptions.Singleline, TimeSpan.FromSeconds(1));


### PR DESCRIPTION
Why should C# devs have all the fun.

@veler @CyrusNajmabadi let me know if this is not ready yet for any reason. Seems to work (screenshot is from the old API, I will need to move the impl to the `int[]` API once things are inserted, before Razor actually calls this)

<img width="527" alt="image" src="https://github.com/dotnet/roslyn/assets/754264/09b24b78-3dff-416e-b45b-f9b2985c0caa">
