### PR TITLE
Relax ref readonly parameter signature matching

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3252,8 +3252,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Parameter types should be taken from the least overridden member:
             var parameters = methodResult.LeastOverriddenMember.GetParameters();
-            // But ref kinds should be taken from the actually called member:
-            var actualParameters = methodResult.Member.GetParameters();
 
             for (int arg = 0; arg < arguments.Count; ++arg)
             {
@@ -3269,7 +3267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Disallow using `ref readonly` parameters with no or `in` argument modifier,
                         // same as older versions of the compiler would (since they would see the parameter as `ref`).
                         if (argRefKind is RefKind.None or RefKind.In &&
-                            GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.RefReadOnlyParameter)
+                            GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
                         {
                             var available = CheckFeatureAvailability(argument.Syntax, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
                             Debug.Assert(!available);
@@ -3280,7 +3278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Warn for `ref`/`in` or None/`ref readonly` mismatch.
                         if (argRefKind == RefKind.Ref)
                         {
-                            if (GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.In)
+                            if (GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.In)
                             {
                                 // The 'ref' modifier for argument {0} corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
                                 diagnostics.Add(
@@ -3290,7 +3288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
                         else if (argRefKind == RefKind.None &&
-                            GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.RefReadOnlyParameter)
+                            GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
                         {
                             if (!this.CheckValueKind(argument.Syntax, argument, BindValueKind.RefersToLocation, checkingReceiver: false, BindingDiagnosticBag.Discarded))
                             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3252,6 +3252,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Parameter types should be taken from the least overridden member:
             var parameters = methodResult.LeastOverriddenMember.GetParameters();
+            // But ref kinds should be taken from the actually called member:
+            var actualParameters = methodResult.Member.GetParameters();
 
             for (int arg = 0; arg < arguments.Count; ++arg)
             {
@@ -3267,7 +3269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Disallow using `ref readonly` parameters with no or `in` argument modifier,
                         // same as older versions of the compiler would (since they would see the parameter as `ref`).
                         if (argRefKind is RefKind.None or RefKind.In &&
-                            GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
+                            GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.RefReadOnlyParameter)
                         {
                             var available = CheckFeatureAvailability(argument.Syntax, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
                             Debug.Assert(!available);
@@ -3278,7 +3280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Warn for `ref`/`in` or None/`ref readonly` mismatch.
                         if (argRefKind == RefKind.Ref)
                         {
-                            if (GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.In)
+                            if (GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.In)
                             {
                                 // The 'ref' modifier for argument {0} corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
                                 diagnostics.Add(
@@ -3288,7 +3290,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
                         else if (argRefKind == RefKind.None &&
-                            GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.RefReadOnlyParameter)
+                            GetCorrespondingParameter(ref result, actualParameters, arg).RefKind == RefKind.RefReadOnlyParameter)
                         {
                             if (!this.CheckValueKind(argument.Syntax, argument, BindValueKind.RefersToLocation, checkingReceiver: false, BindingDiagnosticBag.Discarded))
                             {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7718,10 +7718,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_HidingDifferentRefness_Title" xml:space="preserve">
     <value>Modifier of parameter doesn't match the corresponding parameter in hidden member.</value>
   </data>
-  <data name="WRN_PartialDifferentRefness" xml:space="preserve">
+  <data name="ERR_PartialDifferentRefness" xml:space="preserve">
     <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</value>
-  </data>
-  <data name="WRN_PartialDifferentRefness_Title" xml:space="preserve">
-    <value>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7707,18 +7707,18 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>ref readonly parameters</value>
   </data>
   <data name="WRN_OverridingDifferentRefness" xml:space="preserve">
-    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</value>
+    <value>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</value>
   </data>
   <data name="WRN_OverridingDifferentRefness_Title" xml:space="preserve">
-    <value>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</value>
+    <value>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</value>
   </data>
   <data name="WRN_HidingDifferentRefness" xml:space="preserve">
-    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</value>
+    <value>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</value>
   </data>
   <data name="WRN_HidingDifferentRefness_Title" xml:space="preserve">
-    <value>Modifier of parameter doesn't match the corresponding parameter in hidden member.</value>
+    <value>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</value>
   </data>
   <data name="ERR_PartialDifferentRefness" xml:space="preserve">
-    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</value>
+    <value>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7718,7 +7718,4 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_HidingDifferentRefness_Title" xml:space="preserve">
     <value>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</value>
   </data>
-  <data name="ERR_PartialDifferentRefness" xml:space="preserve">
-    <value>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</value>
-  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7706,4 +7706,22 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureRefReadonlyParameters" xml:space="preserve">
     <value>ref readonly parameters</value>
   </data>
+  <data name="WRN_OverridingDifferentRefness" xml:space="preserve">
+    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</value>
+  </data>
+  <data name="WRN_OverridingDifferentRefness_Title" xml:space="preserve">
+    <value>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</value>
+  </data>
+  <data name="WRN_HidingDifferentRefness" xml:space="preserve">
+    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</value>
+  </data>
+  <data name="WRN_HidingDifferentRefness_Title" xml:space="preserve">
+    <value>Modifier of parameter doesn't match the corresponding parameter in hidden member.</value>
+  </data>
+  <data name="WRN_PartialDifferentRefness" xml:space="preserve">
+    <value>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</value>
+  </data>
+  <data name="WRN_PartialDifferentRefness_Title" xml:space="preserve">
+    <value>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2248,7 +2248,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_ArgExpectedIn = 9506,
         WRN_OverridingDifferentRefness = 9507,
         WRN_HidingDifferentRefness = 9508,
-        ERR_PartialDifferentRefness = 9509,
         ERR_OutAttrOnRefReadonlyParam = 9520,
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2248,7 +2248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_ArgExpectedIn = 9506,
         WRN_OverridingDifferentRefness = 9507,
         WRN_HidingDifferentRefness = 9508,
-        WRN_PartialDifferentRefness = 9509,
+        ERR_PartialDifferentRefness = 9509,
         ERR_OutAttrOnRefReadonlyParam = 9520,
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2246,6 +2246,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_RefReadonlyNotVariable = 9504,
         ERR_BadArgExtraRefLangVersion = 9505,
         WRN_ArgExpectedIn = 9506,
+        WRN_OverridingDifferentRefness = 9507,
+        WRN_HidingDifferentRefness = 9508,
+        WRN_PartialDifferentRefness = 9509,
         ERR_OutAttrOnRefReadonlyParam = 9520,
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -542,7 +542,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ArgExpectedIn:
                 case ErrorCode.WRN_OverridingDifferentRefness:
                 case ErrorCode.WRN_HidingDifferentRefness:
-                case ErrorCode.WRN_PartialDifferentRefness:
                     return 1;
                 default:
                     return 0;
@@ -2374,7 +2373,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ArgExpectedIn:
                 case ErrorCode.WRN_OverridingDifferentRefness:
                 case ErrorCode.WRN_HidingDifferentRefness:
-                case ErrorCode.WRN_PartialDifferentRefness:
+                case ErrorCode.ERR_PartialDifferentRefness:
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
                     return false;
                 default:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2373,7 +2373,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ArgExpectedIn:
                 case ErrorCode.WRN_OverridingDifferentRefness:
                 case ErrorCode.WRN_HidingDifferentRefness:
-                case ErrorCode.ERR_PartialDifferentRefness:
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
                     return false;
                 default:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -540,6 +540,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ArgExpectedRefOrIn:
                 case ErrorCode.WRN_RefReadonlyNotVariable:
                 case ErrorCode.WRN_ArgExpectedIn:
+                case ErrorCode.WRN_OverridingDifferentRefness:
+                case ErrorCode.WRN_HidingDifferentRefness:
+                case ErrorCode.WRN_PartialDifferentRefness:
                     return 1;
                 default:
                     return 0;
@@ -2369,6 +2372,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_RefReadonlyNotVariable:
                 case ErrorCode.ERR_BadArgExtraRefLangVersion:
                 case ErrorCode.WRN_ArgExpectedIn:
+                case ErrorCode.WRN_OverridingDifferentRefness:
+                case ErrorCode.WRN_HidingDifferentRefness:
+                case ErrorCode.WRN_PartialDifferentRefness:
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
                     return false;
                 default:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -325,7 +325,6 @@
                 case ErrorCode.WRN_ArgExpectedIn:
                 case ErrorCode.WRN_OverridingDifferentRefness:
                 case ErrorCode.WRN_HidingDifferentRefness:
-                case ErrorCode.WRN_PartialDifferentRefness:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -323,6 +323,9 @@
                 case ErrorCode.WRN_ArgExpectedRefOrIn:
                 case ErrorCode.WRN_RefReadonlyNotVariable:
                 case ErrorCode.WRN_ArgExpectedIn:
+                case ErrorCode.WRN_OverridingDifferentRefness:
+                case ErrorCode.WRN_HidingDifferentRefness:
+                case ErrorCode.WRN_PartialDifferentRefness:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var refKind2 = param2.RefKind;
 
                 // Metadata signatures don't distinguish ref/out, but C# does - even when comparing metadata method signatures.
-                if (refKindCompareMode != RefKindCompareMode.DoNotConsiderDifferences)
+                if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) != 0)
                 {
                     if (refKind1 != refKind2 &&
                         !((refKindCompareMode & RefKindCompareMode.AllowRefReadonlyVsInMismatch) != 0 &&

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch, // PROTOTYPE: Figure out how to test this.
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -301,20 +301,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
-            typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
-
-        // NOTE: Not used anywhere. Do we still need to keep it?
-        /// <summary>
-        /// This instance is used to search for members that have the same name, parameters, (return) type, and constraints (if any)
-        /// according to the C# definition. Custom modifiers are ignored.
-        /// </summary>
-        public static readonly MemberSignatureComparer CSharpSignatureAndConstraintsAndReturnTypeComparer = new MemberSignatureComparer(
-            considerName: true,
-            considerExplicitlyImplementedInterfaces: true,
-            considerReturnType: true,
-            considerTypeConstraints: true,
-            considerCallingConvention: true,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -339,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences, // PROTOTYPE: AllowRefReadonlyVsInMismatch?
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -350,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerCallingConvention: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindCompareMode: RefKindCompareMode.ConsiderDifferences, // PROTOTYPE: RefReadonlyParameterRules?
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences, // PROTOTYPE: AllowRefReadonlyVsInMismatch?
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -776,19 +776,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var refKind2 = param2.RefKind;
 
                 // Metadata signatures don't distinguish ref/out, but C# does - even when comparing metadata method signatures.
-                var refKindMismatchAllowed = refKindMatching == RefKindMatching.RefReadonlyParameterRules &&
-                    ((refKind1 == RefKind.RefReadOnlyParameter && refKind2 == RefKind.In) ||
-                    (refKind1 == RefKind.In && refKind2 == RefKind.RefReadOnlyParameter));
                 if (refKindMatching != RefKindMatching.None)
                 {
-                    if (refKind1 != refKind2 && !refKindMismatchAllowed)
+                    if (refKind1 != refKind2 && !(refKindMatching == RefKindMatching.RefReadonlyParameterRules &&
+                        ((refKind1 == RefKind.RefReadOnlyParameter && refKind2 == RefKind.In) ||
+                        (refKind1 == RefKind.In && refKind2 == RefKind.RefReadOnlyParameter))))
                     {
                         return false;
                     }
                 }
                 else
                 {
-                    if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None) && !refKindMismatchAllowed)
+                    if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None))
                     {
                         return false;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -45,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             considerCallingConvention: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerArity: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -166,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerArity: false,
             typeComparison: TypeCompareKind.AllNullableIgnoreOptions);
 
@@ -179,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames);
 
         /// <summary>
@@ -205,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -218,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -232,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -245,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -260,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -272,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -286,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.RefReadonlyParameterRules, // PROTOTYPE: Figure out how to test this.
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences | RefKindCompareMode.AllowRefReadonlyVsInMismatch, // PROTOTYPE: Figure out how to test this.
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -299,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.None,
+            refKindCompareMode: RefKindCompareMode.DoNotConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         // NOTE: Not used anywhere. Do we still need to keep it?
@@ -313,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: true,
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -325,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers); //if it was a true explicit impl, we expect it to remain so after retargeting
 
         /// <summary>
@@ -338,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences, // PROTOTYPE: RefReadonlyParameterRules?
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences, // PROTOTYPE: RefReadonlyParameterRules?
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -349,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -371,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Compare the full calling conventions.  Still compares varargs if false.
         private readonly bool _considerCallingConvention;
 
-        private readonly RefKindMatching _refKindMatching;
+        private readonly RefKindCompareMode _refKindCompareMode;
 
         // Equality options for parameter types and return types (if return is considered).
         private readonly TypeCompareKind _typeComparison;
@@ -382,7 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool considerReturnType,
             bool considerTypeConstraints,
             bool considerCallingConvention,
-            RefKindMatching refKindMatching,
+            RefKindCompareMode refKindCompareMode,
             bool considerArity = true,
             TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers)
         {
@@ -394,12 +395,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _considerReturnType = considerReturnType;
             _considerTypeConstraints = considerTypeConstraints;
             _considerCallingConvention = considerCallingConvention;
-            _refKindMatching = refKindMatching;
+            _refKindCompareMode = refKindCompareMode;
             _considerArity = considerArity;
             _typeComparison = typeComparison;
             Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) == 0,
-                         $"Rely on the {nameof(RefKindMatching.ConsiderRefKindDifferences)} flag to set this to ensure all cases are handled.");
-            if (refKindMatching == RefKindMatching.None)
+                         $"Rely on the {nameof(refKindCompareMode)} flag to set this to ensure all cases are handled.");
+            if ((refKindCompareMode & RefKindCompareMode.ConsiderDifferences) == 0)
             {
                 _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
             }
@@ -457,7 +458,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (member1.GetParameterCount() > 0 && !HaveSameParameterTypes(member1.GetParameters(), typeMap1, member2.GetParameters(), typeMap2,
-                                                                           _refKindMatching, _typeComparison))
+                                                                           _refKindCompareMode, _typeComparison))
             {
                 return false;
             }
@@ -747,7 +748,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private static bool HaveSameParameterTypes(ImmutableArray<ParameterSymbol> params1, TypeMap typeMap1, ImmutableArray<ParameterSymbol> params2, TypeMap typeMap2,
-                                                   RefKindMatching refKindMatching, TypeCompareKind typeComparison)
+                                                   RefKindCompareMode refKindCompareMode, TypeCompareKind typeComparison)
         {
             Debug.Assert(params1.Length == params2.Length);
 
@@ -776,9 +777,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var refKind2 = param2.RefKind;
 
                 // Metadata signatures don't distinguish ref/out, but C# does - even when comparing metadata method signatures.
-                if (refKindMatching != RefKindMatching.None)
+                if (refKindCompareMode != RefKindCompareMode.DoNotConsiderDifferences)
                 {
-                    if (refKind1 != refKind2 && !(refKindMatching == RefKindMatching.RefReadonlyParameterRules &&
+                    if (refKind1 != refKind2 &&
+                        !((refKindCompareMode & RefKindCompareMode.AllowRefReadonlyVsInMismatch) != 0 &&
                         ((refKind1 == RefKind.RefReadOnlyParameter && refKind2 == RefKind.In) ||
                         (refKind1 == RefKind.In && refKind2 == RefKind.RefReadOnlyParameter))))
                     {
@@ -851,22 +853,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 CSharpWithoutTupleNamesComparer.Equals(member1, member2);
         }
 
-        private enum RefKindMatching
+        [Flags]
+        private enum RefKindCompareMode
         {
             /// <summary>
             /// Ref parameter modifiers are ignored.
             /// </summary>
-            None,
+            DoNotConsiderDifferences = 0,
 
             /// <summary>
             /// Parameters with different ref modifiers are considered different.
             /// </summary>
-            ConsiderRefKindDifferences,
+            ConsiderDifferences = 1 << 0,
 
             /// <summary>
-            /// Like <see cref="ConsiderRefKindDifferences"/> but 'in'/'ref readonly' modifiers are considered equivalent.
+            /// 'in'/'ref readonly' modifiers are considered equivalent.
             /// </summary>
-            RefReadonlyParameterRules,
+            AllowRefReadonlyVsInMismatch = 1 << 1,
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             considerCallingConvention: true,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.AllIgnoreOptions); //shouldn't actually matter for source members
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.ObliviousNullableModifierMatchesAny);
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             considerArity: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             considerArity: false,
             typeComparison: TypeCompareKind.AllNullableIgnoreOptions);
 
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames);
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.RefReadonlyParameterRules, // PROTOTYPE: Figure out how to test this.
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
-            considerRefKindDifferences: false,
+            refKindMatching: RefKindMatching.None,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         // NOTE: Not used anywhere. Do we still need to keep it?
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: true,
             considerCallingConvention: true,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers);
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: true,
             considerTypeConstraints: false,
             considerCallingConvention: true,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             typeComparison: TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreNativeIntegers); //if it was a true explicit impl, we expect it to remain so after retargeting
 
         /// <summary>
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerReturnType: false,
             considerTypeConstraints: false,
             considerCallingConvention: false, //ignore static-ness
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences, // PROTOTYPE: RefReadonlyParameterRules?
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
             considerTypeConstraints: false,
-            considerRefKindDifferences: true,
+            refKindMatching: RefKindMatching.ConsiderRefKindDifferences,
             considerCallingConvention: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
@@ -371,8 +371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // Compare the full calling conventions.  Still compares varargs if false.
         private readonly bool _considerCallingConvention;
 
-        // True to consider RefKind differences, false to consider them the same.
-        private readonly bool _considerRefKindDifferences;
+        private readonly RefKindMatching _refKindMatching;
 
         // Equality options for parameter types and return types (if return is considered).
         private readonly TypeCompareKind _typeComparison;
@@ -383,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool considerReturnType,
             bool considerTypeConstraints,
             bool considerCallingConvention,
-            bool considerRefKindDifferences,
+            RefKindMatching refKindMatching,
             bool considerArity = true,
             TypeCompareKind typeComparison = TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreNativeIntegers)
         {
@@ -395,12 +394,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _considerReturnType = considerReturnType;
             _considerTypeConstraints = considerTypeConstraints;
             _considerCallingConvention = considerCallingConvention;
-            _considerRefKindDifferences = considerRefKindDifferences;
+            _refKindMatching = refKindMatching;
             _considerArity = considerArity;
             _typeComparison = typeComparison;
             Debug.Assert((_typeComparison & TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly) == 0,
-                         $"Rely on the {nameof(considerRefKindDifferences)} flag to set this to ensure all cases are handled.");
-            if (!considerRefKindDifferences)
+                         $"Rely on the {nameof(RefKindMatching.ConsiderRefKindDifferences)} flag to set this to ensure all cases are handled.");
+            if (refKindMatching == RefKindMatching.None)
             {
                 _typeComparison |= TypeCompareKind.FunctionPointerRefMatchesOutInRefReadonly;
             }
@@ -458,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (member1.GetParameterCount() > 0 && !HaveSameParameterTypes(member1.GetParameters(), typeMap1, member2.GetParameters(), typeMap2,
-                                                                           _considerRefKindDifferences, _typeComparison))
+                                                                           _refKindMatching, _typeComparison))
             {
                 return false;
             }
@@ -748,7 +747,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private static bool HaveSameParameterTypes(ImmutableArray<ParameterSymbol> params1, TypeMap typeMap1, ImmutableArray<ParameterSymbol> params2, TypeMap typeMap2,
-                                                   bool considerRefKindDifferences, TypeCompareKind typeComparison)
+                                                   RefKindMatching refKindMatching, TypeCompareKind typeComparison)
         {
             Debug.Assert(params1.Length == params2.Length);
 
@@ -777,16 +776,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var refKind2 = param2.RefKind;
 
                 // Metadata signatures don't distinguish ref/out, but C# does - even when comparing metadata method signatures.
-                if (considerRefKindDifferences)
+                var refKindMismatchAllowed = refKindMatching == RefKindMatching.RefReadonlyParameterRules &&
+                    ((refKind1 == RefKind.RefReadOnlyParameter && refKind2 == RefKind.In) ||
+                    (refKind1 == RefKind.In && refKind2 == RefKind.RefReadOnlyParameter));
+                if (refKindMatching != RefKindMatching.None)
                 {
-                    if (refKind1 != refKind2)
+                    if (refKind1 != refKind2 && !refKindMismatchAllowed)
                     {
                         return false;
                     }
                 }
                 else
                 {
-                    if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None))
+                    if ((refKind1 == RefKind.None) != (refKind2 == RefKind.None) && !refKindMismatchAllowed)
                     {
                         return false;
                     }
