### PR TITLE
Allow declaring ref fields as elements of inline arrays.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7641,7 +7641,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Inline array struct must not have explicit layout.</value>
   </data>
   <data name="ERR_InvalidInlineArrayFields" xml:space="preserve">
-    <value>Inline array struct must declare one and only one instance field which must not be a ref field.</value>
+    <value>Inline array struct must declare one and only one instance field.</value>
   </data>
   <data name="ERR_ExpressionTreeContainsInlineArrayOperation" xml:space="preserve">
     <value>An expression tree may not contain an inline array access or conversion</value>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1752,7 +1752,7 @@ next:;
                     diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayLayout, GetFirstLocation());
                 }
 
-                if (TryGetInlineArrayElementField() is null)
+                if (TryGetPossiblyUnsupportedByLanguageInlineArrayElementField() is null)
                 {
                     diagnostics.Add(ErrorCode.ERR_InvalidInlineArrayFields, GetFirstLocation());
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2470,7 +2470,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract bool HasInlineArrayAttribute(out int length);
 
 #nullable enable
-        internal FieldSymbol? TryGetInlineArrayElementField()
+        internal FieldSymbol? TryGetPossiblyUnsupportedByLanguageInlineArrayElementField()
         {
             Debug.Assert(HasInlineArrayAttribute(out var length) && length > 0);
 
@@ -2482,7 +2482,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if (!field.IsStatic)
                     {
-                        if (field.RefKind != RefKind.None || elementField is not null)
+                        if (elementField is not null)
                         {
                             return null;
                         }
@@ -2500,6 +2500,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return elementField;
+        }
+
+        internal FieldSymbol? TryGetInlineArrayElementField()
+        {
+            return TryGetPossiblyUnsupportedByLanguageInlineArrayElementField() is { RefKind: RefKind.None } field ? field : null;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayFields">
-        <source>Inline array struct must declare one and only one instance field which must not be a ref field.</source>
-        <target state="new">Inline array struct must declare one and only one instance field which must not be a ref field.</target>
+        <source>Inline array struct must declare one and only one instance field.</source>
+        <target state="new">Inline array struct must declare one and only one instance field.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidInlineArrayLayout">

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/InlineArrayTests.cs
@@ -447,7 +447,7 @@ struct Buffer
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );
@@ -512,7 +512,7 @@ struct Buffer
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );
@@ -602,7 +602,7 @@ struct Buffer
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );
@@ -983,17 +983,28 @@ ref struct Buffer
     private ref int _element0;
 }
 ";
-            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
+
+            string consumer = @"
+class C
+{
+    void Test(Buffer b)
+    {
+        _ = b[0];
+    }
+}
+";
+
+            var comp = CreateCompilation(consumer + src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,12): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
-                // ref struct Buffer
-                Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 12)
+                // (6,13): error CS0021: Cannot apply indexing with [] to an expression of type 'Buffer'
+                //         _ = b[0];
+                Diagnostic(ErrorCode.ERR_BadIndexLHS, "b[0]").WithArguments("Buffer").WithLocation(6, 13)
                 );
 
             verify(comp);
 
             var ilSource = @"
-.class private sequential ansi sealed beforefieldinit Buffer
+.class public sequential ansi sealed beforefieldinit Buffer
     extends [mscorlib]System.ValueType
 {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -1028,7 +1039,13 @@ ref struct Buffer
 }
 ";
 
-            comp = CreateCompilationWithIL("", ilSource, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            comp = CreateCompilationWithIL(consumer, ilSource, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            comp.VerifyDiagnostics(
+                // (6,13): error CS0021: Cannot apply indexing with [] to an expression of type 'Buffer'
+                //         _ = b[0];
+                Diagnostic(ErrorCode.ERR_BadIndexLHS, "b[0]").WithArguments("Buffer").WithLocation(6, 13)
+                );
+
             verify(comp);
 
             void verify(CSharpCompilation comp)
@@ -1051,17 +1068,27 @@ ref struct Buffer
     private ref readonly int _element0;
 }
 ";
-            var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
+
+            string consumer = @"
+class C
+{
+    void Test(Buffer b)
+    {
+        _ = b[0];
+    }
+}
+";
+            var comp = CreateCompilation(consumer + src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,12): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
-                // ref struct Buffer
-                Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 12)
+                // (6,13): error CS0021: Cannot apply indexing with [] to an expression of type 'Buffer'
+                //         _ = b[0];
+                Diagnostic(ErrorCode.ERR_BadIndexLHS, "b[0]").WithArguments("Buffer").WithLocation(6, 13)
                 );
 
             verify(comp);
 
             var ilSource = @"
-.class private sequential ansi sealed beforefieldinit Buffer
+.class public sequential ansi sealed beforefieldinit Buffer
     extends [mscorlib]System.ValueType
 {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -1099,7 +1126,13 @@ ref struct Buffer
 }
 ";
 
-            comp = CreateCompilationWithIL("", ilSource, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            comp = CreateCompilationWithIL(consumer, ilSource, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            comp.VerifyDiagnostics(
+                // (6,13): error CS0021: Cannot apply indexing with [] to an expression of type 'Buffer'
+                //         _ = b[0];
+                Diagnostic(ErrorCode.ERR_BadIndexLHS, "b[0]").WithArguments("Buffer").WithLocation(6, 13)
+                );
+
             verify(comp);
 
             void verify(CSharpCompilation comp)
@@ -1346,7 +1379,7 @@ struct Buffer
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );
@@ -1371,7 +1404,7 @@ struct Buffer
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );
@@ -1395,7 +1428,7 @@ record struct Buffer(int p)
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,15): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,15): error CS9169: Inline array struct must declare one and only one instance field.
                 // record struct Buffer(int p)
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 15)
                 );
@@ -1693,7 +1726,7 @@ struct Buffer(int p)
 ";
             var comp = CreateCompilation(src, targetFramework: TargetFramework.Net80);
             comp.VerifyDiagnostics(
-                // (3,8): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field.
+                // (3,8): error CS9169: Inline array struct must declare one and only one instance field.
                 // struct Buffer(int p)
                 Diagnostic(ErrorCode.ERR_InvalidInlineArrayFields, "Buffer").WithLocation(3, 8)
                 );


### PR DESCRIPTION
Closes #68819.
Consumption of such inline array types is still not supported.

Relates to test plan https://github.com/dotnet/roslyn/issues/67826