### PR TITLE
Source generators/track values etw

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -90,12 +90,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             var expected = ImmutableArray.Create((10, EntryState.Modified, 0), (11, EntryState.Added, 1), (2, EntryState.Cached, 0), (3, EntryState.Cached, 1), (20, EntryState.Modified, 0), (21, EntryState.Modified, 1), (22, EntryState.Added, 2), (6, EntryState.Removed, 0));
             AssertTableEntries(newTable, expected);
-            Assert.Equal(new[] { 2, 3 }, YieldItems(cachedEntries.Items));
+            Assert.Equal(new[] { 2, 3 }, yieldItems(cachedEntries.Items));
             Assert.Equal(1, removedEntries.Count);
             Assert.Equal(6, removedEntries[0]);
             Assert.True(didRemoveEntries);
 
-            static IEnumerable<int> YieldItems(OneOrMany<int> items)
+            static IEnumerable<int> yieldItems(OneOrMany<int> items)
             {
                 foreach (var value in items)
                     yield return value;

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -37,5 +37,8 @@ namespace Microsoft.CodeAnalysis
 
         [Event(4, Message = "Generator {0} ran for {2} ticks", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.SingleGeneratorRunTime)]
         internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id) => WriteEvent(4, generatorName, assemblyPath, elapsedTicks, id);
+
+        [Event(5, Message = "Generator '{0}' failed with exception: {1}", Level = EventLevel.Error)]
+        internal void GeneratorException(string generatorName, string exception) => WriteEvent(5, generatorName, exception);
     }
 }

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -16,12 +16,14 @@ namespace Microsoft.CodeAnalysis
         public static class Keywords
         {
             public const EventKeywords Performance = (EventKeywords)1;
+            public const EventKeywords Correctness = (EventKeywords)2;
         }
 
         public static class Tasks
         {
             public const EventTask GeneratorDriverRunTime = (EventTask)1;
             public const EventTask SingleGeneratorRunTime = (EventTask)2;
+            public const EventTask BuildStateTable = (EventTask)3;
         }
 
         private CodeAnalysisEventSource() { }
@@ -40,5 +42,8 @@ namespace Microsoft.CodeAnalysis
 
         [Event(5, Message = "Generator '{0}' failed with exception: {1}", Level = EventLevel.Error)]
         internal void GeneratorException(string generatorName, string exception) => WriteEvent(5, generatorName, exception);
