### PR TITLE
Service cleanup

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -13,9 +13,11 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
 
@@ -43,6 +45,7 @@ namespace Microsoft.CodeAnalysis.ColorSchemes
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public ColorSchemeApplier(
             IThreadingContext threadingContext,
+            IVsService<SVsFontAndColorStorage, IVsFontAndColorStorage> fontAndColorStorage,
             IGlobalOptionService globalOptions,
             SVsServiceProvider serviceProvider)
         {
@@ -52,7 +55,7 @@ namespace Microsoft.CodeAnalysis.ColorSchemes
 
             _settings = new ColorSchemeSettings(threadingContext, _serviceProvider, globalOptions);
             _colorSchemes = ColorSchemeSettings.GetColorSchemes();
-            _classificationVerifier = new ClassificationVerifier(threadingContext, _asyncServiceProvider, _colorSchemes);
+            _classificationVerifier = new ClassificationVerifier(threadingContext, fontAndColorStorage, _colorSchemes);
         }
 
         public async Task InitializeAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -24,6 +25,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Setup;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 using Task = System.Threading.Tasks.Task;
 
@@ -37,6 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         private const int RunCodeAnalysisForSelectedProjectCommandId = 1647;
 
         private readonly VisualStudioWorkspace _workspace;
+        private readonly IVsService<IVsStatusbar> _statusbar;
         private readonly IDiagnosticAnalyzerService _diagnosticService;
         private readonly IThreadingContext _threadingContext;
         private readonly IVsHierarchyItemManager _vsHierarchyItemManager;
@@ -50,6 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioDiagnosticAnalyzerService(
             VisualStudioWorkspace workspace,
+            IVsService<SVsStatusbar, IVsStatusbar> statusbar,
             IDiagnosticAnalyzerService diagnosticService,
             IThreadingContext threadingContext,
             IVsHierarchyItemManager vsHierarchyItemManager,
@@ -58,6 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             IGlobalOptionService globalOptions)
         {
             _workspace = workspace;
+            _statusbar = statusbar;
             _diagnosticService = diagnosticService;
             _threadingContext = threadingContext;
             _vsHierarchyItemManager = vsHierarchyItemManager;
@@ -335,35 +340,31 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 }
             }
 
-            // Add a message to VS status bar that we are running code analysis.
-            var statusBar = _serviceProvider?.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
-            var totalProjectCount = project != null ? (1 + otherProjectsForMultiTfmProject.Length) : solution.ProjectIds.Count;
-            var statusBarUpdater = statusBar != null
-                ? new StatusBarUpdater(statusBar, _threadingContext, projectOrSolutionName, (uint)totalProjectCount)
-                : null;
-
             // Force complete analyzer execution in background.
