### PR TITLE
Return correctly formatted URIs for file watching

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -67,7 +67,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);
 
-        Assert.Equal(tempDirectory.Path + Path.DirectorySeparatorChar, watcher.GlobPattern.BaseUri);
+        Assert.Equal(tempDirectory.Path + Path.DirectorySeparatorChar, watcher.GlobPattern.BaseUri.LocalPath);
         Assert.Equal("**/*", watcher.GlobPattern.Pattern);
 
         // Get rid of the registration and it should be gone again
@@ -99,7 +99,7 @@ public class LspFileChangeWatcherTests : AbstractLanguageServerHostTests
 
         var watcher = GetSingleFileWatcher(dynamicCapabilitiesRpcTarget);
 
-        Assert.Equal("Z:\\", watcher.GlobPattern.BaseUri);
+        Assert.Equal("Z:\\", watcher.GlobPattern.BaseUri.LocalPath);
         Assert.Equal("SingleFile.txt", watcher.GlobPattern.Pattern);
 
         // Get rid of the registration and it should be gone again

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspContractTypes.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspContractTypes.cs
@@ -27,7 +27,7 @@ internal class FileSystemWatcher
 [DataContract]
 internal class RelativePattern
 {
-    [DataMember(Name = "uri")]
+    [DataMember(Name = "baseUri")]
     [JsonConverter(typeof(DocumentUriConverter))]
     public required Uri BaseUri { get; set; }
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspContractTypes.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspContractTypes.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -26,8 +27,9 @@ internal class FileSystemWatcher
 [DataContract]
 internal class RelativePattern
 {
-    [DataMember(Name = "baseUri")]
-    public required string BaseUri { get; set; }
+    [DataMember(Name = "uri")]
+    [JsonConverter(typeof(DocumentUriConverter))]
+    public required Uri BaseUri { get; set; }
 
     [DataMember(Name = "pattern")]
     public required string Pattern { get; set; }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
@@ -76,7 +76,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 {
                     GlobPattern = new RelativePattern
                     {
-                        BaseUri = d.Path,
+                        BaseUri = new Uri(d.Path, UriKind.Absolute),
                         Pattern = d.ExtensionFilter is not null ? "**/*" + d.ExtensionFilter : "**/*"
                     }
                 }).ToArray();
@@ -139,7 +139,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 // TODO: figure out how I just can do an absolute path watch
                 GlobPattern = new RelativePattern
                 {
-                    BaseUri = Path.GetDirectoryName(filePath)!,
+                    BaseUri = new Uri(Path.GetDirectoryName(filePath)!, UriKind.Absolute),
                     Pattern = Path.GetFileName(filePath)
                 }
             };

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
@@ -76,7 +76,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 {
                     GlobPattern = new RelativePattern
                     {
-                        BaseUri = new Uri(d.Path, UriKind.Absolute),
+                        BaseUri = ProtocolConversions.GetUriFromFilePath(d.Path),
                         Pattern = d.ExtensionFilter is not null ? "**/*" + d.ExtensionFilter : "**/*"
                     }
                 }).ToArray();
@@ -139,7 +139,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 // TODO: figure out how I just can do an absolute path watch
                 GlobPattern = new RelativePattern
                 {
-                    BaseUri = new Uri(Path.GetDirectoryName(filePath)!, UriKind.Absolute),
+                    BaseUri = ProtocolConversions.GetUriFromFilePath(Path.GetDirectoryName(filePath)!),
                     Pattern = Path.GetFileName(filePath)
                 }
             };


### PR DESCRIPTION
After
<img width="1149" alt="image" src="https://github.com/dotnet/roslyn/assets/5749229/08e4ecc1-9350-4381-9c63-f4ed5ad5e262">

Before
<img width="1558" alt="image" src="https://github.com/dotnet/roslyn/assets/5749229/31b7b33f-2a49-4702-8b9e-7d5963aaee4b">

Resolves https://github.com/microsoft/vscode-dotnettools/issues/170
