### PR TITLE
Improve sequence point placement in primary constructors and records

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
@@ -194,7 +194,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(accessor.MethodKind == MethodKind.PropertySet);
-
                 var parameter = accessor.Parameters[0];
                 statement = new BoundExpressionStatement(
                     accessor.SyntaxNode,

--- a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs
@@ -194,6 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(accessor.MethodKind == MethodKind.PropertySet);
+
                 var parameter = accessor.Parameters[0];
                 statement = new BoundExpressionStatement(
                     accessor.SyntaxNode,

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
@@ -45,29 +45,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequencePointWithSpan(usingSyntax, rewrittenStatement, span);
         }
 
-        private static TextSpan CreateSpanForConstructorInitializer(ConstructorDeclarationSyntax constructorSyntax)
-        {
-            if (constructorSyntax.Initializer != null)
-            {
-                //  [SomeAttribute] public MyCtorName(params int[] values): [|base()|] { ... }
-                var start = constructorSyntax.Initializer.ThisOrBaseKeyword.SpanStart;
-                var end = constructorSyntax.Initializer.ArgumentList.CloseParenToken.Span.End;
-                return TextSpan.FromBounds(start, end);
-            }
-
-            if (constructorSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
-            {
-                Debug.Assert(constructorSyntax.Body != null);
-
-                // [SomeAttribute] static MyCtorName(...) [|{|] ... }
-                var start = constructorSyntax.Body.OpenBraceToken.SpanStart;
-                var end = constructorSyntax.Body.OpenBraceToken.Span.End;
-                return TextSpan.FromBounds(start, end);
-            }
-
-            //  [SomeAttribute] [|public MyCtorName(params int[] values)|] { ... }
-            return CreateSpan(constructorSyntax.Modifiers, constructorSyntax.Identifier, constructorSyntax.ParameterList.CloseParenToken);
-        }
+        private static TextSpan CreateSpan(ParameterSyntax parameter)
+            // exclude attributes and default value:
+            // [A] [|in T p|] = default
+            => CreateSpan(parameter.Modifiers, parameter.Type, parameter.Identifier);
 
         private static TextSpan CreateSpan(SyntaxTokenList startOpt, SyntaxNodeOrToken startFallbackOpt, SyntaxNodeOrToken endOpt)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -5,7 +5,9 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -53,6 +55,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     statements.Add(F.Assignment(F.Field(F.This(), field), F.Field(param, field)));
                 }
             }
+
+            // Add a sequence point at the end of the copy-constructor, so that a breakpoint placed on the record constructor
+            // can be hit whenever a new instance of the record is created (either via a primary constructor or vie a copy constructor).
+            // 
+            // If the record doesn't have base initializer the span overlaps the span of the sequence point generated for primary
+            // constructor implicit base initializer:
+            //
+            // record [|C<T>(int P, int Q)|]               // implicit base constructor initializer span
+            // record C<T>(int P, int Q) : [|B(...)|]      // explicit base constructor initializer span
+            // record [|C<T>|](int P, int Q)               // copy-constructor span
+            //
+            // The copy-constructor span does not include the parameter list since the parameters are not in scope.
+            var recordDeclaration = (RecordDeclarationSyntax)F.Syntax;
+            statements.Add(new BoundSequencePointWithSpan(recordDeclaration, statementOpt: null,
+                (recordDeclaration.TypeParameterList == null) ? recordDeclaration.Identifier.Span :
+                TextSpan.FromBounds(recordDeclaration.Identifier.Span.Start, recordDeclaration.TypeParameterList.Span.End)));
         }
 
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordCopyCtor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Add a sequence point at the end of the copy-constructor, so that a breakpoint placed on the record constructor
-            // can be hit whenever a new instance of the record is created (either via a primary constructor or vie a copy constructor).
+            // can be hit whenever a new instance of the record is created (either via a primary constructor or via a copy constructor).
             // 
             // If the record doesn't have base initializer the span overlaps the span of the sequence point generated for primary
             // constructor implicit base initializer:

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1947,7 +1947,7 @@ record D(int X)
           </customDebugInfo>
           <sequencePoints>
             <entry offset=""0x0"" hidden=""true"" document=""1"" />
-            <entry offset=""0xd"" startLine=""3"" startColumn=""10"" endLine=""3"" endColumn=""15"" document=""1"" />
+            <entry offset=""0xd"" hidden=""true"" document=""1"" />
             <entry offset=""0x19"" startLine=""5"" startColumn=""34"" endLine=""5"" endColumn=""74"" document=""1"" />
             <entry offset=""0x31"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""16"" document=""1"" />
           </sequencePoints>
@@ -1974,6 +1974,15 @@ record D(int X)
         <method containingType=""D"" name=""set_Y"" parameterNames=""value"">
           <sequencePoints>
             <entry offset=""0x0"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""29"" document=""1"" />
+          </sequencePoints>
+        </method>
+        <method containingType=""D"" name="".ctor"" parameterNames=""original"">
+          <customDebugInfo>
+        <forward declaringType=""D"" methodName="".ctor"" parameterNames=""X"" />
+          </customDebugInfo>
+          <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""9"" document=""1"" />
           </sequencePoints>
         </method>
         <method containingType=""D+&lt;&gt;c__DisplayClass0_0"" name=""&lt;.ctor&gt;b__0"" parameterNames=""a"">
@@ -2028,7 +2037,7 @@ record D(int X) : C(F(X, out int z), () => z)
             </using>
           </customDebugInfo>
           <sequencePoints>
-            <entry offset=""0x0"" startLine=""3"" startColumn=""10"" endLine=""3"" endColumn=""15"" document=""1"" />
+            <entry offset=""0x0"" hidden=""true"" document=""1"" />
             <entry offset=""0x7"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""16"" document=""1"" />
           </sequencePoints>
           <scope startOffset=""0x0"" endOffset=""0xf"">
