### PR TITLE
Reduce allocations for LocalScopeBinder.BuildLocals

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
-            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance();
+            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance(DefaultLocalSymbolArrayCapacity);
             BuildLocals(this, _statement, locals);
             return locals.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class LocalScopeBinder : Binder
     {
-        protected const int DefaultLocalSymbolArrayCapacity = 64;
+        protected const int DefaultLocalSymbolArrayCapacity = 16;
 
         private ImmutableArray<LocalSymbol> _locals;
         private ImmutableArray<LocalFunctionSymbol> _localFunctions;

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class LocalScopeBinder : Binder
     {
+        protected const int DefaultLocalSymbolArrayCapacity = 64;
+
         private ImmutableArray<LocalSymbol> _locals;
         private ImmutableArray<LocalFunctionSymbol> _localFunctions;
         private ImmutableArray<LabelSymbol> _labels;
@@ -158,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 #endif
 
-            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance();
+            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance(DefaultLocalSymbolArrayCapacity);
             foreach (var statement in statements)
             {
                 BuildLocals(enclosingBinder, statement, locals);

--- a/src/Compilers/CSharp/Portable/Binder/SimpleProgramBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SimpleProgramBinder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
-            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance();
+            ArrayBuilder<LocalSymbol> locals = ArrayBuilder<LocalSymbol>.GetInstance(DefaultLocalSymbolArrayCapacity);
 
             foreach (var statement in _entryPoint.CompilationUnit.Members)
             {


### PR DESCRIPTION
Update all callers of `LocalScopeBinder.BuildLocals` to pass in an `ArrayBuilder` with a capacity of `DefaultLocalSymbolArrayCapacity`.