+
+        [Event(6, Message = "Node {0} transformed", Keywords = Keywords.Correctness, Level = EventLevel.Verbose, Task = Tasks.BuildStateTable)]
+        internal void NodeTransform(int nodeHashCode, string name, string tableType, int previousTable, string previousTableContent, int newTable, string newTableContent, int input1, int input2) => WriteEvent(6, nodeHashCode, name, tableType, previousTable, previousTableContent, newTable, newTableContent, input1, input2);
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -341,6 +341,11 @@ namespace Microsoft.CodeAnalysis
 
         private static GeneratorState SetGeneratorException(Compilation compilation, CommonMessageProvider provider, GeneratorState generatorState, ISourceGenerator generator, Exception e, DiagnosticBag? diagnosticBag, CancellationToken cancellationToken, TimeSpan? runTime = null, bool isInit = false)
         {
+            if (CodeAnalysisEventSource.Log.IsEnabled())
+            {
+                CodeAnalysisEventSource.Log.GeneratorException(generator.GetGeneratorType().Name, e.ToString());
+            }
+
             var errorCode = isInit ? provider.WRN_GeneratorFailedDuringInitialization : provider.WRN_GeneratorFailedDuringGeneration;
 
             // ISSUE: Diagnostics don't currently allow descriptions with arguments, so we have to manually create the diagnostic description

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -119,28 +119,30 @@ namespace Microsoft.CodeAnalysis
             // - Modified otherwise
 
             // update the table
-            var newTable = builder.CreateTableBuilder(previousTable, _name, _comparer);
+            var tableBuilder = builder.CreateTableBuilder(previousTable, _name, _comparer);
 
             // If this execution is tracking steps, then the source table should have also tracked steps or be the empty table.
-            Debug.Assert(!newTable.TrackIncrementalSteps || (sourceTable.HasTrackedSteps || sourceTable.IsEmpty));
+            Debug.Assert(!tableBuilder.TrackIncrementalSteps || (sourceTable.HasTrackedSteps || sourceTable.IsEmpty));
 
             var stopwatch = SharedStopwatch.StartNew();
 
-            var (sourceValues, sourceInputs) = GetValuesAndInputs(sourceTable, previousTable, newTable);
+            var (sourceValues, sourceInputs) = GetValuesAndInputs(sourceTable, previousTable, tableBuilder);
 
             if (previousTable is null || previousTable.IsEmpty)
             {
-                newTable.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
+                tableBuilder.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
             }
-            else if (!sourceTable.IsCached || !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
+            else if (!sourceTable.IsCached || !tableBuilder.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
             {
-                if (!newTable.TryModifyEntry(sourceValues, _comparer, stopwatch.Elapsed, sourceInputs, EntryState.Modified))
+                if (!tableBuilder.TryModifyEntry(sourceValues, _comparer, stopwatch.Elapsed, sourceInputs, EntryState.Modified))
                 {
-                    newTable.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
+                    tableBuilder.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
                 }
             }
 
-            return newTable.ToImmutableAndFree();
+            var newTable = tableBuilder.ToImmutableAndFree();
+            this.LogTables(_name, previousTable, newTable, sourceTable);
+            return newTable;
         }
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _sourceNode.RegisterOutput(output);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -52,10 +52,10 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(added);
             }
 
-            var builder = graphState.CreateTableBuilder(previousTable, _name, _comparer);
+            var tableBuilder = graphState.CreateTableBuilder(previousTable, _name, _comparer);
 
             // We always have no inputs steps into an InputNode, but we track the difference between "no inputs" (empty collection) and "no step information" (default value)
-            var noInputStepsStepInfo = builder.TrackIncrementalSteps ? ImmutableArray<(IncrementalGeneratorRunStep, int)>.Empty : default;
+            var noInputStepsStepInfo = tableBuilder.TrackIncrementalSteps ? ImmutableArray<(IncrementalGeneratorRunStep, int)>.Empty : default;
 
             if (previousTable is not null)
             {
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
                     if (itemsSet.Remove(oldItem))
                     {
                         // we're iterating the table, so know that it has entries
-                        var usedCache = builder.TryUseCachedEntries(elapsedTime, noInputStepsStepInfo);
+                        var usedCache = tableBuilder.TryUseCachedEntries(elapsedTime, noInputStepsStepInfo);
                         Debug.Assert(usedCache);
                     }
                     else if (inputItems.Length == previousTable.Count)
@@ -75,13 +75,13 @@ namespace Microsoft.CodeAnalysis
                         // This allows us to correctly 'replace' items even when they aren't actually the same. In the case that the
                         // item really isn't modified, but a new item, we still function correctly as we mostly treat them the same,
                         // but will perform an extra comparison that is omitted in the pure 'added' case.
-                        var modified = builder.TryModifyEntry(inputItems[itemIndex], _comparer, elapsedTime, noInputStepsStepInfo, EntryState.Modified);
+                        var modified = tableBuilder.TryModifyEntry(inputItems[itemIndex], _comparer, elapsedTime, noInputStepsStepInfo, EntryState.Modified);
                         Debug.Assert(modified);
                         itemsSet.Remove(inputItems[itemIndex]);
                     }
                     else
                     {
-                        var removed = builder.TryRemoveEntries(elapsedTime, noInputStepsStepInfo);
+                        var removed = tableBuilder.TryRemoveEntries(elapsedTime, noInputStepsStepInfo);
                         Debug.Assert(removed);
                     }
                     itemIndex++;
@@ -91,10 +91,13 @@ namespace Microsoft.CodeAnalysis
             // any remaining new items are added
             foreach (var newItem in itemsSet)
             {
-                builder.AddEntry(newItem, EntryState.Added, elapsedTime, noInputStepsStepInfo, EntryState.Added);
+                tableBuilder.AddEntry(newItem, EntryState.Added, elapsedTime, noInputStepsStepInfo, EntryState.Added);
             }
 
-            return builder.ToImmutableAndFree();
+            var newTable = tableBuilder.ToImmutableAndFree();
+            this.LogTables(previousTable, newTable, inputItems);
+            return newTable;
+
         }
 
         public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, comparer, _name);
