### PR TITLE
Fixes SyntaxFactory.UsingDirective overload which always throws - #68761

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/UsingDirectiveSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/UsingDirectiveSyntax.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name)
-            => UsingDirective(globalKeyword: default, usingKeyword: default, staticKeyword, unsafeKeyword: default, alias, namespaceOrType: name, semicolonToken: default);
+            => UsingDirective(globalKeyword: default, usingKeyword: Token(SyntaxKind.UsingKeyword), staticKeyword, unsafeKeyword: default, alias, namespaceOrType: name, semicolonToken: Token(SyntaxKind.SemicolonToken));
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(SyntaxToken globalKeyword, SyntaxToken usingKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var someValidName = SyntaxFactory.ParseName(name);
             var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.StaticKeyword), null, someValidName);
             Assert.NotNull(usingDirective);
-            Assert.Equal(usingDirective.StaticKeyword.Kind(), SyntaxKind.StaticKeyword);
+            Assert.Equal(SyntaxKind.StaticKeyword, usingDirective.StaticKeyword.Kind());
             Assert.Null(usingDirective.Alias);
-            Assert.Equal(usingDirective.Name.ToFullString(), name);
+            Assert.Equal(name, usingDirective.Name.ToFullString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.StaticKeyword, usingDirective.StaticKeyword.Kind());
             Assert.Null(usingDirective.Alias);
             Assert.Equal("System.String", usingDirective.Name.ToFullString());
+            Assert.Equal(SyntaxKind.SemicolonToken, usingDirective.SemicolonToken.Kind());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -30,13 +30,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void UsingDirective()
         {
-            string name = "System.String";
-            var someValidName = SyntaxFactory.ParseName(name);
+            var someValidName = SyntaxFactory.ParseName("System.String");
             var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.StaticKeyword), null, someValidName);
             Assert.NotNull(usingDirective);
             Assert.Equal(SyntaxKind.StaticKeyword, usingDirective.StaticKeyword.Kind());
             Assert.Null(usingDirective.Alias);
-            Assert.Equal(name, usingDirective.Name.ToFullString());
+            Assert.Equal("System.String", usingDirective.Name.ToFullString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -28,6 +28,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void UsingDirective()
+        {
+            string name = "System.String";
+            var someValidName = SyntaxFactory.ParseName(name);
+            var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.StaticKeyword), null, someValidName);
+            Assert.NotNull(usingDirective);
+            Assert.Equal(usingDirective.StaticKeyword.Kind(), SyntaxKind.StaticKeyword);
+            Assert.Null(usingDirective.Alias);
+            Assert.Equal(usingDirective.Name.ToFullString(), name);
+        }
+
+        [Fact]
         public void SyntaxTree()
         {
             var text = SyntaxFactory.SyntaxTree(SyntaxFactory.CompilationUnit(), encoding: null).GetText();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68761

Note: alternative approach would be to have the generated code deal with the default case. I haven't looked into how to do that.

I'll have a bit more of a check around in case there are other similar issues nearby tomorrow, but nothing jumped out.