### PR TITLE
Fix SuppressMessage attributes working on primary constructors

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5165,7 +5165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var symbol = GetDeclaredSymbolCore(declaration, cancellationToken);
             return symbol != null
                 ? ImmutableArray.Create(symbol)
-                : ImmutableArray.Create<ISymbol>();
+                : ImmutableArray<ISymbol>.Empty;
         }
 
         internal override void ComputeDeclarationsInSpan(TextSpan span, bool getSymbol, ArrayBuilder<DeclarationInfo> builder, CancellationToken cancellationToken)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5171,11 +5171,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected static SynthesizedPrimaryConstructor TryGetSynthesizedPrimaryConstructor(TypeDeclarationSyntax node, NamedTypeSymbol type)
         {
-            if (type is SourceMemberContainerTypeSymbol { PrimaryConstructor: { } symbol }
-                && symbol.SyntaxRef.SyntaxTree == node.SyntaxTree
-                && symbol.GetSyntax() == node)
+            if (type is SourceMemberContainerTypeSymbol { PrimaryConstructor: { } primaryConstructor }
+                && primaryConstructor.SyntaxRef.SyntaxTree == node.SyntaxTree
+                && primaryConstructor.GetSyntax() == node)
             {
-                return symbol;
+                return primaryConstructor;
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5155,15 +5155,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SuppressMessage(...)]`, it will be found when walking up to the type declaration.
             if (declaration is TypeDeclarationSyntax { ParameterList: not null } typeDeclaration)
             {
-                using var result = TemporaryArray<ISymbol>.Empty;
-
                 var namedType = GetDeclaredSymbol(typeDeclaration, cancellationToken);
-                result.Add(namedType);
 
-                if (namedType.GetSymbol<NamedTypeSymbol>() is SourceMemberContainerTypeSymbol { PrimaryConstructor: { } primaryConstructor })
-                    result.Add(primaryConstructor.GetPublicSymbol());
-
-                return result.ToImmutableAndClear();
+                return namedType.GetSymbol<NamedTypeSymbol>() is SourceMemberContainerTypeSymbol { PrimaryConstructor: { } primaryConstructor }
+                    ? ImmutableArray.Create<ISymbol>(namedType, primaryConstructor.GetPublicSymbol())
+                    : ImmutableArray.Create<ISymbol>(namedType);
             }
 
             var symbol = GetDeclaredSymbolCore(declaration, cancellationToken);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1247,7 +1247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private SynthesizedPrimaryConstructor TryGetSynthesizedPrimaryConstructor(TypeDeclarationSyntax node)
+        protected override SynthesizedPrimaryConstructor TryGetSynthesizedPrimaryConstructor(TypeDeclarationSyntax node)
         {
             NamedTypeSymbol type = GetDeclaredType(node);
             var symbol = (type as SourceMemberContainerTypeSymbol)?.PrimaryConstructor;

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1247,18 +1247,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override SynthesizedPrimaryConstructor TryGetSynthesizedPrimaryConstructor(TypeDeclarationSyntax node)
-        {
-            NamedTypeSymbol type = GetDeclaredType(node);
-            var symbol = (type as SourceMemberContainerTypeSymbol)?.PrimaryConstructor;
-
-            if (symbol?.SyntaxRef.SyntaxTree != node.SyntaxTree || symbol.GetSyntax() != node)
-            {
-                return null;
-            }
-
-            return symbol;
-        }
+        private SynthesizedPrimaryConstructor TryGetSynthesizedPrimaryConstructor(TypeDeclarationSyntax node)
+            => TryGetSynthesizedPrimaryConstructor(node, GetDeclaredType(node));
 
         private FieldSymbol GetDeclaredFieldSymbol(VariableDeclaratorSyntax variableDecl)
         {

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -399,8 +399,13 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Gets the symbol associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
-        /// this method returns all symbols declared by a given declaration syntax node. Specifically, in the case of field declaration syntax nodes,
-        /// which can declare multiple symbols, this method returns all declared symbols.
+        /// this method returns all symbols declared by a given declaration syntax node. Specifically:
+        /// <list type="number">
+        /// <item>in the case of field declaration syntax nodes, which can declare multiple symbols, this method returns
+        /// all declared symbols.</item>
+        /// <item>in the case of type declarations with a primary constructor, both the <see cref="INamedTypeSymbol"/>
+        /// for the type, and the <see cref="IMethodSymbol"/> for the primary contructor will be returned.</item>
+        /// </list>
         /// </summary>
         /// <param name="declaration">A syntax node that is a declaration. This can be any type
         /// derived from MemberDeclarationSyntax, TypeDeclarationSyntax, EnumDeclarationSyntax,

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis
         protected abstract ISymbol? GetDeclaredSymbolCore(SyntaxNode declaration, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Gets the symbol associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
+        /// Gets the symbols associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
         /// this method returns all symbols declared by a given declaration syntax node. Specifically:
         /// <list type="number">
         /// <item>in the case of field declaration syntax nodes, which can declare multiple symbols, this method returns
@@ -419,7 +419,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the symbol associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
+        /// Gets the symbols associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
         /// this method returns all symbols declared by a given declaration syntax node. Specifically:
         /// <list type="number">
         /// <item>in the case of field declaration syntax nodes, which can declare multiple symbols, this method returns

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -420,8 +420,13 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Gets the symbol associated with a declaration syntax node. Unlike <see cref="GetDeclaredSymbolForNode(SyntaxNode, CancellationToken)"/>,
-        /// this method returns all symbols declared by a given declaration syntax node. Specifically, in the case of field declaration syntax nodes,
-        /// which can declare multiple symbols, this method returns all declared symbols.
+        /// this method returns all symbols declared by a given declaration syntax node. Specifically:
+        /// <list type="number">
+        /// <item>in the case of field declaration syntax nodes, which can declare multiple symbols, this method returns
+        /// all declared symbols.</item>
+        /// <item>in the case of type declarations with a primary constructor, both the <see cref="INamedTypeSymbol"/>
+        /// for the type, and the <see cref="IMethodSymbol"/> for the primary contructor will be returned.</item>
+        /// </list>
         /// </summary>
         /// <param name="declaration">A syntax node that is a declaration. This can be any type
         /// derived from MemberDeclarationSyntax, TypeDeclarationSyntax, EnumDeclarationSyntax,


### PR DESCRIPTION
When migrating a normal constructor to a primary constructor, the way to keep its attributes assocaited with the constructor is to use the `[method:` target on the attribute.  However, this does not work with the SuppressMessage attribute the analyzer driver looks for.  Specifically, once *syntactically* on the type decl, the attribute is not found as only the corresponding *named type* is checked for attributes, not the primary constructor that the attribute is still associated with.

This is fixed up by examining the primary constructor in these cases, ensuring that attributes on it are seen when syntactically examining the named type node itself.