### PR TITLE
Force public APIs to return complete results

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -26,7 +26,10 @@ namespace Microsoft.CodeAnalysis.Completion
         public bool ProvideRegexCompletions { get; init; } = true;
 
         /// <summary>
-        /// Test-only option.
+        /// Force completion APIs to produce complete results, even in cases where caches have not been pre-populated.
+        /// This is typically used for testing scenarios, and by public APIs where consumers do not have access to
+        /// other internal APIs used to control cache creation and/or wait for caches to be populated before examining
+        /// completion results.
         /// </summary>
         public bool ForceExpandedCompletionIndexCreation { get; init; } = false;
 

--- a/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return ValueTaskFactory.CompletedTask;
             }
 
-            public ImmutableArray<CompletionProvider> GetCachedProjectCompletionProvidersOrQueueLoadInBackground(Project? project)
+            public ImmutableArray<CompletionProvider> GetCachedProjectCompletionProvidersOrQueueLoadInBackground(Project? project, CompletionOptions options)
             {
                 if (project is null || project.Solution.WorkspaceKind == WorkspaceKind.Interactive)
                 {
@@ -101,9 +101,14 @@ namespace Microsoft.CodeAnalysis.Completion
                     return ImmutableArray<CompletionProvider>.Empty;
                 }
 
-                // Don't load providers if they are not already cached,
-                // return immediately and load them in background instead.
+                // On primary completion paths, don't load providers if they are not already cached,
+                // return immediately and load them in background instead. If the test hook
+                // 'ForceExpandedCompletionIndexCreation' is set, calculate the values immediately.
                 // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1620947
+                if (options.ForceExpandedCompletionIndexCreation)
+                {
+                    return ProjectCompletionProvider.GetExtensions(_service.Language, project.AnalyzerReferences);
+                }
 
                 if (ProjectCompletionProvider.TryGetCachedExtensions(project.AnalyzerReferences, out var providers))
                     return providers;
@@ -153,14 +158,17 @@ namespace Microsoft.CodeAnalysis.Completion
                     return provider;
 
                 using var _ = PooledDelegates.GetPooledFunction(static (p, n) => p.Name == n, item.ProviderName, out Func<CompletionProvider, bool> isNameMatchingProviderPredicate);
-                return GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project).FirstOrDefault(isNameMatchingProviderPredicate);
+
+                // Publicly available options will not impact this call, since the completion item must have already
+                // existed if it produced the input completion item.
+                return GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project, CompletionOptions.Default).FirstOrDefault(isNameMatchingProviderPredicate);
             }
 
             public ConcatImmutableArray<CompletionProvider> GetFilteredProviders(
                 Project? project, ImmutableHashSet<string>? roles, CompletionTrigger trigger, in CompletionOptions options)
             {
                 var allCompletionProviders = FilterProviders(GetImportedAndBuiltInProviders(roles), trigger, options);
-                var projectCompletionProviders = FilterProviders(GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project), trigger, options);
+                var projectCompletionProviders = FilterProviders(GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project, options), trigger, options);
                 return allCompletionProviders.ConcatFast(projectCompletionProviders);
             }
 
@@ -283,12 +291,12 @@ namespace Microsoft.CodeAnalysis.Completion
                     return _providerManager.GetImportedAndBuiltInProviders(roles);
                 }
 
-                public async Task<ImmutableArray<CompletionProvider>> GetProjectProvidersAsync(Project project)
+                public ImmutableArray<CompletionProvider> GetProjectProviders(Project project)
                 {
-                    _providerManager._projectProvidersWorkQueue.AddWork(project.AnalyzerReferences);
-                    await _providerManager._projectProvidersWorkQueue.WaitUntilCurrentBatchCompletesAsync().ConfigureAwait(false);
-                    // Now the extension cache is guaranteed to be populated.
-                    return _providerManager.GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project);
+                    // Force-load the extension completion providers
+                    return _providerManager.GetCachedProjectCompletionProvidersOrQueueLoadInBackground(
+                        project,
+                        CompletionOptions.Default with { ForceExpandedCompletionIndexCreation = true });
                 }
             }
         }

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -100,8 +100,9 @@ namespace Microsoft.CodeAnalysis.Completion
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
             var languageServices = document?.Project.Services ?? _services.GetLanguageServices(Language);
 
-            // Publicly available options do not affect this API.
-            var completionOptions = CompletionOptions.Default;
+            // Publicly available options do not affect this API. Force complete results from this public API since
+            // external consumers do not have access to Roslyn's waiters.
+            var completionOptions = CompletionOptions.Default with { ForceExpandedCompletionIndexCreation = true };
             var passThroughOptions = options ?? document?.Project.Solution.Options ?? OptionSet.Empty;
 
             return ShouldTriggerCompletion(document?.Project, languageServices, text, caretPosition, trigger, completionOptions, passThroughOptions, roles);
@@ -342,8 +343,8 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <summary>
         /// Don't call. Used for pre-load project providers only.
         /// </summary>
-        internal void TriggerLoadProjectProviders(Project project)
-                => _providerManager.GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project);
+        internal void TriggerLoadProjectProviders(Project project, CompletionOptions options)
+                => _providerManager.GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project, options);
 
         internal CompletionProvider? GetProvider(CompletionItem item, Project? project)
             => _providerManager.GetProvider(item, project);
@@ -361,8 +362,8 @@ namespace Microsoft.CodeAnalysis.Completion
             public ImmutableArray<CompletionProvider> GetImportedAndBuiltInProviders(ImmutableHashSet<string> roles)
                 => _completionServiceWithProviders._providerManager.GetTestAccessor().GetImportedAndBuiltInProviders(roles);
 
-            public Task<ImmutableArray<CompletionProvider>> GetProjectProvidersAsync(Project project)
-                => _completionServiceWithProviders._providerManager.GetTestAccessor().GetProjectProvidersAsync(project);
+            public ImmutableArray<CompletionProvider> GetProjectProviders(Project project)
+                => _completionServiceWithProviders._providerManager.GetTestAccessor().GetProjectProviders(project);
 
             public async Task<CompletionContext> GetContextAsync(
                 CompletionProvider provider,

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -40,8 +40,9 @@ namespace Microsoft.CodeAnalysis.Completion
             OptionSet? options = null,
             CancellationToken cancellationToken = default)
         {
-            // Publicly available options do not affect this API.
-            var completionOptions = CompletionOptions.Default;
+            // Publicly available options do not affect this API. Force complete results from this public API since
+            // external consumers do not have access to Roslyn's waiters.
+            var completionOptions = CompletionOptions.Default with { ForceExpandedCompletionIndexCreation = true };
             var passThroughOptions = options ?? document.Project.Solution.Options;
 
             return GetCompletionsAsync(document, caretPosition, completionOptions, passThroughOptions, trigger, roles, cancellationToken);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     // from a race caused by multiple features (codefix, refactoring, etc.) attempting to get extensions
                     // from analyzer references at the same time when they are not cached.
                     if (project.GetLanguageService<CompletionService>() is CompletionService completionService)
-                        completionService.TriggerLoadProjectProviders(project);
+                        completionService.TriggerLoadProjectProviders(project, GlobalOptions.GetCompletionOptions(project.Language));
 
                     await InitializeServiceForProjectWithOpenedDocumentAsync(project).ConfigureAwait(false);
                 }


### PR DESCRIPTION
External consumers of CompletionService (for unit testing CompletionProvider implementations) don't have access to the waiter APIs necessary to use non-blocking completion in testing scenarios. These APIs are updated to adhere to their behavior prior to #64352 introducing non-deterministic results.