@@ -848,6 +850,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return !CSharpWithTupleNamesComparer.Equals(member1, member2) &&
                 CSharpWithoutTupleNamesComparer.Equals(member1, member2);
+        }
+
+        private enum RefKindMatching
+        {
+            /// <summary>
+            /// Ref parameter modifiers are ignored.
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// Parameters with different ref modifiers are considered different.
+            /// </summary>
+            ConsiderRefKindDifferences,
+
+            /// <summary>
+            /// Like <see cref="ConsiderRefKindDifferences"/> but 'in'/'ref readonly' modifiers are considered equivalent.
+            /// </summary>
+            RefReadonlyParameterRules,
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventSymbol.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // Note: we delayed nullable-related checks that could pull on NonNullTypes
                 EventSymbol explicitlyImplementedEvent = _explicitInterfaceImplementations[0];
-                TypeSymbol.CheckNullableReferenceTypeAndScopedMismatchOnImplementingMember(this.ContainingType, this, explicitlyImplementedEvent, isExplicit: true, diagnostics);
+                TypeSymbol.CheckModifierMismatchOnImplementingMember(this.ContainingType, this, explicitlyImplementedEvent, isExplicit: true, diagnostics);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1497,10 +1497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <returns>
-        /// <see langword="true"/> if a diagnostic was added.
-        /// </returns>
-        internal static bool CheckRefReadonlyInMismatch<TArg>(
+        internal static void CheckRefReadonlyInMismatch<TArg>(
             MethodSymbol? baseMethod,
             MethodSymbol? overrideMethod,
             BindingDiagnosticBag diagnostics,
@@ -1513,10 +1510,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (baseMethod is null || overrideMethod is null)
             {
-                return false;
+                return;
             }
 
-            bool hasErrors = false;
             var baseParameters = baseMethod.Parameters;
             var overrideParameters = overrideMethod.Parameters;
             var overrideParameterOffset = invokedAsExtensionMethod ? 1 : 0;
@@ -1529,11 +1525,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if ((baseParameter.RefKind, overrideParameter.RefKind) is (RefKind.RefReadOnlyParameter, RefKind.In) or (RefKind.In, RefKind.RefReadOnlyParameter))
                 {
                     reportMismatchInParameterType(diagnostics, baseMethod, overrideMethod, overrideParameter, topLevel: true, (baseParameter, extraArgument));
-                    hasErrors = true;
                 }
             }
-
-            return hasErrors;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1633,7 +1633,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(ErrorCode.WRN_NewRequired, hidingMemberLocation, hidingMember, hiddenMembers[0]);
                 }
-                else if (hidingMember is MethodSymbol hidingMethod && hiddenMembers[0] is MethodSymbol hiddenMethod)
+
+                if (hidingMember is MethodSymbol hidingMethod && hiddenMembers[0] is MethodSymbol hiddenMethod)
                 {
                     CheckRefReadonlyInMismatch(
                         hiddenMethod, hidingMethod, diagnostics,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1193,7 +1193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         static (diagnostics, _, _, overridingParameter, _, arg) =>
                         {
                             var (overriddenParameter, location) = arg;
-                            // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.
+                            // Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.
                             diagnostics.Add(ErrorCode.WRN_OverridingDifferentRefness, location, overridingParameter, overriddenParameter);
                         },
                         overridingMemberLocation,
@@ -1641,7 +1641,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         static (diagnostics, _, _, hidingParameter, _, arg) =>
                         {
                             var (hiddenParameter, location) = arg;
-                            // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.
+                            // Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.
                             diagnostics.Add(ErrorCode.WRN_HidingDifferentRefness, location, hidingParameter, hiddenParameter);
                         },
                         hidingMemberLocation,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                                   out _lazyRefCustomModifiers,
                                                                   out _lazyParameters, alsoCopyParamsModifier: false);
                     this.FindExplicitlyImplementedMemberVerification(overriddenOrExplicitlyImplementedMethod, diagnostics);
-                    TypeSymbol.CheckNullableReferenceTypeAndScopedMismatchOnImplementingMember(this.ContainingType, this, overriddenOrExplicitlyImplementedMethod, isExplicit: true, diagnostics);
+                    TypeSymbol.CheckModifierMismatchOnImplementingMember(this.ContainingType, this, overriddenOrExplicitlyImplementedMethod, isExplicit: true, diagnostics);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     var (definitionParameter, _) = arg;
                     var location = implementation.GetFirstLocation();
-                    // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.
+                    // Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.
                     diagnostics.Add(ErrorCode.ERR_PartialDifferentRefness, location, definitionParameter, implementationParameter);
                 },
                 extraArgument: (object)null,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -565,21 +565,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 hasTypeDifferences = true;
             }
 
