### PR TITLE
target and crossgen servicehub binaries for .NET 8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -327,6 +327,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- We should try to keep this version in sync with the version of app-local runtime in VS. -->
-    <MicrosoftNetCoreAppPackagesVersion>6.0.6</MicrosoftNetCoreAppPackagesVersion>
+    <MicrosoftNetCoreAppRuntimePackagesVersion>8.0.0-preview.5.23280.8</MicrosoftNetCoreAppRuntimePackagesVersion>
+    <MicrosoftWindowsDesktopAppRuntimePackagesVersion>8.0.0-preview.5.23302.2</MicrosoftWindowsDesktopAppRuntimePackagesVersion>
   </PropertyGroup>
 </Project>

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -293,6 +293,7 @@ namespace BuildBoss
                     case "net6.0-windows":
                     case "net7.0":
                     case "net8.0":
+                    case "net8.0-windows":
                         continue;
                 }
 

--- a/src/Workspaces/CSharpTest/Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj
+++ b/src/Workspaces/CSharpTest/Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.UnitTests</RootNamespace>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Workspaces/CoreTest/Microsoft.CodeAnalysis.Workspaces.UnitTests.csproj
+++ b/src/Workspaces/CoreTest/Microsoft.CodeAnalysis.Workspaces.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
+++ b/src/Workspaces/CoreTestUtilities/Microsoft.CodeAnalysis.Workspaces.Test.Utilities.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.UnitTests</RootNamespace>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>

--- a/src/Workspaces/MSBuildTest/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
+++ b/src/Workspaces/MSBuildTest/Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.MSBuild.UnitTests</RootNamespace>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -96,7 +96,7 @@
           Inputs="%(_CrossgenTargetPaths.FullPath)"
           Outputs="%(_CrossgenTargetPaths.OutputPath)">    
     <PropertyGroup>
-      <_Crossgen2Path>$(PkgMicrosoft_NETCore_App_crossgen2_win-x64)\tools\crossgen2.dll</_Crossgen2Path>
+      <_Crossgen2ExePath>$(PkgMicrosoft_NETCore_App_crossgen2_win-x64)\tools\crossgen2.exe</_Crossgen2ExePath>
       <_R2ROptimizeAssemblyPath>%(_CrossgenTargetPaths.FullPath)</_R2ROptimizeAssemblyPath>
       <_R2ROptimizeAssemblyOutputPath>$(PublishDir)%(_CrossgenTargetPaths.Filename)%(_CrossgenTargetPaths.Extension)</_R2ROptimizeAssemblyOutputPath>      
       <_RspFilePath>$(CrossgenWorkDir)%(_CrossgenTargetPaths.Filename).CrossgenArgs.rsp</_RspFilePath>
@@ -114,7 +114,7 @@
     <WriteLinesToFile File="$(_RspFilePath)" Lines="" Overwrite="true" />
     <WriteLinesToFile File="$(_RspFilePath)" Lines="@(_RspFileLines)" />
   
-    <Exec Command='"$(DotNetTool)" exec "$(_Crossgen2Path)" @"$(_RspFilePath)"' ConsoleToMSBuild="true" IgnoreExitCode="true">
+    <Exec Command='"$(_Crossgen2ExePath)" @"$(_RspFilePath)"' ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_Crossgen2Output" />
       <Output TaskParameter="ExitCode" PropertyName="_Crossgen2ErrorCode" />
     </Exec>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -9,7 +9,7 @@
     <IsShipping>false</IsShipping>
 
     <GenerateReadyToRun Condition="'$(GenerateReadyToRun)' == '' and '$(Configuration)' == 'Release' and '$(OfficialBuild)' == 'true'">true</GenerateReadyToRun>
-    <MicrosoftNETCoreAppcrossgen2winx64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftNETCoreAppcrossgen2winx64Version>
+    <MicrosoftNETCoreAppcrossgen2winx64Version>$(MicrosoftNetCoreAppRuntimePackagesVersion)</MicrosoftNETCoreAppcrossgen2winx64Version>
   </PropertyGroup>  
 
   <ItemGroup>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -145,7 +145,7 @@
         two would eventually be in sync. But we'd need to include those binaries during the out-of-sync period.
         Note, for the same reasone, we can't safely exclude shared dependencies from ServiceHub host folder.
       -->