@@ -2053,6 +2062,15 @@ record D(int X) : C(F(X, out int z), () => z)
             <entry offset=""0x0"" startLine=""6"" startColumn=""11"" endLine=""6"" endColumn=""18"" document=""1"" />
             <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
             <entry offset=""0x9"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+          </sequencePoints>
+        </method>
+        <method containingType=""C"" name="".ctor"" parameterNames=""original"">
+          <customDebugInfo>
+        <forward declaringType=""C"" methodName="".ctor"" parameterNames=""X"" />
+          </customDebugInfo>
+          <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x13"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""9"" document=""1"" />
           </sequencePoints>
         </method>
         <method containingType=""D"" name="".ctor"" parameterNames=""X"">
@@ -2087,6 +2105,12 @@ record D(int X) : C(F(X, out int z), () => z)
             <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""15"" document=""1"" />
             <entry offset=""0x4"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""22"" document=""1"" />
             <entry offset=""0xa"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
+          </sequencePoints>
+        </method>
+        <method containingType=""D"" name="".ctor"" parameterNames=""original"">
+          <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8"" startLine=""11"" startColumn=""8"" endLine=""11"" endColumn=""9"" document=""1"" />
           </sequencePoints>
         </method>
         <method containingType=""D+&lt;&gt;c__DisplayClass0_0"" name=""&lt;.ctor&gt;b__0"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1912,7 +1912,7 @@ class Test
         }
 
         [Fact]