-            if (SourceMemberContainerTypeSymbol.CheckRefReadonlyInMismatch(
-                constructedDefinition, implementation, diagnostics,
-                static (diagnostics, _, implementation, implementationParameter, _, arg) =>
-                {
-                    var (definitionParameter, _) = arg;
-                    var location = implementation.GetFirstLocation();
-                    // Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.
-                    diagnostics.Add(ErrorCode.ERR_PartialDifferentRefness, location, definitionParameter, implementationParameter);
-                },
-                extraArgument: (object)null,
-                invokedAsExtensionMethod: false))
-            {
-                hasTypeDifferences = true;
-            }
-
             if ((!hasTypeDifferences && !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)) ||
                 hasDifferencesInParameterOrTypeParameterName(definition, implementation))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var (definitionParameter, _) = arg;
                     var location = implementation.GetFirstLocation();
                     // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.
-                    diagnostics.Add(ErrorCode.WRN_PartialDifferentRefness, location, definitionParameter, implementationParameter);
+                    diagnostics.Add(ErrorCode.ERR_PartialDifferentRefness, location, definitionParameter, implementationParameter);
                 },
                 extraArgument: (object)null,
                 invokedAsExtensionMethod: false))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -565,6 +565,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 hasTypeDifferences = true;
             }
 
