### PR TITLE
Semantic snippets - `svm` and `sim` snippets

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpSimSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpSimSnippetCompletionProviderTests.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.Snippets
+{
+    public class CSharpSimSnippetCompletionProviderTests : AbstractCSharpSnippetCompletionProviderTests
+    {
+        protected override string ItemToCommit => "sim";
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInNamespace()
+        {
+            await VerifyItemIsAbsentAsync("""
+                namespace Test
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInFileScopedNamespace()
+        {
+            await VerifyItemIsAbsentAsync("""
+                namespace Test;
+                
+                $$
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInTopLevelContext()
+        {
+            await VerifyItemIsAbsentAsync("""
+                System.Console.WriteLine();
+                $$
+                """, ItemToCommit);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        [InlineData("record")]
+        [InlineData("record class")]
+        [InlineData("record struct")]
+        public async Task TestInsertSnippetInType(string type)
+        {
+            await VerifyCustomCommitProviderAsync($$"""
+                {{type}} Program
+                {
+                    $$
+                }
+                """, ItemToCommit, $$"""
+                {{type}} Program
+                {
+                    static int Main(string[] args)
+                    {
+                        $$
+                        return 0;
+                    }
+                }
+                """);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInEnum()
+        {
+            await VerifyItemIsAbsentAsync("""
+                enum MyEnum
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInMethod()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    void M()
+                    {
+                        $$
+                    }
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInConstructor()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    public Program()
+                    {
+                        $$
+                    }
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("public")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public async Task TestInsertSnippetAfterAccessibilityModifier(string modifier)
+        {
+            await VerifyCustomCommitProviderAsync($$"""
+                class Program
+                {
+                    {{modifier}} $$
+                }
+                """, ItemToCommit, $$"""
+                class Program
+                {
+                    {{modifier}} static int Main(string[] args)
+                    {
+                        $$
+                        return 0;
+                    }
+                }
+                """);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("static")]
+        [InlineData("virtual")]
+        [InlineData("abstract")]
+        [InlineData("override")]
+        [InlineData("file")]
+        public async Task TestMissingAfterIncorrectModifiers(string modifier)
+        {
+            await VerifyItemIsAbsentAsync($$"""
+                class Program
+                {
+                    {{modifier}} $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingIfAnotherMemberWithNameMainExists()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    public int Main => 0;
+
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingIfTopLevelStatementsArePresent()
+        {
+            await VerifyItemIsAbsentAsync("""
+                System.Console.WriteLine();
+                
+                class Program
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpSvmSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpSvmSnippetCompletionProviderTests.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.Snippets
+{
+    public class CSharpSvmSnippetCompletionProviderTests : AbstractCSharpSnippetCompletionProviderTests
+    {
+        protected override string ItemToCommit => "svm";
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInNamespace()
+        {
+            await VerifyItemIsAbsentAsync("""
+                namespace Test
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInFileScopedNamespace()
+        {
+            await VerifyItemIsAbsentAsync("""
+                namespace Test;
+                
+                $$
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInTopLevelContext()
+        {
+            await VerifyItemIsAbsentAsync("""
+                System.Console.WriteLine();
+                $$
+                """, ItemToCommit);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        [InlineData("record")]
+        [InlineData("record class")]
+        [InlineData("record struct")]
+        public async Task TestInsertSnippetInType(string type)
+        {
+            await VerifyCustomCommitProviderAsync($$"""
+                {{type}} Program
+                {
+                    $$
+                }
+                """, ItemToCommit, $$"""
+                {{type}} Program
+                {
+                    static void Main(string[] args)
+                    {
+                        $$
+                    }
+                }
+                """);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInEnum()
+        {
+            await VerifyItemIsAbsentAsync("""
+                enum MyEnum
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInMethod()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    void M()
+                    {
+                        $$
+                    }
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingInConstructor()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    public Program()
+                    {
+                        $$
+                    }
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("public")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public async Task TestInsertSnippetAfterAccessibilityModifier(string modifier)
+        {
+            await VerifyCustomCommitProviderAsync($$"""
+                class Program
+                {
+                    {{modifier}} $$
+                }
+                """, ItemToCommit, $$"""
+                class Program
+                {
+                    {{modifier}} static void Main(string[] args)
+                    {
+                        $$
+                    }
+                }
+                """);
+        }
+
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("static")]
+        [InlineData("virtual")]
+        [InlineData("abstract")]
+        [InlineData("override")]
+        [InlineData("file")]
+        public async Task TestMissingAfterIncorrectModifiers(string modifier)
+        {
+            await VerifyItemIsAbsentAsync($$"""
+                class Program
+                {
+                    {{modifier}} $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingIfAnotherMemberWithNameMainExists()
+        {
+            await VerifyItemIsAbsentAsync("""
+                class Program
+                {
+                    public int Main => 0;
+
+                    $$
+                }
+                """, ItemToCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestMissingIfTopLevelStatementsArePresent()
+        {
+            await VerifyItemIsAbsentAsync("""
+                System.Console.WriteLine();
+                
+                class Program
+                {
+                    $$
+                }
+                """, ItemToCommit);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -599,4 +599,12 @@
     <value>reversed for loop</value>
     <comment>{Locked="for"} "for" is a C# keyword and should not be localized.</comment>
   </data>
+  <data name="static_void_Main" xml:space="preserve">
+    <value>static void Main</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="static_int_Main" xml:space="preserve">
+    <value>static int Main</value>
+    <comment>{Locked}</comment>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     {
         private static readonly HashSet<string> s_snippetsWithReplacements = new()
         {
-            "class", "cw", "ctor", "else", "enum", "for", "forr", "foreach", "if", "interface", "lock", "prop", "propg", "struct", "while"
+            "class", "cw", "ctor", "else", "enum", "for", "forr", "foreach", "if", "interface", "lock", "prop", "propg", "sim", "struct", "svm", "while"
         };
 
         internal override bool IsSnippetProvider => true;

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -107,13 +107,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            GetPartsOfForStatement(caretTarget, out _, out _, out _, out var statement);
-            var blockStatement = (BlockSyntax)statement!;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ForStatementSyntax>(
+                caretTarget,
+                static s => (BlockSyntax)s.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpForLoopSnippetProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<ForStatementSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ForStatementSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpMainMethodSnippetProvider.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
+
+namespace Microsoft.CodeAnalysis.CSharp.Snippets
+{
+    internal abstract class AbstractCSharpMainMethodSnippetProvider : AbstractMainMethodSnippetProvider
+    {
+        protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
+            var syntaxContext = (CSharpSyntaxContext)document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
+
+            if (!syntaxContext.IsMemberDeclarationContext(
+                validModifiers: SyntaxKindSet.AccessibilityModifiers,
+                validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
+                canBePartial: true,
+                cancellationToken: cancellationToken))
+            {
+                return false;
+            }
+
+            // Syntactically correct position, now semantic checks
+
+            var enclosingTypeSymbol = semanticModel.GetDeclaredSymbol(syntaxContext.ContainingTypeDeclaration!, cancellationToken);
+
+            // If there are any members with name `Main` in enclosing type, inserting `Main` method will create an error
+            if (enclosingTypeSymbol is not null &&
+                !semanticModel.LookupSymbols(position, container: enclosingTypeSymbol, name: WellKnownMemberNames.EntryPointMethodName).IsEmpty)
+            {
+                return false;
+            }
+
+            // If compilation already has top-level statements, suppress showing `Main` method snippets
+            return semanticModel.Compilation.GetTopLevelStatementsMethod() is null;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpTypeSnippetProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
                 return document;
 
             var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
-            var indentationString = СSharpSnippetIndentationHelpers.GetBlockLikeIndentationString(document, originalTypeDeclaration.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
+            var indentationString = CSharpSnippetHelpers.GetBlockLikeIndentationString(document, originalTypeDeclaration.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
 
             var newTypeDeclaration = originalTypeDeclaration.WithCloseBraceToken(
                 originalTypeDeclaration.CloseBraceToken.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString)));

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<ConstructorDeclarationSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ConstructorDeclarationSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static d => d.Body!,

--- a/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpConstructorSnippetProvider.cs
@@ -40,19 +40,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
                     cancellationToken: cancellationToken);
         }
 
-        /// <summary>
-        /// Gets the start of the BlockSyntax of the constructor declaration
-        /// to be able to insert the caret position at that location.
-        /// </summary>
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            var constructorDeclaration = (ConstructorDeclarationSyntax)caretTarget;
-            var blockStatement = constructorDeclaration.Body;
-
-            var triviaSpan = blockStatement!.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ConstructorDeclarationSyntax>(
+                caretTarget,
+                static d => d.Body!,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -67,13 +67,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            var elseClauseSyntax = (ElseClauseSyntax)caretTarget;
-            var blockStatement = (BlockSyntax)elseClauseSyntax.Statement;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ElseClauseSyntax>(
+                caretTarget,
+                static c => (BlockSyntax)c.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpElseSnippetProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<ElseClauseSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ElseClauseSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static c => (BlockSyntax)c.Statement,

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<ForEachStatementSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<ForEachStatementSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -69,7 +69,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
                 arrayBuilder.Add(new SnippetPlaceholder(expression.ToString(), expression.SpanStart));
 
             return arrayBuilder.ToImmutableArray();
+        }
 
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+        {
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<ForEachStatementSyntax>(
+                caretTarget,
+                static s => (BlockSyntax)s.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
@@ -79,21 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,
                 cancellationToken);
-        }
-
-        /// <summary>
-        /// Gets the start of the BlockSyntax of the for statement
-        /// to be able to insert the caret position at that location.
-        /// </summary>
-        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-        {
-            var foreachStatement = (ForEachStatementSyntax)caretTarget;
-            var blockStatement = (BlockSyntax)foreachStatement.Statement;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
         }
 
         private static void GetPartsOfForEachStatement(SyntaxNode node, out SyntaxToken identifier, out SyntaxNode expression, out SyntaxNode statement)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<IfStatementSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<IfStatementSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -24,21 +24,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
         }
 
-        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-        {
-            var ifStatement = (IfStatementSyntax)caretTarget;
-            var blockStatement = (BlockSyntax)ifStatement.Statement;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
-        }
-
         protected override SyntaxNode GetCondition(SyntaxNode node)
         {
             var ifStatement = (IfStatementSyntax)node;
             return ifStatement.Condition;
+        }
+
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+        {
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<IfStatementSyntax>(
+                caretTarget,
+                static s => (BlockSyntax)s.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Snippets;
+using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Snippets
+{
+    [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
+    internal sealed class CSharpIntMainSnippetProvider : AbstractCSharpMainMethodSnippetProvider
+    {
+        public override string Identifier => "sim";
+
+        public override string Description => CSharpFeaturesResources.static_int_Main;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpIntMainSnippetProvider()
+        {
+        }
+
+        protected override SyntaxNode GenerateReturnType(SyntaxGenerator generator)
+            => generator.TypeExpression(SpecialType.System_Int32);
+
+        protected override IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator)
+        {
+            var returnStatement = generator.ReturnStatement(generator.LiteralExpression(0));
+            return SpecializedCollections.SingletonEnumerable(returnStatement);
+        }
+
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+        {
+            var methodDeclaration = (MethodDeclarationSyntax)caretTarget;
+            var body = methodDeclaration.Body!;
+            var returnStatement = body.Statements.First();
+
+            var triviaSpan = returnStatement.GetLeadingTrivia().Span;
+            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
+            // Getting the location at the end of the line before the newline.
+            return line.Span.End;
+        }
+
+        protected override async Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var snippetNode = root.GetAnnotatedNodes(FindSnippetAnnotation).FirstOrDefault();
+
+            if (snippetNode is not MethodDeclarationSyntax methodDeclaration)
+                return document;
+
+            var body = methodDeclaration.Body!;
+            var returnStatement = body.Statements.First();
+
+            var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
+            var indentationString = СSharpSnippetIndentationHelpers.GetBlockLikeIndentationString(document, body.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
+
+            var updatedReturnStatement = returnStatement.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString));
+            var updatedRoot = root.ReplaceNode(returnStatement, updatedReturnStatement);
+
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIntMainSnippetProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var returnStatement = body.Statements.First();
 
             var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
-            var indentationString = СSharpSnippetIndentationHelpers.GetBlockLikeIndentationString(document, body.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
+            var indentationString = CSharpSnippetHelpers.GetBlockLikeIndentationString(document, body.OpenBraceToken.SpanStart, syntaxFormattingOptions, cancellationToken);
 
             var updatedReturnStatement = returnStatement.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString));
             var updatedRoot = root.ReplaceNode(returnStatement, updatedReturnStatement);

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<LockStatementSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<LockStatementSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,

--- a/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpLockSnippetProvider.cs
@@ -38,13 +38,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            var lockStatement = (LockStatementSyntax)caretTarget;
-            var blockStatement = (BlockSyntax)lockStatement.Statement;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<LockStatementSyntax>(
+                caretTarget,
+                static s => (BlockSyntax)s.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
@@ -10,11 +10,24 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
 internal static class CSharpSnippetHelpers
 {
+    public static int GetTargetCaretPositionInBlock<TTargetNode>(SyntaxNode caretTarget, Func<TTargetNode, BlockSyntax> getBlock, SourceText sourceText)
+        where TTargetNode : SyntaxNode
+    {
+        var targetNode = (TTargetNode)caretTarget;
+        var block = getBlock(targetNode);
+
+        var triviaSpan = block.CloseBraceToken.LeadingTrivia.Span;
+        var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
+        // Getting the location at the end of the line before the newline.
+        return line.Span.End;
+    }
+
     public static string GetBlockLikeIndentationString(Document document, int startPositionOfOpenCurlyBrace, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
     {
         var parsedDocument = ParsedDocument.CreateSynchronously(document, cancellationToken);

--- a/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpSnippetHelpers.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets;
 
-internal static class СSharpSnippetIndentationHelpers
+internal static class CSharpSnippetHelpers
 {
     public static string GetBlockLikeIndentationString(Document document, int startPositionOfOpenCurlyBrace, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
     {

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Snippets;
+using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Snippets
+{
+    [ExportSnippetProvider(nameof(ISnippetProvider), LanguageNames.CSharp), Shared]
+    internal sealed class CSharpVoidMainSnippetProvider : AbstractCSharpMainMethodSnippetProvider
+    {
+        public override string Identifier => "svm";
+
+        public override string Description => CSharpFeaturesResources.static_void_Main;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpVoidMainSnippetProvider()
+        {
+        }
+
+        protected override SyntaxNode GenerateReturnType(SyntaxGenerator generator)
+            => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword));
+
+        protected override IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator)
+            => SpecializedCollections.EmptyEnumerable<SyntaxNode>();
+
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+        {
+            var methodDeclaration = (MethodDeclarationSyntax)caretTarget;
+            var blockStatement = methodDeclaration.Body!;
+
+            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
+            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
+            // Getting the location at the end of the line before the newline.
+            return line.Span.End;
+        }
+
+        protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<MethodDeclarationSyntax>(
+                document,
+                FindSnippetAnnotation,
+                static m => m.Body!,
+                cancellationToken);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -39,13 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            var methodDeclaration = (MethodDeclarationSyntax)caretTarget;
-            var blockStatement = methodDeclaration.Body!;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<MethodDeclarationSyntax>(
+                caretTarget,
+                static d => d.Body!,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpVoidMainSnippetProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<MethodDeclarationSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<MethodDeclarationSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static m => m.Body!,

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -24,21 +24,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
         }
 
-        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
-        {
-            var whileStatement = (WhileStatementSyntax)caretTarget;
-            var blockStatement = (BlockSyntax)whileStatement.Statement;
-
-            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the location at the end of the line before the newline.
-            return line.Span.End;
-        }
-
         protected override SyntaxNode GetCondition(SyntaxNode node)
         {
             var whileStatement = (WhileStatementSyntax)node;
             return whileStatement.Condition;
+        }
+
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
+        {
+            return CSharpSnippetHelpers.GetTargetCaretPositionInBlock<WhileStatementSyntax>(
+                caretTarget,
+                static s => (BlockSyntax)s.Statement,
+                sourceText);
         }
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpWhileLoopSnippetProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override Task<Document> AddIndentationToDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            return СSharpSnippetIndentationHelpers.AddBlockIndentationToDocumentAsync<WhileStatementSyntax>(
+            return CSharpSnippetHelpers.AddBlockIndentationToDocumentAsync<WhileStatementSyntax>(
                 document,
                 FindSnippetAnnotation,
                 static s => (BlockSyntax)s.Statement,

--- a/src/Features/CSharp/Portable/Snippets/СSharpSnippetIndentationHelpers.cs
+++ b/src/Features/CSharp/Portable/Snippets/СSharpSnippetIndentationHelpers.cs
@@ -24,7 +24,7 @@ internal static class СSharpSnippetIndentationHelpers
         var newLine = indentationOptions.FormattingOptions.NewLine;
 
         var indentationService = parsedDocument.LanguageServices.GetRequiredService<IIndentationService>();
-        var indentation = indentationService.GetIndentation(parsedDocument, openBraceLine + 1, indentationOptions, cancellationToken);
+        var indentation = indentationService.GetIndentation(parsedDocument, openBraceLine, indentationOptions, cancellationToken);
 
         // Adding the offset calculated with one tab so that it is indented once past the line containing the opening brace
         var newIndentation = new IndentationResult(indentation.BasePosition, indentation.Offset + syntaxFormattingOptions.TabSize);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractMainMethodSnippetProvider.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
+{
+    internal abstract class AbstractMainMethodSnippetProvider : AbstractSingleChangeSnippetProvider
+    {
+        protected abstract SyntaxNode GenerateReturnType(SyntaxGenerator generator);
+
+        protected abstract IEnumerable<SyntaxNode> GenerateInnerStatements(SyntaxGenerator generator);
+
+        protected override Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var generator = SyntaxGenerator.GetGenerator(document);
+            var method = generator.MethodDeclaration(
+                name: WellKnownMemberNames.EntryPointMethodName,
+                parameters: SpecializedCollections.SingletonEnumerable(generator.ParameterDeclaration(
+                    name: "args",
+                    type: generator.ArrayTypeExpression(generator.TypeExpression(SpecialType.System_String)))),
+                returnType: GenerateReturnType(generator),
+                modifiers: DeclarationModifiers.Static,
+                statements: GenerateInnerStatements(generator));
+
+            return Task.FromResult(new TextChange(TextSpan.FromBounds(position, position), method.NormalizeWhitespace().ToFullString()));
+        }
+
+        protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+            => ImmutableArray<SnippetPlaceholder>.Empty;
+
+        protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
+            => syntaxFacts.IsMethodDeclaration;
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1545,6 +1545,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
         public bool IsMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node)
             => node is MemberAccessExpressionSyntax;
 
+        public bool IsMethodDeclaration([NotNullWhen(true)] SyntaxNode? node)
+            => node is MethodDeclarationSyntax;
+
         public bool IsSimpleName([NotNullWhen(true)] SyntaxNode? node)
             => node is SimpleNameSyntax;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -495,6 +495,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         bool IsBinaryExpression([NotNullWhen(true)] SyntaxNode? node);
         bool IsLiteralExpression([NotNullWhen(true)] SyntaxNode? node);
         bool IsMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node);
+        bool IsMethodDeclaration([NotNullWhen(true)] SyntaxNode? node);
         bool IsSimpleName([NotNullWhen(true)] SyntaxNode? node);
 
         bool IsNamedMemberInitializer([NotNullWhen(true)] SyntaxNode? node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1744,6 +1744,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             Return TypeOf node Is MemberAccessExpressionSyntax
         End Function
 
+        Public Function IsMethodDeclaration(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsMethodDeclaration
+            Return TypeOf node Is MethodBlockSyntax
+        End Function
+
         Public Function IsSimpleName(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsSimpleName
             Return TypeOf node Is SimpleNameSyntax
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/SyntaxKindSet.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/SyntaxKindSet.cs
@@ -2,64 +2,69 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Formatting;
 
 namespace Microsoft.CodeAnalysis.CSharp.Utilities
 {
     internal class SyntaxKindSet
     {
         public static readonly ISet<SyntaxKind> AllTypeModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.AbstractKeyword,
-                SyntaxKind.FileKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ProtectedKeyword,
-                SyntaxKind.SealedKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.UnsafeKeyword,
-                SyntaxKind.ReadOnlyKeyword,
-                SyntaxKind.RefKeyword
-            };
+        {
+            SyntaxKind.AbstractKeyword,
+            SyntaxKind.FileKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.SealedKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.UnsafeKeyword,
+            SyntaxKind.ReadOnlyKeyword,
+            SyntaxKind.RefKeyword
+        };
 
         public static readonly ISet<SyntaxKind> AllMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.AbstractKeyword,
-                SyntaxKind.AsyncKeyword,
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.OverrideKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ProtectedKeyword,
-                SyntaxKind.ReadOnlyKeyword,
-                SyntaxKind.RequiredKeyword,
-                SyntaxKind.SealedKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.UnsafeKeyword,
-                SyntaxKind.VirtualKeyword,
-                SyntaxKind.VolatileKeyword,
-            };
+        {
+            SyntaxKind.AbstractKeyword,
+            SyntaxKind.AsyncKeyword,
+            SyntaxKind.ExternKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.OverrideKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.ReadOnlyKeyword,
+            SyntaxKind.RequiredKeyword,
+            SyntaxKind.SealedKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.UnsafeKeyword,
+            SyntaxKind.VirtualKeyword,
+            SyntaxKind.VolatileKeyword,
+        };
 
         public static readonly ISet<SyntaxKind> AllGlobalMemberModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
-            {
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.NewKeyword,
-                SyntaxKind.OverrideKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.ReadOnlyKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.UnsafeKeyword,
-                SyntaxKind.VolatileKeyword,
-            };
+        {
+            SyntaxKind.ExternKeyword,
+            SyntaxKind.InternalKeyword,
+            SyntaxKind.NewKeyword,
+            SyntaxKind.OverrideKeyword,
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ReadOnlyKeyword,
+            SyntaxKind.StaticKeyword,
+            SyntaxKind.UnsafeKeyword,
+            SyntaxKind.VolatileKeyword,
+        };
+
+        public static readonly ISet<SyntaxKind> AccessibilityModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
+        {
+            SyntaxKind.PublicKeyword,
+            SyntaxKind.PrivateKeyword,
+            SyntaxKind.ProtectedKeyword,
+            SyntaxKind.InternalKeyword,
+        };
 
         public static readonly ISet<SyntaxKind> AllTypeDeclarations = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
         {


### PR DESCRIPTION
Commit 1: Added `svm` and `sim` snippets
Commits 2 and 3: I realized that there are many snippets that place caret target position inside a block. So I reused helper class (first renamed it, since it now deals not only with indentation) for common helper method for that

@akhera99 for review