-        public void Record_1()
+        public void LiftedPrimaryParameter_Record()
         {
             var source = WithWindowsLineBreaks(@"
 using System;
@@ -1949,7 +1949,7 @@ record D(int X)
             <entry offset=""0x0"" hidden=""true"" document=""1"" />
             <entry offset=""0xd"" startLine=""3"" startColumn=""10"" endLine=""3"" endColumn=""15"" document=""1"" />
             <entry offset=""0x19"" startLine=""5"" startColumn=""34"" endLine=""5"" endColumn=""74"" document=""1"" />
-            <entry offset=""0x31"" startLine=""3"" startColumn=""1"" endLine=""6"" endColumn=""2"" document=""1"" />
+            <entry offset=""0x31"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""16"" document=""1"" />
           </sequencePoints>
           <scope startOffset=""0x0"" endOffset=""0x39"">
             <namespace name=""System"" />
@@ -1989,7 +1989,7 @@ record D(int X)
         }
 
         [Fact]
-        public void Record_2()
+        public void PrimaryBaseInitializer()
         {
             var source = WithWindowsLineBreaks(@"
 using System;
@@ -2029,7 +2029,7 @@ record D(int X) : C(F(X, out int z), () => z)
           </customDebugInfo>
           <sequencePoints>
             <entry offset=""0x0"" startLine=""3"" startColumn=""10"" endLine=""3"" endColumn=""15"" document=""1"" />
-            <entry offset=""0x7"" startLine=""3"" startColumn=""1"" endLine=""9"" endColumn=""2"" document=""1"" />
+            <entry offset=""0x7"" startLine=""3"" startColumn=""8"" endLine=""3"" endColumn=""16"" document=""1"" />
           </sequencePoints>
           <scope startOffset=""0x0"" endOffset=""0xf"">
             <namespace name=""System"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -28,6 +28,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
 {
     public class PDBTests : CSharpPDBTestBase
     {
+        public const PdbValidationOptions SyntaxOffsetPdbValidationOptions =
+            PdbValidationOptions.ExcludeDocuments |
+            PdbValidationOptions.ExcludeSequencePoints |
+            PdbValidationOptions.ExcludeScopes |
+            PdbValidationOptions.ExcludeNamespaces;
+
         private static readonly MetadataReference[] s_valueTupleRefs = new[] { SystemRuntimeFacadeRef, ValueTupleRef };
 
         #region General
@@ -8530,10 +8536,8 @@ class C
             var source = @"class C { bool F(object o) => o is int i && o is 3 && o is bool; }";
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
 
-            c.VerifyPdb("C.F", @"<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
+            c.VerifyPdb("C.F", @"
+<symbols>
   <methods>
     <method containingType=""C"" name=""F"" parameterNames=""o"">
       <customDebugInfo>
@@ -8544,15 +8548,10 @@ class C
           <slot kind=""0"" offset=""12"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x2d"">
-        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x2d"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
-</symbols>");
+</symbols>
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
@@ -10759,47 +10758,26 @@ public class C
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
 
             c.VerifyPdb("C..ctor", @"
-    <symbols>
-      <files>
-        <file id=""1"" name="""" language=""C#"" />
-      </files>
-      <methods>
-        <method containingType=""C"" name="".ctor"">
-          <customDebugInfo>
-            <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
-            <encLocalSlotMap>
-              <slot kind=""30"" offset=""-26"" />
-              <slot kind=""temp"" />
-              <slot kind=""35"" offset=""-26"" />
-            </encLocalSlotMap>
-            <encLambdaMap>
-              <methodOrdinal>2</methodOrdinal>
-              <closure offset=""-26"" />
-              <lambda offset=""-4"" closure=""0"" />
-            </encLambdaMap>
-          </customDebugInfo>
-          <sequencePoints>
-            <entry offset=""0x0"" hidden=""true"" document=""1"" />
-            <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""54"" document=""1"" />
-            <entry offset=""0x15"" startLine=""7"" startColumn=""27"" endLine=""7"" endColumn=""53"" document=""1"" />
-            <entry offset=""0x16"" hidden=""true"" document=""1"" />
-            <entry offset=""0x18"" startLine=""7"" startColumn=""41"" endLine=""7"" endColumn=""51"" document=""1"" />
-            <entry offset=""0x2c"" hidden=""true"" document=""1"" />
-            <entry offset=""0x2f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""54"" document=""1"" />
-            <entry offset=""0x30"" hidden=""true"" document=""1"" />
-            <entry offset=""0x37"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""8"" document=""1"" />
-            <entry offset=""0x3e"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""10"" document=""1"" />
-            <entry offset=""0x3f"" startLine=""5"" startColumn=""11"" endLine=""5"" endColumn=""12"" document=""1"" />
-          </sequencePoints>
-          <scope startOffset=""0x0"" endOffset=""0x40"">
-            <scope startOffset=""0x0"" endOffset=""0x37"">
-              <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x37"" attributes=""0"" />
-            </scope>
-          </scope>
-        </method>
-      </methods>
-    </symbols>
-");
+<symbols>
+  <methods>
+    <method containingType=""C"" name="".ctor"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
+        <encLocalSlotMap>
+          <slot kind=""30"" offset=""-26"" />
+          <slot kind=""temp"" />
+          <slot kind=""35"" offset=""-26"" />
+        </encLocalSlotMap>
+        <encLambdaMap>
+          <methodOrdinal>2</methodOrdinal>
+          <closure offset=""-26"" />
+          <lambda offset=""-4"" closure=""0"" />
+        </encLambdaMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [WorkItem(43468, "https://github.com/dotnet/roslyn/issues/43468")]
@@ -11188,10 +11166,8 @@ public class C
             var source = @"class C { int F() { (int a, (_, int c)) = (1, (2, 3)); return a + c; } }";
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
-            c.VerifyPdb("C.F", @"<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
+            c.VerifyPdb("C.F", @"
+<symbols>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -11204,19 +11180,9 @@ public class C
           <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" document=""1"" />
-        <entry offset=""0x5"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""69"" document=""1"" />
-        <entry offset=""0xb"" startLine=""1"" startColumn=""70"" endLine=""1"" endColumn=""71"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xd"">
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
-        <local name=""c"" il_index=""1"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
-</symbols>");
+</symbols>", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11271,10 +11237,8 @@ public class C
             var source = @"class C { int F() { (int, (int, int)) x = (1, (2, 3)); return x.Item1 + x.Item2.Item1 + x.Item2.Item2; } }";
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
-            c.VerifyPdb("C.F", @"<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
+            c.VerifyPdb("C.F", @"
+<symbols>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -11286,19 +11250,9 @@ public class C
           <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" document=""1"" />
-        <entry offset=""0x10"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""103"" document=""1"" />
-        <entry offset=""0x31"" startLine=""1"" startColumn=""104"" endLine=""1"" endColumn=""105"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x33"">
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x33"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
-</symbols>"
-);
+</symbols>", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11307,10 +11261,8 @@ public class C
             var source = @"class C { int F() { var x = (1, 2); return x.Item1 + x.Item2; } }";
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
-            c.VerifyPdb("C.F", @"<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
+            c.VerifyPdb("C.F", @"
+<symbols>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -11322,18 +11274,9 @@ public class C
           <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""36"" document=""1"" />
-        <entry offset=""0xa"" startLine=""1"" startColumn=""37"" endLine=""1"" endColumn=""62"" document=""1"" />
-        <entry offset=""0x1a"" startLine=""1"" startColumn=""63"" endLine=""1"" endColumn=""64"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x1c"">
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
-</symbols>");
+</symbols>", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11342,10 +11285,8 @@ public class C
             var source = @"class C { int F() { (int x, int y) a = (1, 2); return a.Item1 + a.Item2; } }";
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
-            c.VerifyPdb("C.F", @"<symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
+            c.VerifyPdb("C.F", @"
+<symbols>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -11360,18 +11301,9 @@ public class C
           <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x9"" startLine=""1"" startColumn=""48"" endLine=""1"" endColumn=""73"" document=""1"" />
-        <entry offset=""0x19"" startLine=""1"" startColumn=""74"" endLine=""1"" endColumn=""75"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x1b"">
-        <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
-</symbols>");
+</symbols>", options: SyntaxOffsetPdbValidationOptions);
         }
 
         #endregion
@@ -11424,9 +11356,6 @@ class C
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.G", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name=""G"" parameterNames=""x"">
       <customDebugInfo>
@@ -11441,23 +11370,10 @@ class C
           <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""28"" endLine=""1"" endColumn=""29"" document=""1"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""30"" endLine=""1"" endColumn=""40"" document=""1"" />
-        <entry offset=""0x3"" startLine=""1"" startColumn=""41"" endLine=""1"" endColumn=""54"" document=""1"" />
-        <entry offset=""0xc"" startLine=""1"" startColumn=""55"" endLine=""1"" endColumn=""68"" document=""1"" />
-        <entry offset=""0x15"" startLine=""1"" startColumn=""69"" endLine=""1"" endColumn=""82"" document=""1"" />
-        <entry offset=""0x1f"" startLine=""1"" startColumn=""83"" endLine=""1"" endColumn=""84"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x22"">
-        <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
-        <local name=""y"" il_index=""1"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
-        <local name=""w"" il_index=""2"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11489,9 +11405,6 @@ class A
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11504,28 +11417,10 @@ class A
           <slot kind=""0"" offset=""-3"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""26"" document=""1"" />
-        <entry offset=""0xd"" startLine=""5"" startColumn=""20"" endLine=""5"" endColumn=""32"" document=""1"" />
-        <entry offset=""0x1a"" startLine=""7"" startColumn=""11"" endLine=""7"" endColumn=""29"" document=""1"" />
-        <entry offset=""0x28"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x29"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x2a"">
-        <scope startOffset=""0x0"" endOffset=""0xd"">
-          <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
-        </scope>
-        <scope startOffset=""0xd"" endOffset=""0x1a"">
-          <local name=""y"" il_index=""1"" il_start=""0xd"" il_end=""0x1a"" attributes=""0"" />
-        </scope>
-        <scope startOffset=""0x1a"" endOffset=""0x2a"">
-          <local name=""z"" il_index=""2"" il_start=""0x1a"" il_end=""0x2a"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11556,9 +11451,6 @@ class A
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11570,23 +11462,10 @@ class A
           <slot kind=""0"" offset=""16"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""11"" endLine=""4"" endColumn=""29"" document=""1"" />
-        <entry offset=""0xe"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""19"" document=""1"" />
-        <entry offset=""0x11"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""13"" document=""1"" />
-        <entry offset=""0x15"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x16"">
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x16"" attributes=""0"" />
-        <scope startOffset=""0xe"" endOffset=""0x16"">
-          <local name=""y"" il_index=""1"" il_start=""0xe"" il_end=""0x16"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11614,9 +11493,6 @@ class A
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11628,20 +11504,10 @@ class A
           <slot kind=""0"" offset=""13"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""11"" endLine=""4"" endColumn=""29"" document=""1"" />
-        <entry offset=""0xe"" startLine=""5"" startColumn=""8"" endLine=""5"" endColumn=""20"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x17"">
-        <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x17"" attributes=""0"" />
-        <scope startOffset=""0xe"" endOffset=""0x17"">
-          <local name=""y"" il_index=""1"" il_start=""0xe"" il_end=""0x17"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11673,9 +11539,6 @@ class C
 
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11689,40 +11552,22 @@ class C
           <lambda offset=""-2"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6"" startLine=""2000"" startColumn=""5"" endLine=""2000"" endColumn=""40"" document=""1"" />
-        <entry offset=""0x29"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""8"" document=""1"" />
-        <entry offset=""0x30"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x31"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x32"">
-        <scope startOffset=""0x0"" endOffset=""0x29"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x29"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass2_0.<.ctor>b__0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass2_0"" name=""&lt;.ctor&gt;b__0"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2000"" startColumn=""37"" endLine=""2000"" endColumn=""38"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11750,9 +11595,6 @@ class C
 
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11766,37 +11608,22 @@ class C
           <lambda offset=""-2"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6"" startLine=""2000"" startColumn=""23"" endLine=""2000"" endColumn=""48"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x31"">
-        <scope startOffset=""0x0"" endOffset=""0x29"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x29"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass5_0.<.ctor>b__0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass5_0"" name=""&lt;.ctor&gt;b__0"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2000"" startColumn=""46"" endLine=""2000"" endColumn=""47"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11862,9 +11689,6 @@ class C
 
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11881,60 +11705,34 @@ class C
           <lambda offset=""-2"" closure=""1"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6"" startLine=""2000"" startColumn=""5"" endLine=""2000"" endColumn=""39"" document=""1"" />
-        <entry offset=""0x29"" hidden=""true"" document=""1"" />
-        <entry offset=""0x2f"" startLine=""2000"" startColumn=""41"" endLine=""2000"" endColumn=""71"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x5a"">
-        <scope startOffset=""0x0"" endOffset=""0x29"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x29"" attributes=""0"" />
-        </scope>
-        <scope startOffset=""0x29"" endOffset=""0x52"">
-          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0x29"" il_end=""0x52"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass4_0.<.ctor>b__0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass4_0"" name=""&lt;.ctor&gt;b__0"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2000"" startColumn=""37"" endLine=""2000"" endColumn=""38"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass4_1.<.ctor>b__1", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass4_1"" name=""&lt;.ctor&gt;b__1"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""G"" parameterNames=""x"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2000"" startColumn=""69"" endLine=""2000"" endColumn=""70"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -11968,9 +11766,6 @@ class A
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -11986,37 +11781,22 @@ class A
           <lambda offset=""-3"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6"" startLine=""2000"" startColumn=""11"" endLine=""2000"" endColumn=""41"" document=""1"" />
-        <entry offset=""0x2a"" startLine=""2001"" startColumn=""5"" endLine=""2001"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x2b"" startLine=""2002"" startColumn=""5"" endLine=""2002"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x2c"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x2c"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass0_0.<.ctor>b__0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass0_0"" name=""&lt;.ctor&gt;b__0"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".ctor"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2000"" startColumn=""38"" endLine=""2000"" endColumn=""39"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -12046,9 +11826,6 @@ class C
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -12063,28 +11840,13 @@ class C
           <lambda offset=""88"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""8"" document=""1"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""11"" endColumn=""26"" document=""1"" />
-        <entry offset=""0x37"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x38"">
-        <namespace name=""System.Linq"" />
-        <scope startOffset=""0x7"" endOffset=""0x38"">
-          <local name=""q"" il_index=""0"" il_start=""0x7"" il_end=""0x38"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c.<.ctor>b__0_0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__0_0"" parameterNames=""a"">
       <customDebugInfo>
@@ -12093,16 +11855,10 @@ class C
           <slot kind=""0"" offset=""98"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""23"" endLine=""10"" endColumn=""40"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xb"">
-        <local name=""x1"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -12137,9 +11893,6 @@ class C
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -12156,28 +11909,13 @@ class C
           <lambda offset=""112"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""8"" document=""1"" />
-        <entry offset=""0x7"" startLine=""2000"" startColumn=""5"" endLine=""2000"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x8"" startLine=""2001"" startColumn=""9"" endLine=""2004"" endColumn=""26"" document=""1"" />
-        <entry offset=""0x37"" startLine=""2005"" startColumn=""5"" endLine=""2005"" endColumn=""6"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x38"">
-        <namespace name=""System.Linq"" />
-        <scope startOffset=""0x7"" endOffset=""0x38"">
-          <local name=""q"" il_index=""0"" il_start=""0x7"" il_end=""0x38"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c.<.ctor>b__0_0", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__0_0"" parameterNames=""a"">
       <customDebugInfo>
@@ -12186,35 +11924,22 @@ class C
           <slot kind=""30"" offset=""88"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6"" startLine=""2003"" startColumn=""23"" endLine=""2003"" endColumn=""50"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x25"">
-        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x25"" attributes=""0"" />
-      </scope>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
 
             c.VerifyPdb("C+<>c__DisplayClass0_0.<.ctor>b__1", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c__DisplayClass0_0"" name=""&lt;.ctor&gt;b__1"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName="".ctor"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2003"" startColumn=""47"" endLine=""2003"" endColumn=""49"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -12224,47 +11949,24 @@ class C
 
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.G", @"
-    <symbols>
-      <files>
-        <file id=""1"" name="""" language=""C#"" />
-      </files>
-      <methods>
-        <method containingType=""C"" name=""G"">
-          <customDebugInfo>
-            <using>
-              <namespace usingCount=""0"" />
-            </using>
-            <encLocalSlotMap>
-              <slot kind=""0"" offset=""13"" />
-              <slot kind=""temp"" />
-              <slot kind=""35"" offset=""16"" />
-              <slot kind=""temp"" />
-            </encLocalSlotMap>
-          </customDebugInfo>
-          <sequencePoints>
-            <entry offset=""0x0"" startLine=""1"" startColumn=""32"" endLine=""1"" endColumn=""99"" document=""1"" />
-            <entry offset=""0xb"" startLine=""1"" startColumn=""45"" endLine=""1"" endColumn=""99"" document=""1"" />
-            <entry offset=""0xc"" hidden=""true"" document=""1"" />
-            <entry offset=""0x11"" hidden=""true"" document=""1"" />
-            <entry offset=""0x14"" startLine=""1"" startColumn=""64"" endLine=""1"" endColumn=""89"" document=""1"" />
-            <entry offset=""0x15"" hidden=""true"" document=""1"" />
-            <entry offset=""0x1b"" startLine=""1"" startColumn=""78"" endLine=""1"" endColumn=""79"" document=""1"" />
-            <entry offset=""0x1f"" startLine=""1"" startColumn=""86"" endLine=""1"" endColumn=""87"" document=""1"" />
-            <entry offset=""0x23"" hidden=""true"" document=""1"" />
-            <entry offset=""0x26"" startLine=""1"" startColumn=""45"" endLine=""1"" endColumn=""99"" document=""1"" />
-            <entry offset=""0x27"" startLine=""1"" startColumn=""62"" endLine=""1"" endColumn=""89"" document=""1"" />
-            <entry offset=""0x2b"" startLine=""1"" startColumn=""96"" endLine=""1"" endColumn=""97"" document=""1"" />
-            <entry offset=""0x2f"" hidden=""true"" document=""1"" />
-            <entry offset=""0x32"" startLine=""1"" startColumn=""32"" endLine=""1"" endColumn=""99"" document=""1"" />
-            <entry offset=""0x33"" hidden=""true"" document=""1"" />
-          </sequencePoints>
-          <scope startOffset=""0x0"" endOffset=""0x3a"">
-            <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x3a"" attributes=""0"" />
-          </scope>
-        </method>
-      </methods>
-    </symbols>
-");
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""G"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""0"" offset=""13"" />
+          <slot kind=""temp"" />
+          <slot kind=""35"" offset=""16"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         [Fact]
@@ -12284,9 +11986,6 @@ class C(int x) : B(F(out var y), y)
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""B"" name="".ctor"" parameterNames=""x, y"">
       <customDebugInfo>
@@ -12294,9 +11993,6 @@ class C(int x) : B(F(out var y), y)
           <namespace usingCount=""0"" />
         </using>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""2"" startColumn=""7"" endLine=""2"" endColumn=""22"" document=""1"" />
-      </sequencePoints>
     </method>
     <method containingType=""C"" name="".ctor"" parameterNames=""x"">
       <customDebugInfo>
@@ -12306,28 +12002,15 @@ class C(int x) : B(F(out var y), y)
           <slot kind=""0"" offset=""-20"" />
         </encLocalSlotMap>
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""26"" document=""1"" />
-        <entry offset=""0xd"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""36"" document=""1"" />
-      </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x1d"">
-        <local name=""y"" il_index=""0"" il_start=""0x0"" il_end=""0x1d"" attributes=""0"" />
-        <scope startOffset=""0x0"" endOffset=""0xd"">
-          <local name=""z"" il_index=""1"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
-        </scope>
-      </scope>
     </method>
     <method containingType=""C"" name=""F"" parameterNames=""a"">
       <customDebugInfo>
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""x, y"" />
       </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""32"" endLine=""9"" endColumn=""37"" document=""1"" />
-      </sequencePoints>
     </method>
   </methods>
 </symbols>
-");
+", options: SyntaxOffsetPdbValidationOptions);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -12479,7 +12479,7 @@ class A : System.Attribute {}
 }
 ");
         }
-        
+
         [Theory]
         [InlineData("int[] P = default", "int[] P")]
         [InlineData("[A]int[] P", "int[] P")]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -12413,7 +12413,7 @@ class C(int x) : B
 
         [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/63299")]
-        public void SequencePoints_RecordConstructors_ModiifersAndDefault()
+        public void SequencePoints_RecordConstructors_ModifiersAndDefault()
         {
             var source = @"
 record C<T>([A]in T P = default) where T : struct;
@@ -12421,7 +12421,7 @@ record C<T>([A]in T P = default) where T : struct;
 class A : System.Attribute {}
 " + IsExternalInitTypeDefinition;
 
-            var c = CompileAndVerify(source);
+            var c = CompileAndVerify(source, verify: Verification.Skipped);
 
             // primary constructor
             c.VerifyMethodBody("C<T>..ctor(in T)", @"
@@ -12492,7 +12492,7 @@ class A : System.Attribute {}
                 "class A : System.Attribute { }" +
                 IsExternalInitTypeDefinition;
 
-            var c = CompileAndVerify(source);
+            var c = CompileAndVerify(source, verify: Verification.Skipped);
 
             // primary auto-property getter
             c.VerifyMethodBody("C.P.get", $@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -13220,24 +13220,27 @@ public record D(int J) : C(1)
 ";
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, parseOptions: TestOptions.Regular9, options: TestOptions.DebugExe);
             var verifier = CompileAndVerify(comp, expectedOutput: "(1, 2, 42) (10, 20, 42)", verify: ExecutionConditionUtil.IsCoreClr ? Verification.Skipped : Verification.Fails).VerifyDiagnostics();
-            verifier.VerifyIL("D..ctor(D)", @"
- {
-      // Code size       33 (0x21)
-      .maxstack  2
-      IL_0000:  ldarg.0
-      IL_0001:  ldarg.1
-      IL_0002:  call       ""C..ctor(C)""
-      IL_0007:  nop
-      IL_0008:  ldarg.0
-      IL_0009:  ldarg.1
-      IL_000a:  ldfld      ""int D.<J>k__BackingField""
-      IL_000f:  stfld      ""int D.<J>k__BackingField""
-      IL_0014:  ldarg.0
-      IL_0015:  ldarg.1
-      IL_0016:  ldfld      ""int D.field""
-      IL_001b:  stfld      ""int D.field""
-      IL_0020:  ret
-    }
+            verifier.VerifyMethodBody("D..ctor(D)", @"
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""C..ctor(C)""
+  IL_0007:  nop
+  IL_0008:  ldarg.0
+  IL_0009:  ldarg.1
+  IL_000a:  ldfld      ""int D.<J>k__BackingField""
+  IL_000f:  stfld      ""int D.<J>k__BackingField""
+  IL_0014:  ldarg.0
+  IL_0015:  ldarg.1
+  IL_0016:  ldfld      ""int D.field""
+  IL_001b:  stfld      ""int D.field""
+  // sequence point: D
+  IL_0020:  nop
+  IL_0021:  ret
+}
 ");
         }
 

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -56,10 +56,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// don't know the actual IL offset, but only {block/offset-in-the-block} pair.
         ///
         /// Thus, whenever we need to mark some IL position we allocate a new marker id, store it
-        /// in allocatedILMarkers and reference this IL marker in the entity requiring the IL offset.
+        /// in <see cref="_allocatedILMarkers"/> and reference this IL marker in the entity requiring the IL offset.
         ///
         /// IL markers will be 'materialized' when the builder is realized; the resulting offsets
-        /// will be put into allocatedILMarkers array. Note that only markers from reachable blocks
+        /// will be put into <see cref="_allocatedILMarkers"/> array. Note that only markers from reachable blocks
         /// are materialized, the rest will have offset -1.
         /// </summary>
         private ArrayBuilder<ILMarker> _allocatedILMarkers;

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1291,7 +1292,7 @@ $$    (
 
         #endregion
 
-        #region Field and Veriable Declarators
+        #region Field and Variable Declarators
 
         [Fact]
         public void FieldDeclarator_WithoutInitializer_All()
@@ -4407,6 +4408,157 @@ $$    using ([|var vv = goo()|])
     {
     }
 }");
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ImplicitBaseInitializer_OutsideOfIdentifierAndNonEmptyParameters(
+            [CombinatorialValues("class", "struct", "record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "$$[A]class [|C()|];",
+                "$$class [|C()|];",
+                "class$$ [|C()|];",
+                "class [|C($$)|];",
+                "$$class [|C(int a)|];",
+                "$$class [|C(int a, int b)|];",
+                "class [|C(int a, int b)|]$$;",
+                "class [|C(int a, int b)|]$$ { }",
+                "class [|C(int a, int b)|]$$ : B { }",
+                "class [|C<T>(int a, int b)|]$$ where T : notnull;",
+                "class [|C<T>(int a, int b)|] where $$T : notnull;",
+                "class [|C<T>(int a, int b)|] where T : notnull$$;",
+                "class [|C<T>(int a, int b)|] where T : notnull$$ { }")] string source)
+        {
+            TestSpan(source.Replace("class", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ImplicitBaseInitializer_OnIdentifierOrNonEmptyParameters_NonRecord(
+            [CombinatorialValues("class", "struct")] string keyword,
+            [CombinatorialValues(
+                "class [|$$C(int a, int b)|];",
+                "class [|C$$(int a, int b)|];",
+                "class [|C$$<T>(int a, int b)|];",
+                "class [|C<$$T>(int a, int b)|];",
+                "class [|C<$$[A]T>(int a, int b)|];",
+                "class [|C<T>$$(int a, int b)|];",
+                "class [|C<T>($$int a, int b)|];",
+                "class [|C<T>($$[A]int a, int b)|];",
+                "class [|C<T>(int a, int b$$)|];")] string source)
+        {
+            TestSpan(source.Replace("class", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ImplicitBaseInitializer_OnIdentifierOrNonEmptyParameters_Record(
+            [CombinatorialValues("record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "record [|$$C|](int a, int b);",          // copy-ctor
+                "record [|C$$|](int a, int b);",          // copy-ctor
+                "record [|C$$<T>|](int a, int b);",       // copy-ctor
+                "record [|C<$$T>|](int a, int b);",       // copy-ctor
+                "record [|C<$$[A]T>|](int a, int b);",    // copy-ctor
+                "record [|C<T>$$|](int a, int b);",       // copy-ctor
+                "record C<T>([|$$int a|], int b);",       // property getter and setter
+                "record C<T>($$[A][|int a|], int b);",    // property getter and setter
+                "record C<T>($$   [A][|int a|], int b);", // property getter and setter
+                "record C<T>(int a, [|int b$$|]);",       // property getter and setter
+                "record C<T>(int a,  $$ [|int b|]);",     // property getter and setter
+                "record C<T>(int a, [|params int[] b|]  $$);",     // property getter and setter
+                "record C<T>(int a, [|int b|] = default$$);")] string source) // property getter and setter
+        {
+            TestSpan(source.Replace("record", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ImplicitBaseInitializer_NoBreakpoint(
+            [CombinatorialValues("class", "struct", "record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "$$[A]class C;",
+                "$$class C;",
+                "class C$$;",
+                "class C(int a, int b) : B$$ { }",
+                "class C(int a, int b) : B {$$ }",
+                "class C(int a, int b) : B { }$$",
+                "class C(int a, int b) : B, $$I { }")] string source)
+        {
+            TestMissing(source.Replace("class", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ExplicitBaseInitializer_OutsideOfIdentifierAndNonEmptyParameters(
+            [CombinatorialValues("class", "struct", "record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "$$[A]class C() : [|B()|];",
+                "$$class C() : [|B()|];",
+                "$$class C(int a) : [|B()|];",
+                "$$class C(int a, int b) : [|B()|];",
+                "class C(int a, int b)$$ : [|B()|];",
+                "class C(int a, int b) :$$ [|B()|];",
+                "class C(int a, int b) : [|$$B()|];",
+                "class C(int a, int b) : [|B($$)|];",
+                "class C(int a, int b) : [|B()$$|];",
+                "class C(int a, int b) : [|B()|] $$;",
+                "class C(int a, int b) : [|B()|] $$ {}",
+                "class C(int a, int b) : [|B()|], $$I {}",
+                "class C(int a, int b) : [|B()|], I$$ {}",
+                "class C<T>(int a, int b) : [|B()|] $$ where T : notnull;",
+                "class C<T>(int a, int b) : [|B()|], $$I where T : notnull { }",
+                "class C<T>(int a, int b) : [|B()|], I$$ where T : notnull { }",
+                "class C<T>(int a, int b) : [|B()|]  where $$T : notnull;",
+                "class C<T>(int a, int b) : [|B()|]  where T : notnull$$;",
+                "class C<T>(int a, int b) : [|B()|]  where T : notnull$$ { }")] string source)
+        {
+            TestSpan(source.Replace("class", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ExplicitBaseInitializer_OnIdentifierOrNonEmptyParameters_NonRecord(
+            [CombinatorialValues("class", "struct")] string keyword,
+            [CombinatorialValues(
+                "class $$C(int a, int b) : [|B()|];",
+                "class C$$(int a, int b) : [|B()|];",
+                "class C<$$[A]T>(int a, int b) : [|B()|];",
+                "class C<T>$$(int a, int b) : [|B()|];",
+                "record C<T>($$int a, int b) : [|B()|];",
+                "record C<T>(int a, $$int b) : [|B()|];",
+                "record C<T>(int a, int b =$$ 1) : [|B()|];")] string source)
+        {
+            TestSpan(source.Replace("class", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ExplicitBaseInitializer_OnIdentifierOrNonEmptyParameters_Record(
+            [CombinatorialValues("record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "record [|$$C|](int a, int b) : B();",        // copy-constructor
+                "record [|C$$|](int a, int b) : B();",        // copy-constructor
+                "record [|C<$$[A]T>|](int a, int b) : B();",  // copy-constructor
+                "record [|C<T>$$|](int a, int b) : B();",     // copy-constructor
+                "record C<T>([|$$int a|], int b) : B();",     // property getter and setter
+                "record C<T>(int a, [|$$int b|]) : B();",     // property getter and setter
+                "record C<T>(int a, [|$$int b = 1|]) : B();")] string source) // property getter and setter
+        {
+            TestSpan(source.Replace("record", keyword));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void InstanceConstructor_Primary_ExplicitBaseInitializer_NoBreakpoint(
+            [CombinatorialValues("class", "struct", "record", "record struct")] string keyword,
+            [CombinatorialValues(
+                "class C(int a, int b) : B() {$$ }",
+                "class C(int a, int b) : B();$$",
+                "class C(int a, int b) : B() { }$$",
+                "class C(int a, int b) : B(), I { }$$")] string source)
+        {
+            TestMissing(source.Replace("class", keyword));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -55,7 +55,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.Debugging
             else
             {
                 Assert.True(hasBreakpoint);
-                Assert.Equal(expectedSpan.Value, breakpointSpan);
+                AssertEx.AreEqual(
+                    expectedSpan.Value,
+                    breakpointSpan,
+                    message: $"Expected: [|{source.Substring(expectedSpan.Value.Start, expectedSpan.Value.Length)}|], Actual: [|{source.Substring(breakpointSpan.Start, breakpointSpan.Length)}|]");
             }
         }
 
@@ -4424,6 +4427,8 @@ $$    using ([|var vv = goo()|])
                 "class [|C(int a, int b)|]$$;",
                 "class [|C(int a, int b)|]$$ { }",
                 "class [|C(int a, int b)|]$$ : B { }",
+                "class [|C(int a, int b)|] : B$$ { }",
+                "class [|C(int a, int b)|] : B, $$I { }",
                 "class [|C<T>(int a, int b)|]$$ where T : notnull;",
                 "class [|C<T>(int a, int b)|] where $$T : notnull;",
                 "class [|C<T>(int a, int b)|] where T : notnull$$;",
@@ -4480,10 +4485,10 @@ $$    using ([|var vv = goo()|])
                 "$$[A]class C;",
                 "$$class C;",
                 "class C$$;",
-                "class C(int a, int b) : B$$ { }",
-                "class C(int a, int b) : B {$$ }",
-                "class C(int a, int b) : B { }$$",
-                "class C(int a, int b) : B, $$I { }")] string source)
+                "class C;$$",
+                "class C(int a, int b);$$",
+                "class C(int a, int b) : B;$$",
+                "class C(int a, int b) : B { }$$")] string source)
         {
             TestMissing(source.Replace("class", keyword));
         }
@@ -4525,9 +4530,9 @@ $$    using ([|var vv = goo()|])
                 "class C$$(int a, int b) : [|B()|];",
                 "class C<$$[A]T>(int a, int b) : [|B()|];",
                 "class C<T>$$(int a, int b) : [|B()|];",
-                "record C<T>($$int a, int b) : [|B()|];",
-                "record C<T>(int a, $$int b) : [|B()|];",
-                "record C<T>(int a, int b =$$ 1) : [|B()|];")] string source)
+                "class C<T>($$int a, int b) : [|B()|];",
+                "class C<T>(int a, $$int b) : [|B()|];",
+                "class C<T>(int a, int b =$$ 1) : [|B()|];")] string source)
         {
             TestSpan(source.Replace("class", keyword));
         }
@@ -4543,7 +4548,7 @@ $$    using ([|var vv = goo()|])
                 "record [|C<T>$$|](int a, int b) : B();",     // copy-constructor
                 "record C<T>([|$$int a|], int b) : B();",     // property getter and setter
                 "record C<T>(int a, [|$$int b|]) : B();",     // property getter and setter
-                "record C<T>(int a, [|$$int b = 1|]) : B();")] string source) // property getter and setter
+                "record C<T>(int a, [|$$int b|] = 1) : B();")] string source) // property getter and setter
         {
             TestSpan(source.Replace("record", keyword));
         }
@@ -4556,6 +4561,7 @@ $$    using ([|var vv = goo()|])
                 "class C(int a, int b) : B() {$$ }",
                 "class C(int a, int b) : B();$$",
                 "class C(int a, int b) : B() { }$$",
+                "class C(int a, int b) : B {$$ }",
                 "class C(int a, int b) : B(), I { }$$")] string source)
         {
             TestMissing(source.Replace("class", keyword));

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -153,6 +153,86 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ConstructorDeclaration:
                     return CreateSpanForConstructorDeclaration((ConstructorDeclarationSyntax)node, position);
 
+                case SyntaxKind.RecordDeclaration:
+                case SyntaxKind.RecordStructDeclaration:
+                case SyntaxKind.StructDeclaration:
+                case SyntaxKind.ClassDeclaration:
+                    var typeDeclaration = (TypeDeclarationSyntax)node;
+                    if (typeDeclaration.ParameterList != null)
+                    {
+                        // after brace or semicolon
+                        // class C<T>(...) {$$ ... }
+                        // class C<T>(...) ;$$
+                        if (position > LastNotMissing(typeDeclaration.SemicolonToken, typeDeclaration.OpenBraceToken).SpanStart)
+                        {
+                            return null;
+                        }
+
+                        // on or after explicit base initializer:
+                        //   C<T>(...) :$$ [|B(...)|], I
+                        //   C<T>(...) : [|B(...)|], I where ... $$
+                        var baseInitializer = typeDeclaration.BaseList?.Types.FirstOrDefault(t => t.IsKind(SyntaxKind.PrimaryConstructorBaseType));
+                        if (baseInitializer != null && position > typeDeclaration.BaseList!.ColonToken.SpanStart)
+                        {
+                            return baseInitializer.Span;
+                        }
+
+                        // record properties and copy constructor
+                        if (position >= typeDeclaration.Identifier.SpanStart && node is RecordDeclarationSyntax)
+                        {
+                            // on identifier:
+                            // record $$C<T>(...) : B(...);
+                            // record C<T>$$(...) : B(...);
+                            if (position <= typeDeclaration.ParameterList.SpanStart)
+                            {
+                                // copy-constructor: [|C<T>|]
+                                return CreateSpan(
+                                    typeDeclaration.Identifier,
+                                    LastNotMissing(typeDeclaration.Identifier, typeDeclaration.TypeParameterList?.GreaterThanToken ?? default));
+                            }
+
+                            // on parameter:
+                            // record C<T>(..., $$ int p, ...) : B(...);
+                            if (position < typeDeclaration.ParameterList.CloseParenToken.Span.End)
+                            {
+                                var parameter = GetParameter(position, typeDeclaration.ParameterList.Parameters);
+                                if (parameter != null)
+                                {
+                                    // [A][|int p|] = default
+                                    return CreateSpan(parameter.Modifiers, parameter.Type, parameter.Identifier);
+                                }
+
+                                static ParameterSyntax? GetParameter(int position, SeparatedSyntaxList<ParameterSyntax> parameters)
+                                {
+                                    if (parameters.Count == 0)
+                                    {
+                                        return null;
+                                    }
+
+                                    for (var i = 0; i < parameters.SeparatorCount; i++)
+                                    {
+                                        var separator = parameters.GetSeparator(i);
+                                        if (position <= separator.SpanStart)
+                                        {
+                                            return parameters[i];
+                                        }
+                                    }
+
+                                    return parameters.Last();
+                                }
+                            }
+                        }
+
+                        // explicit base initializer
+                        //   C<T>(...) : [|B(...)|]
+                        // implicit base initializer
+                        //   [|C<T>(...)|]
+                        return (baseInitializer != null) ? baseInitializer.Span :
+                            TextSpan.FromBounds(typeDeclaration.Identifier.SpanStart, typeDeclaration.ParameterList.Span.End);
+                    }
+
+                    return null;
+
                 case SyntaxKind.VariableDeclarator:
                     // handled by the parent node
                     return null;
@@ -586,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         private static SyntaxToken LastNotMissing(SyntaxToken token1, SyntaxToken token2)
-            => token2.IsMissing ? token1 : token2;
+            => token2.IsKind(SyntaxKind.None) || token2.IsMissing ? token1 : token2;
 
         private static TextSpan? TryCreateSpanForVariableDeclaration(VariableDeclarationSyntax declaration, int position)
             => declaration.Parent!.Kind() switch


### PR DESCRIPTION
Implements changes described in https://github.com/dotnet/roslyn/issues/63299

Relates to test plan https://github.com/dotnet/roslyn/issues/40726 (records) and https://github.com/dotnet/roslyn/issues/65697 (primary constructors)