+            if (SourceMemberContainerTypeSymbol.CheckRefReadonlyInMismatch(
+                constructedDefinition, implementation, diagnostics,
+                static (diagnostics, _, implementation, implementationParameter, _, arg) =>
+                {
+                    var (definitionParameter, _) = arg;
+                    var location = implementation.GetFirstLocation();
+                    // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.
+                    diagnostics.Add(ErrorCode.WRN_PartialDifferentRefness, location, definitionParameter, implementationParameter);
+                },
+                extraArgument: (object)null,
+                invokedAsExtensionMethod: false))
+            {
+                hasTypeDifferences = true;
+            }
+
             if ((!hasTypeDifferences && !MemberSignatureComparer.PartialMethodsStrictComparer.Equals(definition, implementation)) ||
                 hasDifferencesInParameterOrTypeParameterName(definition, implementation))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Note: we delayed nullable-related checks that could pull on NonNullTypes
                 if (explicitlyImplementedProperty is object)
                 {
-                    TypeSymbol.CheckNullableReferenceTypeAndScopedMismatchOnImplementingMember(this.ContainingType, this, explicitlyImplementedProperty, isExplicit: true, diagnostics);
+                    TypeSymbol.CheckModifierMismatchOnImplementingMember(this.ContainingType, this, explicitlyImplementedProperty, isExplicit: true, diagnostics);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1874,7 +1874,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 {
                                     var (implementedParameter, implementingType) = arg;
                                     var location = GetImplicitImplementationDiagnosticLocation(implementedMethod, implementingType, implementingMethod);
-                                    // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.
+                                    // Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.
                                     diagnostics.Add(ErrorCode.WRN_OverridingDifferentRefness, location, implementingParameter, implementedParameter);
                                 },
                                 implementingType,

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1701,7 +1701,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!reportedAnError && implementingType.DeclaringCompilation != null)
             {
-                CheckNullableReferenceTypeAndScopedMismatchOnImplementingMember(implementingType, implicitImpl, interfaceMember, isExplicit: false, diagnostics);
+                CheckModifierMismatchOnImplementingMember(implementingType, implicitImpl, interfaceMember, isExplicit: false, diagnostics);
             }
 
             // In constructed types, it is possible to see multiple members with the same (runtime) signature.
