### PR TITLE
Retain semicolon during updates of IndexerDeclaration

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 parameterList,
                 accessorList,
                 expressionBody: null,
-                semicolonToken: default);
+                semicolonToken: syntax.SemicolonToken);
         }
 
         public static OperatorDeclarationSyntax Update(

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -86,8 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void IndexerDeclarationUpdateRetainsSemicolonToken()
         {
-            string originalTextAttachedToSemicolon = $"//{nameof(originalTextAttachedToSemicolon)}";
-            var comment = SyntaxFactory.Comment(originalTextAttachedToSemicolon);
+            var comment = SyntaxFactory.Comment("//originalLeadingComment");
             SyntaxToken originalSemicolonToken = SyntaxFactory.Token(SyntaxKind.SemicolonToken).WithLeadingTrivia(comment);
             var initialDeclaration = SyntaxFactory.IndexerDeclaration(SyntaxFactory.ParseName("System.String"))
                 .WithSemicolonToken(originalSemicolonToken);
@@ -100,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 initialDeclaration.ParameterList,
                 initialDeclaration.AccessorList);
 
-            Assert.Equal(originalTextAttachedToSemicolon, mutatedDeclaration.SemicolonToken.GetLeadingTrivia().ToFullString());
+            Assert.Equal("//originalLeadingComment", mutatedDeclaration.SemicolonToken.GetLeadingTrivia().ToFullString());
         }
 
         [WorkItem(528399, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528399")]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -83,6 +83,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.None, c.SemicolonToken.Kind());
         }
 
+        [Fact]
+        public void IndexerDeclarationUpdateRetainsSemicolonToken()
+        {
+            var comment = SyntaxFactory.Comment("//original");
+            SyntaxToken originalSemicolonToken = SyntaxFactory.Token(SyntaxKind.SemicolonToken).WithLeadingTrivia(comment);
+            var initialDeclaration = SyntaxFactory.IndexerDeclaration(SyntaxFactory.ParseName("System.String"))
+                .WithSemicolonToken(originalSemicolonToken);
+
+            var mutatedDeclaration = initialDeclaration.Update(initialDeclaration.AttributeLists,
+                initialDeclaration.Modifiers,
+                initialDeclaration.Type,
+                initialDeclaration.ExplicitInterfaceSpecifier,
+                initialDeclaration.ThisKeyword,
+                initialDeclaration.ParameterList,
+                initialDeclaration.AccessorList);
+
+            Assert.Contains(comment.ToString(), mutatedDeclaration.SemicolonToken.GetLeadingTrivia().ToFullString());
+        }
+
         [WorkItem(528399, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528399")]
         [Fact()]
         public void PassExpressionToSyntaxToken()

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -86,7 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void IndexerDeclarationUpdateRetainsSemicolonToken()
         {
-            var comment = SyntaxFactory.Comment("//original");
+            string originalTextAttachedToSemicolon = $"//{nameof(originalTextAttachedToSemicolon)}";
+            var comment = SyntaxFactory.Comment(originalTextAttachedToSemicolon);
             SyntaxToken originalSemicolonToken = SyntaxFactory.Token(SyntaxKind.SemicolonToken).WithLeadingTrivia(comment);
             var initialDeclaration = SyntaxFactory.IndexerDeclaration(SyntaxFactory.ParseName("System.String"))
                 .WithSemicolonToken(originalSemicolonToken);
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 initialDeclaration.ParameterList,
                 initialDeclaration.AccessorList);
 
-            Assert.Contains(comment.ToString(), mutatedDeclaration.SemicolonToken.GetLeadingTrivia().ToFullString());
+            Assert.Equal(originalTextAttachedToSemicolon, mutatedDeclaration.SemicolonToken.GetLeadingTrivia().ToFullString());
         }
 
         [WorkItem(528399, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528399")]


### PR DESCRIPTION
Spotted this issue while skimming through for similar issues to https://github.com/dotnet/roslyn/pull/68762

Note: I've checked that the test fails prior to the production code change