### PR TITLE
Fix assert when using `__arglist` and `in` arguments together

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -932,7 +932,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // We might have an extra argument for the __arglist() of a varargs method.
             Debug.Assert(arguments.Length == parameters.Length || arguments.Length == parameters.Length + 1, "argument count must match parameter count");
             Debug.Assert(parameters.All(p => p.RefKind == RefKind.None) || !argRefKindsOpt.IsDefault, "there are nontrivial parameters, so we must have argRefKinds");
-            Debug.Assert(argRefKindsOpt.IsDefault || argRefKindsOpt.Length == arguments.Length, "if we have argRefKinds, we should have one for each argument");
+            // We might have a missing ref kind for the __arglist() of a varargs method.
+            Debug.Assert(argRefKindsOpt.IsDefault || argRefKindsOpt.Length == arguments.Length || argRefKindsOpt.Length == arguments.Length - 1, "if we have argRefKinds, we should have one for each argument");
 
             for (int i = 0; i < arguments.Length; i++)
             {

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -930,10 +930,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> argRefKindsOpt)
         {
             // We might have an extra argument for the __arglist() of a varargs method.
-            Debug.Assert(arguments.Length == parameters.Length || arguments.Length == parameters.Length + 1, "argument count must match parameter count");
+            Debug.Assert(arguments.Length == parameters.Length ||
+                (arguments.Length == parameters.Length + 1 && arguments is [.., BoundArgListOperator]), "argument count must match parameter count");
             Debug.Assert(parameters.All(p => p.RefKind == RefKind.None) || !argRefKindsOpt.IsDefault, "there are nontrivial parameters, so we must have argRefKinds");
             // We might have a missing ref kind for the __arglist() of a varargs method.
-            Debug.Assert(argRefKindsOpt.IsDefault || argRefKindsOpt.Length == arguments.Length || argRefKindsOpt.Length == arguments.Length - 1, "if we have argRefKinds, we should have one for each argument");
+            Debug.Assert(argRefKindsOpt.IsDefault || argRefKindsOpt.Length == arguments.Length ||
+                (argRefKindsOpt.Length == arguments.Length - 1 && arguments is [.., BoundArgListOperator]), "if we have argRefKinds, we should have one for each argument");
 
             for (int i = 0; i < arguments.Length; i++)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ArglistTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ArglistTests.cs
@@ -1659,5 +1659,43 @@ class Program
                 options: TestOptions.DebugExe,
                 expectedOutput: "5");
         }
+
+        [ConditionalTheory(typeof(WindowsOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
+        [CombinatorialData]
+        public void RefModifier([CombinatorialValues("ref", "in")] string modifier)
+        {
+            var source = $$"""
+                class C
+                {
+                    static void M({{modifier}} int x, __arglist) => System.Console.Write(x);
+
+                    static void Main()
+                    {
+                        int x = 111;
+                        M({{modifier}} x, __arglist(x));
+                    }
+                }
+                """;
+            CompileAndVerify(source, expectedOutput: "111", verify: Verification.FailsILVerify).VerifyDiagnostics();
+        }
+
+        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/68714")]
+        public void InAsRValue()
+        {
+            var source = """
+                class C
+                {
+                    static void M(in int x, __arglist) => System.Console.Write(x);
+
+                    static void Main()
+                    {
+                        int x = 111;
+                        M(x, __arglist(x));
+                    }
+                }
+                """;
+            CompileAndVerify(source, expectedOutput: "111", verify: Verification.FailsILVerify).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68714.