@@ -1746,7 +1746,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static void CheckNullableReferenceTypeAndScopedMismatchOnImplementingMember(TypeSymbol implementingType, Symbol implementingMember, Symbol interfaceMember, bool isExplicit, BindingDiagnosticBag diagnostics)
+        /// <summary>
+        /// Reports warnings for some mismatches in parameter or return type modifiers (nullability, scoped, refness) between implementing and implemented member.
+        /// </summary>
+        internal static void CheckModifierMismatchOnImplementingMember(TypeSymbol implementingType, Symbol implementingMember, Symbol interfaceMember, bool isExplicit, BindingDiagnosticBag diagnostics)
         {
             if (!implementingMember.IsImplicitlyDeclared && !implementingMember.IsAccessor())
             {
@@ -1860,6 +1863,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     },
                                 (implementingType, isExplicit),
                                 allowVariance: true,
+                                invokedAsExtensionMethod: false);
+                        }
+
+                        if (checkParameterTypes)
+                        {
+                            SourceMemberContainerTypeSymbol.CheckRefReadonlyInMismatch(
+                                implementedMethod, implementingMethod, diagnostics,
+                                static (diagnostics, implementedMethod, implementingMethod, implementingParameter, _, arg) =>
+                                {
+                                    var (implementedParameter, implementingType) = arg;
+                                    var location = GetImplicitImplementationDiagnosticLocation(implementedMethod, implementingType, implementingMethod);
+                                    // Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.
+                                    diagnostics.Add(ErrorCode.WRN_OverridingDifferentRefness, location, implementingParameter, implementedParameter);
+                                },
+                                implementingType,
                                 invokedAsExtensionMethod: false);
                         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">Funkce parameter null-checking se nepodporuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Obě deklarace částečných metod musí mít shodné modifikátory přístupnosti.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametr má modifikátor params ve výrazu lambda, ale ne v cílovém typu delegáta.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">Funkce parameter null-checking se nepodporuje.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Obě deklarace částečných metod musí mít shodné modifikátory přístupnosti.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Použití proměnné v tomto kontextu může vystavit odkazované proměnné mimo rozsah jejich oboru.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Výchozí hodnota parametru neodpovídá v cílovém typu delegáta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Parametr {0} musí mít při ukončení hodnotu jinou než null, protože parametr {1} není null.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametr má modifikátor params ve výrazu lambda, ale ne v cílovém typu delegáta.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">Das "Parameter null-checking"-Feature wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Beide partiellen Methodendeklarationen müssen identische Zugriffsmodifizierer aufweisen.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Der Parameter verfügt über den Modifizierer „params“ in der Lambdafunktion, aber nicht im Delegattyp des Ziels.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">Das "Parameter null-checking"-Feature wird nicht unterstützt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Beide partiellen Methodendeklarationen müssen identische Zugriffsmodifizierer aufweisen.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Die Verwendung der Variablen in diesem Kontext kann dazu führen, dass referenzierte Variablen außerhalb ihres Deklarationsbereichs verfügbar gemacht werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Der Standardparameterwert stimmt nicht mit dem Delegattyp im Ziel überein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Der Parameter "{0}" muss beim Beenden einen Wert ungleich NULL aufweisen, weil Parameter "{1}" nicht NULL ist.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Der Parameter verfügt über den Modifizierer „params“ in der Lambdafunktion, aber nicht im Delegattyp des Ziels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">No se admite la característica "parameter null-checking".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Ambas declaraciones de método parcial deben tener modificadores de accesibilidad idénticos.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">No se admite la característica "parameter null-checking".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Ambas declaraciones de método parcial deben tener modificadores de accesibilidad idénticos.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">El parámetro tiene modificador de parámetros en lambda, pero no en el tipo delegado de destino.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Usar la variable en este contexto puede exponer variables a las que se hace referencia fuera de su ámbito de declaración</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">El valor del parámetro predeterminado no coincide en el tipo delegado de destino.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">El parámetro "{0}" debe tener un valor que no sea NULL al salir porque el parámetro "{1}" no es NULL.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">El parámetro tiene modificador de parámetros en lambda, pero no en el tipo delegado de destino.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">La fonctionnalité « paramètre null-checking » n’est pas prise en charge.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Les deux déclarations de méthodes partielles doivent avoir des modificateurs d'accessibilité identiques.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">La fonctionnalité « paramètre null-checking » n’est pas prise en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Les deux déclarations de méthodes partielles doivent avoir des modificateurs d'accessibilité identiques.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Le paramètre a un modificateur de paramètres dans l’expression lambda mais pas dans le type délégué cible.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Utiliser la variable dans ce contexte peut exposer des variables de référence en dehors de leur étendue de déclaration</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">La valeur du paramètre par défaut ne correspond pas au type délégué cible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Le paramètre '{0}' doit avoir une valeur non null au moment de la sortie, car le paramètre '{1}' a une valeur non null.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Le paramètre a un modificateur de paramètres dans l’expression lambda mais pas dans le type délégué cible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">La funzionalità 'parameter null-checking' non è supportata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">I modificatori di accessibilità devono essere identici in entrambe le dichiarazioni di metodo parziale.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Il parametro contiene un modificatore di parametri in lambda ma non nel tipo delegato di destinazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">La funzionalità 'parameter null-checking' non è supportata.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">I modificatori di accessibilità devono essere identici in entrambe le dichiarazioni di metodo parziale.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">L'uso di variabili in questo contesto potrebbe esporre le variabili a cui si fa riferimento al di fuori dell'ambito della dichiarazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Il valore del parametro predefinito non corrisponde al tipo delegato di destinazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Il parametro '{0}' deve avere un valore non Null quando viene terminato perché il parametro '{1}' è non Null.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Il parametro contiene un modificatore di parametri in lambda ma non nel tipo delegato di destinazione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">'parameter null-checking' 機能はサポートされていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">両方の部分メソッド宣言には、同じアクセシビリティ修飾子を指定する必要があります。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">'parameter null-checking' 機能はサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">両方の部分メソッド宣言には、同じアクセシビリティ修飾子を指定する必要があります。</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">パラメーターにラムダの params 修飾子がありますが、ターゲット デリゲート型にはありません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">このコンテキストでの変数の使用は、参照される変数が宣言のスコープ外に公開される可能性があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">既定のパラメーター値がターゲット デリゲート型と一致しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">パラメーター '{1}' が null 以外であるため、パラメーター '{0}' には、終了時に null 以外の値が含まれている必要があります。</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">パラメーターにラムダの params 修飾子がありますが、ターゲット デリゲート型にはありません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">'parameter null-checking' 기능은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">두 부분 메서드 선언에는 동일한 접근성 한정자가 있어야 합니다.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">매개 변수에 람다의 매개 변수 한정자가 있지만 대상 대리자 형식에는 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">'parameter null-checking' 기능은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">두 부분 메서드 선언에는 동일한 접근성 한정자가 있어야 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">이 컨텍스트에서 변수를 사용하면 선언 범위 외부에서 참조된 변수가 노출될 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">기본 매개 변수 값이 대상 대리자 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">매개 변수 '{1}'이(가) null이 아니므로 매개 변수 '{0}'은(는) 종료할 때 null이 아닌 값을 가져야 합니다.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">매개 변수에 람다의 매개 변수 한정자가 있지만 대상 대리자 형식에는 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">Funkcja „sprawdzanie wartości null parametru” nie jest obsługiwana.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Obie deklaracje metody częściowej muszą mieć identyczne modyfikatory dostępności.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">Funkcja „sprawdzanie wartości null parametru” nie jest obsługiwana.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Obie deklaracje metody częściowej muszą mieć identyczne modyfikatory dostępności.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametr ma modyfikator params w wyrażeniu lambda, ale nie ma w docelowym typie delegata.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Nie można używać zmiennej w tym kontekście, ponieważ może uwidaczniać odwoływane zmienne poza ich zakresem deklaracji</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Domyślna wartość parametru nie jest zgodna w docelowym typie delegata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">Parametr „{0}” musi mieć wartość inną niż null podczas kończenia działania, ponieważ parametr „{1}” ma wartość inną niż null.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametr ma modyfikator params w wyrażeniu lambda, ale nie ma w docelowym typie delegata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">O recurso de 'verificação nula de parâmetro' não tem suporte.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">As duas declarações de métodos parciais precisam ter modificadores de acessibilidade idênticos.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">O parâmetro tem modificador de parâmetros em lambda, mas não no tipo delegado de destino.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">O recurso de 'verificação nula de parâmetro' não tem suporte.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">As duas declarações de métodos parciais precisam ter modificadores de acessibilidade idênticos.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">O uso de variável neste contexto pode expor variáveis referenciadas fora de seu escopo de declaração</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">O valor do parâmetro padrão não corresponde ao tipo delegado de destino.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">O parâmetro '{0}' precisa ter um valor não nulo durante a saída porque o parâmetro '{1}' não é nulo.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">O parâmetro tem modificador de parâmetros em lambda, mas não no tipo delegado de destino.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">Функция "проверка значений NULL параметров" не поддерживается.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Оба объявления разделяемого метода должны иметь одинаковые модификаторы доступа.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">Функция "проверка значений NULL параметров" не поддерживается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Оба объявления разделяемого метода должны иметь одинаковые модификаторы доступа.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">У параметра есть модификатор params в лямбде, но не в типе целевого делегата.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Использование переменной в этом контексте может представить ссылочные переменные за пределами области их объявления.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Значение параметра по умолчанию не совпадает с типом целевого делегата.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">При выходе параметр "{0}" должен иметь значение, отличное от NULL, так как параметр "{1}" имеет значение, отличное от NULL.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">У параметра есть модификатор params в лямбде, но не в типе целевого делегата.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">'Parametre null denetimi' özelliği desteklenmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Her iki kısmi metot bildirimi aynı erişilebilirlik değiştiricilerine sahip olmalıdır.</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametre, lambda içinde parametre değiştiricisi içeriyor ancak hedef temsilci türünde içermiyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">'Parametre null denetimi' özelliği desteklenmiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">Her iki kısmi metot bildirimi aynı erişilebilirlik değiştiricilerine sahip olmalıdır.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">Bu bağlamda değişken kullanımı, başvurulan değişkenleri bildirim kapsamının dışında gösterebilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">Varsayılan parametre değeri hedef temsilci türünde eşleşmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">'{1}' parametresi null olmadığından '{0}' parametresi çıkış yaparken null olmayan bir değere sahip olmalıdır.</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">Parametre, lambda içinde parametre değiştiricisi içeriyor ancak hedef temsilci türünde içermiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">不支持 'parameter null-checking' 功能。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">两个分部方法声明必须具有相同的可访问性修饰符。</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">参数在 lambda 中具有参数修饰符，但在目标委托类型中没有参数修饰符。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">不支持 'parameter null-checking' 功能。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">两个分部方法声明必须具有相同的可访问性修饰符。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">在此上下文中使用变量可能会在变量声明范围以外公开所引用的变量</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">默认参数值在目标委托类型中不匹配。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">退出时参数“{0}”必须具有非 null 值，因为参数“{1}”是非 null。</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">参数在 lambda 中具有参数修饰符，但在目标委托类型中没有参数修饰符。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1442,11 +1442,6 @@
         <target state="translated">不支援 'parameter null-checking' 功能。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">兩個部分方法宣告都必須有完全相同的存取範圍修飾詞。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">不支援 'parameter null-checking' 功能。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
         <source>Both partial method declarations must have identical accessibility modifiers.</source>
         <target state="translated">兩個部分方法宣告都必須有完全相同的存取範圍修飾詞。</target>
@@ -2655,16 +2660,6 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">參數在 Lambda 中具有參數修飾元，但不在目標委派類型中。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_PartialDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1443,8 +1443,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodAccessibilityDifference">
@@ -2513,13 +2513,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_HidingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
@@ -2623,13 +2623,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness">
-        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_OverridingDifferentRefness_Title">
-        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
-        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <source>Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Reference kind modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2507,6 +2507,16 @@
         <target state="translated">在此內容中使用變數，可能會將參考的變數公開在其宣告範圍外</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in hidden member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_HidingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in hidden member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in hidden member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_InterceptorSignatureMismatch">
         <source>Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</source>
         <target state="new">Intercepting a call to '{0}' with interceptor '{1}', but the signatures do not match.</target>
@@ -2607,6 +2617,16 @@
         <target state="translated">目標委派類型中的預設參數值不相符。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_OverridingDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in overridden or implemented member.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">
         <source>Parameter '{0}' must have a non-null value when exiting because parameter '{1}' is non-null.</source>
         <target state="translated">因為參數 '{1}' 不是 null，所以參數 '{0}' 在結束時必須具有非 Null 值。</target>
@@ -2635,6 +2655,16 @@
       <trans-unit id="WRN_ParamsArrayInLambdaOnly_Title">
         <source>Parameter has params modifier in lambda but not in target delegate type.</source>
         <target state="translated">參數在 Lambda 中具有參數修飾元，但不在目標委派類型中。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness">
+        <source>Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</source>
+        <target state="new">Modifier of parameter '{0}' doesn't match the corresponding parameter '{1}' in partial declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_PartialDifferentRefness_Title">
+        <source>Modifier of parameter doesn't match the corresponding parameter in partial declaration.</source>
+        <target state="new">Modifier of parameter doesn't match the corresponding parameter in partial declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_RecordEqualsWithoutGetHashCode">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -6094,6 +6094,13 @@ unsafe class C<T>
     static void M2(C<delegate*<{refKind1} object, void>[]> c) => throw null;
     static void M2(C<delegate*<{refKind2} object, void>[]> c) => throw null;
 }}