-            var asyncToken = _listener.BeginAsyncOperation($"{nameof(VisualStudioDiagnosticAnalyzerService)}_{nameof(RunAnalyzers)}");
-            Task.Run(async () =>
+            _threadingContext.JoinableTaskFactory.RunAsync(async () =>
             {
-                try
-                {
-                    var onProjectAnalyzed = statusBarUpdater != null ? statusBarUpdater.OnProjectAnalyzed : (Action<Project>)((Project _) => { });
-                    await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, project?.Id, CancellationToken.None).ConfigureAwait(false);
+                using var asyncToken = _listener.BeginAsyncOperation($"{nameof(VisualStudioDiagnosticAnalyzerService)}_{nameof(RunAnalyzers)}");
 
-                    foreach (var otherProject in otherProjectsForMultiTfmProject)
-                        await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, otherProject.Id, CancellationToken.None).ConfigureAwait(false);
+                // Add a message to VS status bar that we are running code analysis.
+                var statusBar = await _statusbar.GetValueOrNullAsync().ConfigureAwait(true);
+                var totalProjectCount = project != null ? (1 + otherProjectsForMultiTfmProject.Length) : solution.ProjectIds.Count;
+                using var statusBarUpdater = statusBar != null
+                    ? new StatusBarUpdater(statusBar, _threadingContext, projectOrSolutionName, (uint)totalProjectCount)
+                    : null;
 
-                    // If user has disabled live analyzer execution for any project(s), i.e. set RunAnalyzersDuringLiveAnalysis = false,
-                    // then ForceAnalyzeAsync will not cause analyzers to execute.
-                    // We explicitly fetch diagnostics for such projects and report these as "Host" diagnostics.
-                    HandleProjectsWithDisabledAnalysis();
-                }
-                finally
-                {
-                    statusBarUpdater?.Dispose();
-                }
-            }).CompletesAsyncOperation(asyncToken);
+                await TaskScheduler.Default;
+
+                var onProjectAnalyzed = statusBarUpdater != null ? statusBarUpdater.OnProjectAnalyzed : (Action<Project>)((Project _) => { });
+                await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, project?.Id, CancellationToken.None).ConfigureAwait(false);
+
+                foreach (var otherProject in otherProjectsForMultiTfmProject)
+                    await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, otherProject.Id, CancellationToken.None).ConfigureAwait(false);
+
+                // If user has disabled live analyzer execution for any project(s), i.e. set RunAnalyzersDuringLiveAnalysis = false,
+                // then ForceAnalyzeAsync will not cause analyzers to execute.
+                // We explicitly fetch diagnostics for such projects and report these as "Host" diagnostics.
+                HandleProjectsWithDisabledAnalysis();
+            });
 
             return;
 

--- a/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
@@ -7,15 +7,12 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.LogHub;
 using Microsoft.VisualStudio.RpcContracts.Logging;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using StreamJsonRpc;
 
@@ -30,17 +27,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         /// </summary>
         private static int s_logHubSessionId;
 
-        private readonly IAsyncServiceProvider _asyncServiceProvider;
-        private readonly IThreadingContext _threadingContext;
+        private readonly IVsService<IBrokeredServiceContainer> _brokeredServiceContainer;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioLogHubLoggerFactory(
-            [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider asyncServiceProvider,
-            IThreadingContext threadingContext)
+            IVsService<SVsBrokeredServiceContainer, IBrokeredServiceContainer> brokeredServiceContainer)
         {
-            _asyncServiceProvider = asyncServiceProvider;
-            _threadingContext = threadingContext;
+            _brokeredServiceContainer = brokeredServiceContainer;
         }
 
         public async Task<ILspServiceLogger> CreateLoggerAsync(string serverTypeName, JsonRpc jsonRpc, CancellationToken cancellationToken)
@@ -48,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             var logName = $"Roslyn.{serverTypeName}.{Interlocked.Increment(ref s_logHubSessionId)}";
             var logId = new LogId(logName, new ServiceMoniker(typeof(AbstractLanguageServer<>).FullName));
 
-            var serviceContainer = await _asyncServiceProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);
+            var serviceContainer = await _brokeredServiceContainer.GetValueAsync(cancellationToken).ConfigureAwait(false);
             var service = serviceContainer.GetFullAccessServiceBroker();
 
             var configuration = await TraceConfiguration.CreateTraceConfigurationInstanceAsync(service, ownsServiceBroker: true, cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/Options/LocalUserRegistryOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/LocalUserRegistryOptionPersister.cs
@@ -25,10 +25,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
             _registryKey = registryKey;
         }
 
