### PR TITLE
Bind to EnvironmentFontFamily in DocumentOutLineWindow.

### DIFF
--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -16,8 +16,8 @@
              x:Name="DocumentOutline"
              Background="{StaticResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"
              platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}"
-             FontFamily="{DynamicResource {x:Static vsshell:VsFonts.EnvironmentFontFamilyKey}}"
-             FontSize="{DynamicResource {x:Static vsshell:VsFonts.EnvironmentFontSizeKey}}">
+             FontFamily="{StaticResource {x:Static vsshell:VsFonts.EnvironmentFontFamilyKey}}"
+             FontSize="{StaticResource {x:Static vsshell:VsFonts.EnvironmentFontSizeKey}}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -15,7 +15,9 @@
              d:DesignHeight="450" d:DesignWidth="800"
              x:Name="DocumentOutline"
              Background="{StaticResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"
-             platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}">
+             platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}"
+             FontFamily="{DynamicResource {x:Static vsshell:VsFonts.EnvironmentFontFamilyKey}}"
+             FontSize="{DynamicResource {x:Static vsshell:VsFonts.EnvironmentFontSizeKey}}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -60,13 +62,9 @@
             <Style TargetType="TreeView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTreeViewStyleKey}}" >
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Padding" Value="0, 5, 0, 0" />
-                <Setter Property="FontFamily" Value="{StaticResource {x:Static vsshell:VsFonts.CaptionFontFamilyKey}}" />
-                <Setter Property="FontSize" Value="{StaticResource {x:Static vsshell:VsFonts.CaptionFontSizeKey}}" />
             </Style>
 
             <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogTextBoxStyleKey}}" >
-                <Setter Property="FontFamily" Value="{StaticResource {x:Static vsshell:VsFonts.CaptionFontFamilyKey}}" />
-                <Setter Property="FontSize" Value="{StaticResource {x:Static vsshell:VsFonts.CaptionFontSizeKey}}" />
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/68809
It is needed because we need the ability to display GB18030.
In order to display it, OullineWindow must be able to change the font, since not all the font supports the character set.
After the change, all the character can be displayed:
<img width="1392" alt="image" src="https://github.com/dotnet/roslyn/assets/24360909/b0c94aac-103b-459b-abeb-3832e69339cf">


Several problems in the existing code.
1. Currently DocumentOutlineWindow is wrapped in a Windows form control in order to get the handle and send it back to shell. https://github.com/dotnet/roslyn/blob/575bc42589145ba18b4f1cc2267d02695f861d8f/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService%602.VsCodeWindowManager.cs#L277
I don't know a lot about WinForm but it doesn't inherit the property from the parent like in WPF.
Like:
The child font doesn't match its parent font
<img width="1335" alt="image" src="https://github.com/dotnet/roslyn/assets/24360909/34ae5cfc-a1f3-4f56-8b07-a5342ba5551a">
<img width="1774" alt="image" src="https://github.com/dotnet/roslyn/assets/24360909/d7574dfe-3dd8-4049-be32-3bf86c929c33">
In this case, all the elements (except the one with font-family property) in the window would inherit from the windows form control. And I don't find there is a way to change this.

2. We only set Font for TreeView and TextBox now. This feels wrong since the tool window might have SearchTextBox.

3. The Font used is `vsshell:VsFonts.CaptionFontFamilyKey`, I don't know what it means in the shell. But from what I understand [here](http://index/?leftProject=Microsoft.VisualStudio.Shell.15.0&leftSymbol=plv2gfzc1car&file=UI%5CResourceSynchronization%5CResourceSynchronizer.cs&line=227), this is the font used in VS title bar. I don't feel it is meaningful to keep the font here the same as the Title bar.