+
+namespace System.Runtime.CompilerServices
+{{
+    class RequiresLocationAttribute : System.Attribute
+    {{
+    }}
+}}
 ");
 
             comp.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -6080,11 +6080,10 @@ Ref");
 ");
         }
 
-        [Theory]
-        [InlineData("ref", "out")]
-        [InlineData("ref", "in")]
-        [InlineData("out", "in")]
-        public void Overloading_InvalidParameterRefness(string refKind1, string refKind2)
+        [Theory, CombinatorialData]
+        public void Overloading_InvalidParameterRefness(
+            [CombinatorialValues("ref", "in", "out", "ref readonly")] string refKind1,
+            [CombinatorialValues("ref", "in", "out", "ref readonly")] string refKind2)
         {
             var comp = CreateCompilationWithFunctionPointers($@"
 unsafe class C<T>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2831,9 +2831,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (7,29): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //     protected override void M(ref readonly int x) => System.Console.WriteLine("C.M" + x);
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 29),
-            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
-            //         c.M(ref x);
-            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
+            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
 
         static void verify(ModuleSymbol m)
         {
@@ -2890,9 +2890,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (22,9): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //         set { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "set").WithArguments("ref readonly int x", "in int x").WithLocation(22, 9),
-            // (28,19): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
-            //         _ = c[ref x];
-            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(28, 19));
+            // (30,15): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         _ = c[x];
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(30, 15));
 
         static void verify(ModuleSymbol m)
         {
@@ -2933,9 +2933,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (7,29): warning CS9507: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
             //     protected override void M(in int x) => System.Console.WriteLine("C.M" + x);
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 29),
-            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
-            //         c.M(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
+            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            //         c.M(ref x);
+            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
 
         static void verify(ModuleSymbol m)
         {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3158,9 +3158,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (7,29): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //     protected override void M(ref readonly int x) => System.Console.WriteLine("C.M" + x);
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 29),
-            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
-            //         c.M(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
+            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            //         c.M(ref x);
+            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
 
         static void verify(ModuleSymbol m)
         {
@@ -3217,9 +3217,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (22,9): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //         set { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "set").WithArguments("ref readonly int x", "in int x").WithLocation(22, 9),
-            // (30,15): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
-            //         _ = c[x];
-            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(30, 15));
+            // (28,19): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            //         _ = c[ref x];
+            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(28, 19));
 
         static void verify(ModuleSymbol m)
         {
@@ -3260,9 +3260,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (7,29): warning CS9507: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
             //     protected override void M(in int x) => System.Console.WriteLine("C.M" + x);
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 29),
-            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
-            //         c.M(ref x);
-            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
+            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
 
         static void verify(ModuleSymbol m)
         {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -4044,30 +4044,8 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments($"C.M({modifier}int)").WithLocation(8, 28));
     }
 
-    [Fact]
-    public void MethodGroupComparer_In()
-    {
-        var source = """
-            class C
-            {
-                void M(ref readonly int x) { }
-                void M2()
-                {
-                    var m = this.M;
-                    System.Console.Write(m.GetType());
-                }
-                static void Main() => new C().M2();
-            }
-            static class E1
-            {
-                public static void M(this C c, in int x) { }
-            }
-            """;
-        CompileAndVerify(source, expectedOutput: "<>f__AnonymousDelegate0`1[System.Int32]").VerifyDiagnostics();
-    }
-
     [Theory, CombinatorialData]
-    public void MethodGroupComparer_NotIn([CombinatorialValues("ref", "")] string modifier)
+    public void MethodGroupComparer([CombinatorialValues("ref", "in", "")] string modifier)
     {
         var source = $$"""
             class C
@@ -4076,9 +4054,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
                 void M2()
                 {
                     var m = this.M;
-                    System.Console.Write(m.GetType());
                 }
-                static void Main() => new C().M2();
             }
             static class E1
             {

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3145,9 +3145,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (7,25): warning CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
+            // (7,25): error CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
             //     public partial void M(in int x) => throw null;
-            Diagnostic(ErrorCode.WRN_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 25));
+            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 25));
     }
 
     [Fact]
@@ -3168,9 +3168,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
             //     public partial string? M(in int x) => throw null;
             Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M").WithLocation(8, 28),
-            // (8,28): warning CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
+            // (8,28): error CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
             //     public partial string? M(in int x) => throw null;
-            Diagnostic(ErrorCode.WRN_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(8, 28));
+            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(8, 28));
     }
 
     [Theory, CombinatorialData]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3800,7 +3800,8 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
                 static void Main()
                 {
                     var x = 1;
-                    new C().M(in x);
+                    I c = new C();
+                    c.M(in x);
                 }
             }
             """;
@@ -3845,7 +3846,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
                 static void Main()
                 {
                     var x = 1;
-                    var c = new C();
+                    I c = new C();
                     c.M1(in x);
                     c.M2(in x);
                 }
@@ -3922,7 +3923,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
                 static void Main()
                 {
                     var x = 1;
-                    var c = new C();
+                    I c = new C();
                     _ = c[in x];
                     c[in x] = 0;
                 }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3999,70 +3999,8 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         CreateCompilation(source).VerifyEmitDiagnostics();
     }
 
-    [Fact]
-    public void PartialMembers_In()
-    {
-        var source = """
-            partial class C
-            {
-                public partial void M(ref readonly int x);
-            }
-            partial class C
-            {
-                public partial void M(in int x) => throw null;
-            }
-            """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (7,25): error CS9509: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
-            //     public partial void M(in int x) => throw null;
-            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 25));
-    }
-
-    [Fact]
-    public void PartialMembers_In_DifferentNullability()
-    {
-        var source = """
-            #nullable enable
-            partial class C
-            {
-                public partial void M(ref readonly object x);
-            }
-            partial class C
-            {
-                public partial void M(in object? x) => throw null!;
-            }
-            """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (8,25): error CS9509: Reference kind modifier of parameter 'ref readonly object x' doesn't match the corresponding parameter 'in object? x' in partial declaration.
-            //     public partial void M(in object? x) => throw null;
-            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly object x", "in object? x").WithLocation(8, 25));
-    }
-
-    [Fact]
-    public void PartialMembers_In_DifferentReturnType()
-    {
-        var source = """
-            #nullable enable
-            partial class C
-            {
-                public partial string M(ref readonly int x);
-            }
-            partial class C
-            {
-                public partial string? M(in int x) => throw null!;
-            }
-            """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
-            //     public partial string? M(in int x) => throw null;
-            Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M").WithLocation(8, 28),
-            // (8,28): error CS9509: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
-            //     public partial string? M(in int x) => throw null;
-            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(8, 28));
-    }
-
     [Theory, CombinatorialData]
