### PR TITLE
Emit modopt for ref readonly parameters in function pointers

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/RefKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RefKindExtensions.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 case RefKind.None:
                 case RefKind.In:
+                case RefKind.RefReadOnlyParameter:
                     return false;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(refKind);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -160,6 +160,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return modifiers.Any(static modifier => !modifier.IsOptional && ((CSharpCustomModifier)modifier).ModifierSymbol.IsWellKnownTypeInAttribute());
         }
 
+        internal static bool HasRequiresLocationAttributeModifier(this ImmutableArray<CustomModifier> modifiers)
+        {
+            return modifiers.Any(static modifier => modifier.IsOptional && ((CSharpCustomModifier)modifier).ModifierSymbol.IsWellKnownTypeRequiresLocationAttribute());
+        }
+
         internal static bool HasIsExternalInitModifier(this ImmutableArray<CustomModifier> modifiers)
         {
             return modifiers.Any(static modifier => !modifier.IsOptional && ((CSharpCustomModifier)modifier).ModifierSymbol.IsWellKnownTypeIsExternalInit());

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -88,8 +88,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Debug.Assert(addRefReadOnlyModifier, "If addReadonlyRef isn't true, we must have found a different location to encode the readonlyness of a function pointer");
                     ImmutableArray<CustomModifier> customModifiers = refKind switch
                     {
-                        // PROTOTYPE: Confirm encoding of ref readonly parameters in function pointers.
-                        RefKind.In or RefKind.RefReadOnlyParameter => CreateInModifiers(binder, diagnostics, syntax),
+                        RefKind.In => CreateInModifiers(binder, diagnostics, syntax),
+                        RefKind.RefReadOnlyParameter => CreateRefReadonlyParameterModifiers(binder, diagnostics, syntax),
                         RefKind.Out => CreateOutModifiers(binder, diagnostics, syntax),
                         _ => ImmutableArray<CustomModifier>.Empty
                     };
@@ -993,6 +993,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static ImmutableArray<CustomModifier> CreateInModifiers(Binder binder, BindingDiagnosticBag diagnostics, SyntaxNode syntax)
         {
             return CreateModifiers(WellKnownType.System_Runtime_InteropServices_InAttribute, binder, diagnostics, syntax);
+        }
+
+        // only for function pointer parameters
+        private static ImmutableArray<CustomModifier> CreateRefReadonlyParameterModifiers(Binder binder, BindingDiagnosticBag diagnostics, SyntaxNode syntax)
+        {
+            var requiresLocationType = binder.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_RequiresLocationAttribute, diagnostics, syntax);
+            return ImmutableArray.Create(CSharpCustomModifier.CreateOptional(requiresLocationType));
         }
 
         internal static ImmutableArray<CustomModifier> CreateOutModifiers(Binder binder, BindingDiagnosticBag diagnostics, SyntaxNode syntax)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -2007,6 +2007,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static bool IsWellKnownTypeInAttribute(this TypeSymbol typeSymbol)
             => typeSymbol.IsWellKnownInteropServicesTopLevelType("InAttribute");
 
+        internal static bool IsWellKnownTypeRequiresLocationAttribute(this TypeSymbol typeSymbol)
+            => typeSymbol.IsWellKnownCompilerServicesTopLevelType("RequiresLocationAttribute");
+
         internal static bool IsWellKnownTypeUnmanagedType(this TypeSymbol typeSymbol)
             => typeSymbol.IsWellKnownInteropServicesTopLevelType("UnmanagedType");
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -47,7 +47,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         None,
         In,
         RequiresLocation,