-      <_PublishRuntimeLibraries>true</_PublishRuntimeLibraries>
+      <_PublishRuntimeLibraries>false</_PublishRuntimeLibraries>
     </PropertyGroup>
     <ItemGroup>
       <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/arm64/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/arm64/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.csproj
@@ -3,11 +3,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TargetArch>arm64</TargetArch>
 
-    <MicrosoftNETCoreAppRuntimewinarm64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftNETCoreAppRuntimewinarm64Version>
-    <MicrosoftWindowsDesktopAppRuntimewinarm64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftWindowsDesktopAppRuntimewinarm64Version>
+    <MicrosoftNETCoreAppRuntimewinarm64Version>$(MicrosoftNetCoreAppRuntimePackagesVersion)</MicrosoftNETCoreAppRuntimewinarm64Version>
+    <MicrosoftWindowsDesktopAppRuntimewinarm64Version>$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)</MicrosoftWindowsDesktopAppRuntimewinarm64Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-arm64" Version="$(MicrosoftNETCoreAppRuntimewinarm64Version)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/x64/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/x64/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.x64.csproj
@@ -3,11 +3,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TargetArch>x64</TargetArch>
 
-    <MicrosoftNETCoreAppRuntimewinx64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftNETCoreAppRuntimewinx64Version>
-    <MicrosoftWindowsDesktopAppRuntimewinx64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftWindowsDesktopAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRuntimewinx64Version>$(MicrosoftNetCoreAppRuntimePackagesVersion)</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftWindowsDesktopAppRuntimewinx64Version>$(MicrosoftWindowsDesktopAppRuntimePackagesVersion)</MicrosoftWindowsDesktopAppRuntimewinx64Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// the same <paramref name="solutionChecksum"/>). However, this is used by Pythia/Razor/UnitTesting which all
         /// assume they can get that solution instance and use as desired by them.
         /// </summary>
-        [Obsolete("Use RunServiceAsync (that is passsed a Solution) instead", error: false)]
+        [Obsolete("Use RunServiceAsync (that is passed a Solution) instead", error: false)]
         public async ValueTask<Solution> GetSolutionAsync(ServiceBrokerClient client, Checksum solutionChecksum, CancellationToken cancellationToken)
         {
             var assetSource = new SolutionAssetSource(client);
@@ -152,7 +152,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 var assemblyName = new AssemblyName(assemblyFullName);
                 if (!string.IsNullOrEmpty(codeBasePath))
                 {
+#pragma warning disable SYSLIB0044 // Type or member is obsolete
                     assemblyName.CodeBase = codeBasePath;
+#pragma warning restore SYSLIB0044 // Type or member is obsolete
                 }
 
                 return LoadAssembly(assemblyName);

--- a/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/Microsoft.CodeAnalysis.Remote.ServiceHub.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.Remote</RootNamespace>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- NuGet -->
     <IsPackable>true</IsPackable>

--- a/src/Workspaces/Remote/ServiceHubTest/Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests.csproj
+++ b/src/Workspaces/Remote/ServiceHubTest/Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>Microsoft.CodeAnalysis.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Workspaces/VisualBasicTest/Microsoft.CodeAnalysis.VisualBasic.Workspaces.UnitTests.vbproj
+++ b/src/Workspaces/VisualBasicTest/Microsoft.CodeAnalysis.VisualBasic.Workspaces.UnitTests.vbproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OptionStrict>Off</OptionStrict>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <RootNamespace></RootNamespace>
   </PropertyGroup>
   <ItemGroup Label="Project References">


### PR DESCRIPTION
VS is planning to move to .NET 8 runtime in 17.8, so adjust tfm and crossgen accordingly.
Validation run, RPS result looks good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/479575