@@ -104,5 +107,23 @@ namespace Microsoft.CodeAnalysis
         public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _inputComparer, _comparer, _name);
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _registerOutput(output);
+
+        private void LogTables(NodeStateTable<T> previousTable, NodeStateTable<T> newTable, ImmutableArray<T> inputs)
+        {
+            if (!CodeAnalysisEventSource.Log.IsEnabled())
+            {
+                // don't bother building the dummy table if we're not going to log anyway
+                return;
+            }
+
+            var tableBuilder = NodeStateTable<T>.Empty.ToBuilder(_name, stepTrackingEnabled: false);
+            foreach (var input in inputs)
+            {
+                tableBuilder.AddEntry(input, EntryState.Added, TimeSpan.Zero, stepInputs: default, EntryState.Added);
+            }
+            var inputTable = tableBuilder.ToImmutableAndFree();
+
+            this.LogTables(_name, previousTable, newTable, inputTable);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _registerOutput(output);
 
-        private void LogTables(NodeStateTable<T> previousTable, NodeStateTable<T> newTable, ImmutableArray<T> inputs)
+        private void LogTables(NodeStateTable<T>? previousTable, NodeStateTable<T> newTable, ImmutableArray<T> inputs)
         {
             if (!CodeAnalysisEventSource.Log.IsEnabled())
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
@@ -14,15 +14,15 @@ namespace Microsoft.CodeAnalysis
             if (CodeAnalysisEventSource.Log.IsEnabled())
             {
                 // don't log the new table if we skipped creating a new one
-                newTable = newTable != previousTable ? newTable : null;
+                var newTableOpt = newTable != previousTable ? newTable : null;
 
                 CodeAnalysisEventSource.Log.NodeTransform(self.GetHashCode(),
                                                           name ?? "<anonymous>",
                                                           typeof(TSelf).FullName,
                                                           previousTable?.GetHashCode() ?? -1,
                                                           previousTable?.GetPackedStates() ?? "",
-                                                          newTable?.GetHashCode() ?? -1,
-                                                          newTable?.GetPackedStates() ?? "",
+                                                          newTableOpt?.GetHashCode() ?? -1,
+                                                          newTableOpt?.GetPackedStates() ?? "",
                                                           inputNode1.GetHashCode(),
                                                           inputNode2?.GetHashCode() ?? -1);
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis
 
                 CodeAnalysisEventSource.Log.NodeTransform(self.GetHashCode(),
                                                           name ?? "<anonymous>",
-                                                          typeof(TSelf).FullName,
+                                                          typeof(TSelf).FullName ?? "<unknown>",
                                                           previousTable?.GetHashCode() ?? -1,
                                                           previousTable?.GetPackedStates() ?? "",
                                                           newTableOpt?.GetHashCode() ?? -1,

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class NodeExtensions
+    {
+        public static void LogTables<TSelf, TInput>(this IIncrementalGeneratorNode<TSelf> self, string? name, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput> inputTable)
+            => LogTables<TSelf, TInput, TInput>(self, name, previousTable, newTable, inputTable, inputNode2: null);
+
+        public static void LogTables<TSelf, TInput1, TInput2>(this IIncrementalGeneratorNode<TSelf> self, string? name, NodeStateTable<TSelf>? previousTable, NodeStateTable<TSelf> newTable, NodeStateTable<TInput1> inputNode1, NodeStateTable<TInput2>? inputNode2)
+        {
+            if (CodeAnalysisEventSource.Log.IsEnabled())
+            {
+                // don't log the new table if we skipped creating a new one
+                newTable = newTable != previousTable ? newTable : null;
+
+                CodeAnalysisEventSource.Log.NodeTransform(self.GetHashCode(),
+                                                          name ?? "<anonymous>",
+                                                          typeof(TSelf).FullName,
+                                                          previousTable?.GetHashCode() ?? -1,
+                                                          previousTable?.GetPackedStates() ?? "",
+                                                          newTable?.GetHashCode() ?? -1,
+                                                          newTable?.GetPackedStates() ?? "",
+                                                          inputNode1.GetHashCode(),
+                                                          inputNode2?.GetHashCode() ?? -1);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis
             {
                 for (int i = 0; i < state.Count; i++)
                 {
-                    pooled.Builder.Append(state.GetState(0).ToString()[0]);
+                    pooled.Builder.Append(state.GetState(i).ToString()[0]);
                 }
                 pooled.Builder.Append(',');
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -154,6 +154,20 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
+        public string GetPackedStates()
+        {
+            var pooled = PooledStringBuilder.GetInstance();
+            foreach (var state in _states)
+            {
+                for (int i = 0; i < state.Count; i++)
+                {
+                    pooled.Builder.Append(state.GetState(0).ToString()[0]);
+                }
+                pooled.Builder.Append(',');
+            }
+            return pooled.ToStringAndFree();
+        }
+
         /// <remarks>
         /// The builder is <b>not</b> threadsafe.
         /// </remarks>

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/TransformNode.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis
             var sourceTable = builder.GetLatestStateTableForNode(_sourceNode);
             if (sourceTable.IsCached && previousTable is not null)
             {
+                this.LogTables(_name, previousTable, previousTable, sourceTable);
                 if (builder.DriverState.TrackIncrementalSteps)
                 {
                     return previousTable.CreateCachedTableWithUpdatedSteps(sourceTable, _name, _comparer);
@@ -59,31 +60,33 @@ namespace Microsoft.CodeAnalysis
             // - Modified: perform transform and do element wise comparison with previous results
 
             var totalEntryItemCount = sourceTable.GetTotalEntryItemCount();
-            var newTable = builder.CreateTableBuilder(previousTable, _name, _comparer, totalEntryItemCount);
+            var tableBuilder = builder.CreateTableBuilder(previousTable, _name, _comparer, totalEntryItemCount);
 
             foreach (var entry in sourceTable)
             {
-                var inputs = newTable.TrackIncrementalSteps ? ImmutableArray.Create((entry.Step!, entry.OutputIndex)) : default;
+                var inputs = tableBuilder.TrackIncrementalSteps ? ImmutableArray.Create((entry.Step!, entry.OutputIndex)) : default;
                 if (entry.State == EntryState.Removed)
                 {
-                    newTable.TryRemoveEntries(TimeSpan.Zero, inputs);
+                    tableBuilder.TryRemoveEntries(TimeSpan.Zero, inputs);
                 }
-                else if (entry.State != EntryState.Cached || !newTable.TryUseCachedEntries(TimeSpan.Zero, inputs))
+                else if (entry.State != EntryState.Cached || !tableBuilder.TryUseCachedEntries(TimeSpan.Zero, inputs))
                 {
                     var stopwatch = SharedStopwatch.StartNew();
                     // generate the new entries
                     var newOutputs = _func(entry.Item, cancellationToken);
 
-                    if (entry.State != EntryState.Modified || !newTable.TryModifyEntries(newOutputs, _comparer, stopwatch.Elapsed, inputs, entry.State))
+                    if (entry.State != EntryState.Modified || !tableBuilder.TryModifyEntries(newOutputs, _comparer, stopwatch.Elapsed, inputs, entry.State))
                     {
-                        newTable.AddEntries(newOutputs, EntryState.Added, stopwatch.Elapsed, inputs, entry.State);
+                        tableBuilder.AddEntries(newOutputs, EntryState.Added, stopwatch.Elapsed, inputs, entry.State);
                     }
                 }
             }
 
             // Can't assert anything about the count of items.  _func may have produced a different amount of items if
             // it's not a 1:1 function.
-            return newTable.ToImmutableAndFree();
+            var newTable = tableBuilder.ToImmutableAndFree();
+            this.LogTables(_name, previousTable, newTable, sourceTable);
+            return newTable;
         }
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _sourceNode.RegisterOutput(output);


### PR DESCRIPTION
This adds ETW logging to each of the incremental generator nodes that writes out the state of the table after transformation. We're not actually logging the value in the table, just the type name and a list of states (Added, Modified, etc), as well as the upstream table it was built from.

I've written a simple parser for the ETW events that confirms we can reconstruct the graph state from the logged messages. 

Note: we currently don't log syntax inputs as they are more complicated than regular inputs. We can consider adding them in the future if we see issues with them, but for now I'd rather get some fairly good, if incomplete, coverage in.