### PR TITLE
Mitigate costly syntax tree walks in 'remove unused members'.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -2,59 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.RemoveUnusedMembers;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpRemoveUnusedMembersDiagnosticAnalyzer
-        : AbstractRemoveUnusedMembersDiagnosticAnalyzer<DocumentationCommentTriviaSyntax, IdentifierNameSyntax>
+        : AbstractRemoveUnusedMembersDiagnosticAnalyzer<
+            DocumentationCommentTriviaSyntax,
+            IdentifierNameSyntax,
+            TypeDeclarationSyntax,
+            MemberDeclarationSyntax>
     {
-        protected override void AddAllDocumentationComments(
-            INamedTypeSymbol namedType,
-            ArrayBuilder<DocumentationCommentTriviaSyntax> documentationComments,
-            CancellationToken cancellationToken)
+        protected override IEnumerable<TypeDeclarationSyntax> GetTypeDeclarations(INamedTypeSymbol namedType, CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<TypeDeclarationSyntax>.GetInstance(out var stack);
-
-            foreach (var reference in namedType.DeclaringSyntaxReferences)
-            {
-                if (reference.GetSyntax(cancellationToken) is not TypeDeclarationSyntax typeDeclaration)
-                    continue;
-
-                stack.Clear();
-                stack.Push(typeDeclaration);
-
-                while (stack.Count > 0)
-                {
-                    var currentType = stack.Pop();
-
-                    // Add the doc comments on the type itself.
-                    AddDocumentationComments(currentType, documentationComments);
-
-                    // Walk each member
-                    foreach (var member in currentType.GetMembers())
-                    {
-                        if (member is TypeDeclarationSyntax childType)
-                        {
-                            // If the member is a nested type, recurse into it.
-                            stack.Push(childType);
-                        }
-                        else
-                        {
-                            // Otherwise, add the doc comments on the member itself.
-                            AddDocumentationComments(member, documentationComments);
-                        }
-                    }
-                }
-            }
-
-            return;
+            return namedType.DeclaringSyntaxReferences
+                .Select(r => r.GetSyntax(cancellationToken))
+                .OfType<TypeDeclarationSyntax>();
         }
+
+        protected override SyntaxList<MemberDeclarationSyntax> GetMembers(TypeDeclarationSyntax typeDeclaration)
+            => typeDeclaration.Members;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.RemoveUnusedMembers;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers
@@ -12,5 +15,46 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers
     internal class CSharpRemoveUnusedMembersDiagnosticAnalyzer
         : AbstractRemoveUnusedMembersDiagnosticAnalyzer<DocumentationCommentTriviaSyntax, IdentifierNameSyntax>
     {
+        protected override void AddAllDocumentationComments(
+            INamedTypeSymbol namedType,
+            ArrayBuilder<DocumentationCommentTriviaSyntax> documentationComments,
+            CancellationToken cancellationToken)
+        {
+            using var _ = ArrayBuilder<TypeDeclarationSyntax>.GetInstance(out var stack);
+
+            foreach (var reference in namedType.DeclaringSyntaxReferences)
+            {
+                if (reference.GetSyntax(cancellationToken) is not TypeDeclarationSyntax typeDeclaration)
+                    continue;
+
+                stack.Clear();
+                stack.Push(typeDeclaration);
+
+                while (stack.Count > 0)
+                {
+                    var currentType = stack.Pop();
+
+                    // Add the doc comments on the type itself.
+                    AddDocumentationComments(currentType, documentationComments);
+
+                    // Walk each member
+                    foreach (var member in currentType.GetMembers())
+                    {
+                        if (member is TypeDeclarationSyntax childType)
+                        {
+                            // If the member is a nested type, recurse into it.
+                            stack.Push(childType);
+                        }
+                        else
+                        {
+                            // Otherwise, add the doc comments on the member itself.
+                            AddDocumentationComments(member, documentationComments);
+                        }
+                    }
+                }
+            }
+
+            return;
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
 
             private static bool HasSyntaxErrors(INamedTypeSymbol namedTypeSymbol, CancellationToken cancellationToken)
             {
-                foreach (var tree in namedTypeSymbol.Locations.Select(l => l.SourceTree).WhereNotNull())
+                foreach (var tree in namedTypeSymbol.Locations.Select(l => l.SourceTree).Distinct().WhereNotNull())
                 {
                     if (tree.GetDiagnostics(cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error))
                     {

--- a/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
@@ -56,6 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
             For Each reference In namedType.DeclaringSyntaxReferences
                 Dim node = reference.GetSyntax(cancellationToken)
 
+                node = If(TryCast(node, TypeStatementSyntax)?.Parent, node)
                 Dim typeBlock = TryCast(node, TypeBlockSyntax)
                 If typeBlock Is Nothing Then
                     Continue For


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68842

Current approach walks the *entire* syntax tree for *every* type found in a file.  In the linked issue, the developer has roughly 4000 types in a single file, so we end up doing all the same work 4000 times.

THe new approach only walks the syntax for the particular type we're looking at, not the whole tree.

This PR is easier to read one commit at a time, and with whitespace off.