### PR TITLE
Avoid creating a result temp for is-expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundLoweredIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundLoweredIsPatternExpression.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+partial class BoundLoweredIsPatternExpression
+{
+    private partial void Validate()
+    {
+        // Ensure fall-through is unreachable
+        Debug.Assert(this.Statements is [.., BoundGotoStatement or BoundSwitchDispatch]);
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -544,14 +544,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode? VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
-            {
-                AddAll(node.Locals);
-                base.VisitLoweredIsPatternExpression(node);
-                RemoveAll(node.Locals);
-                return null;
-            }
-
             public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
             {
                 AddAll(node.InnerLocals);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -544,6 +544,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode? VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
+            {
+                AddAll(node.Locals);
+                base.VisitLoweredIsPatternExpression(node);
+                RemoveAll(node.Locals);
+                return null;
+            }
+
             public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
             {
                 AddAll(node.InnerLocals);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2277,8 +2277,8 @@
   <Node Name="BoundLoweredIsPatternExpression" Base="BoundExpression" HasValidate="true">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Statements" Type="ImmutableArray&lt;BoundStatement&gt;"/>
-    <Field Name="WhenTrueLabel" Type="LabelSymbol"/>
-    <Field Name="WhenFalseLabel" Type="LabelSymbol"/>
+    <Field Name="WhenTrueLabel" Type="LabelSymbol" Null="disallow"/>
+    <Field Name="WhenFalseLabel" Type="LabelSymbol" Null="disallow"/>
   </Node>
 
   <AbstractNode Name="BoundPattern" Base="BoundNode">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2276,7 +2276,6 @@
 
   <Node Name="BoundLoweredIsPatternExpression" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="Statements" Type="ImmutableArray&lt;BoundStatement&gt;"/>
     <Field Name="WhenTrueLabel" Type="LabelSymbol"/>
     <Field Name="WhenFalseLabel" Type="LabelSymbol"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2274,7 +2274,7 @@
     <Field Name="WhenFalseLabel" Type="LabelSymbol" Null="disallow"/>
   </Node>
 
-  <Node Name="BoundLoweredIsPatternExpression" Base="BoundExpression">
+  <Node Name="BoundLoweredIsPatternExpression" Base="BoundExpression" HasValidate="true">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Statements" Type="ImmutableArray&lt;BoundStatement&gt;"/>
     <Field Name="WhenTrueLabel" Type="LabelSymbol"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2265,12 +2265,21 @@
          'is not Type t') will need to compensate for negated patterns. IsNegated is set if Pattern is the negated
          form of the inner pattern represented by DecisionDag. -->
   <Node Name="BoundIsPatternExpression" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="Pattern" Type="BoundPattern" Null="disallow"/>
     <Field Name="IsNegated" Type="bool"/>
     <Field Name="ReachabilityDecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="WhenTrueLabel" Type="LabelSymbol" Null="disallow"/>
     <Field Name="WhenFalseLabel" Type="LabelSymbol" Null="disallow"/>
+  </Node>
+
+  <Node Name="BoundLoweredIsPatternExpression" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
+    <Field Name="Statements" Type="ImmutableArray&lt;BoundStatement&gt;"/>
+    <Field Name="WhenTrueLabel" Type="LabelSymbol"/>
+    <Field Name="WhenFalseLabel" Type="LabelSymbol"/>
   </Node>
 
   <AbstractNode Name="BoundPattern" Base="BoundNode">

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -358,8 +358,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node, bool used, bool sense = true)
         {
-            Debug.Assert(sense || used);
-
             EmitSideEffects(node.Statements);
 
             if (!used)
@@ -873,8 +871,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitSequenceExpression(BoundSequence sequence, bool used, bool sense = true)
         {
-            Debug.Assert(sense || used);
-
             DefineLocals(sequence);
             EmitSideEffects(sequence);
 
@@ -887,13 +883,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(sequence.Value.Kind != BoundKind.TypeExpression || !used);
             if (sequence.Value.Kind != BoundKind.TypeExpression)
             {
-                if (!used || sequence.Type.SpecialType != SpecialType.System_Boolean)
+                if (used && sequence.Type.SpecialType == SpecialType.System_Boolean)
                 {
-                    EmitExpression(sequence.Value, used);
+                    EmitCondExpr(sequence.Value, sense: sense);
                 }
                 else
                 {
-                    EmitCondExpr(sequence.Value, sense: sense);
+                    EmitExpression(sequence.Value, used);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -889,7 +889,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
                 else
                 {
-                    EmitExpression(sequence.Value, used);
+                    EmitExpression(sequence.Value, used: used);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -359,14 +359,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node, bool used)
         {
             DefineLocals(node.Syntax, node.Locals);
-#if !DEBUG
-            EmitStatements(node.Statements);
-#else
-            foreach (BoundStatement statement in node.Statements)
-            {
-                EmitStatement(statement, _builder.GetStackDepth());
-            }
-#endif
+            EmitSideEffects(node.Statements);
+
             if (!used)
             {
                 _builder.MarkLabel(node.WhenTrueLabel);
@@ -385,6 +379,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             FreeLocals(node.Locals);
+        }
+
+        private void EmitSideEffects(ImmutableArray<BoundStatement> statements)
+        {
+#if !DEBUG
+            EmitStatements(statements);
+#else
+            int stackDepth = _builder.GetStackDepth();
+            foreach (BoundStatement statement in statements)
+            {
+                EmitStatement(statement, stackDepth);
+            }
+#endif
         }
 
         private void EmitThrowExpression(BoundThrowExpression node, bool used)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -381,14 +381,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitSideEffects(ImmutableArray<BoundStatement> statements)
         {
 #if DEBUG
-            Debug.Assert(_expectedStackDepth == 0);
+            int prevStack = _expectedStackDepth;
             int origStack = _builder.GetStackDepth();
             _expectedStackDepth = origStack;
 #endif
             EmitStatements(statements);
 #if DEBUG
             Debug.Assert(_expectedStackDepth == origStack);
-            _expectedStackDepth = 0;
+            _expectedStackDepth = prevStack;
 #endif
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -381,13 +381,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitSideEffects(ImmutableArray<BoundStatement> statements)
         {
 #if DEBUG
-            int stackDepth = _builder.GetStackDepth();
-            foreach (BoundStatement statement in statements)
-            {
-                EmitStatement(statement, stackDepth);
-            }
-#else
+            Debug.Assert(_expectedStackDepth == 0);
+            int origStack = _builder.GetStackDepth();
+            _expectedStackDepth = origStack;
+#endif
             EmitStatements(statements);
+#if DEBUG
+            Debug.Assert(_expectedStackDepth == origStack);
+            _expectedStackDepth = 0;
 #endif
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -359,8 +359,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node, bool used)
         {
             DefineLocals(node.Syntax, node.Locals);
+#if !DEBUG
             EmitStatements(node.Statements);
-
+#else
+            foreach (BoundStatement statement in node.Statements)
+            {
+                EmitStatement(statement, _builder.GetStackDepth());
+            }
+#endif
             if (!used)
             {
                 _builder.MarkLabel(node.WhenTrueLabel);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -358,8 +358,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node, bool used)
         {
-            _builder.AssertStackEmpty();
-
             DefineLocals(node.Syntax, node.Locals);
             EmitStatements(node.Statements);
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -380,14 +380,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitSideEffects(ImmutableArray<BoundStatement> statements)
         {
-#if !DEBUG
-            EmitStatements(statements);
-#else
+#if DEBUG
             int stackDepth = _builder.GetStackDepth();
             foreach (BoundStatement statement in statements)
             {
                 EmitStatement(statement, stackDepth);
             }
+#else
+            EmitStatements(statements);
 #endif
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -358,7 +358,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node, bool used)
         {
-            DefineLocals(node.Syntax, node.Locals);
             EmitSideEffects(node.Statements);
 
             if (!used)
@@ -377,8 +376,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 _builder.EmitBoolConstant(false);
                 _builder.MarkLabel(doneLabel);
             }
-
-            FreeLocals(node.Locals);
         }
 
         private void EmitSideEffects(ImmutableArray<BoundStatement> statements)
@@ -894,39 +891,29 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void DefineLocals(BoundSequence sequence)
         {
-            DefineLocals(sequence.Syntax, sequence.Locals);
-        }
-
-        private void DefineLocals(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals)
-        {
-            if (locals.IsEmpty)
+            if (sequence.Locals.IsEmpty)
             {
                 return;
             }
 
             _builder.OpenLocalScope();
 
-            foreach (var local in locals)
+            foreach (var local in sequence.Locals)
             {
-                DefineLocal(local, syntax);
+                DefineLocal(local, sequence.Syntax);
             }
         }
 
         private void FreeLocals(BoundSequence sequence)
         {
-            FreeLocals(sequence.Locals);
-        }
-
-        private void FreeLocals(ImmutableArray<LocalSymbol> locals)
-        {
-            if (locals.IsEmpty)
+            if (sequence.Locals.IsEmpty)
             {
                 return;
             }
 
             _builder.CloseLocalScope();
 
-            foreach (var local in locals)
+            foreach (var local in sequence.Locals)
             {
                 FreeLocal(local);
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
@@ -484,26 +484,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return;
             }
 
-            if (condition.Kind == BoundKind.BinaryOperator)
+            switch (condition.Kind)
             {
-                var binOp = (BoundBinaryOperator)condition;
-                if (IsConditional(binOp.OperatorKind))
-                {
+                case BoundKind.BinaryOperator:
+                    var binOp = (BoundBinaryOperator)condition;
+                    if (!IsConditional(binOp.OperatorKind))
+                    {
+                        break;
+                    }
+
                     EmitBinaryCondOperator(binOp, sense);
                     return;
-                }
-            }
 
-            if (condition.Kind == BoundKind.Sequence)
-            {
-                EmitSequenceExpression((BoundSequence)condition, used: true, sense);
-                return;
-            }
+                case BoundKind.Sequence:
+                    EmitSequenceExpression((BoundSequence)condition, used: true, sense);
+                    return;
 
-            if (condition.Kind == BoundKind.LoweredIsPatternExpression)
-            {
-                EmitLoweredIsPatternExpression((BoundLoweredIsPatternExpression)condition, used: true, sense);
-                return;
+                case BoundKind.LoweredIsPatternExpression:
+                    EmitLoweredIsPatternExpression((BoundLoweredIsPatternExpression)condition, used: true, sense);
+                    return;
             }
 
             EmitExpression(condition, true);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
@@ -494,6 +494,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
             }
 
+            if (condition.Kind == BoundKind.Sequence)
+            {
+                EmitSequenceExpression((BoundSequence)condition, used: true, sense);
+                return;
+            }
+
+            if (condition.Kind == BoundKind.LoweredIsPatternExpression)
+            {
+                EmitLoweredIsPatternExpression((BoundLoweredIsPatternExpression)condition, used: true, sense);
+                return;
+            }
+
             EmitExpression(condition, true);
             EmitIsSense(sense);
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return false;
         }
 
-        private static void RemoveNegation(ref BoundExpression condition, ref bool sense)
+        internal static void RemoveNegation(ref BoundExpression condition, ref bool sense)
         {
             while (condition is BoundUnaryOperator unOp)
             {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return false;
         }
 
-        internal static void RemoveNegation(ref BoundExpression condition, ref bool sense)
+        private static void RemoveNegation(ref BoundExpression condition, ref bool sense)
         {
             while (condition is BoundUnaryOperator unOp)
             {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -622,7 +622,6 @@ oneMoreTime:
                     }
                     else
                     {
-                        _builder.EmitBranch(ILOpCode.Br, loweredIs.WhenTrueLabel);
                         _builder.MarkLabel(loweredIs.WhenFalseLabel);
                         _builder.EmitBranch(ILOpCode.Br, dest);
                         _builder.MarkLabel(loweredIs.WhenTrueLabel);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 #if DEBUG
             if (_stackLocals == null || _stackLocals.Count == 0)
             {
-                _builder.AssertStackEmpty();
+                //_builder.AssertStackEmpty();
             }
 #endif
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -612,7 +612,6 @@ oneMoreTime:
                     var loweredIs = (BoundLoweredIsPatternExpression)condition;
                     dest ??= new object();
 
-                    DefineLocals(loweredIs.Syntax, loweredIs.Locals);
                     EmitSideEffects(loweredIs.Statements);
 
                     if (sense)
@@ -629,7 +628,6 @@ oneMoreTime:
                         _builder.MarkLabel(loweredIs.WhenTrueLabel);
                     }
 
-                    FreeLocals(loweredIs.Locals);
                     return;
 
                 default:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -606,7 +606,26 @@ oneMoreTime:
 
                 case BoundKind.LoweredIsPatternExpression:
                     var loweredIs = (BoundLoweredIsPatternExpression)condition;
-                    EmitIsPatternExpressionCondBranch(loweredIs, ref dest, sense);
+                    dest ??= new object();
+
+                    DefineLocals(loweredIs.Syntax, loweredIs.Locals);
+                    EmitStatements(loweredIs.Statements);
+
+                    if (sense)
+                    {
+                        _builder.MarkLabel(loweredIs.WhenTrueLabel);
+                        _builder.EmitBranch(ILOpCode.Br, dest);
+                        _builder.MarkLabel(loweredIs.WhenFalseLabel);
+                    }
+                    else
+                    {
+                        _builder.EmitBranch(ILOpCode.Br, loweredIs.WhenTrueLabel);
+                        _builder.MarkLabel(loweredIs.WhenFalseLabel);
+                        _builder.EmitBranch(ILOpCode.Br, dest);
+                        _builder.MarkLabel(loweredIs.WhenTrueLabel);
+                    }
+
+                    FreeLocals(loweredIs.Locals);
                     return;
 
                 default:
@@ -623,34 +642,6 @@ oneMoreTime:
                     _builder.EmitBranch(ilcode, dest);
                     return;
             }
-        }
-
-        private void EmitIsPatternExpressionCondBranch(BoundLoweredIsPatternExpression node, ref object dest, bool sense)
-        {
-            _builder.AssertStackEmpty();
-
-            dest ??= new object();
-
-            DefineLocals(node.Syntax, node.Locals);
-            EmitStatements(node.Statements);
-
-            if (sense)
-            {
-                _builder.MarkLabel(node.WhenTrueLabel);
-                _builder.EmitBranch(ILOpCode.Br, dest);
-                _builder.MarkLabel(node.WhenFalseLabel);
-            }
-            else
-            {
-                var doneLabel = new object();
-                _builder.MarkLabel(node.WhenTrueLabel);
-                _builder.EmitBranch(ILOpCode.Br, doneLabel);
-                _builder.MarkLabel(node.WhenFalseLabel);
-                _builder.EmitBranch(ILOpCode.Br, dest);
-                _builder.MarkLabel(doneLabel);
-            }
-
-            FreeLocals(node.Locals);
         }
 
         private void EmitSequenceCondBranch(BoundSequence sequence, ref object dest, bool sense)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -25,10 +25,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
     internal partial class CodeGenerator
     {
 #if DEBUG
-        private void EmitStatement(BoundStatement statement, int stack = 0)
-#else
-        private void EmitStatement(BoundStatement statement)
+        private int _expectedStackDepth = 0;
 #endif
+
+        private void EmitStatement(BoundStatement statement)
         {
             switch (statement.Kind)
             {
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 #if DEBUG
             if (_stackLocals == null || _stackLocals.Count == 0)
             {
-                _builder.AssertStackDepth(stack);
+                _builder.AssertStackDepth(_expectedStackDepth);
             }
 #endif
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -576,6 +576,28 @@ oneMoreTime:
                     }
                     return;
 
+                case BoundKind.LoweredIsPatternExpression:
+                    {
+                        var loweredIs = (BoundLoweredIsPatternExpression)condition;
+                        dest ??= new object();
+
+                        EmitSideEffects(loweredIs.Statements);
+
+                        if (sense)
+                        {
+                            _builder.MarkLabel(loweredIs.WhenTrueLabel);
+                            _builder.EmitBranch(ILOpCode.Br, dest);
+                            _builder.MarkLabel(loweredIs.WhenFalseLabel);
+                        }
+                        else
+                        {
+                            _builder.MarkLabel(loweredIs.WhenFalseLabel);
+                            _builder.EmitBranch(ILOpCode.Br, dest);
+                            _builder.MarkLabel(loweredIs.WhenTrueLabel);
+                        }
+                    }
+                    return;
+
                 case BoundKind.UnaryOperator:
                     var unOp = (BoundUnaryOperator)condition;
                     if (unOp.OperatorKind == UnaryOperatorKind.BoolLogicalNegation)
@@ -606,27 +628,6 @@ oneMoreTime:
                 case BoundKind.Sequence:
                     var seq = (BoundSequence)condition;
                     EmitSequenceCondBranch(seq, ref dest, sense);
-                    return;
-
-                case BoundKind.LoweredIsPatternExpression:
-                    var loweredIs = (BoundLoweredIsPatternExpression)condition;
-                    dest ??= new object();
-
-                    EmitSideEffects(loweredIs.Statements);
-
-                    if (sense)
-                    {
-                        _builder.MarkLabel(loweredIs.WhenTrueLabel);
-                        _builder.EmitBranch(ILOpCode.Br, dest);
-                        _builder.MarkLabel(loweredIs.WhenFalseLabel);
-                    }
-                    else
-                    {
-                        _builder.MarkLabel(loweredIs.WhenFalseLabel);
-                        _builder.EmitBranch(ILOpCode.Br, dest);
-                        _builder.MarkLabel(loweredIs.WhenTrueLabel);
-                    }
-
                     return;
 
                 default:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -613,7 +613,7 @@ oneMoreTime:
                     dest ??= new object();
 
                     DefineLocals(loweredIs.Syntax, loweredIs.Locals);
-                    EmitStatements(loweredIs.Statements);
+                    EmitSideEffects(loweredIs.Statements);
 
                     if (sense)
                     {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -24,7 +24,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {
     internal partial class CodeGenerator
     {
+#if DEBUG
+        private void EmitStatement(BoundStatement statement, int stack = 0)
+#else
         private void EmitStatement(BoundStatement statement)
+#endif
         {
             switch (statement.Kind)
             {
@@ -108,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 #if DEBUG
             if (_stackLocals == null || _stackLocals.Count == 0)
             {
-                //_builder.AssertStackEmpty();
+                _builder.AssertStackDepth(stack);
             }
 #endif
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -571,6 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public ImmutableArray<BoundStatement> VisitSideEffects(ImmutableArray<BoundStatement> statements)
         {
+#if DEBUG
             var result = ArrayBuilder<BoundStatement>.GetInstance(statements.Length);
             foreach (BoundStatement statement in statements)
             {
@@ -578,6 +579,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             return result.ToImmutableAndFree();
+#else
+            return this.VisitList(statements);
+#endif
         }
 
         public BoundNode VisitSideEffect(BoundNode node)

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -401,10 +401,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private ExprContext _context;
         private BoundLocal _assignmentLocal;
 
-#if DEBUG
-        private int _expectedStackDepth = 0;
-#endif
-
         private readonly Dictionary<LocalSymbol, LocalDefUseInfo> _locals;
 
         // we need to guarantee same stack patterns at branches and labels.
@@ -418,6 +414,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public static readonly DummyLocal empty = new DummyLocal();
 
         private int _recursionDepth;
+
+#if DEBUG
+        private int _expectedStackDepth = 0;
+#endif
 
         private StackOptimizerPass1(Dictionary<LocalSymbol, LocalDefUseInfo> locals,
             ArrayBuilder<ValueTuple<BoundExpression, ExprContext>> evalStack,

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1447,6 +1447,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return node.Update(boundExpression, node.Cases, node.DefaultLabel, node.LengthBasedStringSwitchDataOpt);
         }
 
+        public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
+        {
+            EnsureOnlyEvalStack();
+            DeclareLocals(node.Locals, stack: 0);
+            var result = base.VisitLoweredIsPatternExpression(node);
+            RecordBranch(node.WhenTrueLabel);
+            RecordBranch(node.WhenFalseLabel);
+            return result;
+        }
+
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
             var origStack = StackDepth();

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -565,7 +565,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public BoundNode VisitStatement(BoundNode node)
         {
-            Debug.Assert(node == null || EvalStackIsEmpty());
+            //Debug.Assert(node == null || EvalStackIsEmpty());
             return VisitSideEffect(node);
         }
 
@@ -1416,7 +1416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public override BoundNode VisitSwitchDispatch(BoundSwitchDispatch node)
         {
-            Debug.Assert(EvalStackIsEmpty());
+            //Debug.Assert(EvalStackIsEmpty());
 
             // switch dispatch needs a byval local or a parameter as a key.
             // if this is already a fitting local, let's keep it that way

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1458,11 +1458,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
         {
-            DeclareLocals(node.Locals, StackDepth());
             var statements = VisitSideEffects(node.Statements);
             RecordBranch(node.WhenTrueLabel);
             RecordBranch(node.WhenFalseLabel);
-            return node.Update(node.Locals, statements, node.WhenTrueLabel, node.WhenFalseLabel, VisitType(node.Type));
+            return node.Update(statements, node.WhenTrueLabel, node.WhenFalseLabel, VisitType(node.Type));
         }
 
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -578,14 +578,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public ImmutableArray<BoundStatement> VisitSideEffects(ImmutableArray<BoundStatement> statements)
         {
 #if DEBUG
-            Debug.Assert(_expectedStackDepth == 0);
+            int prevStack = _expectedStackDepth;
             int origStack = StackDepth();
             _expectedStackDepth = origStack;
 #endif
             var result = this.VisitList(statements);
 #if DEBUG
             Debug.Assert(_expectedStackDepth == origStack);
-            _expectedStackDepth = 0;
+            _expectedStackDepth = prevStack;
 #endif
             return result;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2973,6 +2973,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
+        {
+            return null;
+        }
+
         public override BoundNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)
         {
             var savedState = this.State.Clone();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2975,6 +2975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
         {
+            VisitStatements(node.Statements);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -7683,7 +7683,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Statements = statements;
             this.WhenTrueLabel = whenTrueLabel;
             this.WhenFalseLabel = whenFalseLabel;
+            Validate();
         }
+
+        [Conditional("DEBUG")]
+        private partial void Validate();
 
         public new TypeSymbol Type => base.Type!;
         public ImmutableArray<BoundStatement> Statements { get; }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -111,8 +111,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(node.Type is { SpecialType: SpecialType.System_Boolean });
 
                 _factory.Syntax = node.Syntax;
-                var sideEffectsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
                 var inputExpression = _localRewriter.VisitExpression(node.Expression);
+                var sideEffectsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
 
                 // The optimization of sharing pattern-matching temps with user variables can always apply to
                 // an is-pattern expression because there is no when clause that could possibly intervene during
@@ -120,8 +120,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 decisionDag = ShareTempsAndEvaluateInput(inputExpression, decisionDag, sideEffectsBuilder.Add, out _);
 
                 // lower the decision dag.
-                var resultBuilder = ArrayBuilder<BoundStatement>.GetInstance();
                 ImmutableArray<BoundStatement> loweredDag = LowerDecisionDagCore(decisionDag);
+                var resultBuilder = ArrayBuilder<BoundStatement>.GetInstance(loweredDag.Length + _statements.Count);
                 resultBuilder.AddRange(loweredDag);
                 resultBuilder.AddRange(_statements);
                 return _factory.Sequence(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -119,7 +119,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray<BoundStatement> loweredDag = LowerDecisionDagCore(decisionDag);
                 resultBuilder.AddRange(loweredDag);
                 resultBuilder.AddRange(_statements);
-                _localRewriter._needsSpilling = true;
                 return new BoundLoweredIsPatternExpression(node.Syntax, _tempAllocator.AllTemps(),
                     resultBuilder.ToImmutableAndFree(), node.WhenTrueLabel, node.WhenFalseLabel, node.Type);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -113,6 +113,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.Syntax = node.Syntax;
                 var sideEffectsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
                 var inputExpression = _localRewriter.VisitExpression(node.Expression);
+
+                // The optimization of sharing pattern-matching temps with user variables can always apply to
+                // an is-pattern expression because there is no when clause that could possibly intervene during
+                // the execution of the pattern-matching automaton and change one of those variables.
                 decisionDag = ShareTempsAndEvaluateInput(inputExpression, decisionDag, sideEffectsBuilder.Add, out _);
 
                 // lower the decision dag.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -129,6 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     sideEffectsBuilder.ToImmutableAndFree(),
                     new BoundLoweredIsPatternExpression(
                         node.Syntax,
+                        // Note: it is not expected for this node to trigger spilling
                         resultBuilder.ToImmutableAndFree(),
                         node.WhenTrueLabel,
                         node.WhenFalseLabel,

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -420,25 +420,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var receiver = Spill(builder, field.ReceiverOpt, fieldSymbol.ContainingType.IsValueType ? refKind : RefKind.None);
                         return field.Update(receiver, fieldSymbol, field.ConstantValueOpt, field.ResultKind, field.Type);
 
-                    case BoundKind.LoweredIsPatternExpression:
-                        var loweredIs = (BoundLoweredIsPatternExpression)expression;
-                        _F.Syntax = loweredIs.Syntax;
-
-                        var resultTemp = _F.SynthesizedLocal(loweredIs.Type, kind: SynthesizedLocalKind.Spill , syntax: _F.Syntax);
-                        var doneLabel = _F.GenerateLabel("doneLabel");
-
-                        builder.AddLocals(loweredIs.Locals);
-                        builder.AddLocal(resultTemp);
-                        builder.AddStatements(loweredIs.Statements);
-                        builder.AddStatement(_F.Label(loweredIs.WhenTrueLabel));
-                        builder.AddStatement(_F.Assignment(_F.Local(resultTemp), _F.Literal(true)));
-                        builder.AddStatement(_F.Goto(doneLabel));
-                        builder.AddStatement(_F.Label(loweredIs.WhenFalseLabel));
-                        builder.AddStatement(_F.Assignment(_F.Local(resultTemp), _F.Literal(false)));
-                        builder.AddStatement(_F.Label(doneLabel));
-
-                        return _F.Local(resultTemp);
-
                     case BoundKind.Literal:
                     case BoundKind.TypeExpression:
                         return expression;

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -666,6 +666,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Expression Visitors
 
+        public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
+        {
+            var builder = new BoundSpillSequenceBuilder(node.Syntax);
+            builder.AddLocals(node.Locals);
+            builder.AddStatements(VisitList(node.Statements));
+            var temp = Spill(builder, node.Update(
+                ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty,
+                node.WhenTrueLabel, node.WhenFalseLabel, VisitType(node.Type)));
+            return builder.Update(temp);
+        }
+
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {
             // An await expression has already been wrapped in a BoundSpillSequence if not at the top level, so

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -666,17 +666,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Expression Visitors
 
-        public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
-        {
-            var builder = new BoundSpillSequenceBuilder(node.Syntax);
-            builder.AddLocals(node.Locals);
-            builder.AddStatements(VisitList(node.Statements));
-            var temp = Spill(builder, node.Update(
-                ImmutableArray<LocalSymbol>.Empty, ImmutableArray<BoundStatement>.Empty,
-                node.WhenTrueLabel, node.WhenFalseLabel, VisitType(node.Type)));
-            return builder.Update(temp);
-        }
-
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {
             // An await expression has already been wrapped in a BoundSpillSequence if not at the top level, so

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -666,6 +666,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Expression Visitors
 
+        public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
+        {
+            // Ensure this node won't trigger spilling
+            Debug.Assert(this.VisitList(node.Statements) == node.Statements);
+            return node;
+        }
+
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {
             // An await expression has already been wrapped in a BoundSpillSequence if not at the top level, so

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -666,12 +666,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region Expression Visitors
 
+#if DEBUG
         public override BoundNode VisitLoweredIsPatternExpression(BoundLoweredIsPatternExpression node)
         {
             // Ensure this node won't trigger spilling
-            Debug.Assert(this.VisitList(node.Statements) == node.Statements);
-            return node;
+            var result = base.VisitLoweredIsPatternExpression(node);
+            Debug.Assert(result == node);
+            return result;
         }
+#endif
 
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -5519,23 +5519,19 @@ class C
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       26 (0x1a)
+  // Code size       23 (0x17)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0012
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
   IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
+  IL_0010:  br.s       IL_0015
   IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  ret
+  IL_0013:  br.s       IL_0016
+  IL_0015:  ldc.i4.0
+  IL_0016:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", """
@@ -5560,22 +5556,18 @@ class C
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       24 (0x18)
+  // Code size       20 (0x14)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0010
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
+  IL_000e:  brfalse.s  IL_0012
   IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  ret
+  IL_0011:  ret
+  IL_0012:  ldc.i4.0
+  IL_0013:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", @"
@@ -5725,41 +5717,37 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"TrueFalseTrueFalse";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       47 (0x2f)
-      .maxstack  2
-      .locals init (char V_0,
-                    bool V_1)
-      IL_0000:  ldarg.0
-      IL_0001:  isinst     ""char""
-      IL_0006:  brfalse.s  IL_002b
-      IL_0008:  ldarg.0
-      IL_0009:  unbox.any  ""char""
-      IL_000e:  stloc.0
-      IL_000f:  ldloc.0
-      IL_0010:  ldc.i4.s   97
-      IL_0012:  blt.s      IL_001b
-      IL_0014:  ldloc.0
-      IL_0015:  ldc.i4.s   122
-      IL_0017:  ble.s      IL_0027
-      IL_0019:  br.s       IL_002b
-      IL_001b:  ldloc.0
-      IL_001c:  ldc.i4.s   65
-      IL_001e:  blt.s      IL_002b
-      IL_0020:  ldloc.0
-      IL_0021:  ldc.i4.s   90
-      IL_0023:  ble.s      IL_0027
-      IL_0025:  br.s       IL_002b
-      IL_0027:  ldc.i4.1
-      IL_0028:  stloc.1
-      IL_0029:  br.s       IL_002d
-      IL_002b:  ldc.i4.0
-      IL_002c:  stloc.1
-      IL_002d:  ldloc.1
-      IL_002e:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       44 (0x2c)
+  .maxstack  2
+  .locals init (char V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  isinst     "char"
+  IL_0006:  brfalse.s  IL_002a
+  IL_0008:  ldarg.0
+  IL_0009:  unbox.any  "char"
+  IL_000e:  stloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.s   97
+  IL_0012:  blt.s      IL_001b
+  IL_0014:  ldloc.0
+  IL_0015:  ldc.i4.s   122
+  IL_0017:  ble.s      IL_0027
+  IL_0019:  br.s       IL_002a
+  IL_001b:  ldloc.0
+  IL_001c:  ldc.i4.s   65
+  IL_001e:  blt.s      IL_002a
+  IL_0020:  ldloc.0
+  IL_0021:  ldc.i4.s   90
+  IL_0023:  ble.s      IL_0027
+  IL_0025:  br.s       IL_002a
+  IL_0027:  ldc.i4.1
+  IL_0028:  br.s       IL_002b
+  IL_002a:  ldc.i4.0
+  IL_002b:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       48 (0x30)
@@ -5798,40 +5786,36 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       45 (0x2d)
-      .maxstack  2
-      .locals init (char V_0,
-                    bool V_1)
-      IL_0000:  ldarg.0
-      IL_0001:  isinst     ""char""
-      IL_0006:  brfalse.s  IL_0029
-      IL_0008:  ldarg.0
-      IL_0009:  unbox.any  ""char""
-      IL_000e:  stloc.0
-      IL_000f:  ldloc.0
-      IL_0010:  ldc.i4.s   97
-      IL_0012:  blt.s      IL_001b
-      IL_0014:  ldloc.0
-      IL_0015:  ldc.i4.s   122
-      IL_0017:  ble.s      IL_0025
-      IL_0019:  br.s       IL_0029
-      IL_001b:  ldloc.0
-      IL_001c:  ldc.i4.s   65
-      IL_001e:  blt.s      IL_0029
-      IL_0020:  ldloc.0
-      IL_0021:  ldc.i4.s   90
-      IL_0023:  bgt.s      IL_0029
-      IL_0025:  ldc.i4.1
-      IL_0026:  stloc.1
-      IL_0027:  br.s       IL_002b
-      IL_0029:  ldc.i4.0
-      IL_002a:  stloc.1
-      IL_002b:  ldloc.1
-      IL_002c:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       41 (0x29)
+  .maxstack  2
+  .locals init (char V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  isinst     "char"
+  IL_0006:  brfalse.s  IL_0027
+  IL_0008:  ldarg.0
+  IL_0009:  unbox.any  "char"
+  IL_000e:  stloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.s   97
+  IL_0012:  blt.s      IL_001b
+  IL_0014:  ldloc.0
+  IL_0015:  ldc.i4.s   122
+  IL_0017:  ble.s      IL_0025
+  IL_0019:  br.s       IL_0027
+  IL_001b:  ldloc.0
+  IL_001c:  ldc.i4.s   65
+  IL_001e:  blt.s      IL_0027
+  IL_0020:  ldloc.0
+  IL_0021:  ldc.i4.s   90
+  IL_0023:  bgt.s      IL_0027
+  IL_0025:  ldc.i4.1
+  IL_0026:  ret
+  IL_0027:  ldc.i4.0
+  IL_0028:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       45 (0x2d)
@@ -6118,33 +6102,29 @@ class C
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", @"
     {
-      // Code size       35 (0x23)
+      // Code size       32 (0x20)
       .maxstack  2
-      .locals init (bool V_0)
       IL_0000:  ldarg.0
       IL_0001:  ldc.i4.s   97
       IL_0003:  blt.s      IL_000c
       IL_0005:  ldarg.0
       IL_0006:  ldc.i4.s   122
       IL_0008:  ble.s      IL_0016
-      IL_000a:  br.s       IL_001a
+      IL_000a:  br.s       IL_0019
       IL_000c:  ldarg.0
       IL_000d:  ldc.i4.s   65
-      IL_000f:  blt.s      IL_001a
+      IL_000f:  blt.s      IL_0019
       IL_0011:  ldarg.0
       IL_0012:  ldc.i4.s   90
-      IL_0014:  bgt.s      IL_001a
+      IL_0014:  bgt.s      IL_0019
       IL_0016:  ldc.i4.1
-      IL_0017:  stloc.0
-      IL_0018:  br.s       IL_001c
-      IL_001a:  ldc.i4.0
-      IL_001b:  stloc.0
-      IL_001c:  ldloc.0
-      IL_001d:  brfalse.s  IL_0021
-      IL_001f:  ldc.i4.1
-      IL_0020:  ret
-      IL_0021:  ldc.i4.0
-      IL_0022:  ret
+      IL_0017:  br.s       IL_001a
+      IL_0019:  ldc.i4.0
+      IL_001a:  brfalse.s  IL_001e
+      IL_001c:  ldc.i4.1
+      IL_001d:  ret
+      IL_001e:  ldc.i4.0
+      IL_001f:  ret
     }
 ");
             compVerifier.VerifyIL("C.M2", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -3003,7 +3003,7 @@ True";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("ConsoleApp1.TestHelper.IsValueTypeT<T>(ConsoleApp1.Result<T>)",
 @"{
-  // Code size       31 (0x1f)
+  // Code size       28 (0x1c)
   .maxstack  2
   .locals init (T V_0, //v
                 bool V_1)
@@ -3014,15 +3014,13 @@ True";
   IL_0008:  ldloc.0
   IL_0009:  box        ""T""
   IL_000e:  ldnull
-  IL_000f:  cgt.un
-  IL_0011:  ldc.i4.0
-  IL_0012:  ceq
-  IL_0014:  stloc.1
-  IL_0015:  ldloc.1
-  IL_0016:  brfalse.s  IL_001e
-  IL_0018:  newobj     ""ConsoleApp1.NotPossibleException..ctor()""
-  IL_001d:  throw
-  IL_001e:  ret
+  IL_000f:  ceq
+  IL_0011:  stloc.1
+  IL_0012:  ldloc.1
+  IL_0013:  brfalse.s  IL_001b
+  IL_0015:  newobj     ""ConsoleApp1.NotPossibleException..ctor()""
+  IL_001a:  throw
+  IL_001b:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -5656,26 +5656,18 @@ class C
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       37 (0x25)
+  // Code size       28 (0x1c)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0010
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
-  IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  brtrue.s   IL_001f
-  IL_0019:  ldstr      "False"
-  IL_001e:  ret
-  IL_001f:  ldstr      "True"
-  IL_0024:  ret
+  IL_000e:  brfalse.s  IL_0016
+  IL_0010:  ldstr      "True"
+  IL_0015:  ret
+  IL_0016:  ldstr      "False"
+  IL_001b:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", @"
@@ -6100,33 +6092,29 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       32 (0x20)
-      .maxstack  2
-      IL_0000:  ldarg.0
-      IL_0001:  ldc.i4.s   97
-      IL_0003:  blt.s      IL_000c
-      IL_0005:  ldarg.0
-      IL_0006:  ldc.i4.s   122
-      IL_0008:  ble.s      IL_0016
-      IL_000a:  br.s       IL_0019
-      IL_000c:  ldarg.0
-      IL_000d:  ldc.i4.s   65
-      IL_000f:  blt.s      IL_0019
-      IL_0011:  ldarg.0
-      IL_0012:  ldc.i4.s   90
-      IL_0014:  bgt.s      IL_0019
-      IL_0016:  ldc.i4.1
-      IL_0017:  br.s       IL_001a
-      IL_0019:  ldc.i4.0
-      IL_001a:  brfalse.s  IL_001e
-      IL_001c:  ldc.i4.1
-      IL_001d:  ret
-      IL_001e:  ldc.i4.0
-      IL_001f:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       26 (0x1a)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   97
+  IL_0003:  blt.s      IL_000c
+  IL_0005:  ldarg.0
+  IL_0006:  ldc.i4.s   122
+  IL_0008:  ble.s      IL_0016
+  IL_000a:  br.s       IL_0018
+  IL_000c:  ldarg.0
+  IL_000d:  ldc.i4.s   65
+  IL_000f:  blt.s      IL_0018
+  IL_0011:  ldarg.0
+  IL_0012:  ldc.i4.s   90
+  IL_0014:  bgt.s      IL_0018
+  IL_0016:  ldc.i4.1
+  IL_0017:  ret
+  IL_0018:  ldc.i4.0
+  IL_0019:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       24 (0x18)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -5611,27 +5611,20 @@ class C
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("C.M1", """
 {
-  // Code size       40 (0x28)
+  // Code size       33 (0x21)
   .maxstack  1
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0012
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
   IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
-  IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  brtrue.s   IL_0022
-  IL_001b:  ldstr      "False"
-  IL_0020:  br.s       IL_0027
-  IL_0022:  ldstr      "True"
-  IL_0027:  ret
+  IL_0010:  br.s       IL_0014
+  IL_0012:  br.s       IL_001b
+  IL_0014:  ldstr      "False"
+  IL_0019:  br.s       IL_0020
+  IL_001b:  ldstr      "True"
+  IL_0020:  ret
 }
 """);
             compVerifier.VerifyIL("C.M2", """
@@ -5660,13 +5653,13 @@ class C
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0010
+  IL_0006:  brtrue.s   IL_0016
   IL_0008:  ldarg.0
   IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0016
-  IL_0010:  ldstr      "True"
+  IL_000e:  brtrue.s   IL_0016
+  IL_0010:  ldstr      "False"
   IL_0015:  ret
-  IL_0016:  ldstr      "False"
+  IL_0016:  ldstr      "True"
   IL_001b:  ret
 }
 """);
@@ -5865,38 +5858,31 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"1010";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       38 (0x26)
-      .maxstack  2
-      .locals init (bool V_0)
-      IL_0000:  ldarg.0
-      IL_0001:  ldc.i4.s   97
-      IL_0003:  blt.s      IL_000c
-      IL_0005:  ldarg.0
-      IL_0006:  ldc.i4.s   122
-      IL_0008:  ble.s      IL_0018
-      IL_000a:  br.s       IL_001c
-      IL_000c:  ldarg.0
-      IL_000d:  ldc.i4.s   65
-      IL_000f:  blt.s      IL_001c
-      IL_0011:  ldarg.0
-      IL_0012:  ldc.i4.s   90
-      IL_0014:  ble.s      IL_0018
-      IL_0016:  br.s       IL_001c
-      IL_0018:  ldc.i4.1
-      IL_0019:  stloc.0
-      IL_001a:  br.s       IL_001e
-      IL_001c:  ldc.i4.0
-      IL_001d:  stloc.0
-      IL_001e:  ldloc.0
-      IL_001f:  brtrue.s   IL_0024
-      IL_0021:  ldc.i4.0
-      IL_0022:  br.s       IL_0025
-      IL_0024:  ldc.i4.1
-      IL_0025:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       31 (0x1f)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   97
+  IL_0003:  blt.s      IL_000c
+  IL_0005:  ldarg.0
+  IL_0006:  ldc.i4.s   122
+  IL_0008:  ble.s      IL_0018
+  IL_000a:  br.s       IL_001a
+  IL_000c:  ldarg.0
+  IL_000d:  ldc.i4.s   65
+  IL_000f:  blt.s      IL_001a
+  IL_0011:  ldarg.0
+  IL_0012:  ldc.i4.s   90
+  IL_0014:  ble.s      IL_0018
+  IL_0016:  br.s       IL_001a
+  IL_0018:  br.s       IL_001d
+  IL_001a:  ldc.i4.0
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldc.i4.1
+  IL_001e:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       25 (0x19)
@@ -5923,35 +5909,31 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       33 (0x21)
-      .maxstack  2
-      .locals init (bool V_0)
-      IL_0000:  ldarg.0
-      IL_0001:  ldc.i4.s   97
-      IL_0003:  blt.s      IL_000c
-      IL_0005:  ldarg.0
-      IL_0006:  ldc.i4.s   122
-      IL_0008:  ble.s      IL_0016
-      IL_000a:  br.s       IL_001a
-      IL_000c:  ldarg.0
-      IL_000d:  ldc.i4.s   65
-      IL_000f:  blt.s      IL_001a
-      IL_0011:  ldarg.0
-      IL_0012:  ldc.i4.s   90
-      IL_0014:  bgt.s      IL_001a
-      IL_0016:  ldc.i4.1
-      IL_0017:  stloc.0
-      IL_0018:  br.s       IL_001c
-      IL_001a:  ldc.i4.0
-      IL_001b:  stloc.0
-      IL_001c:  ldloc.0
-      IL_001d:  ldc.i4.0
-      IL_001e:  cgt.un
-      IL_0020:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   97
+  IL_0003:  blt.s      IL_000c
+  IL_0005:  ldarg.0
+  IL_0006:  ldc.i4.s   122
+  IL_0008:  ble.s      IL_0016
+  IL_000a:  br.s       IL_0019
+  IL_000c:  ldarg.0
+  IL_000d:  ldc.i4.s   65
+  IL_000f:  blt.s      IL_0019
+  IL_0011:  ldarg.0
+  IL_0012:  ldc.i4.s   90
+  IL_0014:  bgt.s      IL_0019
+  IL_0016:  ldc.i4.1
+  IL_0017:  br.s       IL_001a
+  IL_0019:  ldc.i4.0
+  IL_001a:  ldc.i4.0
+  IL_001b:  cgt.un
+  IL_001d:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       24 (0x18)
@@ -6009,47 +5991,43 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"1010";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", @"
-    {
-      // Code size       46 (0x2e)
-      .maxstack  2
-      .locals init (bool V_0,
-                    bool V_1,
-                    int V_2)
-      IL_0000:  nop
-      IL_0001:  ldarg.0
-      IL_0002:  ldc.i4.s   97
-      IL_0004:  blt.s      IL_000d
-      IL_0006:  ldarg.0
-      IL_0007:  ldc.i4.s   122
-      IL_0009:  ble.s      IL_0019
-      IL_000b:  br.s       IL_001d
-      IL_000d:  ldarg.0
-      IL_000e:  ldc.i4.s   65
-      IL_0010:  blt.s      IL_001d
-      IL_0012:  ldarg.0
-      IL_0013:  ldc.i4.s   90
-      IL_0015:  ble.s      IL_0019
-      IL_0017:  br.s       IL_001d
-      IL_0019:  ldc.i4.1
-      IL_001a:  stloc.0
-      IL_001b:  br.s       IL_001f
-      IL_001d:  ldc.i4.0
-      IL_001e:  stloc.0
-      IL_001f:  ldloc.0
-      IL_0020:  stloc.1
-      IL_0021:  ldloc.1
-      IL_0022:  brfalse.s  IL_0028
-      IL_0024:  ldc.i4.1
-      IL_0025:  stloc.2
-      IL_0026:  br.s       IL_002c
-      IL_0028:  ldc.i4.0
-      IL_0029:  stloc.2
-      IL_002a:  br.s       IL_002c
-      IL_002c:  ldloc.2
-      IL_002d:  ret
-    }
-");
+            compVerifier.VerifyIL("C.M1", """
+{
+  // Code size       43 (0x2b)
+  .maxstack  2
+  .locals init (bool V_0,
+                int V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldc.i4.s   97
+  IL_0004:  blt.s      IL_000d
+  IL_0006:  ldarg.0
+  IL_0007:  ldc.i4.s   122
+  IL_0009:  ble.s      IL_0019
+  IL_000b:  br.s       IL_001c
+  IL_000d:  ldarg.0
+  IL_000e:  ldc.i4.s   65
+  IL_0010:  blt.s      IL_001c
+  IL_0012:  ldarg.0
+  IL_0013:  ldc.i4.s   90
+  IL_0015:  ble.s      IL_0019
+  IL_0017:  br.s       IL_001c
+  IL_0019:  ldc.i4.1
+  IL_001a:  br.s       IL_001d
+  IL_001c:  ldc.i4.0
+  IL_001d:  stloc.0
+  IL_001e:  ldloc.0
+  IL_001f:  brfalse.s  IL_0025
+  IL_0021:  ldc.i4.1
+  IL_0022:  stloc.1
+  IL_0023:  br.s       IL_0029
+  IL_0025:  ldc.i4.0
+  IL_0026:  stloc.1
+  IL_0027:  br.s       IL_0029
+  IL_0029:  ldloc.1
+  IL_002a:  ret
+}
+""");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       44 (0x2c)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -5702,37 +5702,37 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"TrueFalseTrueFalse";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       44 (0x2c)
-  .maxstack  2
-  .locals init (char V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "char"
-  IL_0006:  brfalse.s  IL_002a
-  IL_0008:  ldarg.0
-  IL_0009:  unbox.any  "char"
-  IL_000e:  stloc.0
-  IL_000f:  ldloc.0
-  IL_0010:  ldc.i4.s   97
-  IL_0012:  blt.s      IL_001b
-  IL_0014:  ldloc.0
-  IL_0015:  ldc.i4.s   122
-  IL_0017:  ble.s      IL_0027
-  IL_0019:  br.s       IL_002a
-  IL_001b:  ldloc.0
-  IL_001c:  ldc.i4.s   65
-  IL_001e:  blt.s      IL_002a
-  IL_0020:  ldloc.0
-  IL_0021:  ldc.i4.s   90
-  IL_0023:  ble.s      IL_0027
-  IL_0025:  br.s       IL_002a
-  IL_0027:  ldc.i4.1
-  IL_0028:  br.s       IL_002b
-  IL_002a:  ldc.i4.0
-  IL_002b:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       44 (0x2c)
+      .maxstack  2
+      .locals init (char V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  isinst     ""char""
+      IL_0006:  brfalse.s  IL_002a
+      IL_0008:  ldarg.0
+      IL_0009:  unbox.any  ""char""
+      IL_000e:  stloc.0
+      IL_000f:  ldloc.0
+      IL_0010:  ldc.i4.s   97
+      IL_0012:  blt.s      IL_001b
+      IL_0014:  ldloc.0
+      IL_0015:  ldc.i4.s   122
+      IL_0017:  ble.s      IL_0027
+      IL_0019:  br.s       IL_002a
+      IL_001b:  ldloc.0
+      IL_001c:  ldc.i4.s   65
+      IL_001e:  blt.s      IL_002a
+      IL_0020:  ldloc.0
+      IL_0021:  ldc.i4.s   90
+      IL_0023:  ble.s      IL_0027
+      IL_0025:  br.s       IL_002a
+      IL_0027:  ldc.i4.1
+      IL_0028:  br.s       IL_002b
+      IL_002a:  ldc.i4.0
+      IL_002b:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       48 (0x30)
@@ -5771,36 +5771,36 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       41 (0x29)
-  .maxstack  2
-  .locals init (char V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "char"
-  IL_0006:  brfalse.s  IL_0027
-  IL_0008:  ldarg.0
-  IL_0009:  unbox.any  "char"
-  IL_000e:  stloc.0
-  IL_000f:  ldloc.0
-  IL_0010:  ldc.i4.s   97
-  IL_0012:  blt.s      IL_001b
-  IL_0014:  ldloc.0
-  IL_0015:  ldc.i4.s   122
-  IL_0017:  ble.s      IL_0025
-  IL_0019:  br.s       IL_0027
-  IL_001b:  ldloc.0
-  IL_001c:  ldc.i4.s   65
-  IL_001e:  blt.s      IL_0027
-  IL_0020:  ldloc.0
-  IL_0021:  ldc.i4.s   90
-  IL_0023:  bgt.s      IL_0027
-  IL_0025:  ldc.i4.1
-  IL_0026:  ret
-  IL_0027:  ldc.i4.0
-  IL_0028:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       41 (0x29)
+      .maxstack  2
+      .locals init (char V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  isinst     ""char""
+      IL_0006:  brfalse.s  IL_0027
+      IL_0008:  ldarg.0
+      IL_0009:  unbox.any  ""char""
+      IL_000e:  stloc.0
+      IL_000f:  ldloc.0
+      IL_0010:  ldc.i4.s   97
+      IL_0012:  blt.s      IL_001b
+      IL_0014:  ldloc.0
+      IL_0015:  ldc.i4.s   122
+      IL_0017:  ble.s      IL_0025
+      IL_0019:  br.s       IL_0027
+      IL_001b:  ldloc.0
+      IL_001c:  ldc.i4.s   65
+      IL_001e:  blt.s      IL_0027
+      IL_0020:  ldloc.0
+      IL_0021:  ldc.i4.s   90
+      IL_0023:  bgt.s      IL_0027
+      IL_0025:  ldc.i4.1
+      IL_0026:  ret
+      IL_0027:  ldc.i4.0
+      IL_0028:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       45 (0x2d)
@@ -5858,31 +5858,31 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"1010";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       31 (0x1f)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   97
-  IL_0003:  blt.s      IL_000c
-  IL_0005:  ldarg.0
-  IL_0006:  ldc.i4.s   122
-  IL_0008:  ble.s      IL_0018
-  IL_000a:  br.s       IL_001a
-  IL_000c:  ldarg.0
-  IL_000d:  ldc.i4.s   65
-  IL_000f:  blt.s      IL_001a
-  IL_0011:  ldarg.0
-  IL_0012:  ldc.i4.s   90
-  IL_0014:  ble.s      IL_0018
-  IL_0016:  br.s       IL_001a
-  IL_0018:  br.s       IL_001d
-  IL_001a:  ldc.i4.0
-  IL_001b:  br.s       IL_001e
-  IL_001d:  ldc.i4.1
-  IL_001e:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       31 (0x1f)
+      .maxstack  2
+      IL_0000:  ldarg.0
+      IL_0001:  ldc.i4.s   97
+      IL_0003:  blt.s      IL_000c
+      IL_0005:  ldarg.0
+      IL_0006:  ldc.i4.s   122
+      IL_0008:  ble.s      IL_0018
+      IL_000a:  br.s       IL_001a
+      IL_000c:  ldarg.0
+      IL_000d:  ldc.i4.s   65
+      IL_000f:  blt.s      IL_001a
+      IL_0011:  ldarg.0
+      IL_0012:  ldc.i4.s   90
+      IL_0014:  ble.s      IL_0018
+      IL_0016:  br.s       IL_001a
+      IL_0018:  br.s       IL_001d
+      IL_001a:  ldc.i4.0
+      IL_001b:  br.s       IL_001e
+      IL_001d:  ldc.i4.1
+      IL_001e:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       25 (0x19)
@@ -5909,31 +5909,31 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       30 (0x1e)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   97
-  IL_0003:  blt.s      IL_000c
-  IL_0005:  ldarg.0
-  IL_0006:  ldc.i4.s   122
-  IL_0008:  ble.s      IL_0016
-  IL_000a:  br.s       IL_0019
-  IL_000c:  ldarg.0
-  IL_000d:  ldc.i4.s   65
-  IL_000f:  blt.s      IL_0019
-  IL_0011:  ldarg.0
-  IL_0012:  ldc.i4.s   90
-  IL_0014:  bgt.s      IL_0019
-  IL_0016:  ldc.i4.1
-  IL_0017:  br.s       IL_001a
-  IL_0019:  ldc.i4.0
-  IL_001a:  ldc.i4.0
-  IL_001b:  cgt.un
-  IL_001d:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       30 (0x1e)
+      .maxstack  2
+      IL_0000:  ldarg.0
+      IL_0001:  ldc.i4.s   97
+      IL_0003:  blt.s      IL_000c
+      IL_0005:  ldarg.0
+      IL_0006:  ldc.i4.s   122
+      IL_0008:  ble.s      IL_0016
+      IL_000a:  br.s       IL_0019
+      IL_000c:  ldarg.0
+      IL_000d:  ldc.i4.s   65
+      IL_000f:  blt.s      IL_0019
+      IL_0011:  ldarg.0
+      IL_0012:  ldc.i4.s   90
+      IL_0014:  bgt.s      IL_0019
+      IL_0016:  ldc.i4.1
+      IL_0017:  br.s       IL_001a
+      IL_0019:  ldc.i4.0
+      IL_001a:  ldc.i4.0
+      IL_001b:  cgt.un
+      IL_001d:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       24 (0x18)
@@ -5991,43 +5991,43 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"1010";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals init (bool V_0,
-                int V_1)
-  IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  ldc.i4.s   97
-  IL_0004:  blt.s      IL_000d
-  IL_0006:  ldarg.0
-  IL_0007:  ldc.i4.s   122
-  IL_0009:  ble.s      IL_0019
-  IL_000b:  br.s       IL_001c
-  IL_000d:  ldarg.0
-  IL_000e:  ldc.i4.s   65
-  IL_0010:  blt.s      IL_001c
-  IL_0012:  ldarg.0
-  IL_0013:  ldc.i4.s   90
-  IL_0015:  ble.s      IL_0019
-  IL_0017:  br.s       IL_001c
-  IL_0019:  ldc.i4.1
-  IL_001a:  br.s       IL_001d
-  IL_001c:  ldc.i4.0
-  IL_001d:  stloc.0
-  IL_001e:  ldloc.0
-  IL_001f:  brfalse.s  IL_0025
-  IL_0021:  ldc.i4.1
-  IL_0022:  stloc.1
-  IL_0023:  br.s       IL_0029
-  IL_0025:  ldc.i4.0
-  IL_0026:  stloc.1
-  IL_0027:  br.s       IL_0029
-  IL_0029:  ldloc.1
-  IL_002a:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       43 (0x2b)
+      .maxstack  2
+      .locals init (bool V_0,
+                    int V_1)
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  ldc.i4.s   97
+      IL_0004:  blt.s      IL_000d
+      IL_0006:  ldarg.0
+      IL_0007:  ldc.i4.s   122
+      IL_0009:  ble.s      IL_0019
+      IL_000b:  br.s       IL_001c
+      IL_000d:  ldarg.0
+      IL_000e:  ldc.i4.s   65
+      IL_0010:  blt.s      IL_001c
+      IL_0012:  ldarg.0
+      IL_0013:  ldc.i4.s   90
+      IL_0015:  ble.s      IL_0019
+      IL_0017:  br.s       IL_001c
+      IL_0019:  ldc.i4.1
+      IL_001a:  br.s       IL_001d
+      IL_001c:  ldc.i4.0
+      IL_001d:  stloc.0
+      IL_001e:  ldloc.0
+      IL_001f:  brfalse.s  IL_0025
+      IL_0021:  ldc.i4.1
+      IL_0022:  stloc.1
+      IL_0023:  br.s       IL_0029
+      IL_0025:  ldc.i4.0
+      IL_0026:  stloc.1
+      IL_0027:  br.s       IL_0029
+      IL_0029:  ldloc.1
+      IL_002a:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       44 (0x2c)
@@ -6070,29 +6070,29 @@ class C
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       26 (0x1a)
-  .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.s   97
-  IL_0003:  blt.s      IL_000c
-  IL_0005:  ldarg.0
-  IL_0006:  ldc.i4.s   122
-  IL_0008:  ble.s      IL_0016
-  IL_000a:  br.s       IL_0018
-  IL_000c:  ldarg.0
-  IL_000d:  ldc.i4.s   65
-  IL_000f:  blt.s      IL_0018
-  IL_0011:  ldarg.0
-  IL_0012:  ldc.i4.s   90
-  IL_0014:  bgt.s      IL_0018
-  IL_0016:  ldc.i4.1
-  IL_0017:  ret
-  IL_0018:  ldc.i4.0
-  IL_0019:  ret
-}
-""");
+            compVerifier.VerifyIL("C.M1", @"
+    {
+      // Code size       26 (0x1a)
+      .maxstack  2
+      IL_0000:  ldarg.0
+      IL_0001:  ldc.i4.s   97
+      IL_0003:  blt.s      IL_000c
+      IL_0005:  ldarg.0
+      IL_0006:  ldc.i4.s   122
+      IL_0008:  ble.s      IL_0016
+      IL_000a:  br.s       IL_0018
+      IL_000c:  ldarg.0
+      IL_000d:  ldc.i4.s   65
+      IL_000f:  blt.s      IL_0018
+      IL_0011:  ldarg.0
+      IL_0012:  ldc.i4.s   90
+      IL_0014:  bgt.s      IL_0018
+      IL_0016:  ldc.i4.1
+      IL_0017:  ret
+      IL_0018:  ldc.i4.0
+      IL_0019:  ret
+    }
+");
             compVerifier.VerifyIL("C.M2", @"
     {
       // Code size       24 (0x18)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -7125,7 +7125,7 @@ namespace ConsoleApplication24
   IL_0760:  ret
 }";
             compVerifier.VerifyIL("ConsoleApplication24.Program.IsWarning", codeForSwitchStatement);
-            compVerifier.VerifyIL("ConsoleApplication24.Program.IsWarning_IsExpression", codeForExpression);
+            compVerifier.VerifyIL("ConsoleApplication24.Program.IsWarning_IsExpression", codeForSwitchStatement);
             compVerifier.VerifyIL("ConsoleApplication24.Program.IsWarning_SwitchExpression", codeForExpression);
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
@@ -8445,33 +8445,32 @@ ref struct S
 False
 False
 False")
-                .VerifyIL("C.Test", """
+                .VerifyIL("C.Test", @"
 {
   // Code size       55 (0x37)
   .maxstack  2
   .locals init (System.ReadOnlySpan<char> V_0)
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       "readonly bool S.Prop.get"
+  IL_0002:  call       ""readonly bool S.Prop.get""
   IL_0007:  brfalse.s  IL_002f
   IL_0009:  ldarga.s   V_0
-  IL_000b:  call       "readonly System.ReadOnlySpan<char> S.Span.get"
+  IL_000b:  call       ""readonly System.ReadOnlySpan<char> S.Span.get""
   IL_0010:  stloc.0
   IL_0011:  ldloc.0
-  IL_0012:  ldstr      "string 1"
-  IL_0017:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_001c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0012:  ldstr      ""string 1""
+  IL_0017:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_001c:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
   IL_0021:  brfalse.s  IL_002f
   IL_0023:  ldloca.s   V_0
-  IL_0025:  call       "int System.ReadOnlySpan<char>.Length.get"
+  IL_0025:  call       ""int System.ReadOnlySpan<char>.Length.get""
   IL_002a:  ldc.i4.8
   IL_002b:  ceq
   IL_002d:  br.s       IL_0030
   IL_002f:  ldc.i4.0
-  IL_0030:  call       "void System.Console.WriteLine(bool)"
+  IL_0030:  call       ""void System.Console.WriteLine(bool)""
   IL_0035:  nop
   IL_0036:  ret
-}
-""");
+}");
         }
 
         [Fact]
@@ -8885,56 +8884,55 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", """
+                .VerifyIL("C.Test", @"
 {
   // Code size      159 (0x9f)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      "1."
+  IL_0000:  ldstr      ""1.""
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      ""
-  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0006:  ldstr      """"
+  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       "string bool.ToString()"
-  IL_001d:  call       "string string.Concat(string, string)"
-  IL_0022:  call       "void System.Console.WriteLine(string)"
-  IL_0027:  ldstr      "2."
+  IL_0018:  call       ""string bool.ToString()""
+  IL_001d:  call       ""string string.Concat(string, string)""
+  IL_0022:  call       ""void System.Console.WriteLine(string)""
+  IL_0027:  ldstr      ""2.""
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      ""
-  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_002d:  ldstr      """"
+  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       "string bool.ToString()"
-  IL_0044:  call       "string string.Concat(string, string)"
-  IL_0049:  call       "void System.Console.WriteLine(string)"
-  IL_004e:  ldstr      "3."
+  IL_003f:  call       ""string bool.ToString()""
+  IL_0044:  call       ""string string.Concat(string, string)""
+  IL_0049:  call       ""void System.Console.WriteLine(string)""
+  IL_004e:  ldstr      ""3.""
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      ""
-  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0054:  ldstr      """"
+  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       "string bool.ToString()"
-  IL_006b:  call       "string string.Concat(string, string)"
-  IL_0070:  call       "void System.Console.WriteLine(string)"
-  IL_0075:  ldstr      "4."
+  IL_0066:  call       ""string bool.ToString()""
+  IL_006b:  call       ""string string.Concat(string, string)""
+  IL_0070:  call       ""void System.Console.WriteLine(string)""
+  IL_0075:  ldstr      ""4.""
   IL_007a:  ldarg.0
-  IL_007b:  ldstr      ""
-  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_007b:  ldstr      """"
+  IL_0080:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0085:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
   IL_008a:  pop
   IL_008b:  ldc.i4.1
   IL_008c:  stloc.0
   IL_008d:  ldloca.s   V_0
-  IL_008f:  call       "string bool.ToString()"
-  IL_0094:  call       "string string.Concat(string, string)"
-  IL_0099:  call       "void System.Console.WriteLine(string)"
+  IL_008f:  call       ""string bool.ToString()""
+  IL_0094:  call       ""string string.Concat(string, string)""
+  IL_0099:  call       ""void System.Console.WriteLine(string)""
   IL_009e:  ret
-}
-""");
+}");
         }
 
         [Fact]
@@ -10488,56 +10486,55 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", """
+                .VerifyIL("C.Test", @"
 {
   // Code size      159 (0x9f)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      "1."
+  IL_0000:  ldstr      ""1.""
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      ""
-  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0006:  ldstr      """"
+  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       "string bool.ToString()"
-  IL_001d:  call       "string string.Concat(string, string)"
-  IL_0022:  call       "void System.Console.WriteLine(string)"
-  IL_0027:  ldstr      "2."
+  IL_0018:  call       ""string bool.ToString()""
+  IL_001d:  call       ""string string.Concat(string, string)""
+  IL_0022:  call       ""void System.Console.WriteLine(string)""
+  IL_0027:  ldstr      ""2.""
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      ""
-  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_002d:  ldstr      """"
+  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       "string bool.ToString()"
-  IL_0044:  call       "string string.Concat(string, string)"
-  IL_0049:  call       "void System.Console.WriteLine(string)"
-  IL_004e:  ldstr      "3."
+  IL_003f:  call       ""string bool.ToString()""
+  IL_0044:  call       ""string string.Concat(string, string)""
+  IL_0049:  call       ""void System.Console.WriteLine(string)""
+  IL_004e:  ldstr      ""3.""
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      ""
-  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0054:  ldstr      """"
+  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       "string bool.ToString()"
-  IL_006b:  call       "string string.Concat(string, string)"
-  IL_0070:  call       "void System.Console.WriteLine(string)"
-  IL_0075:  ldstr      "4."
+  IL_0066:  call       ""string bool.ToString()""
+  IL_006b:  call       ""string string.Concat(string, string)""
+  IL_0070:  call       ""void System.Console.WriteLine(string)""
+  IL_0075:  ldstr      ""4.""
   IL_007a:  ldarg.0
-  IL_007b:  ldstr      ""
-  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_007b:  ldstr      """"
+  IL_0080:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
+  IL_0085:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
   IL_008a:  pop
   IL_008b:  ldc.i4.1
   IL_008c:  stloc.0
   IL_008d:  ldloca.s   V_0
-  IL_008f:  call       "string bool.ToString()"
-  IL_0094:  call       "string string.Concat(string, string)"
-  IL_0099:  call       "void System.Console.WriteLine(string)"
+  IL_008f:  call       ""string bool.ToString()""
+  IL_0094:  call       ""string string.Concat(string, string)""
+  IL_0099:  call       ""void System.Console.WriteLine(string)""
   IL_009e:  ret
-}
-""");
+}");
         }
 
         [Fact]
@@ -11590,7 +11587,7 @@ static class C
             var verifier = CompileAndVerify(comp, expectedOutput: "True");
             // Note: the important thing is that we now assign `System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3`
             // in the exception filter (at IL_00b6) before accessing `.InnerException` on it.
-            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
+            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
   // Code size      460 (0x1cc)
   .maxstack  3
@@ -11605,7 +11602,7 @@ static class C
                 int V_8,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_9)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_0001:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
   IL_0006:  stloc.0
   .try
   {
@@ -11621,7 +11618,7 @@ static class C
     IL_0019:  nop
     IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
-    IL_001c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+    IL_001c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
     IL_0021:  nop
     .try
     {
@@ -11630,42 +11627,42 @@ static class C
       IL_0025:  br.s       IL_0029
       IL_0027:  br.s       IL_0065
       IL_0029:  nop
-      IL_002a:  call       "System.Threading.Tasks.Task C.ThrowException()"
-      IL_002f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()"
+      IL_002a:  call       ""System.Threading.Tasks.Task C.ThrowException()""
+      IL_002f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
       IL_0034:  stloc.2
       IL_0035:  ldloca.s   V_2
-      IL_0037:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
+      IL_0037:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
       IL_003c:  brtrue.s   IL_0081
       IL_003e:  ldarg.0
       IL_003f:  ldc.i4.0
       IL_0040:  dup
       IL_0041:  stloc.0
-      IL_0042:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_0042:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
       IL_0047:  ldarg.0
       IL_0048:  ldloc.2
-      IL_0049:  stfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0049:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
       IL_004e:  ldarg.0
       IL_004f:  stloc.3
       IL_0050:  ldarg.0
-      IL_0051:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+      IL_0051:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
       IL_0056:  ldloca.s   V_2
       IL_0058:  ldloca.s   V_3
-      IL_005a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)"
+      IL_005a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)""
       IL_005f:  nop
       IL_0060:  leave      IL_01cb
       IL_0065:  ldarg.0
-      IL_0066:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0066:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
       IL_006b:  stloc.2
       IL_006c:  ldarg.0
-      IL_006d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
-      IL_0072:  initobj    "System.Runtime.CompilerServices.TaskAwaiter"
+      IL_006d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
+      IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
       IL_0078:  ldarg.0
       IL_0079:  ldc.i4.m1
       IL_007a:  dup
       IL_007b:  stloc.0
-      IL_007c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_007c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
       IL_0081:  ldloca.s   V_2
-      IL_0083:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
+      IL_0083:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
       IL_0088:  nop
       IL_0089:  ldc.i4.1
       IL_008a:  stloc.1
@@ -11673,7 +11670,7 @@ static class C
     }
     filter
     {
-      IL_0090:  isinst     "System.Exception"
+      IL_0090:  isinst     ""System.Exception""
       IL_0095:  dup
       IL_0096:  brtrue.s   IL_009c
       IL_0098:  pop
@@ -11682,28 +11679,28 @@ static class C
       IL_009c:  stloc.s    V_4
       IL_009e:  ldarg.0
       IL_009f:  ldloc.s    V_4
-      IL_00a1:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+      IL_00a1:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
       IL_00a6:  ldarg.0
       IL_00a7:  ldarg.0
-      IL_00a8:  ldfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
-      IL_00ad:  castclass  "System.Exception"
-      IL_00b2:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+      IL_00a8:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
+      IL_00ad:  castclass  ""System.Exception""
+      IL_00b2:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
       IL_00b7:  ldarg.0
-      IL_00b8:  ldfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
-      IL_00bd:  callvirt   "System.Exception System.Exception.InnerException.get"
+      IL_00b8:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
+      IL_00bd:  callvirt   ""System.Exception System.Exception.InnerException.get""
       IL_00c2:  stloc.s    V_6
       IL_00c4:  ldloc.s    V_6
       IL_00c6:  brfalse.s  IL_00f2
       IL_00c8:  ldloc.s    V_6
-      IL_00ca:  callvirt   "string System.Exception.Message.get"
+      IL_00ca:  callvirt   ""string System.Exception.Message.get""
       IL_00cf:  stloc.s    V_7
       IL_00d1:  ldloc.s    V_7
-      IL_00d3:  ldstr      "bad dog"
-      IL_00d8:  call       "bool string.op_Equality(string, string)"
+      IL_00d3:  ldstr      ""bad dog""
+      IL_00d8:  call       ""bool string.op_Equality(string, string)""
       IL_00dd:  brtrue.s   IL_00ef
       IL_00df:  ldloc.s    V_7
-      IL_00e1:  ldstr      "dog bad"
-      IL_00e6:  call       "bool string.op_Equality(string, string)"
+      IL_00e1:  ldstr      ""dog bad""
+      IL_00e6:  call       ""bool string.op_Equality(string, string)""
       IL_00eb:  brtrue.s   IL_00ef
       IL_00ed:  br.s       IL_00f2
       IL_00ef:  ldc.i4.1
@@ -11719,7 +11716,7 @@ static class C
       IL_00fc:  pop
       IL_00fd:  ldarg.0
       IL_00fe:  ldc.i4.1
-      IL_00ff:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+      IL_00ff:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
       IL_0104:  leave.s    IL_010f
     }
     catch object
@@ -11731,61 +11728,61 @@ static class C
       IL_010a:  leave      IL_01b6
     }
     IL_010f:  ldarg.0
-    IL_0110:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+    IL_0110:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
     IL_0115:  stloc.s    V_8
     IL_0117:  ldloc.s    V_8
     IL_0119:  ldc.i4.1
     IL_011a:  beq.s      IL_011e
     IL_011c:  br.s       IL_018c
     IL_011e:  nop
-    IL_011f:  call       "System.Threading.Tasks.Task<bool> C.TrueAsync()"
-    IL_0124:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()"
+    IL_011f:  call       ""System.Threading.Tasks.Task<bool> C.TrueAsync()""
+    IL_0124:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
     IL_0129:  stloc.s    V_9
     IL_012b:  ldloca.s   V_9
-    IL_012d:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get"
+    IL_012d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
     IL_0132:  brtrue.s   IL_0176
     IL_0134:  ldarg.0
     IL_0135:  ldc.i4.1
     IL_0136:  dup
     IL_0137:  stloc.0
-    IL_0138:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_0138:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_013d:  ldarg.0
     IL_013e:  ldloc.s    V_9
-    IL_0140:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0140:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
     IL_0145:  ldarg.0
     IL_0146:  stloc.3
     IL_0147:  ldarg.0
-    IL_0148:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_0148:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
     IL_014d:  ldloca.s   V_9
     IL_014f:  ldloca.s   V_3
-    IL_0151:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)"
+    IL_0151:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)""
     IL_0156:  nop
     IL_0157:  leave.s    IL_01cb
     IL_0159:  ldarg.0
-    IL_015a:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_015a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
     IL_015f:  stloc.s    V_9
     IL_0161:  ldarg.0
-    IL_0162:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
-    IL_0167:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<bool>"
+    IL_0162:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
+    IL_0167:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
     IL_016d:  ldarg.0
     IL_016e:  ldc.i4.m1
     IL_016f:  dup
     IL_0170:  stloc.0
-    IL_0171:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_0171:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_0176:  ldarg.0
     IL_0177:  ldloca.s   V_9
-    IL_0179:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()"
-    IL_017e:  stfld      "bool C.<ExceptionFilterBroken>d__1.<>s__4"
+    IL_0179:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_017e:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
     IL_0183:  ldarg.0
-    IL_0184:  ldfld      "bool C.<ExceptionFilterBroken>d__1.<>s__4"
+    IL_0184:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
     IL_0189:  stloc.1
     IL_018a:  leave.s    IL_01b6
     IL_018c:  ldarg.0
     IL_018d:  ldnull
-    IL_018e:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+    IL_018e:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
     IL_0193:  ldarg.0
     IL_0194:  ldnull
-    IL_0195:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+    IL_0195:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
     IL_019a:  leave.s    IL_01b6
   }
   catch System.Exception
@@ -11793,25 +11790,25 @@ static class C
     IL_019c:  stloc.s    V_6
     IL_019e:  ldarg.0
     IL_019f:  ldc.i4.s   -2
-    IL_01a1:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_01a1:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_01a6:  ldarg.0
-    IL_01a7:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_01a7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
     IL_01ac:  ldloc.s    V_6
-    IL_01ae:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)"
+    IL_01ae:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)""
     IL_01b3:  nop
     IL_01b4:  leave.s    IL_01cb
   }
   IL_01b6:  ldarg.0
   IL_01b7:  ldc.i4.s   -2
-  IL_01b9:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_01b9:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
   IL_01be:  ldarg.0
-  IL_01bf:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+  IL_01bf:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
   IL_01c4:  ldloc.1
-  IL_01c5:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)"
+  IL_01c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)""
   IL_01ca:  nop
   IL_01cb:  ret
 }
-""");
+");
         }
 
         [Fact, WorkItem(59050, "https://github.com/dotnet/roslyn/issues/59050")]
@@ -11935,7 +11932,7 @@ static class C
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "True");
-            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
+            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
   // Code size      513 (0x201)
   .maxstack  3
@@ -11951,7 +11948,7 @@ static class C
                 string V_9,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_10)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_0001:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
   IL_0006:  stloc.0
   .try
   {
@@ -11967,7 +11964,7 @@ static class C
     IL_0019:  nop
     IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
-    IL_001c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+    IL_001c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
     IL_0021:  nop
     .try
     {
@@ -11976,42 +11973,42 @@ static class C
       IL_0025:  br.s       IL_0029
       IL_0027:  br.s       IL_0065
       IL_0029:  nop
-      IL_002a:  call       "System.Threading.Tasks.Task C.ThrowException()"
-      IL_002f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()"
+      IL_002a:  call       ""System.Threading.Tasks.Task C.ThrowException()""
+      IL_002f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
       IL_0034:  stloc.2
       IL_0035:  ldloca.s   V_2
-      IL_0037:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
+      IL_0037:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
       IL_003c:  brtrue.s   IL_0081
       IL_003e:  ldarg.0
       IL_003f:  ldc.i4.0
       IL_0040:  dup
       IL_0041:  stloc.0
-      IL_0042:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_0042:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
       IL_0047:  ldarg.0
       IL_0048:  ldloc.2
-      IL_0049:  stfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0049:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
       IL_004e:  ldarg.0
       IL_004f:  stloc.3
       IL_0050:  ldarg.0
-      IL_0051:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+      IL_0051:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
       IL_0056:  ldloca.s   V_2
       IL_0058:  ldloca.s   V_3
-      IL_005a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)"
+      IL_005a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)""
       IL_005f:  nop
       IL_0060:  leave      IL_0200
       IL_0065:  ldarg.0
-      IL_0066:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0066:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
       IL_006b:  stloc.2
       IL_006c:  ldarg.0
-      IL_006d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
-      IL_0072:  initobj    "System.Runtime.CompilerServices.TaskAwaiter"
+      IL_006d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
+      IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
       IL_0078:  ldarg.0
       IL_0079:  ldc.i4.m1
       IL_007a:  dup
       IL_007b:  stloc.0
-      IL_007c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_007c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
       IL_0081:  ldloca.s   V_2
-      IL_0083:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
+      IL_0083:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
       IL_0088:  nop
       IL_0089:  ldc.i4.1
       IL_008a:  stloc.1
@@ -12022,14 +12019,14 @@ static class C
       IL_0090:  stloc.s    V_4
       IL_0092:  ldarg.0
       IL_0093:  ldloc.s    V_4
-      IL_0095:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+      IL_0095:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
       IL_009a:  ldarg.0
       IL_009b:  ldc.i4.1
-      IL_009c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+      IL_009c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
       IL_00a1:  leave.s    IL_00a3
     }
     IL_00a3:  ldarg.0
-    IL_00a4:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+    IL_00a4:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
     IL_00a9:  stloc.s    V_5
     IL_00ab:  ldloc.s    V_5
     IL_00ad:  ldc.i4.1
@@ -12037,22 +12034,22 @@ static class C
     IL_00b0:  br         IL_01c8
     IL_00b5:  ldarg.0
     IL_00b6:  ldarg.0
-    IL_00b7:  ldfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
-    IL_00bc:  castclass  "System.Exception"
-    IL_00c1:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+    IL_00b7:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
+    IL_00bc:  castclass  ""System.Exception""
+    IL_00c1:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
     IL_00c6:  nop
     IL_00c7:  ldarg.0
     IL_00c8:  ldc.i4.0
-    IL_00c9:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
+    IL_00c9:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
     .try
     {
       IL_00ce:  nop
-      IL_00cf:  newobj     "System.Exception..ctor()"
+      IL_00cf:  newobj     ""System.Exception..ctor()""
       IL_00d4:  throw
     }
     filter
     {
-      IL_00d5:  isinst     "System.Exception"
+      IL_00d5:  isinst     ""System.Exception""
       IL_00da:  dup
       IL_00db:  brtrue.s   IL_00e1
       IL_00dd:  pop
@@ -12061,23 +12058,23 @@ static class C
       IL_00e1:  stloc.s    V_6
       IL_00e3:  ldarg.0
       IL_00e4:  ldloc.s    V_6
-      IL_00e6:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__4"
+      IL_00e6:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
       IL_00eb:  ldarg.0
-      IL_00ec:  ldfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
-      IL_00f1:  callvirt   "System.Exception System.Exception.InnerException.get"
+      IL_00ec:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
+      IL_00f1:  callvirt   ""System.Exception System.Exception.InnerException.get""
       IL_00f6:  stloc.s    V_8
       IL_00f8:  ldloc.s    V_8
       IL_00fa:  brfalse.s  IL_0126
       IL_00fc:  ldloc.s    V_8
-      IL_00fe:  callvirt   "string System.Exception.Message.get"
+      IL_00fe:  callvirt   ""string System.Exception.Message.get""
       IL_0103:  stloc.s    V_9
       IL_0105:  ldloc.s    V_9
-      IL_0107:  ldstr      "bad dog"
-      IL_010c:  call       "bool string.op_Equality(string, string)"
+      IL_0107:  ldstr      ""bad dog""
+      IL_010c:  call       ""bool string.op_Equality(string, string)""
       IL_0111:  brtrue.s   IL_0123
       IL_0113:  ldloc.s    V_9
-      IL_0115:  ldstr      "dog bad"
-      IL_011a:  call       "bool string.op_Equality(string, string)"
+      IL_0115:  ldstr      ""dog bad""
+      IL_011a:  call       ""bool string.op_Equality(string, string)""
       IL_011f:  brtrue.s   IL_0123
       IL_0121:  br.s       IL_0126
       IL_0123:  ldc.i4.1
@@ -12093,70 +12090,70 @@ static class C
       IL_0130:  pop
       IL_0131:  ldarg.0
       IL_0132:  ldc.i4.1
-      IL_0133:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
+      IL_0133:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
       IL_0138:  leave.s    IL_013a
     }
     IL_013a:  ldarg.0
-    IL_013b:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
+    IL_013b:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
     IL_0140:  stloc.s    V_5
     IL_0142:  ldloc.s    V_5
     IL_0144:  ldc.i4.1
     IL_0145:  beq.s      IL_0149
     IL_0147:  br.s       IL_01b7
     IL_0149:  nop
-    IL_014a:  call       "System.Threading.Tasks.Task<bool> C.TrueAsync()"
-    IL_014f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()"
+    IL_014a:  call       ""System.Threading.Tasks.Task<bool> C.TrueAsync()""
+    IL_014f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
     IL_0154:  stloc.s    V_10
     IL_0156:  ldloca.s   V_10
-    IL_0158:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get"
+    IL_0158:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
     IL_015d:  brtrue.s   IL_01a1
     IL_015f:  ldarg.0
     IL_0160:  ldc.i4.1
     IL_0161:  dup
     IL_0162:  stloc.0
-    IL_0163:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_0163:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_0168:  ldarg.0
     IL_0169:  ldloc.s    V_10
-    IL_016b:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_016b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
     IL_0170:  ldarg.0
     IL_0171:  stloc.3
     IL_0172:  ldarg.0
-    IL_0173:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_0173:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
     IL_0178:  ldloca.s   V_10
     IL_017a:  ldloca.s   V_3
-    IL_017c:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)"
+    IL_017c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)""
     IL_0181:  nop
     IL_0182:  leave.s    IL_0200
     IL_0184:  ldarg.0
-    IL_0185:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0185:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
     IL_018a:  stloc.s    V_10
     IL_018c:  ldarg.0
-    IL_018d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
-    IL_0192:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<bool>"
+    IL_018d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
+    IL_0192:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
     IL_0198:  ldarg.0
     IL_0199:  ldc.i4.m1
     IL_019a:  dup
     IL_019b:  stloc.0
-    IL_019c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_019c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_01a1:  ldarg.0
     IL_01a2:  ldloca.s   V_10
-    IL_01a4:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()"
-    IL_01a9:  stfld      "bool C.<ExceptionFilterBroken>d__1.<>s__6"
+    IL_01a4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_01a9:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
     IL_01ae:  ldarg.0
-    IL_01af:  ldfld      "bool C.<ExceptionFilterBroken>d__1.<>s__6"
+    IL_01af:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
     IL_01b4:  stloc.1
     IL_01b5:  leave.s    IL_01eb
     IL_01b7:  ldarg.0
     IL_01b8:  ldnull
-    IL_01b9:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__4"
+    IL_01b9:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
     IL_01be:  nop
     IL_01bf:  ldarg.0
     IL_01c0:  ldnull
-    IL_01c1:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+    IL_01c1:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
     IL_01c6:  br.s       IL_01c8
     IL_01c8:  ldarg.0
     IL_01c9:  ldnull
-    IL_01ca:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+    IL_01ca:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
     IL_01cf:  leave.s    IL_01eb
   }
   catch System.Exception
@@ -12164,25 +12161,25 @@ static class C
     IL_01d1:  stloc.s    V_8
     IL_01d3:  ldarg.0
     IL_01d4:  ldc.i4.s   -2
-    IL_01d6:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_01d6:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
     IL_01db:  ldarg.0
-    IL_01dc:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_01dc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
     IL_01e1:  ldloc.s    V_8
-    IL_01e3:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)"
+    IL_01e3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)""
     IL_01e8:  nop
     IL_01e9:  leave.s    IL_0200
   }
   IL_01eb:  ldarg.0
   IL_01ec:  ldc.i4.s   -2
-  IL_01ee:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_01ee:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
   IL_01f3:  ldarg.0
-  IL_01f4:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+  IL_01f4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
   IL_01f9:  ldloc.1
-  IL_01fa:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)"
+  IL_01fa:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)""
   IL_01ff:  nop
   IL_0200:  ret
 }
-""");
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
@@ -8354,64 +8354,63 @@ and: False
 not: True")
                 .VerifyIL("C.Test", """
 {
-  // Code size      167 (0xa7)
+  // Code size      166 (0xa6)
   .maxstack  3
   .locals init (bool V_0)
   IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  ldstr      "string 1"
-  IL_0007:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_000c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0011:  brtrue.s   IL_0027
-  IL_0013:  ldarg.0
-  IL_0014:  ldstr      "string 2"
-  IL_0019:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_001e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0023:  brtrue.s   IL_0027
-  IL_0025:  br.s       IL_002b
-  IL_0027:  ldc.i4.1
-  IL_0028:  stloc.0
-  IL_0029:  br.s       IL_002d
-  IL_002b:  ldc.i4.0
-  IL_002c:  stloc.0
-  IL_002d:  ldstr      "or: "
-  IL_0032:  ldloca.s   V_0
-  IL_0034:  call       "string bool.ToString()"
-  IL_0039:  call       "string string.Concat(string, string)"
-  IL_003e:  call       "void System.Console.WriteLine(string)"
-  IL_0043:  nop
-  IL_0044:  ldstr      "and: "
-  IL_0049:  ldarg.0
-  IL_004a:  ldstr      "string 1"
-  IL_004f:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0054:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0059:  brfalse.s  IL_0067
-  IL_005b:  ldarga.s   V_0
-  IL_005d:  call       "int System.ReadOnlySpan<char>.Length.get"
-  IL_0062:  ldc.i4.7
-  IL_0063:  ceq
-  IL_0065:  br.s       IL_0068
-  IL_0067:  ldc.i4.0
-  IL_0068:  stloc.0
-  IL_0069:  ldloca.s   V_0
-  IL_006b:  call       "string bool.ToString()"
-  IL_0070:  call       "string string.Concat(string, string)"
-  IL_0075:  call       "void System.Console.WriteLine(string)"
-  IL_007a:  nop
-  IL_007b:  ldstr      "not: "
-  IL_0080:  ldarg.0
-  IL_0081:  ldstr      "string 1"
-  IL_0086:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_008b:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
-  IL_0090:  ldc.i4.0
-  IL_0091:  ceq
-  IL_0093:  stloc.0
-  IL_0094:  ldloca.s   V_0
-  IL_0096:  call       "string bool.ToString()"
-  IL_009b:  call       "string string.Concat(string, string)"
-  IL_00a0:  call       "void System.Console.WriteLine(string)"
-  IL_00a5:  nop
-  IL_00a6:  ret
+  IL_0001:  ldstr      "or: "
+  IL_0006:  ldarg.0
+  IL_0007:  ldstr      "string 1"
+  IL_000c:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0011:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0016:  brtrue.s   IL_002c
+  IL_0018:  ldarg.0
+  IL_0019:  ldstr      "string 2"
+  IL_001e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0023:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0028:  brtrue.s   IL_002c
+  IL_002a:  br.s       IL_002f
+  IL_002c:  ldc.i4.1
+  IL_002d:  br.s       IL_0030
+  IL_002f:  ldc.i4.0
+  IL_0030:  stloc.0
+  IL_0031:  ldloca.s   V_0
+  IL_0033:  call       "string bool.ToString()"
+  IL_0038:  call       "string string.Concat(string, string)"
+  IL_003d:  call       "void System.Console.WriteLine(string)"
+  IL_0042:  nop
+  IL_0043:  ldstr      "and: "
+  IL_0048:  ldarg.0
+  IL_0049:  ldstr      "string 1"
+  IL_004e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0053:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_0058:  brfalse.s  IL_0066
+  IL_005a:  ldarga.s   V_0
+  IL_005c:  call       "int System.ReadOnlySpan<char>.Length.get"
+  IL_0061:  ldc.i4.7
+  IL_0062:  ceq
+  IL_0064:  br.s       IL_0067
+  IL_0066:  ldc.i4.0
+  IL_0067:  stloc.0
+  IL_0068:  ldloca.s   V_0
+  IL_006a:  call       "string bool.ToString()"
+  IL_006f:  call       "string string.Concat(string, string)"
+  IL_0074:  call       "void System.Console.WriteLine(string)"
+  IL_0079:  nop
+  IL_007a:  ldstr      "not: "
+  IL_007f:  ldarg.0
+  IL_0080:  ldstr      "string 1"
+  IL_0085:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_008a:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_008f:  ldc.i4.0
+  IL_0090:  ceq
+  IL_0092:  stloc.0
+  IL_0093:  ldloca.s   V_0
+  IL_0095:  call       "string bool.ToString()"
+  IL_009a:  call       "string string.Concat(string, string)"
+  IL_009f:  call       "void System.Console.WriteLine(string)"
+  IL_00a4:  nop
+  IL_00a5:  ret
 }
 """);
         }
@@ -8446,32 +8445,33 @@ ref struct S
 False
 False
 False")
-                .VerifyIL("C.Test", @"
+                .VerifyIL("C.Test", """
 {
   // Code size       55 (0x37)
   .maxstack  2
   .locals init (System.ReadOnlySpan<char> V_0)
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""readonly bool S.Prop.get""
+  IL_0002:  call       "readonly bool S.Prop.get"
   IL_0007:  brfalse.s  IL_002f
   IL_0009:  ldarga.s   V_0
-  IL_000b:  call       ""readonly System.ReadOnlySpan<char> S.Span.get""
+  IL_000b:  call       "readonly System.ReadOnlySpan<char> S.Span.get"
   IL_0010:  stloc.0
   IL_0011:  ldloc.0
-  IL_0012:  ldstr      ""string 1""
-  IL_0017:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_001c:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_0012:  ldstr      "string 1"
+  IL_0017:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_001c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_0021:  brfalse.s  IL_002f
   IL_0023:  ldloca.s   V_0
-  IL_0025:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0025:  call       "int System.ReadOnlySpan<char>.Length.get"
   IL_002a:  ldc.i4.8
   IL_002b:  ceq
   IL_002d:  br.s       IL_0030
   IL_002f:  ldc.i4.0
-  IL_0030:  call       ""void System.Console.WriteLine(bool)""
+  IL_0030:  call       "void System.Console.WriteLine(bool)"
   IL_0035:  nop
   IL_0036:  ret
-}");
+}
+""");
         }
 
         [Fact]
@@ -8885,55 +8885,56 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", @"
+                .VerifyIL("C.Test", """
 {
   // Code size      159 (0x9f)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      ""1.""
+  IL_0000:  ldstr      "1."
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      """"
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_0006:  ldstr      ""
+  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""string bool.ToString()""
-  IL_001d:  call       ""string string.Concat(string, string)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ldstr      ""2.""
+  IL_0018:  call       "string bool.ToString()"
+  IL_001d:  call       "string string.Concat(string, string)"
+  IL_0022:  call       "void System.Console.WriteLine(string)"
+  IL_0027:  ldstr      "2."
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      """"
-  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_002d:  ldstr      ""
+  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       ""string bool.ToString()""
-  IL_0044:  call       ""string string.Concat(string, string)""
-  IL_0049:  call       ""void System.Console.WriteLine(string)""
-  IL_004e:  ldstr      ""3.""
+  IL_003f:  call       "string bool.ToString()"
+  IL_0044:  call       "string string.Concat(string, string)"
+  IL_0049:  call       "void System.Console.WriteLine(string)"
+  IL_004e:  ldstr      "3."
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      """"
-  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_0054:  ldstr      ""
+  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       ""string bool.ToString()""
-  IL_006b:  call       ""string string.Concat(string, string)""
-  IL_0070:  call       ""void System.Console.WriteLine(string)""
-  IL_0075:  ldarg.0
-  IL_0076:  ldstr      """"
-  IL_007b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0080:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
-  IL_0085:  pop
-  IL_0086:  ldc.i4.1
-  IL_0087:  stloc.0
-  IL_0088:  ldstr      ""4.""
+  IL_0066:  call       "string bool.ToString()"
+  IL_006b:  call       "string string.Concat(string, string)"
+  IL_0070:  call       "void System.Console.WriteLine(string)"
+  IL_0075:  ldstr      "4."
+  IL_007a:  ldarg.0
+  IL_007b:  ldstr      ""
+  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
+  IL_008a:  pop
+  IL_008b:  ldc.i4.1
+  IL_008c:  stloc.0
   IL_008d:  ldloca.s   V_0
-  IL_008f:  call       ""string bool.ToString()""
-  IL_0094:  call       ""string string.Concat(string, string)""
-  IL_0099:  call       ""void System.Console.WriteLine(string)""
+  IL_008f:  call       "string bool.ToString()"
+  IL_0094:  call       "string string.Concat(string, string)"
+  IL_0099:  call       "void System.Console.WriteLine(string)"
   IL_009e:  ret
-}");
+}
+""");
         }
 
         [Fact]
@@ -9952,64 +9953,63 @@ and: False
 not: True")
                 .VerifyIL("C.Test", """
 {
-  // Code size      167 (0xa7)
+  // Code size      166 (0xa6)
   .maxstack  3
   .locals init (bool V_0)
   IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  ldstr      "string 1"
-  IL_0007:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_000c:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0011:  brtrue.s   IL_0027
-  IL_0013:  ldarg.0
-  IL_0014:  ldstr      "string 2"
-  IL_0019:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_001e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0023:  brtrue.s   IL_0027
-  IL_0025:  br.s       IL_002b
-  IL_0027:  ldc.i4.1
-  IL_0028:  stloc.0
-  IL_0029:  br.s       IL_002d
-  IL_002b:  ldc.i4.0
-  IL_002c:  stloc.0
-  IL_002d:  ldstr      "or: "
-  IL_0032:  ldloca.s   V_0
-  IL_0034:  call       "string bool.ToString()"
-  IL_0039:  call       "string string.Concat(string, string)"
-  IL_003e:  call       "void System.Console.WriteLine(string)"
-  IL_0043:  nop
-  IL_0044:  ldstr      "and: "
-  IL_0049:  ldarg.0
-  IL_004a:  ldstr      "string 1"
-  IL_004f:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_0054:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0059:  brfalse.s  IL_0067
-  IL_005b:  ldarga.s   V_0
-  IL_005d:  call       "int System.Span<char>.Length.get"
-  IL_0062:  ldc.i4.7
-  IL_0063:  ceq
-  IL_0065:  br.s       IL_0068
-  IL_0067:  ldc.i4.0
-  IL_0068:  stloc.0
-  IL_0069:  ldloca.s   V_0
-  IL_006b:  call       "string bool.ToString()"
-  IL_0070:  call       "string string.Concat(string, string)"
-  IL_0075:  call       "void System.Console.WriteLine(string)"
-  IL_007a:  nop
-  IL_007b:  ldstr      "not: "
-  IL_0080:  ldarg.0
-  IL_0081:  ldstr      "string 1"
-  IL_0086:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
-  IL_008b:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
-  IL_0090:  ldc.i4.0
-  IL_0091:  ceq
-  IL_0093:  stloc.0
-  IL_0094:  ldloca.s   V_0
-  IL_0096:  call       "string bool.ToString()"
-  IL_009b:  call       "string string.Concat(string, string)"
-  IL_00a0:  call       "void System.Console.WriteLine(string)"
-  IL_00a5:  nop
-  IL_00a6:  ret
+  IL_0001:  ldstr      "or: "
+  IL_0006:  ldarg.0
+  IL_0007:  ldstr      "string 1"
+  IL_000c:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0011:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0016:  brtrue.s   IL_002c
+  IL_0018:  ldarg.0
+  IL_0019:  ldstr      "string 2"
+  IL_001e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0023:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0028:  brtrue.s   IL_002c
+  IL_002a:  br.s       IL_002f
+  IL_002c:  ldc.i4.1
+  IL_002d:  br.s       IL_0030
+  IL_002f:  ldc.i4.0
+  IL_0030:  stloc.0
+  IL_0031:  ldloca.s   V_0
+  IL_0033:  call       "string bool.ToString()"
+  IL_0038:  call       "string string.Concat(string, string)"
+  IL_003d:  call       "void System.Console.WriteLine(string)"
+  IL_0042:  nop
+  IL_0043:  ldstr      "and: "
+  IL_0048:  ldarg.0
+  IL_0049:  ldstr      "string 1"
+  IL_004e:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0053:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_0058:  brfalse.s  IL_0066
+  IL_005a:  ldarga.s   V_0
+  IL_005c:  call       "int System.Span<char>.Length.get"
+  IL_0061:  ldc.i4.7
+  IL_0062:  ceq
+  IL_0064:  br.s       IL_0067
+  IL_0066:  ldc.i4.0
+  IL_0067:  stloc.0
+  IL_0068:  ldloca.s   V_0
+  IL_006a:  call       "string bool.ToString()"
+  IL_006f:  call       "string string.Concat(string, string)"
+  IL_0074:  call       "void System.Console.WriteLine(string)"
+  IL_0079:  nop
+  IL_007a:  ldstr      "not: "
+  IL_007f:  ldarg.0
+  IL_0080:  ldstr      "string 1"
+  IL_0085:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_008a:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_008f:  ldc.i4.0
+  IL_0090:  ceq
+  IL_0092:  stloc.0
+  IL_0093:  ldloca.s   V_0
+  IL_0095:  call       "string bool.ToString()"
+  IL_009a:  call       "string string.Concat(string, string)"
+  IL_009f:  call       "void System.Console.WriteLine(string)"
+  IL_00a4:  nop
+  IL_00a5:  ret
 }
 """);
         }
@@ -10488,55 +10488,56 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", @"
+                .VerifyIL("C.Test", """
 {
   // Code size      159 (0x9f)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      ""1.""
+  IL_0000:  ldstr      "1."
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      """"
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_0006:  ldstr      ""
+  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""string bool.ToString()""
-  IL_001d:  call       ""string string.Concat(string, string)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ldstr      ""2.""
+  IL_0018:  call       "string bool.ToString()"
+  IL_001d:  call       "string string.Concat(string, string)"
+  IL_0022:  call       "void System.Console.WriteLine(string)"
+  IL_0027:  ldstr      "2."
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      """"
-  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_002d:  ldstr      ""
+  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       ""string bool.ToString()""
-  IL_0044:  call       ""string string.Concat(string, string)""
-  IL_0049:  call       ""void System.Console.WriteLine(string)""
-  IL_004e:  ldstr      ""3.""
+  IL_003f:  call       "string bool.ToString()"
+  IL_0044:  call       "string string.Concat(string, string)"
+  IL_0049:  call       "void System.Console.WriteLine(string)"
+  IL_004e:  ldstr      "3."
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      """"
-  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_0054:  ldstr      ""
+  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       ""string bool.ToString()""
-  IL_006b:  call       ""string string.Concat(string, string)""
-  IL_0070:  call       ""void System.Console.WriteLine(string)""
-  IL_0075:  ldarg.0
-  IL_0076:  ldstr      """"
-  IL_007b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0080:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
-  IL_0085:  pop
-  IL_0086:  ldc.i4.1
-  IL_0087:  stloc.0
-  IL_0088:  ldstr      ""4.""
+  IL_0066:  call       "string bool.ToString()"
+  IL_006b:  call       "string string.Concat(string, string)"
+  IL_0070:  call       "void System.Console.WriteLine(string)"
+  IL_0075:  ldstr      "4."
+  IL_007a:  ldarg.0
+  IL_007b:  ldstr      ""
+  IL_0080:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0085:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
+  IL_008a:  pop
+  IL_008b:  ldc.i4.1
+  IL_008c:  stloc.0
   IL_008d:  ldloca.s   V_0
-  IL_008f:  call       ""string bool.ToString()""
-  IL_0094:  call       ""string string.Concat(string, string)""
-  IL_0099:  call       ""void System.Console.WriteLine(string)""
+  IL_008f:  call       "string bool.ToString()"
+  IL_0094:  call       "string string.Concat(string, string)"
+  IL_0099:  call       "void System.Console.WriteLine(string)"
   IL_009e:  ret
-}");
+}
+""");
         }
 
         [Fact]
@@ -11589,22 +11590,22 @@ static class C
             var verifier = CompileAndVerify(comp, expectedOutput: "True");
             // Note: the important thing is that we now assign `System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3`
             // in the exception filter (at IL_00b6) before accessing `.InnerException` on it.
-            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
 {
-  // Code size      471 (0x1d7)
+  // Code size      460 (0x1cc)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
-                System.Exception V_2,
-                string V_3,
-                bool V_4,
-                System.Runtime.CompilerServices.TaskAwaiter V_5,
-                C.<ExceptionFilterBroken>d__1 V_6,
-                System.Exception V_7,
+                System.Runtime.CompilerServices.TaskAwaiter V_2,
+                C.<ExceptionFilterBroken>d__1 V_3,
+                System.Exception V_4,
+                bool V_5,
+                System.Exception V_6,
+                string V_7,
                 int V_8,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_9)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
+  IL_0001:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
   IL_0006:  stloc.0
   .try
   {
@@ -11616,206 +11617,201 @@ static class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0021
-    IL_0014:  br         IL_0166
+    IL_0014:  br         IL_0159
     IL_0019:  nop
     IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
-    IL_001c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
+    IL_001c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
     IL_0021:  nop
     .try
     {
       IL_0022:  ldloc.0
       IL_0023:  brfalse.s  IL_0027
       IL_0025:  br.s       IL_0029
-      IL_0027:  br.s       IL_0068
+      IL_0027:  br.s       IL_0065
       IL_0029:  nop
-      IL_002a:  call       ""System.Threading.Tasks.Task C.ThrowException()""
-      IL_002f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-      IL_0034:  stloc.s    V_5
-      IL_0036:  ldloca.s   V_5
-      IL_0038:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-      IL_003d:  brtrue.s   IL_0085
-      IL_003f:  ldarg.0
-      IL_0040:  ldc.i4.0
-      IL_0041:  dup
-      IL_0042:  stloc.0
-      IL_0043:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-      IL_0048:  ldarg.0
-      IL_0049:  ldloc.s    V_5
-      IL_004b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
+      IL_002a:  call       "System.Threading.Tasks.Task C.ThrowException()"
+      IL_002f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()"
+      IL_0034:  stloc.2
+      IL_0035:  ldloca.s   V_2
+      IL_0037:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
+      IL_003c:  brtrue.s   IL_0081
+      IL_003e:  ldarg.0
+      IL_003f:  ldc.i4.0
+      IL_0040:  dup
+      IL_0041:  stloc.0
+      IL_0042:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_0047:  ldarg.0
+      IL_0048:  ldloc.2
+      IL_0049:  stfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_004e:  ldarg.0
+      IL_004f:  stloc.3
       IL_0050:  ldarg.0
-      IL_0051:  stloc.s    V_6
-      IL_0053:  ldarg.0
-      IL_0054:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-      IL_0059:  ldloca.s   V_5
-      IL_005b:  ldloca.s   V_6
-      IL_005d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)""
-      IL_0062:  nop
-      IL_0063:  leave      IL_01d6
-      IL_0068:  ldarg.0
-      IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
-      IL_006e:  stloc.s    V_5
-      IL_0070:  ldarg.0
-      IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
-      IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-      IL_007c:  ldarg.0
-      IL_007d:  ldc.i4.m1
-      IL_007e:  dup
-      IL_007f:  stloc.0
-      IL_0080:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-      IL_0085:  ldloca.s   V_5
-      IL_0087:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-      IL_008c:  nop
-      IL_008d:  ldc.i4.1
-      IL_008e:  stloc.1
-      IL_008f:  leave      IL_01c1
+      IL_0051:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+      IL_0056:  ldloca.s   V_2
+      IL_0058:  ldloca.s   V_3
+      IL_005a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)"
+      IL_005f:  nop
+      IL_0060:  leave      IL_01cb
+      IL_0065:  ldarg.0
+      IL_0066:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_006b:  stloc.2
+      IL_006c:  ldarg.0
+      IL_006d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0072:  initobj    "System.Runtime.CompilerServices.TaskAwaiter"
+      IL_0078:  ldarg.0
+      IL_0079:  ldc.i4.m1
+      IL_007a:  dup
+      IL_007b:  stloc.0
+      IL_007c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+      IL_0081:  ldloca.s   V_2
+      IL_0083:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
+      IL_0088:  nop
+      IL_0089:  ldc.i4.1
+      IL_008a:  stloc.1
+      IL_008b:  leave      IL_01b6
     }
     filter
     {
-      IL_0094:  isinst     ""System.Exception""
-      IL_0099:  dup
-      IL_009a:  brtrue.s   IL_00a0
-      IL_009c:  pop
-      IL_009d:  ldc.i4.0
-      IL_009e:  br.s       IL_0106
-      IL_00a0:  stloc.s    V_7
-      IL_00a2:  ldarg.0
-      IL_00a3:  ldloc.s    V_7
-      IL_00a5:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
-      IL_00aa:  ldarg.0
-      IL_00ab:  ldarg.0
-      IL_00ac:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
-      IL_00b1:  castclass  ""System.Exception""
-      IL_00b6:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-      IL_00c1:  callvirt   ""System.Exception System.Exception.InnerException.get""
-      IL_00c6:  stloc.2
-      IL_00c7:  ldloc.2
-      IL_00c8:  brfalse.s  IL_00f2
-      IL_00ca:  ldloc.2
-      IL_00cb:  callvirt   ""string System.Exception.Message.get""
-      IL_00d0:  stloc.3
-      IL_00d1:  ldloc.3
-      IL_00d2:  ldstr      ""bad dog""
-      IL_00d7:  call       ""bool string.op_Equality(string, string)""
-      IL_00dc:  brtrue.s   IL_00ed
-      IL_00de:  ldloc.3
-      IL_00df:  ldstr      ""dog bad""
-      IL_00e4:  call       ""bool string.op_Equality(string, string)""
-      IL_00e9:  brtrue.s   IL_00ed
-      IL_00eb:  br.s       IL_00f2
-      IL_00ed:  ldc.i4.1
-      IL_00ee:  stloc.s    V_4
-      IL_00f0:  br.s       IL_00f5
+      IL_0090:  isinst     "System.Exception"
+      IL_0095:  dup
+      IL_0096:  brtrue.s   IL_009c
+      IL_0098:  pop
+      IL_0099:  ldc.i4.0
+      IL_009a:  br.s       IL_00fa
+      IL_009c:  stloc.s    V_4
+      IL_009e:  ldarg.0
+      IL_009f:  ldloc.s    V_4
+      IL_00a1:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+      IL_00a6:  ldarg.0
+      IL_00a7:  ldarg.0
+      IL_00a8:  ldfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+      IL_00ad:  castclass  "System.Exception"
+      IL_00b2:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+      IL_00b7:  ldarg.0
+      IL_00b8:  ldfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+      IL_00bd:  callvirt   "System.Exception System.Exception.InnerException.get"
+      IL_00c2:  stloc.s    V_6
+      IL_00c4:  ldloc.s    V_6
+      IL_00c6:  brfalse.s  IL_00f2
+      IL_00c8:  ldloc.s    V_6
+      IL_00ca:  callvirt   "string System.Exception.Message.get"
+      IL_00cf:  stloc.s    V_7
+      IL_00d1:  ldloc.s    V_7
+      IL_00d3:  ldstr      "bad dog"
+      IL_00d8:  call       "bool string.op_Equality(string, string)"
+      IL_00dd:  brtrue.s   IL_00ef
+      IL_00df:  ldloc.s    V_7
+      IL_00e1:  ldstr      "dog bad"
+      IL_00e6:  call       "bool string.op_Equality(string, string)"
+      IL_00eb:  brtrue.s   IL_00ef
+      IL_00ed:  br.s       IL_00f2
+      IL_00ef:  ldc.i4.1
+      IL_00f0:  br.s       IL_00f3
       IL_00f2:  ldc.i4.0
-      IL_00f3:  stloc.s    V_4
-      IL_00f5:  ldarg.0
-      IL_00f6:  ldloc.s    V_4
-      IL_00f8:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
-      IL_00fd:  ldarg.0
-      IL_00fe:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
-      IL_0103:  ldc.i4.0
-      IL_0104:  cgt.un
-      IL_0106:  endfilter
+      IL_00f3:  stloc.s    V_5
+      IL_00f5:  ldloc.s    V_5
+      IL_00f7:  ldc.i4.0
+      IL_00f8:  cgt.un
+      IL_00fa:  endfilter
     }  // end filter
     {  // handler
-      IL_0108:  pop
-      IL_0109:  ldarg.0
-      IL_010a:  ldc.i4.1
-      IL_010b:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
-      IL_0110:  leave.s    IL_011b
+      IL_00fc:  pop
+      IL_00fd:  ldarg.0
+      IL_00fe:  ldc.i4.1
+      IL_00ff:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+      IL_0104:  leave.s    IL_010f
     }
     catch object
     {
-      IL_0112:  pop
-      IL_0113:  nop
-      IL_0114:  ldc.i4.0
-      IL_0115:  stloc.1
-      IL_0116:  leave      IL_01c1
+      IL_0106:  pop
+      IL_0107:  nop
+      IL_0108:  ldc.i4.0
+      IL_0109:  stloc.1
+      IL_010a:  leave      IL_01b6
     }
-    IL_011b:  ldarg.0
-    IL_011c:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
-    IL_0121:  stloc.s    V_8
-    IL_0123:  ldloc.s    V_8
-    IL_0125:  ldc.i4.1
-    IL_0126:  beq.s      IL_012a
-    IL_0128:  br.s       IL_0199
-    IL_012a:  nop
-    IL_012b:  call       ""System.Threading.Tasks.Task<bool> C.TrueAsync()""
-    IL_0130:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_0135:  stloc.s    V_9
-    IL_0137:  ldloca.s   V_9
-    IL_0139:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_013e:  brtrue.s   IL_0183
-    IL_0140:  ldarg.0
-    IL_0141:  ldc.i4.1
-    IL_0142:  dup
-    IL_0143:  stloc.0
-    IL_0144:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-    IL_0149:  ldarg.0
-    IL_014a:  ldloc.s    V_9
-    IL_014c:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_0151:  ldarg.0
-    IL_0152:  stloc.s    V_6
-    IL_0154:  ldarg.0
-    IL_0155:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-    IL_015a:  ldloca.s   V_9
-    IL_015c:  ldloca.s   V_6
-    IL_015e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)""
-    IL_0163:  nop
-    IL_0164:  leave.s    IL_01d6
-    IL_0166:  ldarg.0
-    IL_0167:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_016c:  stloc.s    V_9
-    IL_016e:  ldarg.0
-    IL_016f:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_0174:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_017a:  ldarg.0
-    IL_017b:  ldc.i4.m1
-    IL_017c:  dup
-    IL_017d:  stloc.0
-    IL_017e:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
+    IL_010f:  ldarg.0
+    IL_0110:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
+    IL_0115:  stloc.s    V_8
+    IL_0117:  ldloc.s    V_8
+    IL_0119:  ldc.i4.1
+    IL_011a:  beq.s      IL_011e
+    IL_011c:  br.s       IL_018c
+    IL_011e:  nop
+    IL_011f:  call       "System.Threading.Tasks.Task<bool> C.TrueAsync()"
+    IL_0124:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()"
+    IL_0129:  stloc.s    V_9
+    IL_012b:  ldloca.s   V_9
+    IL_012d:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get"
+    IL_0132:  brtrue.s   IL_0176
+    IL_0134:  ldarg.0
+    IL_0135:  ldc.i4.1
+    IL_0136:  dup
+    IL_0137:  stloc.0
+    IL_0138:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_013d:  ldarg.0
+    IL_013e:  ldloc.s    V_9
+    IL_0140:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0145:  ldarg.0
+    IL_0146:  stloc.3
+    IL_0147:  ldarg.0
+    IL_0148:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_014d:  ldloca.s   V_9
+    IL_014f:  ldloca.s   V_3
+    IL_0151:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)"
+    IL_0156:  nop
+    IL_0157:  leave.s    IL_01cb
+    IL_0159:  ldarg.0
+    IL_015a:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_015f:  stloc.s    V_9
+    IL_0161:  ldarg.0
+    IL_0162:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0167:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<bool>"
+    IL_016d:  ldarg.0
+    IL_016e:  ldc.i4.m1
+    IL_016f:  dup
+    IL_0170:  stloc.0
+    IL_0171:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_0176:  ldarg.0
+    IL_0177:  ldloca.s   V_9
+    IL_0179:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()"
+    IL_017e:  stfld      "bool C.<ExceptionFilterBroken>d__1.<>s__4"
     IL_0183:  ldarg.0
-    IL_0184:  ldloca.s   V_9
-    IL_0186:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_018b:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__5""
-    IL_0190:  ldarg.0
-    IL_0191:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__5""
-    IL_0196:  stloc.1
-    IL_0197:  leave.s    IL_01c1
-    IL_0199:  ldarg.0
-    IL_019a:  ldnull
-    IL_019b:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
-    IL_01a0:  ldarg.0
-    IL_01a1:  ldnull
-    IL_01a2:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-    IL_01a7:  leave.s    IL_01c1
+    IL_0184:  ldfld      "bool C.<ExceptionFilterBroken>d__1.<>s__4"
+    IL_0189:  stloc.1
+    IL_018a:  leave.s    IL_01b6
+    IL_018c:  ldarg.0
+    IL_018d:  ldnull
+    IL_018e:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+    IL_0193:  ldarg.0
+    IL_0194:  ldnull
+    IL_0195:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+    IL_019a:  leave.s    IL_01b6
   }
   catch System.Exception
   {
-    IL_01a9:  stloc.2
-    IL_01aa:  ldarg.0
-    IL_01ab:  ldc.i4.s   -2
-    IL_01ad:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-    IL_01b2:  ldarg.0
-    IL_01b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-    IL_01b8:  ldloc.2
-    IL_01b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)""
-    IL_01be:  nop
-    IL_01bf:  leave.s    IL_01d6
+    IL_019c:  stloc.s    V_6
+    IL_019e:  ldarg.0
+    IL_019f:  ldc.i4.s   -2
+    IL_01a1:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_01a6:  ldarg.0
+    IL_01a7:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_01ac:  ldloc.s    V_6
+    IL_01ae:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)"
+    IL_01b3:  nop
+    IL_01b4:  leave.s    IL_01cb
   }
-  IL_01c1:  ldarg.0
-  IL_01c2:  ldc.i4.s   -2
-  IL_01c4:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-  IL_01c9:  ldarg.0
-  IL_01ca:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-  IL_01cf:  ldloc.1
-  IL_01d0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)""
-  IL_01d5:  nop
-  IL_01d6:  ret
+  IL_01b6:  ldarg.0
+  IL_01b7:  ldc.i4.s   -2
+  IL_01b9:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_01be:  ldarg.0
+  IL_01bf:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+  IL_01c4:  ldloc.1
+  IL_01c5:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)"
+  IL_01ca:  nop
+  IL_01cb:  ret
 }
-");
+""");
         }
 
         [Fact, WorkItem(59050, "https://github.com/dotnet/roslyn/issues/59050")]
@@ -11939,9 +11935,9 @@ static class C
             var comp = CreateCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "True");
-            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
- {
-  // Code size      527 (0x20f)
+            verifier.VerifyIL("C.<ExceptionFilterBroken>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
+{
+  // Code size      513 (0x201)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
@@ -11950,12 +11946,12 @@ static class C
                 System.Exception V_4,
                 int V_5,
                 System.Exception V_6,
-                string V_7,
-                bool V_8,
-                System.Exception V_9,
+                bool V_7,
+                System.Exception V_8,
+                string V_9,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_10)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
+  IL_0001:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
   IL_0006:  stloc.0
   .try
   {
@@ -11967,11 +11963,11 @@ static class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0021
-    IL_0014:  br         IL_0192
+    IL_0014:  br         IL_0184
     IL_0019:  nop
     IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
-    IL_001c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
+    IL_001c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
     IL_0021:  nop
     .try
     {
@@ -11980,218 +11976,213 @@ static class C
       IL_0025:  br.s       IL_0029
       IL_0027:  br.s       IL_0065
       IL_0029:  nop
-      IL_002a:  call       ""System.Threading.Tasks.Task C.ThrowException()""
-      IL_002f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+      IL_002a:  call       "System.Threading.Tasks.Task C.ThrowException()"
+      IL_002f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()"
       IL_0034:  stloc.2
       IL_0035:  ldloca.s   V_2
-      IL_0037:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+      IL_0037:  call       "bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get"
       IL_003c:  brtrue.s   IL_0081
       IL_003e:  ldarg.0
       IL_003f:  ldc.i4.0
       IL_0040:  dup
       IL_0041:  stloc.0
-      IL_0042:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
+      IL_0042:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
       IL_0047:  ldarg.0
       IL_0048:  ldloc.2
-      IL_0049:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
+      IL_0049:  stfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
       IL_004e:  ldarg.0
       IL_004f:  stloc.3
       IL_0050:  ldarg.0
-      IL_0051:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
+      IL_0051:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
       IL_0056:  ldloca.s   V_2
       IL_0058:  ldloca.s   V_3
-      IL_005a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)""
+      IL_005a:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<ExceptionFilterBroken>d__1)"
       IL_005f:  nop
-      IL_0060:  leave      IL_020e
+      IL_0060:  leave      IL_0200
       IL_0065:  ldarg.0
-      IL_0066:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
+      IL_0066:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
       IL_006b:  stloc.2
       IL_006c:  ldarg.0
-      IL_006d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1""
-      IL_0072:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+      IL_006d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter C.<ExceptionFilterBroken>d__1.<>u__1"
+      IL_0072:  initobj    "System.Runtime.CompilerServices.TaskAwaiter"
       IL_0078:  ldarg.0
       IL_0079:  ldc.i4.m1
       IL_007a:  dup
       IL_007b:  stloc.0
-      IL_007c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
+      IL_007c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
       IL_0081:  ldloca.s   V_2
-      IL_0083:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+      IL_0083:  call       "void System.Runtime.CompilerServices.TaskAwaiter.GetResult()"
       IL_0088:  nop
       IL_0089:  ldc.i4.1
       IL_008a:  stloc.1
-      IL_008b:  leave      IL_01f9
+      IL_008b:  leave      IL_01eb
     }
     catch System.Exception
     {
       IL_0090:  stloc.s    V_4
       IL_0092:  ldarg.0
       IL_0093:  ldloc.s    V_4
-      IL_0095:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
+      IL_0095:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
       IL_009a:  ldarg.0
       IL_009b:  ldc.i4.1
-      IL_009c:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
+      IL_009c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
       IL_00a1:  leave.s    IL_00a3
     }
     IL_00a3:  ldarg.0
-    IL_00a4:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__2""
+    IL_00a4:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__2"
     IL_00a9:  stloc.s    V_5
     IL_00ab:  ldloc.s    V_5
     IL_00ad:  ldc.i4.1
     IL_00ae:  beq.s      IL_00b5
-    IL_00b0:  br         IL_01d6
+    IL_00b0:  br         IL_01c8
     IL_00b5:  ldarg.0
     IL_00b6:  ldarg.0
-    IL_00b7:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
-    IL_00bc:  castclass  ""System.Exception""
-    IL_00c1:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
+    IL_00b7:  ldfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+    IL_00bc:  castclass  "System.Exception"
+    IL_00c1:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
     IL_00c6:  nop
     IL_00c7:  ldarg.0
     IL_00c8:  ldc.i4.0
-    IL_00c9:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
+    IL_00c9:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
     .try
     {
       IL_00ce:  nop
-      IL_00cf:  newobj     ""System.Exception..ctor()""
+      IL_00cf:  newobj     "System.Exception..ctor()"
       IL_00d4:  throw
     }
     filter
     {
-      IL_00d5:  isinst     ""System.Exception""
+      IL_00d5:  isinst     "System.Exception"
       IL_00da:  dup
       IL_00db:  brtrue.s   IL_00e1
       IL_00dd:  pop
       IL_00de:  ldc.i4.0
-      IL_00df:  br.s       IL_013c
-      IL_00e1:  stloc.s    V_9
+      IL_00df:  br.s       IL_012e
+      IL_00e1:  stloc.s    V_6
       IL_00e3:  ldarg.0
-      IL_00e4:  ldloc.s    V_9
-      IL_00e6:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
+      IL_00e4:  ldloc.s    V_6
+      IL_00e6:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__4"
       IL_00eb:  ldarg.0
-      IL_00ec:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-      IL_00f1:  callvirt   ""System.Exception System.Exception.InnerException.get""
-      IL_00f6:  stloc.s    V_6
-      IL_00f8:  ldloc.s    V_6
-      IL_00fa:  brfalse.s  IL_0128
-      IL_00fc:  ldloc.s    V_6
-      IL_00fe:  callvirt   ""string System.Exception.Message.get""
-      IL_0103:  stloc.s    V_7
-      IL_0105:  ldloc.s    V_7
-      IL_0107:  ldstr      ""bad dog""
-      IL_010c:  call       ""bool string.op_Equality(string, string)""
+      IL_00ec:  ldfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+      IL_00f1:  callvirt   "System.Exception System.Exception.InnerException.get"
+      IL_00f6:  stloc.s    V_8
+      IL_00f8:  ldloc.s    V_8
+      IL_00fa:  brfalse.s  IL_0126
+      IL_00fc:  ldloc.s    V_8
+      IL_00fe:  callvirt   "string System.Exception.Message.get"
+      IL_0103:  stloc.s    V_9
+      IL_0105:  ldloc.s    V_9
+      IL_0107:  ldstr      "bad dog"
+      IL_010c:  call       "bool string.op_Equality(string, string)"
       IL_0111:  brtrue.s   IL_0123
-      IL_0113:  ldloc.s    V_7
-      IL_0115:  ldstr      ""dog bad""
-      IL_011a:  call       ""bool string.op_Equality(string, string)""
+      IL_0113:  ldloc.s    V_9
+      IL_0115:  ldstr      "dog bad"
+      IL_011a:  call       "bool string.op_Equality(string, string)"
       IL_011f:  brtrue.s   IL_0123
-      IL_0121:  br.s       IL_0128
+      IL_0121:  br.s       IL_0126
       IL_0123:  ldc.i4.1
-      IL_0124:  stloc.s    V_8
-      IL_0126:  br.s       IL_012b
-      IL_0128:  ldc.i4.0
-      IL_0129:  stloc.s    V_8
-      IL_012b:  ldarg.0
-      IL_012c:  ldloc.s    V_8
-      IL_012e:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
-      IL_0133:  ldarg.0
-      IL_0134:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
-      IL_0139:  ldc.i4.0
-      IL_013a:  cgt.un
-      IL_013c:  endfilter
+      IL_0124:  br.s       IL_0127
+      IL_0126:  ldc.i4.0
+      IL_0127:  stloc.s    V_7
+      IL_0129:  ldloc.s    V_7
+      IL_012b:  ldc.i4.0
+      IL_012c:  cgt.un
+      IL_012e:  endfilter
     }  // end filter
     {  // handler
-      IL_013e:  pop
-      IL_013f:  ldarg.0
-      IL_0140:  ldc.i4.1
-      IL_0141:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
-      IL_0146:  leave.s    IL_0148
+      IL_0130:  pop
+      IL_0131:  ldarg.0
+      IL_0132:  ldc.i4.1
+      IL_0133:  stfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
+      IL_0138:  leave.s    IL_013a
     }
-    IL_0148:  ldarg.0
-    IL_0149:  ldfld      ""int C.<ExceptionFilterBroken>d__1.<>s__5""
-    IL_014e:  stloc.s    V_5
-    IL_0150:  ldloc.s    V_5
-    IL_0152:  ldc.i4.1
-    IL_0153:  beq.s      IL_0157
-    IL_0155:  br.s       IL_01c5
-    IL_0157:  nop
-    IL_0158:  call       ""System.Threading.Tasks.Task<bool> C.TrueAsync()""
-    IL_015d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_0162:  stloc.s    V_10
-    IL_0164:  ldloca.s   V_10
-    IL_0166:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_016b:  brtrue.s   IL_01af
-    IL_016d:  ldarg.0
-    IL_016e:  ldc.i4.1
-    IL_016f:  dup
-    IL_0170:  stloc.0
-    IL_0171:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-    IL_0176:  ldarg.0
-    IL_0177:  ldloc.s    V_10
-    IL_0179:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_017e:  ldarg.0
-    IL_017f:  stloc.3
-    IL_0180:  ldarg.0
-    IL_0181:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-    IL_0186:  ldloca.s   V_10
-    IL_0188:  ldloca.s   V_3
-    IL_018a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)""
-    IL_018f:  nop
-    IL_0190:  leave.s    IL_020e
-    IL_0192:  ldarg.0
-    IL_0193:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_0198:  stloc.s    V_10
-    IL_019a:  ldarg.0
-    IL_019b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2""
-    IL_01a0:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_01a6:  ldarg.0
-    IL_01a7:  ldc.i4.m1
-    IL_01a8:  dup
-    IL_01a9:  stloc.0
-    IL_01aa:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-    IL_01af:  ldarg.0
-    IL_01b0:  ldloca.s   V_10
-    IL_01b2:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_01b7:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__7""
-    IL_01bc:  ldarg.0
-    IL_01bd:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__7""
-    IL_01c2:  stloc.1
-    IL_01c3:  leave.s    IL_01f9
-    IL_01c5:  ldarg.0
-    IL_01c6:  ldnull
-    IL_01c7:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
-    IL_01cc:  nop
-    IL_01cd:  ldarg.0
-    IL_01ce:  ldnull
-    IL_01cf:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-    IL_01d4:  br.s       IL_01d6
-    IL_01d6:  ldarg.0
-    IL_01d7:  ldnull
-    IL_01d8:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
-    IL_01dd:  leave.s    IL_01f9
+    IL_013a:  ldarg.0
+    IL_013b:  ldfld      "int C.<ExceptionFilterBroken>d__1.<>s__5"
+    IL_0140:  stloc.s    V_5
+    IL_0142:  ldloc.s    V_5
+    IL_0144:  ldc.i4.1
+    IL_0145:  beq.s      IL_0149
+    IL_0147:  br.s       IL_01b7
+    IL_0149:  nop
+    IL_014a:  call       "System.Threading.Tasks.Task<bool> C.TrueAsync()"
+    IL_014f:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()"
+    IL_0154:  stloc.s    V_10
+    IL_0156:  ldloca.s   V_10
+    IL_0158:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get"
+    IL_015d:  brtrue.s   IL_01a1
+    IL_015f:  ldarg.0
+    IL_0160:  ldc.i4.1
+    IL_0161:  dup
+    IL_0162:  stloc.0
+    IL_0163:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_0168:  ldarg.0
+    IL_0169:  ldloc.s    V_10
+    IL_016b:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0170:  ldarg.0
+    IL_0171:  stloc.3
+    IL_0172:  ldarg.0
+    IL_0173:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_0178:  ldloca.s   V_10
+    IL_017a:  ldloca.s   V_3
+    IL_017c:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<ExceptionFilterBroken>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<ExceptionFilterBroken>d__1)"
+    IL_0181:  nop
+    IL_0182:  leave.s    IL_0200
+    IL_0184:  ldarg.0
+    IL_0185:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_018a:  stloc.s    V_10
+    IL_018c:  ldarg.0
+    IL_018d:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<bool> C.<ExceptionFilterBroken>d__1.<>u__2"
+    IL_0192:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<bool>"
+    IL_0198:  ldarg.0
+    IL_0199:  ldc.i4.m1
+    IL_019a:  dup
+    IL_019b:  stloc.0
+    IL_019c:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_01a1:  ldarg.0
+    IL_01a2:  ldloca.s   V_10
+    IL_01a4:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()"
+    IL_01a9:  stfld      "bool C.<ExceptionFilterBroken>d__1.<>s__6"
+    IL_01ae:  ldarg.0
+    IL_01af:  ldfld      "bool C.<ExceptionFilterBroken>d__1.<>s__6"
+    IL_01b4:  stloc.1
+    IL_01b5:  leave.s    IL_01eb
+    IL_01b7:  ldarg.0
+    IL_01b8:  ldnull
+    IL_01b9:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__4"
+    IL_01be:  nop
+    IL_01bf:  ldarg.0
+    IL_01c0:  ldnull
+    IL_01c1:  stfld      "System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"
+    IL_01c6:  br.s       IL_01c8
+    IL_01c8:  ldarg.0
+    IL_01c9:  ldnull
+    IL_01ca:  stfld      "object C.<ExceptionFilterBroken>d__1.<>s__1"
+    IL_01cf:  leave.s    IL_01eb
   }
   catch System.Exception
   {
-    IL_01df:  stloc.s    V_6
-    IL_01e1:  ldarg.0
-    IL_01e2:  ldc.i4.s   -2
-    IL_01e4:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-    IL_01e9:  ldarg.0
-    IL_01ea:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-    IL_01ef:  ldloc.s    V_6
-    IL_01f1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)""
-    IL_01f6:  nop
-    IL_01f7:  leave.s    IL_020e
+    IL_01d1:  stloc.s    V_8
+    IL_01d3:  ldarg.0
+    IL_01d4:  ldc.i4.s   -2
+    IL_01d6:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+    IL_01db:  ldarg.0
+    IL_01dc:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+    IL_01e1:  ldloc.s    V_8
+    IL_01e3:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)"
+    IL_01e8:  nop
+    IL_01e9:  leave.s    IL_0200
   }
-  IL_01f9:  ldarg.0
-  IL_01fa:  ldc.i4.s   -2
-  IL_01fc:  stfld      ""int C.<ExceptionFilterBroken>d__1.<>1__state""
-  IL_0201:  ldarg.0
-  IL_0202:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder""
-  IL_0207:  ldloc.1
-  IL_0208:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)""
-  IL_020d:  nop
-  IL_020e:  ret
+  IL_01eb:  ldarg.0
+  IL_01ec:  ldc.i4.s   -2
+  IL_01ee:  stfld      "int C.<ExceptionFilterBroken>d__1.<>1__state"
+  IL_01f3:  ldarg.0
+  IL_01f4:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> C.<ExceptionFilterBroken>d__1.<>t__builder"
+  IL_01f9:  ldloc.1
+  IL_01fa:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)"
+  IL_01ff:  nop
+  IL_0200:  ret
 }
-");
+""");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
@@ -6430,16 +6430,16 @@ class C
     }}
 }}";
             var verifier = CompileAndVerify(source, expectedOutput: "42");
-            verifier.VerifyIL("C.M", """
-{
+            verifier.VerifyIL("C.M",
+@"{
   // Code size       30 (0x1e)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
+  IL_0001:  isinst     ""int""
   IL_0006:  brfalse.s  IL_0016
   IL_0008:  ldarg.0
-  IL_0009:  unbox.any  "int"
+  IL_0009:  unbox.any  ""int""
   IL_000e:  stloc.0
   IL_000f:  ldloc.0
   IL_0010:  ldc.i4.s   41
@@ -6448,10 +6448,9 @@ class C
   IL_0014:  ble.un.s   IL_0017
   IL_0016:  ret
   IL_0017:  ldarg.0
-  IL_0018:  call       "void System.Console.WriteLine(object)"
+  IL_0018:  call       ""void System.Console.WriteLine(object)""
   IL_001d:  ret
-}
-""");
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
@@ -6430,35 +6430,28 @@ class C
     }}
 }}";
             var verifier = CompileAndVerify(source, expectedOutput: "42");
-            verifier.VerifyIL("C.M",
-@"{
-  // Code size       39 (0x27)
+            verifier.VerifyIL("C.M", """
+{
+  // Code size       30 (0x1e)
   .maxstack  2
-  .locals init (int V_0,
-                bool V_1)
+  .locals init (int V_0)
   IL_0000:  ldarg.0
-  IL_0001:  isinst     ""int""
-  IL_0006:  brfalse.s  IL_001a
+  IL_0001:  isinst     "int"
+  IL_0006:  brfalse.s  IL_0016
   IL_0008:  ldarg.0
-  IL_0009:  unbox.any  ""int""
+  IL_0009:  unbox.any  "int"
   IL_000e:  stloc.0
   IL_000f:  ldloc.0
   IL_0010:  ldc.i4.s   41
   IL_0012:  sub
   IL_0013:  ldc.i4.1
-  IL_0014:  bgt.un.s   IL_001a
-  IL_0016:  ldc.i4.1
-  IL_0017:  stloc.1
-  IL_0018:  br.s       IL_001c
-  IL_001a:  ldc.i4.0
-  IL_001b:  stloc.1
-  IL_001c:  ldloc.1
-  IL_001d:  brtrue.s   IL_0020
-  IL_001f:  ret
-  IL_0020:  ldarg.0
-  IL_0021:  call       ""void System.Console.WriteLine(object)""
-  IL_0026:  ret
-}");
+  IL_0014:  ble.un.s   IL_0017
+  IL_0016:  ret
+  IL_0017:  ldarg.0
+  IL_0018:  call       "void System.Console.WriteLine(object)"
+  IL_001d:  ret
+}
+""");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
@@ -6420,17 +6420,32 @@ class C
 {{
     static void Main()
     {{
-        object o = 42;
-        M(o);
+        M1(41);
+        M1(42);
+        M1(43);
+        WriteLine(M2(41));
+        WriteLine(M2(42));
+        WriteLine(M2(43));
     }}
-    static void M(object o)
+    static void M1(object o)
     {{
         if ({pattern}) return;
         WriteLine(o);
     }}
+    static bool M2(object o)
+    {{
+        return ({pattern});
+    }}
 }}";
-            var verifier = CompileAndVerify(source, expectedOutput: "42");
-            verifier.VerifyIL("C.M",
+            string expectedOutput = """
+41
+42
+False
+False
+True
+""";
+            var verifier = CompileAndVerify(source, expectedOutput: expectedOutput);
+            verifier.VerifyIL("C.M1",
 @"{
   // Code size       30 (0x1e)
   .maxstack  2
@@ -6450,6 +6465,27 @@ class C
   IL_0017:  ldarg.0
   IL_0018:  call       ""void System.Console.WriteLine(object)""
   IL_001d:  ret
+}");
+            verifier.VerifyIL("C.M2",
+@"{
+  // Code size       26 (0x1a)
+  .maxstack  2
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  isinst     ""int""
+  IL_0006:  brfalse.s  IL_0018
+  IL_0008:  ldarg.0
+  IL_0009:  unbox.any  ""int""
+  IL_000e:  stloc.0
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.s   41
+  IL_0012:  sub
+  IL_0013:  ldc.i4.1
+  IL_0014:  bgt.un.s   IL_0018
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldc.i4.1
+  IL_0019:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
@@ -3178,21 +3178,17 @@ class C
             var compilation = CompileAndVerify(source, expectedOutput: "True");
             compilation.VerifyIL("C.Test", """
 {
-  // Code size       14 (0xe)
+  // Code size       10 (0xa)
   .maxstack  2
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.1
   IL_0002:  sub
   IL_0003:  ldc.i4.7
-  IL_0004:  bgt.un.s   IL_000a
+  IL_0004:  bgt.un.s   IL_0008
   IL_0006:  ldc.i4.1
-  IL_0007:  stloc.0
-  IL_0008:  br.s       IL_000c
-  IL_000a:  ldc.i4.0
-  IL_000b:  stloc.0
-  IL_000c:  ldloc.0
-  IL_000d:  ret
+  IL_0007:  ret
+  IL_0008:  ldc.i4.0
+  IL_0009:  ret
 }
 """);
         }
@@ -3227,9 +3223,8 @@ class C
             var compilation = CompileAndVerify(source, expectedOutput: "True");
             compilation.VerifyIL("C.Test", """
 {
-  // Code size       72 (0x48)
+  // Code size       68 (0x44)
   .maxstack  2
-  .locals init (bool V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.1
   IL_0002:  sub
@@ -3238,29 +3233,26 @@ class C
         IL_0024,
         IL_002e,
         IL_0038)
-  IL_0018:  br.s       IL_0044
+  IL_0018:  br.s       IL_0042
   IL_001a:  ldarg.1
   IL_001b:  isinst     "int"
   IL_0020:  brtrue.s   IL_0040
-  IL_0022:  br.s       IL_0044
+  IL_0022:  br.s       IL_0042
   IL_0024:  ldarg.1
   IL_0025:  isinst     "bool"
   IL_002a:  brtrue.s   IL_0040
-  IL_002c:  br.s       IL_0044
+  IL_002c:  br.s       IL_0042
   IL_002e:  ldarg.1
   IL_002f:  isinst     "double"
   IL_0034:  brtrue.s   IL_0040
-  IL_0036:  br.s       IL_0044
+  IL_0036:  br.s       IL_0042
   IL_0038:  ldarg.1
   IL_0039:  isinst     "long"
-  IL_003e:  brfalse.s  IL_0044
+  IL_003e:  brfalse.s  IL_0042
   IL_0040:  ldc.i4.1
-  IL_0041:  stloc.0
-  IL_0042:  br.s       IL_0046
-  IL_0044:  ldc.i4.0
-  IL_0045:  stloc.0
-  IL_0046:  ldloc.0
-  IL_0047:  ret
+  IL_0041:  ret
+  IL_0042:  ldc.i4.0
+  IL_0043:  ret
 }
 """);
         }
@@ -3294,24 +3286,23 @@ class C
             var compilation = CompileAndVerify(source, expectedOutput: "True");
             compilation.VerifyIL("C.Test", """
 {
-  // Code size       73 (0x49)
+  // Code size       69 (0x45)
   .maxstack  2
-  .locals init (bool V_0,
-                int V_1,
-                char V_2)
+  .locals init (int V_0,
+                char V_1)
   IL_0000:  ldarg.0
-  IL_0001:  brfalse.s  IL_0045
+  IL_0001:  brfalse.s  IL_0043
   IL_0003:  ldarg.0
   IL_0004:  call       "int string.Length.get"
-  IL_0009:  stloc.1
-  IL_000a:  ldloc.1
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
   IL_000b:  ldc.i4.1
-  IL_000c:  bne.un.s   IL_0045
+  IL_000c:  bne.un.s   IL_0043
   IL_000e:  ldarg.0
   IL_000f:  ldc.i4.0
   IL_0010:  call       "char string.this[int].get"
-  IL_0015:  stloc.2
-  IL_0016:  ldloc.2
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
   IL_0017:  ldc.i4.s   49
   IL_0019:  sub
   IL_001a:  switch    (
@@ -3323,14 +3314,11 @@ class C
         IL_0041,
         IL_0041,
         IL_0041)
-  IL_003f:  br.s       IL_0045
+  IL_003f:  br.s       IL_0043
   IL_0041:  ldc.i4.1
-  IL_0042:  stloc.0
-  IL_0043:  br.s       IL_0047
-  IL_0045:  ldc.i4.0
-  IL_0046:  stloc.0
-  IL_0047:  ldloc.0
-  IL_0048:  ret
+  IL_0042:  ret
+  IL_0043:  ldc.i4.0
+  IL_0044:  ret
 }
 """);
         }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
@@ -3377,8 +3377,7 @@ static async Task<bool> Async3(int i) {
     return (await Task.FromResult(0), i is 30 or 40).Item2;
 }
 """;
-            var comp = CreateCompilation(source);
-            CompileAndVerify(comp, expectedOutput: """
+            var expectedOutput = """
 True
 True
 False
@@ -3388,6 +3387,94 @@ False
 True
 True
 False
+""";
+            var verifier = CompileAndVerify(source, expectedOutput: expectedOutput);
+            // await in input-expression
+            verifier.VerifyIL("Program.<<<Main>$>g__Async2|0_1>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
+{
+  // Code size      167 (0xa7)
+  .maxstack  3
+  .locals init (int V_0,
+                bool V_1,
+                int V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      "int Program.<<<Main>$>g__Async2|0_1>d.<>1__state"
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0044
+    IL_000a:  ldarg.0
+    IL_000b:  ldfld      "int Program.<<<Main>$>g__Async2|0_1>d.i"
+    IL_0010:  call       "System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)"
+    IL_0015:  callvirt   "System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()"
+    IL_001a:  stloc.3
+    IL_001b:  ldloca.s   V_3
+    IL_001d:  call       "bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get"
+    IL_0022:  brtrue.s   IL_0060
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.0
+    IL_0028:  stfld      "int Program.<<<Main>$>g__Async2|0_1>d.<>1__state"
+    IL_002d:  ldarg.0
+    IL_002e:  ldloc.3
+    IL_002f:  stfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<<Main>$>g__Async2|0_1>d.<>u__1"
+    IL_0034:  ldarg.0
+    IL_0035:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> Program.<<<Main>$>g__Async2|0_1>d.<>t__builder"
+    IL_003a:  ldloca.s   V_3
+    IL_003c:  ldarg.0
+    IL_003d:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<<<Main>$>g__Async2|0_1>d>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<<<Main>$>g__Async2|0_1>d)"
+    IL_0042:  leave.s    IL_00a6
+    IL_0044:  ldarg.0
+    IL_0045:  ldfld      "System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<<Main>$>g__Async2|0_1>d.<>u__1"
+    IL_004a:  stloc.3
+    IL_004b:  ldarg.0
+    IL_004c:  ldflda     "System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<<Main>$>g__Async2|0_1>d.<>u__1"
+    IL_0051:  initobj    "System.Runtime.CompilerServices.TaskAwaiter<int>"
+    IL_0057:  ldarg.0
+    IL_0058:  ldc.i4.m1
+    IL_0059:  dup
+    IL_005a:  stloc.0
+    IL_005b:  stfld      "int Program.<<<Main>$>g__Async2|0_1>d.<>1__state"
+    IL_0060:  ldloca.s   V_3
+    IL_0062:  call       "int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()"
+    IL_0067:  stloc.2
+    IL_0068:  ldloc.2
+    IL_0069:  ldc.i4.s   30
+    IL_006b:  beq.s      IL_0072
+    IL_006d:  ldloc.2
+    IL_006e:  ldc.i4.s   40
+    IL_0070:  bne.un.s   IL_0075
+    IL_0072:  ldc.i4.1
+    IL_0073:  br.s       IL_0076
+    IL_0075:  ldc.i4.0
+    IL_0076:  stloc.1
+    IL_0077:  leave.s    IL_0092
+  }
+  catch System.Exception
+  {
+    IL_0079:  stloc.s    V_4
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.s   -2
+    IL_007e:  stfld      "int Program.<<<Main>$>g__Async2|0_1>d.<>1__state"
+    IL_0083:  ldarg.0
+    IL_0084:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> Program.<<<Main>$>g__Async2|0_1>d.<>t__builder"
+    IL_0089:  ldloc.s    V_4
+    IL_008b:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetException(System.Exception)"
+    IL_0090:  leave.s    IL_00a6
+  }
+  IL_0092:  ldarg.0
+  IL_0093:  ldc.i4.s   -2
+  IL_0095:  stfld      "int Program.<<<Main>$>g__Async2|0_1>d.<>1__state"
+  IL_009a:  ldarg.0
+  IL_009b:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool> Program.<<<Main>$>g__Async2|0_1>d.<>t__builder"
+  IL_00a0:  ldloc.1
+  IL_00a1:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<bool>.SetResult(bool)"
+  IL_00a6:  ret
+}
 """);
         }
     }

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -1080,7 +1080,7 @@ tryAgain:
         [Conditional("DEBUG")]
         internal void AssertStackEmpty()
         {
-            //Debug.Assert(_emitState.CurStack == 0);
+            Debug.Assert(_emitState.CurStack == 0);
         }
 
         // true if there may have been a label generated with no subsequent code

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -1080,7 +1080,7 @@ tryAgain:
         [Conditional("DEBUG")]
         internal void AssertStackEmpty()
         {
-            Debug.Assert(_emitState.CurStack == 0);
+            //Debug.Assert(_emitState.CurStack == 0);
         }
 
         // true if there may have been a label generated with no subsequent code

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -1083,6 +1083,16 @@ tryAgain:
             Debug.Assert(_emitState.CurStack == 0);
         }
 
+        [Conditional("DEBUG")]
+        internal void AssertStackDepth(int stack)
+        {
+            Debug.Assert(_emitState.CurStack == stack);
+        }
+
+#if DEBUG
+        internal int GetStackDepth() => _emitState.CurStack;
+#endif
+
         // true if there may have been a label generated with no subsequent code
         internal bool IsJustPastLabel()
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/59615
Closes https://github.com/dotnet/roslyn/issues/55334

~The idea is that while the expression is still spilled~, the expression is no longer spilled by default and the boolean result will be pushed to the stack. The input expression will be evaluated as sequence side effects which will in turn spill if necessary. As a result, codegen is now closer to binary expressions' (but not quite).

The same optimization could be applied to switch expression - looking at conditionals, we will have to merge stack type for that to work. I'll leave it out of this PR for now, I'm new to this so there may be a better way to accomplish the same. 


Thanks.