-        Unknown
+        DoNotVerify
     }
 
     private static void VerifyRefReadonlyParameter(ParameterSymbol parameter,
@@ -77,7 +77,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             case VerifyModifiers.RequiresLocation:
                 verifyModifier(parameter, RequiresLocationAttributeQualifiedName, optional: true);
                 break;
-            case VerifyModifiers.Unknown:
+            case VerifyModifiers.DoNotVerify:
                 break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(customModifiers);
@@ -794,7 +794,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
 
         var ptr = (FunctionPointerTypeSymbol)comp.GlobalNamespace.GetMember<FieldSymbol>("C.D").Type;
         var p = ptr.Signature.Parameters.Single();
-        VerifyRefReadonlyParameter(p, refKind: false, attributes: false, customModifiers: VerifyModifiers.Unknown);
+        VerifyRefReadonlyParameter(p, refKind: false, attributes: false, customModifiers: VerifyModifiers.DoNotVerify);
         Assert.Equal(RefKind.In, p.RefKind);
         Assert.Empty(p.GetAttributes());
         AssertEx.SetEqual(new[]
@@ -863,7 +863,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         {
             var ptr = (FunctionPointerTypeSymbol)comp.GlobalNamespace.GetMember<FieldSymbol>("C.D").Type;
             var p = ptr.Signature.Parameters.Single();
-            VerifyRefReadonlyParameter(p, attributes: false, customModifiers: VerifyModifiers.Unknown);
+            VerifyRefReadonlyParameter(p, attributes: false, customModifiers: VerifyModifiers.DoNotVerify);
             Assert.Empty(p.GetAttributes());
             AssertEx.SetEqual(new[]
             {
@@ -916,7 +916,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
 
         var ptr = (FunctionPointerTypeSymbol)comp.GlobalNamespace.GetMember<FieldSymbol>("C.D").Type;
         var p = ptr.Signature.Parameters.Single();
-        VerifyRefReadonlyParameter(p, attributes: false, customModifiers: VerifyModifiers.Unknown, useSiteError: true);
+        VerifyRefReadonlyParameter(p, attributes: false, customModifiers: VerifyModifiers.DoNotVerify, useSiteError: true);
         Assert.Empty(p.GetAttributes());
         AssertEx.SetEqual(new[]
         {
@@ -965,7 +965,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
 
         var ptr = (FunctionPointerTypeSymbol)comp.GlobalNamespace.GetMember<FieldSymbol>("C.D").Type;
         var p = ptr.Signature.Parameters.Single();
-        VerifyRefReadonlyParameter(p, refKind: false, metadataIn: false, attributes: false, customModifiers: VerifyModifiers.Unknown, useSiteError: true);
+        VerifyRefReadonlyParameter(p, refKind: false, metadataIn: false, attributes: false, customModifiers: VerifyModifiers.DoNotVerify, useSiteError: true);
         Assert.Equal(RefKind.Ref, p.RefKind);
         Assert.Empty(p.GetAttributes());
         var mod = Assert.Single(p.RefCustomModifiers);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/FunctionPointerTypeSymbolTests.cs
@@ -1907,6 +1907,9 @@ unsafe class C
                 // (8,19): error CS8808: 'in' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.
                 //         delegate*<in int> ptr2;
                 Diagnostic(ErrorCode.ERR_InvalidFuncPointerReturnTypeModifier, "in").WithArguments("in").WithLocation(8, 19),
+                // (9,19): error CS0518: Predefined type 'System.Runtime.CompilerServices.RequiresLocationAttribute' is not defined or imported
+                //         delegate*<ref readonly int, void> ptr3;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "ref readonly int").WithArguments("System.Runtime.CompilerServices.RequiresLocationAttribute").WithLocation(9, 19),
                 // (9,23): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //         delegate*<ref readonly int, void> ptr3;
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(9, 23),
@@ -1926,7 +1929,7 @@ unsafe class C
 
             Assert.Equal("delegate*<System.Int32> ptr1", model.GetDeclaredSymbol(decls[0]).ToTestDisplayString());
             Assert.Equal("delegate*<System.Int32> ptr2", model.GetDeclaredSymbol(decls[1]).ToTestDisplayString());
-            Assert.Equal("delegate*<ref readonly modreq(System.Runtime.InteropServices.InAttribute) System.Int32, System.Void> ptr3", model.GetDeclaredSymbol(decls[2]).ToTestDisplayString());
+            Assert.Equal("delegate*<ref readonly modopt(System.Runtime.CompilerServices.RequiresLocationAttribute[missing]) System.Int32, System.Void> ptr3", model.GetDeclaredSymbol(decls[2]).ToTestDisplayString());
             Assert.Equal("delegate*<System.Void, System.Void> ptr4", model.GetDeclaredSymbol(decls[3]).ToTestDisplayString());
             Assert.Equal("delegate*<ref System.Void> ptr5", model.GetDeclaredSymbol(decls[4]).ToTestDisplayString());
         }


### PR DESCRIPTION
Speclet change: https://github.com/dotnet/csharplang/pull/7307 ([the relevant section with the selected design](https://github.com/dotnet/csharplang/blob/e95d2d1c63a4b3d459d808e12589be90dd7ff772/proposals/ref-readonly-parameters.md#function-pointers))
Test plan: https://github.com/dotnet/roslyn/issues/68056