-    public void PartialMembers_NotIn([CombinatorialValues("ref", "out")] string modifier)
+    public void PartialMembers([CombinatorialValues("ref ", "out ", "in ", "")] string modifier)
     {
         var source = $$"""
             partial class C
@@ -4080,11 +4018,11 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_PartialMethodWithAccessibilityModsMustHaveImplementation, "M").WithArguments("C.M(ref readonly int)").WithLocation(3, 25),
             // (7,25): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(ref int)'
             //     public partial void M(ref int x) => throw null;
-            Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments($"C.M({modifier} int)").WithLocation(7, 25));
+            Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments($"C.M({modifier}int)").WithLocation(7, 25));
     }
 
     [Theory, CombinatorialData]
-    public void PartialMembers_NotIn_DifferentReturnType([CombinatorialValues("ref", "out")] string modifier)
+    public void PartialMembers_DifferentReturnType([CombinatorialValues("ref ", "out ", "in ", "")] string modifier)
     {
         var source = $$"""
             #nullable enable
@@ -4103,6 +4041,6 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_PartialMethodWithAccessibilityModsMustHaveImplementation, "M").WithArguments("C.M(ref readonly int)").WithLocation(4, 27),
             // (8,28): error CS0759: No defining declaration found for implementing declaration of partial method 'C.M(out int)'
             //     public partial string? M(out int x) => throw null;
-            Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments($"C.M({modifier} int)").WithLocation(8, 28));
+            Diagnostic(ErrorCode.ERR_PartialMethodMustHaveLatent, "M").WithArguments($"C.M({modifier}int)").WithLocation(8, 28));
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3315,6 +3315,26 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
     }
 
     [Fact]