-        public static async Task<LocalUserRegistryOptionPersister> CreateAsync(IVsService<ILocalRegistry4> localRegistryService)
+        public static LocalUserRegistryOptionPersister Create(ILocalRegistry4 localRegistry)
         {
             // SLocalRegistry service is free-threaded -- see https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1408594.
-            var localRegistry = await localRegistryService.GetValueAsync().ConfigureAwait(false);
             Contract.ThrowIfFalse(ErrorHandler.Succeeded(localRegistry.GetLocalRegistryRootEx((uint)__VsLocalRegistryType.RegType_UserSettings, out var rootHandle, out var rootPath)));
 
             var handle = (__VsLocalRegistryRootHandle)rootHandle;

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         private const string NugetTitle = "NuGet";
 
         private readonly VSUtilities.IUIThreadOperationExecutor _operationExecutor;
+        private readonly IVsService<IBrokeredServiceContainer> _brokeredServiceContainer;
         private readonly SVsServiceProvider _serviceProvider;
-        private readonly Shell.IAsyncServiceProvider _asyncServiceProvider;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
         private readonly IAsynchronousOperationListener _listener;
 
@@ -98,8 +98,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             IAsynchronousOperationListenerProvider listenerProvider,
             VisualStudioWorkspaceImpl workspace,
             IGlobalOptionService globalOptions,
+            IVsService<SVsBrokeredServiceContainer, IBrokeredServiceContainer> brokeredServiceContainer,
             SVsServiceProvider serviceProvider,
-            [Import("Microsoft.VisualStudio.Shell.Interop.SAsyncServiceProvider")] object asyncServiceProvider,
             IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
             [Import(AllowDefault = true)] Lazy<IVsPackageInstaller2>? packageInstaller,
             [Import(AllowDefault = true)] Lazy<IVsPackageUninstaller>? packageUninstaller,
@@ -113,11 +113,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         {
             _operationExecutor = operationExecutor;
 
+            _brokeredServiceContainer = brokeredServiceContainer;
             _serviceProvider = serviceProvider;
-            // MEFv2 doesn't support type based contract for Import above and for this particular contract
-            // (SAsyncServiceProvider) actual type cast doesn't work. (https://github.com/microsoft/vs-mef/issues/138)
-            // workaround by getting the service as object and cast to actual interface
-            _asyncServiceProvider = (Shell.IAsyncServiceProvider)asyncServiceProvider;
 
             _editorAdaptersFactoryService = editorAdaptersFactoryService;
             _packageInstaller = packageInstaller;
@@ -500,7 +497,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             // GetServiceAsync/GetProxyAsync and the cast below are all explicitly documented as being BG thread safe.
             await TaskScheduler.Default;
 
-            var serviceContainer = (IBrokeredServiceContainer?)await _asyncServiceProvider.GetServiceAsync(typeof(SVsBrokeredServiceContainer)).ConfigureAwait(false);
+            var serviceContainer = await _brokeredServiceContainer.GetValueOrNullAsync(cancellationToken).ConfigureAwait(false);
             var serviceBroker = serviceContainer?.GetFullAccessServiceBroker();
             if (serviceBroker == null)
                 return default;

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             // we need to load it as early as possible since we can have errors from
             // package from each language very early
-            await this.ComponentModel.GetService<TaskCenterSolutionAnalysisProgressReporter>().InitializeAsync(this).ConfigureAwait(false);
+            await this.ComponentModel.GetService<TaskCenterSolutionAnalysisProgressReporter>().InitializeAsync().ConfigureAwait(false);
             await this.ComponentModel.GetService<VisualStudioSuppressionFixService>().InitializeAsync(this).ConfigureAwait(false);
             await this.ComponentModel.GetService<VisualStudioDiagnosticListTableCommandHandler>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);
             await this.ComponentModel.GetService<VisualStudioDiagnosticListSuppressionStateService>().InitializeAsync(this, cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             // Misc workspace has to be up and running by the time our package is usable so that it can track running
             // doc events and appropriately map files to/from it and other relevant workspaces (like the
             // metadata-as-source workspace).
-            await this.ComponentModel.GetService<MiscellaneousFilesWorkspace>().InitializeAsync(this).ConfigureAwait(false);
+            await this.ComponentModel.GetService<MiscellaneousFilesWorkspace>().InitializeAsync().ConfigureAwait(false);
 
             // Proffer in-process service broker services
             var serviceBrokerContainer = await this.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(this.JoinableTaskFactory).ConfigureAwait(false);


### PR DESCRIPTION
Review commit-by-commit is likely to minimize complexity.

There are many more cases where `IVsService<>` can be used to simplify code, but I wanted to send the changes in smaller reviews to keep reviews as simple as possible.