### PR TITLE
Do not emit empty language property in SARIF log

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
@@ -388,8 +388,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         ""name"": """",
         ""version"": ""1.0.0"",
         ""fileVersion"": """",
-        ""semanticVersion"": ""1.0.0"",
-        ""language"": """"
+        ""semanticVersion"": ""1.0.0""
       }},
       ""results"": [
         {{

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
@@ -425,7 +425,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
           ""version"": """",
           ""dottedQuadFileVersion"": ""1.0.0"",
           ""semanticVersion"": ""1.0.0"",
-          ""language"": """",
           ""rules"": [
             {{
               ""id"": ""uriDiagnostic""

--- a/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
@@ -44,7 +44,11 @@ namespace Microsoft.CodeAnalysis
             _writer.Write("version", toolAssemblyVersion.ToString());
             _writer.Write("fileVersion", toolFileVersion);
             _writer.Write("semanticVersion", toolAssemblyVersion.ToString(fieldCount: 3));
-            _writer.Write("language", culture.Name);
+
+            // Emit the 'language' property only if it is a non-empty string to match the SARIF spec.
+            if (culture.Name.Length > 0)
+                _writer.Write("language", culture.Name);
+
             _writer.WriteObjectEnd(); // tool
 
             _writer.WriteArrayStart("results");

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -201,8 +201,10 @@ namespace Microsoft.CodeAnalysis
             _writer.Write("version", _toolFileVersion);
             _writer.Write("dottedQuadFileVersion", _toolAssemblyVersion.ToString());
             _writer.Write("semanticVersion", _toolAssemblyVersion.ToString(fieldCount: 3));
-            _writer.Write("language", _culture.Name);
 
+            // Emit the 'language' property only if it is a non-empty string to match the SARIF spec.
+            if (_culture.Name.Length > 0)
+                _writer.Write("language", _culture.Name);
             WriteRules();
 
             _writer.WriteObjectEnd(); // driver


### PR DESCRIPTION
Fixes #68745

SARIF spec requires non-empty language name property, which contains the culture name of the diagnostic messages in the SARIF log. Culture name can be empty for InvariantCulture, hence we must handle the empty culture name value in the SARIF error loggers.