+    public void PartialMembers_In_DifferentNullability()
+    {
+        var source = """
+            #nullable enable
+            partial class C
+            {
+                public partial void M(ref readonly object x);
+            }
+            partial class C
+            {
+                public partial void M(in object? x) => throw null!;
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,25): error CS9509: Reference kind modifier of parameter 'ref readonly object x' doesn't match the corresponding parameter 'in object? x' in partial declaration.
+            //     public partial void M(in object? x) => throw null;
+            Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly object x", "in object? x").WithLocation(8, 25));
+    }
+
+    [Fact]
     public void PartialMembers_In_DifferentReturnType()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2774,7 +2774,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """;
         var verifier = CompileAndVerify(source, sourceSymbolValidator: verify, symbolValidator: verify);
         verifier.VerifyDiagnostics(
-            // (7,29): warning CS9507: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
+            // (7,29): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //     protected override void M(ref readonly int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 29));
 
@@ -2802,7 +2802,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """;
         var verifier = CompileAndVerify(source, sourceSymbolValidator: verify, symbolValidator: verify);
         verifier.VerifyDiagnostics(
-            // (7,29): warning CS9507: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
+            // (7,29): warning CS9507: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
             //     protected override void M(in int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 29));
 
@@ -3162,10 +3162,10 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyEmitDiagnostics(
-            // (8,17): warning CS9507: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
+            // (8,17): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //     public void M1(ref readonly int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M1").WithArguments("ref readonly int x", "in int x").WithLocation(8, 17),
-            // (9,17): warning CS9507: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
+            // (9,17): warning CS9507: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
             //     public void M2(in int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M2").WithArguments("in int x", "ref readonly int x").WithLocation(9, 17));
     }
@@ -3186,10 +3186,10 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyEmitDiagnostics(
-            // (8,12): warning CS9507: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
+            // (8,12): warning CS9507: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in overridden or implemented member.
             //     void I.M1(ref readonly int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M1").WithArguments("ref readonly int x", "in int x").WithLocation(8, 12),
-            // (9,12): warning CS9507: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
+            // (9,12): warning CS9507: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in overridden or implemented member.
             //     void I.M2(in int x) { }
             Diagnostic(ErrorCode.WRN_OverridingDifferentRefness, "M2").WithArguments("in int x", "ref readonly int x").WithLocation(9, 12));
     }
@@ -3279,7 +3279,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (7,25): error CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
+            // (7,25): error CS9509: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
             //     public partial void M(in int x) => throw null;
             Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 25));
     }
@@ -3302,7 +3302,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (8,28): warning CS8819: Nullability of reference types in return type doesn't match partial method declaration.
             //     public partial string? M(in int x) => throw null;
             Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnPartial, "M").WithLocation(8, 28),
-            // (8,28): error CS9509: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
+            // (8,28): error CS9509: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in partial declaration.
             //     public partial string? M(in int x) => throw null;
             Diagnostic(ErrorCode.ERR_PartialDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(8, 28));
     }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2880,25 +2880,37 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         var source = """
             class B
             {
-                public void M(in int x) => System.Console.Write("B" + x);
+                public void M(in int x) => System.Console.WriteLine("B" + x);
             }
             class C : B
             {
-                public void M(ref readonly int x) => System.Console.Write("C" + x);
+                public void M(ref readonly int x) => System.Console.WriteLine("C" + x);
                 static void Main()
                 {
                     var x = 111;
-                    new C().M(in x);
+                    var c = new C();
+                    c.M(ref x);
+                    c.M(in x);
+                    c.M(x);
+                    ((B)c).M(in x);
                 }
             }
             """;
-        CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
+        CompileAndVerify(source, expectedOutput: """
+            C111
+            C111
+            C111
+            B111
+            """).VerifyDiagnostics(
             // (7,17): warning CS0108: 'C.M(ref readonly int)' hides inherited member 'B.M(in int)'. Use the new keyword if hiding was intended.
-            //     public void M(ref readonly int x) => System.Console.Write("C" + x);
+            //     public void M(ref readonly int x) => System.Console.WriteLine("C" + x);
             Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(ref readonly int)", "B.M(in int)").WithLocation(7, 17),
-            // (7,17): warning CS9508: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in hidden member.
-            //     public void M(ref readonly int x) => System.Console.Write("C" + x);
-            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 17));
+            // (7,17): warning CS9508: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in hidden member.
+            //     public void M(ref readonly int x) => System.Console.WriteLine("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 17),
+            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
     }
 
     [Fact]
@@ -2907,22 +2919,34 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         var source = """
             class B
             {
-                public void M(in int x) => System.Console.Write("B" + x);
+                public void M(in int x) => System.Console.WriteLine("B" + x);
             }
             class C : B
             {
-                public new void M(ref readonly int x) => System.Console.Write("C" + x);
+                public new void M(ref readonly int x) => System.Console.WriteLine("C" + x);
                 static void Main()
                 {
                     var x = 111;
-                    new C().M(in x);
+                    var c = new C();
+                    c.M(ref x);
+                    c.M(in x);
+                    c.M(x);
+                    ((B)c).M(in x);
                 }
             }
             """;
-        CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
-            // (7,21): warning CS9508: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in hidden member.
-            //     public new void M(ref readonly int x) => System.Console.Write("C" + x);
-            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 21));
+        CompileAndVerify(source, expectedOutput: """
+            C111
+            C111
+            C111
+            B111
+            """).VerifyDiagnostics(
+            // (7,21): warning CS9508: Reference kind modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in hidden member.
+            //     public new void M(ref readonly int x) => System.Console.WriteLine("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 21),
+            // (14,13): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 13));
     }
 
     [Fact]
@@ -2931,25 +2955,37 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         var source = """
             class B
             {
-                public void M(ref readonly int x) => System.Console.Write("B" + x);
+                public void M(ref readonly int x) => System.Console.WriteLine("B" + x);
             }
             class C : B
             {
-                public void M(in int x) => System.Console.Write("C" + x);
+                public void M(in int x) => System.Console.WriteLine("C" + x);
                 static void Main()
                 {
                     var x = 111;
-                    new C().M(in x);
+                    var c = new C();
+                    c.M(ref x);
+                    c.M(in x);
+                    c.M(x);
+                    ((B)c).M(in x);
                 }
             }
             """;
-        CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
+        CompileAndVerify(source, expectedOutput: """
+            C111
+            C111
+            C111
+            B111
+            """).VerifyDiagnostics(
             // (7,17): warning CS0108: 'C.M(in int)' hides inherited member 'B.M(ref readonly int)'. Use the new keyword if hiding was intended.
-            //     public void M(in int x) => System.Console.Write("C" + x);
+            //     public void M(in int x) => System.Console.WriteLine("C" + x);
             Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(in int)", "B.M(ref readonly int)").WithLocation(7, 17),
-            // (7,17): warning CS9508: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in hidden member.
-            //     public void M(in int x) => System.Console.Write("C" + x);
-            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 17));
+            // (7,17): warning CS9508: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in hidden member.
+            //     public void M(in int x) => System.Console.WriteLine("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 17),
+            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            //         c.M(ref x);
+            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
     }
 
     [Fact]
@@ -2958,40 +2994,132 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         var source = """
             class B
             {
-                public void M(ref readonly int x) => System.Console.Write("B" + x);
+                public void M(ref readonly int x) => System.Console.WriteLine("B" + x);
             }
             class C : B
             {
-                public new void M(in int x) => System.Console.Write("C" + x);
+                public new void M(in int x) => System.Console.WriteLine("C" + x);
                 static void Main()
                 {
                     var x = 111;
-                    new C().M(in x);
+                    var c = new C();
+                    c.M(ref x);
+                    c.M(in x);
+                    c.M(x);
+                    ((B)c).M(in x);
                 }
             }
             """;
-        CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
-            // (7,21): warning CS9508: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in hidden member.
-            //     public new void M(in int x) => System.Console.Write("C" + x);
-            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 21));
+        CompileAndVerify(source, expectedOutput: """
+            C111
+            C111
+            C111
+            B111
+            """).VerifyDiagnostics(
+            // (7,21): warning CS9508: Reference kind modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in hidden member.
+            //     public new void M(in int x) => System.Console.WriteLine("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 21),
+            // (12,17): warning CS9502: The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            //         c.M(ref x);
+            Diagnostic(ErrorCode.WRN_BadArgRef, "x").WithArguments("1").WithLocation(12, 17));
     }
 
-    [Theory, CombinatorialData]
-    public void Hiding_RefReadonly_NotIn([CombinatorialValues("ref", "out")] string modifier)
+    [Fact]
+    public void Hiding_RefReadonly_Ref()
     {
-        var source = $$"""
+        var source = """
             class B
             {
-                public void M1({{modifier}} int x) => throw null!;
-                public void M2(ref readonly int x) { }
+                public void M1(ref int x) => System.Console.WriteLine("B.M1");
+                public void M2(ref readonly int x) => System.Console.WriteLine("B.M2");
             }
             class C : B
             {
-                public void M1(ref readonly int x) { }
-                public void M2({{modifier}} int x) => throw null!;
+                public void M1(ref readonly int x) => System.Console.WriteLine("C.M1");
+                public void M2(ref int x) => System.Console.WriteLine("C.M2");
+                static void Main()
+                {
+                    var x = 1;
+                    var c = new C();
+                    c.M1(ref x);
+                    c.M1(in x);
+                    c.M1(x);
+                    ((B)c).M1(ref x);
+                    c.M2(ref x);
+                    c.M2(in x);
+                    c.M2(x);
+                }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics();
+        CompileAndVerify(source, expectedOutput: """
+            C.M1
+            C.M1
+            C.M1
+            B.M1
+            C.M2
+            B.M2
+            B.M2
+            """).VerifyDiagnostics(
+            // (16,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M1(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(16, 14),
+            // (20,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M2(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(20, 14));
+    }
+
+    [Fact]
+    public void Hiding_RefReadonly_Out()
+    {
+        var source = """
+            class B
+            {
+                public void M1(out int x)
+                {
+                    x = 5;
+                    System.Console.WriteLine("B.M1");
+                }
+                public void M2(ref readonly int x) => System.Console.WriteLine("B.M2");
+            }
+            class C : B
+            {
+                public void M1(ref readonly int x) => System.Console.WriteLine("C.M1");
+                public void M2(out int x)
+                {
+                    x = 5;
+                    System.Console.WriteLine("C.M2");
+                }
+                static void Main()
+                {
+                    var x = 1;
+                    var c = new C();
+                    c.M1(ref x);
+                    c.M1(in x);
+                    c.M1(x);
+                    c.M1(out x);
+                    c.M2(ref x);
+                    c.M2(in x);
+                    c.M2(x);
+                    c.M2(out x);
+                }
+            }
+            """;
+        CompileAndVerify(source, expectedOutput: """
+            C.M1
+            C.M1
+            C.M1
+            B.M1
+            B.M2
+            B.M2
+            B.M2
+            C.M2
+            """).VerifyDiagnostics(
+            // (24,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M1(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(24, 14),
+            // (28,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         c.M2(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(28, 14));
     }
 
     [Theory, CombinatorialData]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2894,8 +2894,11 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """;
         CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
             // (7,17): warning CS0108: 'C.M(ref readonly int)' hides inherited member 'B.M(in int)'. Use the new keyword if hiding was intended.
-            //     public void M(ref readonly int x) { }
-            Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(ref readonly int)", "B.M(in int)").WithLocation(7, 17));
+            //     public void M(ref readonly int x) => System.Console.Write("C" + x);
+            Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(ref readonly int)", "B.M(in int)").WithLocation(7, 17),
+            // (7,17): warning CS9508: Modifier of parameter 'ref readonly int x' doesn't match the corresponding parameter 'in int x' in hidden member.
+            //     public void M(ref readonly int x) => System.Console.Write("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("ref readonly int x", "in int x").WithLocation(7, 17));
     }
 
     [Fact]
@@ -2942,8 +2945,11 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """;
         CompileAndVerify(source, expectedOutput: "C111").VerifyDiagnostics(
             // (7,17): warning CS0108: 'C.M(in int)' hides inherited member 'B.M(ref readonly int)'. Use the new keyword if hiding was intended.
-            //     public void M(in int x) { }
-            Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(in int)", "B.M(ref readonly int)").WithLocation(7, 17));
+            //     public void M(in int x) => System.Console.Write("C" + x);
+            Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("C.M(in int)", "B.M(ref readonly int)").WithLocation(7, 17),
+            // (7,17): warning CS9508: Modifier of parameter 'in int x' doesn't match the corresponding parameter 'ref readonly int x' in hidden member.
+            //     public void M(in int x) => System.Console.Write("C" + x);
+            Diagnostic(ErrorCode.WRN_HidingDifferentRefness, "M").WithArguments("in int x", "ref readonly int x").WithLocation(7, 17));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -314,7 +314,6 @@ class X
                         case ErrorCode.WRN_ArgExpectedIn:
                         case ErrorCode.WRN_OverridingDifferentRefness:
                         case ErrorCode.WRN_HidingDifferentRefness:
-                        case ErrorCode.WRN_PartialDifferentRefness:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -312,6 +312,9 @@ class X
                         case ErrorCode.WRN_ArgExpectedRefOrIn:
                         case ErrorCode.WRN_RefReadonlyNotVariable:
                         case ErrorCode.WRN_ArgExpectedIn:
+                        case ErrorCode.WRN_OverridingDifferentRefness:
+                        case ErrorCode.WRN_HidingDifferentRefness:
+                        case ErrorCode.WRN_PartialDifferentRefness:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:


### PR DESCRIPTION
Speclet: https://github.com/dotnet/csharplang/blob/52b90748d1ebab0268468eb5dc8e954bc98c2834/proposals/ref-readonly-parameters.md#interchangeability-with-in (first paragraph in the section)
Test plan: https://github.com/dotnet/roslyn/issues/68056