### PR TITLE
Add effective severities custom property array to error log

### DIFF
--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -160,7 +160,9 @@ Example `rule` entry:
 ### `Rule Configuration Override` format for each rule severity override
 
 The `ruleConfigurationOverrides` section contains an array of entries, with an entry each for every rule severity configuration override for the whole or part of the compilation via options, i.e. editorconfig, globalconfig, command line options, ruleset, etc. Each rule configuration override entry contains the following information:
-1. `descriptor`: Property containing information to map back to the relevant `descriptor` or the `rule` in the `rules` section. Currently, it contains a single child property named `index`, which contains a zero-based index value into the `rules` array for the rule mapping.
+1. `descriptor`: Property containing information to map back to the relevant `descriptor` or the `rule` in the `rules` section. Currently, it contains the below child properties:
+   1. `id`: Rule id string for the rule or diagnostic.
+   2. `index`: A zero-based integral index value into the `rules` array for the rule mapping.
 2. `configuration`: Configuration property for the effective overridden severity for the rule. Currently, it includes a single child property named `level` for the effective severity of the rule, such as `error`, `warning`, `note`, `none`, etc.
 
 Note that we can have multiple `ruleConfigurationOverride` entries for the same descriptor if the rule is configured to fire at different severities across different parts of the compilation. For example, editorconfig based severity configurations can specify different effective severity for the same rule ID for different files or folders in a project.
@@ -169,6 +171,7 @@ Example `ruleConfigurationOverride` entry:
 ```json
 {
   "descriptor": {
+    "id": "CA1000",
     "index": 0
   },
   "configuration": {
@@ -177,6 +180,7 @@ Example `ruleConfigurationOverride` entry:
 },
 {
   "descriptor": {
+    "id": "CA1000",
     "index": 0
   },
   "configuration": {
@@ -185,6 +189,7 @@ Example `ruleConfigurationOverride` entry:
 },
 {
   "descriptor": {
+    "id": "CA1001",
     "index": 1
   },
   "configuration": {

--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -159,7 +159,7 @@ Example `rule` entry:
 
 ### `Rule Configuration Override` format for each rule severity override
 
-The `ruleConfigurationOverrides` section contains an array of entries, with an entry each for every rule severity configuration override for the whole or part of the compilation via options, i.e. editorconfig, globalconfig, command line options, ruleset, etc. Each rule configuration override entry contains the following information:
+The `ruleConfigurationOverrides` section contains an array of entries, with an entry for every rule severity configuration override for the whole or part of the compilation via options, i.e. editorconfig, globalconfig, command line options, ruleset, etc. Each rule configuration override entry contains the following information:
 1. `descriptor`: Property containing information to map back to the relevant `descriptor` or the `rule` in the `rules` section. Currently, it contains the below child properties:
    1. `id`: Rule id string for the rule or diagnostic.
    2. `index`: A zero-based integral index value into the `rules` array for the rule mapping.

--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -111,12 +111,13 @@ The `rules` section contains a rule entry that corresponds to metadata or `Diagn
 5. `helpUri`: Help uri for help information associated with the descriptor.
 6. `properties`: One or more custom properties associated with the descriptor. It includes the following:
    1. `category`: `Category` associated with the descriptor, such as, `Design`, `Performance`, `Security`, etc.
-   2. `executionTimeInSeconds`: Execution time in seconds associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `0.001` seconds are reported as `<0.001`.
-   3. `executionTimeInPercentage`: Execution time in percentage associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `1` are reported as `<1`.
-   4. `isEverSuppressed` and `suppressionKinds`: If a rule had either a source suppression or was disabled for part or whole of the compilation via options, the rule metadata contains a special flag `isEverSuppressed = true` and an array `suppressionKinds` with either or both of the below suppression kinds:
+   2. `effectiveConfigurationLevels`: If a rule had one for severity configurations for a part or whole of the compilation via options, the rule metadata will contain this array of one of more effective severity levels for diagnostics associated with the descriptor, such as `error`, `warning`, `note`, `none` etc.
+   3. `isEverSuppressed` and `suppressionKinds`: If a rule had either a source suppression or was disabled for part or whole of the compilation via options, the rule metadata contains a special flag `isEverSuppressed = true` and an array `suppressionKinds` with either or both of the below suppression kinds:
       1. `inSource` suppression kind for one or more reported diagnostic(s) that were suppressed through pragma directive, SuppressMessageAttribute or a DiagnosticSuppressor.
       2. `external` suppression kind for diagnostic ID that is disabled either for the entire compilation (via global options such as /nowarn, ruleset, globalconfig, etc.) or for certain files or folders in the compilation (via editorconfig options).
-   5. `tags`: An array of one of more `CustomTags` associated with the descriptor.
+   4. `executionTimeInSeconds`: Execution time in seconds associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `0.001` seconds are reported as `<0.001`.
+   5. `executionTimeInPercentage`: Execution time in percentage associated with the analyzer, as reported with the `/reportAnalyzer` compiler switch. Values less than `1` are reported as `<1`.
+   6. `tags`: An array of one of more `CustomTags` associated with the descriptor.
   
 Example `rule` entry:
 ```json
@@ -134,12 +135,16 @@ Example `rule` entry:
   "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001",
   "properties": {
     "category": "Design",
-    "executionTimeInSeconds": "x.xxx",
-    "executionTimeInPercentage": "xx",
+    "effectiveConfigurationLevels": [
+      "error",
+      "none",
+    ],
     "isEverSuppressed": "true",
     "suppressionKinds": [
       "external"
     ],
+    "executionTimeInSeconds": "x.xxx",
+    "executionTimeInPercentage": "xx",
     "tags": [
       "PortedFromFxCop",
       "Telemetry",

--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -46,6 +46,7 @@ Example `runs` section, with stripped off `results`, `rules` and `ruleConfigurat
   },
   "invocations": [
     {
+      "executionSuccessful": true,
       "ruleConfigurationOverrides": [
       ]
     }

--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -163,7 +163,9 @@ The `ruleConfigurationOverrides` section contains an array of entries, with an e
 1. `descriptor`: Property containing information to map back to the relevant `descriptor` or the `rule` in the `rules` section. Currently, it contains the below child properties:
    1. `id`: Rule id string for the rule or diagnostic.
    2. `index`: A zero-based integral index value into the `rules` array for the rule mapping.
-2. `configuration`: Configuration property for the effective overridden severity for the rule. Currently, it includes a single child property named `level` for the effective severity of the rule, such as `error`, `warning`, `note`, `none`, etc.
+2. `configuration`: Configuration property for the effective overridden severity for the rule. Currently, it may include one of the below child properties:
+   1. `enabled`: A boolean property indicating if the rule has been explicitly disabled or enabled with the configuration override entry.
+   1. `level`: Property for the effective severity of the rule, such as `error`, `warning` or `note`. Note that this property is not emitted for rules disabled with configuration override, we instead emit `enabled: false` for them.
 
 Note that we can have multiple `ruleConfigurationOverride` entries for the same descriptor if the rule is configured to fire at different severities across different parts of the compilation. For example, editorconfig based severity configurations can specify different effective severity for the same rule ID for different files or folders in a project.
 
@@ -184,7 +186,7 @@ Example `ruleConfigurationOverride` entry:
     "index": 0
   },
   "configuration": {
-    "level": "none"
+    "enabled": false
   }
 },
 {

--- a/src/Compilers/CSharp/Test/CommandLine/SarifErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifErrorLoggerTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         internal abstract string GetExpectedOutputForSimpleCompilerDiagnosticsSuppressed(MockCSharpCompiler cmd, string sourceFile, params string[] suppressionKinds);
         internal abstract string GetExpectedOutputForAnalyzerDiagnosticsWithAndWithoutLocation(MockCSharpCompiler cmd);
         internal abstract string GetExpectedOutputForAnalyzerDiagnosticsWithSuppression(MockCSharpCompiler cmd, string justification, string suppressionType, params string[] suppressionKinds);
+        internal abstract string GetExpectedOutputForAnalyzerDiagnosticsWithWarnAsError(MockCSharpCompiler cmd);
 
         protected void NoDiagnosticsImpl()
         {
@@ -296,6 +297,38 @@ class C
 
             var actualOutput = File.ReadAllText(errorLogFile).Trim();
             string expectedOutput = GetExpectedOutputForAnalyzerDiagnosticsWithSuppression(cmd, null, suppressionType: "SuppressMessageAttribute", suppressionKinds: "inSource");
+
+            Assert.Equal(expectedOutput, actualOutput);
+
+            CleanupAllGeneratedFiles(sourceFile);
+            CleanupAllGeneratedFiles(errorLogFile);
+        }
+
+        protected void AnalyzerDiagnosticsWithWarnAsErrorImpl()
+        {
+            var source = @"
+class C
+{
+}";
+            var sourceFile = Temp.CreateFile().WriteAllText(source).Path;
+            var errorLogDir = Temp.CreateDirectory();
+            var errorLogFile = Path.Combine(errorLogDir.Path, "ErrorLog.txt");
+
+            string[] arguments = new[] { "/nologo", "/t:library", "/warnaserror", sourceFile, "/preferreduilang:en", $"/errorlog:{errorLogFile}{ErrorLogQualifier}" };
+
+            var cmd = CreateCSharpCompiler(null, WorkingDirectory, arguments,
+               analyzers: new[] { new AnalyzerForErrorLogTest() });
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+
+            var exitCode = cmd.Run(outWriter);
+            var actualConsoleOutput = outWriter.ToString().Trim();
+
+            Assert.Contains("error ID1", actualConsoleOutput);
+            Assert.Contains("error ID2", actualConsoleOutput);
+            Assert.NotEqual(0, exitCode);
+
+            var actualOutput = File.ReadAllText(errorLogFile).Trim();
+            string expectedOutput = GetExpectedOutputForAnalyzerDiagnosticsWithWarnAsError(cmd);
 
             Assert.Equal(expectedOutput, actualOutput);
 

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
@@ -203,6 +203,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             return expectedHeader + expectedIssues;
         }
 
+        internal override string GetExpectedOutputForAnalyzerDiagnosticsWithWarnAsError(MockCSharpCompiler cmd)
+        {
+            var expectedHeader = GetExpectedErrorLogHeader(cmd);
+            var expectedIssues = AnalyzerForErrorLogTest.GetExpectedV1ErrorLogResultsAndRulesText(cmd.Compilation, warnAsError: true);
+            return expectedHeader + expectedIssues;
+        }
+
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void AnalyzerDiagnosticsWithAndWithoutLocation()
         {
@@ -231,6 +238,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         public void AnalyzerDiagnosticsSuppressedWithNullJustification()
         {
             AnalyzerDiagnosticsSuppressedWithNullJustificationImpl();
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void AnalyzerDiagnosticsWithWarnAsError()
+        {
+            AnalyzerDiagnosticsWithWarnAsErrorImpl();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -333,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
                 cmd,
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogWithSuppressionResultsText(cmd.Compilation, justification, suppressionType),
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture, suppressionKinds));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture, suppressionKinds1: suppressionKinds));
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
@@ -446,6 +447,8 @@ class C
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(
                     cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
+                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Suppress),
+                    effectiveSeverities2: ImmutableHashSet.Create(ReportDiagnostic.Suppress),
                     suppressionKinds1: new[] { "external" }, suppressionKinds2: new[] { "external" }));
 
             Assert.Equal(expectedOutput, actualOutput);
@@ -523,7 +526,9 @@ dotnet_diagnostic.ID1.severity = none
                 cmd,
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogWithSuppressionResultsText(cmd.Compilation, "Justification1", suppressionType: "SuppressMessageAttribute"),
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture, suppressionKinds1: new[] { "external", "inSource" }));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
+                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Suppress, ReportDiagnostic.Warn),
+                    suppressionKinds1: new[] { "external", "inSource" }));
 
             Assert.Equal(expectedOutput, actualOutput);
 

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
     {{
 {5},
       ""properties"": {{
-        ""analyzerExecutionTime"": ""{7}""
+        ""analyzerExecutionTime"": ""{8}""
       }},
       ""tool"": {{
         ""driver"": {{
@@ -359,6 +359,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {6}
         }}
       }},
+      {7},
       ""columnKind"": ""utf16CodeUnits""
     }}
   ]
@@ -368,8 +369,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
                 cmd,
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogResultsText(cmd.Compilation, warnAsError: true),
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
-                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Error)));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture),
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText((0, ImmutableHashSet.Create(ReportDiagnostic.Error))));
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
@@ -466,7 +467,7 @@ class C
       ""results"": [
       ],
       ""properties"": {{
-        ""analyzerExecutionTime"": ""{6}""
+        ""analyzerExecutionTime"": ""{7}""
       }},
       ""tool"": {{
         ""driver"": {{
@@ -478,6 +479,7 @@ class C
 {5}
         }}
       }},
+      {6},
       ""columnKind"": ""utf16CodeUnits""
     }}
   ]
@@ -486,11 +488,10 @@ class C
                 expectedOutputMarkup,
                 cmd,
                 hasAnalyzers: true,
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(
-                    cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
-                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Suppress),
-                    effectiveSeverities2: ImmutableHashSet.Create(ReportDiagnostic.Suppress),
-                    suppressionKinds1: new[] { "external" }, suppressionKinds2: new[] { "external" }));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
+                    suppressionKinds1: new[] { "external" }, suppressionKinds2: new[] { "external" }),
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText(
+                    (0, ImmutableHashSet.Create(ReportDiagnostic.Suppress)), (1, ImmutableHashSet.Create(ReportDiagnostic.Suppress))));
 
             Assert.Equal(expectedOutput, actualOutput);
 
@@ -546,7 +547,7 @@ dotnet_diagnostic.ID1.severity = none
     {{
 {5},
       ""properties"": {{
-        ""analyzerExecutionTime"": ""{7}""
+        ""analyzerExecutionTime"": ""{8}""
       }},
       ""tool"": {{
         ""driver"": {{
@@ -558,6 +559,7 @@ dotnet_diagnostic.ID1.severity = none
 {6}
         }}
       }},
+      {7},
       ""columnKind"": ""utf16CodeUnits""
     }}
   ]
@@ -568,8 +570,8 @@ dotnet_diagnostic.ID1.severity = none
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogWithSuppressionResultsText(cmd.Compilation, "Justification1", suppressionType: "SuppressMessageAttribute"),
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
-                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Suppress, ReportDiagnostic.Warn),
-                    suppressionKinds1: new[] { "external", "inSource" }));
+                    suppressionKinds1: new[] { "external", "inSource" }),
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText((0, ImmutableHashSet.Create(ReportDiagnostic.Suppress, ReportDiagnostic.Warn))));
 
             Assert.Equal(expectedOutput, actualOutput);
 

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -370,7 +370,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
                 hasAnalyzers: true,
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogResultsText(cmd.Compilation, warnAsError: true),
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture),
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText((0, ImmutableHashSet.Create(ReportDiagnostic.Error))));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText(
+                    (AnalyzerForErrorLogTest.Descriptor1.Id, 0, ImmutableHashSet.Create(ReportDiagnostic.Error))));
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
@@ -491,7 +492,8 @@ class C
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
                     suppressionKinds1: new[] { "external" }, suppressionKinds2: new[] { "external" }),
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText(
-                    (0, ImmutableHashSet.Create(ReportDiagnostic.Suppress)), (1, ImmutableHashSet.Create(ReportDiagnostic.Suppress))));
+                    (AnalyzerForErrorLogTest.Descriptor1.Id, 0, ImmutableHashSet.Create(ReportDiagnostic.Suppress)),
+                    (AnalyzerForErrorLogTest.Descriptor2.Id, 1, ImmutableHashSet.Create(ReportDiagnostic.Suppress))));
 
             Assert.Equal(expectedOutput, actualOutput);
 
@@ -571,7 +573,8 @@ dotnet_diagnostic.ID1.severity = none
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogWithSuppressionResultsText(cmd.Compilation, "Justification1", suppressionType: "SuppressMessageAttribute"),
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
                     suppressionKinds1: new[] { "external", "inSource" }),
-                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText((0, ImmutableHashSet.Create(ReportDiagnostic.Suppress, ReportDiagnostic.Warn))));
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogInvocationsText(
+                    (AnalyzerForErrorLogTest.Descriptor1.Id, 0, ImmutableHashSet.Create(ReportDiagnostic.Suppress, ReportDiagnostic.Warn))));
 
             Assert.Equal(expectedOutput, actualOutput);
 

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -340,30 +340,32 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         internal override string GetExpectedOutputForAnalyzerDiagnosticsWithWarnAsError(MockCSharpCompiler cmd)
         {
             string expectedOutput =
-@"{{
-  ""$schema"": ""http://json.schemastore.org/sarif-2.1.0"",
-  ""version"": ""2.1.0"",
-  ""runs"": [
+"""
+{{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0",
+  "version": "2.1.0",
+  "runs": [
     {{
 {5},
-      ""properties"": {{
-        ""analyzerExecutionTime"": ""{8}""
+      "properties": {{
+        "analyzerExecutionTime": "{8}"
       }},
-      ""tool"": {{
-        ""driver"": {{
-          ""name"": ""{0}"",
-          ""version"": ""{1}"",
-          ""dottedQuadFileVersion"": ""{2}"",
-          ""semanticVersion"": ""{3}"",
-          ""language"": ""{4}"",
+      "tool": {{
+        "driver": {{
+          "name": "{0}",
+          "version": "{1}",
+          "dottedQuadFileVersion": "{2}",
+          "semanticVersion": "{3}",
+          "language": "{4}",
 {6}
         }}
       }},
       {7},
-      ""columnKind"": ""utf16CodeUnits""
+      "columnKind": "utf16CodeUnits"
     }}
   ]
-}}";
+}}
+""";
             return FormatOutputText(
                 expectedOutput,
                 cmd,

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -337,6 +337,41 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
                 AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture, suppressionKinds1: suppressionKinds));
         }
 
+        internal override string GetExpectedOutputForAnalyzerDiagnosticsWithWarnAsError(MockCSharpCompiler cmd)
+        {
+            string expectedOutput =
+@"{{
+  ""$schema"": ""http://json.schemastore.org/sarif-2.1.0"",
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {{
+{5},
+      ""properties"": {{
+        ""analyzerExecutionTime"": ""{7}""
+      }},
+      ""tool"": {{
+        ""driver"": {{
+          ""name"": ""{0}"",
+          ""version"": ""{1}"",
+          ""dottedQuadFileVersion"": ""{2}"",
+          ""semanticVersion"": ""{3}"",
+          ""language"": ""{4}"",
+{6}
+        }}
+      }},
+      ""columnKind"": ""utf16CodeUnits""
+    }}
+  ]
+}}";
+            return FormatOutputText(
+                expectedOutput,
+                cmd,
+                hasAnalyzers: true,
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogResultsText(cmd.Compilation, warnAsError: true),
+                AnalyzerForErrorLogTest.GetExpectedV2ErrorLogRulesText(cmd.DescriptorsWithInfo, CultureInfo.InvariantCulture,
+                    effectiveSeverities1: ImmutableHashSet.Create(ReportDiagnostic.Error)));
+        }
+
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void AnalyzerDiagnosticsWithAndWithoutLocation()
         {
@@ -365,6 +400,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         public void AnalyzerDiagnosticsSuppressedWithNullJustification()
         {
             AnalyzerDiagnosticsSuppressedWithNullJustificationImpl();
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void AnalyzerDiagnosticsWithWarnAsError()
+        {
+            AnalyzerDiagnosticsWithWarnAsErrorImpl();
         }
 
         private string FormatOutputText(

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -21,7 +21,10 @@ namespace Microsoft.CodeAnalysis
     /// for the <see cref="ErrorLogger"/>. It contains the following:
     ///   1. Analyzer execution time in seconds for the analyzer owning the descriptor.
     ///   2. Analyzer execution time in percentage of the total analyzer execution time.
-    ///   3. A boolean value "HasAnyExternalSuppression" indicating if the diagnostic ID has any
+    ///   3. Set of all effective severities for the diagnostic Id, configured through options
+    ///      from editorconfig, ruleset, command line options, etc. for either part of the compilation
+    ///      or the entire compilation.
+    ///   4. A boolean value "HasAnyExternalSuppression" indicating if the diagnostic ID has any
     ///      external non-source suppression from editorconfig, ruleset, command line options, etc.,
     ///      which disables the descriptor for either part of the compilation or the entire compilation.
     ///      Note that this flag doesn't account for source suppressions from pragma directives,
@@ -31,5 +34,6 @@ namespace Microsoft.CodeAnalysis
     internal readonly record struct DiagnosticDescriptorErrorLoggerInfo(
         double ExecutionTime,
         int ExecutionPercentage,
+        ImmutableHashSet<ReportDiagnostic>? EffectiveSeverities,
         bool HasAnyExternalSuppression);
 }

--- a/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
             _writer.WriteObjectEnd(); // region
         }
 
-        protected static string GetLevel(DiagnosticSeverity? severity)
+        protected static string GetLevel(DiagnosticSeverity severity)
         {
             switch (severity)
             {
@@ -73,9 +73,6 @@ namespace Microsoft.CodeAnalysis
                     // so we represent them similar to Info diagnostics.
                     // In future, if required, we can represent them with a custom property in the SARIF log.
                     goto case DiagnosticSeverity.Info;
-
-                case null:
-                    return "none";
 
                 default:
                     Debug.Assert(false);

--- a/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
             _writer.WriteObjectEnd(); // region
         }
 
-        protected static string GetLevel(DiagnosticSeverity severity)
+        protected static string GetLevel(DiagnosticSeverity? severity)
         {
             switch (severity)
             {
@@ -73,6 +73,9 @@ namespace Microsoft.CodeAnalysis
                     // so we represent them similar to Info diagnostics.
                     // In future, if required, we can represent them with a custom property in the SARIF log.
                     goto case DiagnosticSeverity.Info;
+
+                case null:
+                    return "none";
 
                 default:
                     Debug.Assert(false);

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -354,6 +354,7 @@ namespace Microsoft.CodeAnalysis
             /*
                 "invocations": [                          # See §3.14.11.
                   {                                       # An invocation object (§3.20).
+                    "executionSuccessful" : true,         # See $3.20.14. A boolean value.
                     "ruleConfigurationOverrides": [       # See §3.20.5.
                       {                                   # A configurationOverride object
                                                           #  (§3.51).
@@ -372,6 +373,11 @@ namespace Microsoft.CodeAnalysis
 
             _writer.WriteArrayStart("invocations");
             _writer.WriteObjectStart(); // invocation
+
+            // Boolean property that is true if the engineering system that started the process knows that the analysis tool succeeded,
+            // and false if the engineering system knows that the tool failed.
+            // TODO: Detect when the compiler exits with an exception and emit "false".
+            _writer.Write("executionSuccessful", true);
 
             _writer.WriteArrayStart("ruleConfigurationOverrides");
 

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis
 
             // Boolean property that is true if the engineering system that started the process knows that the analysis tool succeeded,
             // and false if the engineering system knows that the tool failed.
-            // TODO: Detect when the compiler exits with an exception and emit "false".
+            // https://github.com/dotnet/roslyn/issues/70069 tracks detecting when the compiler exits with an exception and emit "false".
             _writer.Write("executionSuccessful", true);
 
             _writer.WriteArrayStart("ruleConfigurationOverrides");

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -227,9 +227,9 @@ namespace Microsoft.CodeAnalysis
             WriteInvocations(effectiveSeverities);
         }
 
-        private ImmutableArray<(int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> WriteRules()
+        private ImmutableArray<(string DescriptorId, int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> WriteRules()
         {
-            var effectiveSeveritiesBuilder = ArrayBuilder<(int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)>.GetInstance(_descriptors.Count);
+            var effectiveSeveritiesBuilder = ArrayBuilder<(string DescriptorId, int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)>.GetInstance(_descriptors.Count);
 
             if (_descriptors.Count > 0)
             {
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis
                         (descriptorInfo.EffectiveSeverities.Count != 1 || descriptorInfo.EffectiveSeverities.Single() != defaultSeverity);
                     if (hasNonDefaultEffectiveSeverities)
                     {
-                        effectiveSeveritiesBuilder.Add((index, descriptorInfo.EffectiveSeverities!));
+                        effectiveSeveritiesBuilder.Add((descriptor.Id, index, descriptorInfo.EffectiveSeverities!));
                     }
                 }
 
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis
             return effectiveSeveritiesBuilder.ToImmutableAndFree();
         }
 
-        private void WriteInvocations(ImmutableArray<(int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> effectiveSeverities)
+        private void WriteInvocations(ImmutableArray<(string DescriptorId, int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> effectiveSeverities)
         {
             if (effectiveSeverities.IsEmpty)
                 return;
@@ -359,6 +359,7 @@ namespace Microsoft.CodeAnalysis
                       {                                   # A configurationOverride object
                                                           #  (§3.51).
                         "descriptor": {                   # See §3.51.2.
+                          "id": "CA1000",
                           "index": 0
                         },
                         "configuration": {                # See §3.51.3.
@@ -381,7 +382,7 @@ namespace Microsoft.CodeAnalysis
 
             _writer.WriteArrayStart("ruleConfigurationOverrides");
 
-            foreach (var (index, severities) in effectiveSeverities)
+            foreach (var (id, index, severities) in effectiveSeverities)
             {
                 Debug.Assert(!severities.IsEmpty);
 
@@ -390,6 +391,7 @@ namespace Microsoft.CodeAnalysis
                     _writer.WriteObjectStart(); // ruleConfigurationOverride
 
                     _writer.WriteObjectStart("descriptor");
+                    _writer.Write("id", id);
                     _writer.Write("index", index);
                     _writer.WriteObjectEnd(); // descriptor
 

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -227,9 +227,9 @@ namespace Microsoft.CodeAnalysis
             WriteInvocations(effectiveSeverities);
         }
 
-        private ImmutableArray<(string DescriptorId, int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> WriteRules()
+        private ImmutableArray<(string DescriptorId, int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)> WriteRules()
         {
-            var effectiveSeveritiesBuilder = ArrayBuilder<(string DescriptorId, int DesciptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)>.GetInstance(_descriptors.Count);
+            var effectiveSeveritiesBuilder = ArrayBuilder<(string DescriptorId, int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)>.GetInstance(_descriptors.Count);
 
             if (_descriptors.Count > 0)
             {

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -395,9 +395,19 @@ namespace Microsoft.CodeAnalysis
                     _writer.Write("index", index);
                     _writer.WriteObjectEnd(); // descriptor
 
+                    // Emit 'configuration' property bag with "enabled: false" for disabled diagnostics and
+                    // "level: severity" for enabled diagnostics with overridden severity. 
                     _writer.WriteObjectStart("configuration");
-                    var level = GetLevel(DiagnosticDescriptor.MapReportToSeverity(severity));
-                    _writer.Write("level", level);
+                    var reportDiagnostic = DiagnosticDescriptor.MapReportToSeverity(severity);
+                    if (!reportDiagnostic.HasValue)
+                    {
+                        _writer.Write("enabled", false);
+                    }
+                    else
+                    {
+                        var level = GetLevel(reportDiagnostic.Value);
+                        _writer.Write("level", level);
+                    }
                     _writer.WriteObjectEnd(); // configuration
 
                     _writer.WriteObjectEnd(); // ruleConfigurationOverride

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -253,6 +253,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        internal static DiagnosticSeverity? MapReportToSeverity(ReportDiagnostic severity)
+        {
+            switch (severity)
+            {
+                case ReportDiagnostic.Error:
+                    return DiagnosticSeverity.Error;
+                case ReportDiagnostic.Warn:
+                    return DiagnosticSeverity.Warning;
+                case ReportDiagnostic.Info:
+                    return DiagnosticSeverity.Info;
+                case ReportDiagnostic.Hidden:
+                    return DiagnosticSeverity.Hidden;
+                case ReportDiagnostic.Suppress:
+                    return null;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(severity);
+            }
+        }
+
         /// <summary>
         /// Returns true if diagnostic descriptor is not configurable, i.e. cannot be suppressed or filtered or have its severity changed.
         /// For example, compiler errors are always non-configurable.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -954,15 +954,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     if (severity != ReportDiagnostic.Default)
                     {
-                        // Handle /warnaserror
-                        if (severity == ReportDiagnostic.Warn &&
-                            compilation.Options.GeneralDiagnosticOption == ReportDiagnostic.Error)
-                        {
-                            severity = ReportDiagnostic.Error;
-                        }
-
                         defaultSeverity = severity;
                     }
+                }
+
+                // Handle /warnaserror
+                if (defaultSeverity == ReportDiagnostic.Warn &&
+                    compilation.Options.GeneralDiagnosticOption == ReportDiagnostic.Error)
+                {
+                    defaultSeverity = ReportDiagnostic.Error;
                 }
 
                 if (compilation.Options.SyntaxTreeOptionsProvider is not { } syntaxTreeProvider ||

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -927,7 +927,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var isDiagnosticIdEverSuppressed = isAnalyzerEverSuppressed ||
                         SuppressedDiagnosticIdsForUnsuppressedAnalyzers.Contains(descriptor.Id);
 
-                    var effectiveSeverities = GetEffectiveSeverties(descriptor, AnalyzerExecutor.Compilation, AnalyzerExecutor.AnalyzerOptions, cancellationToken);
+                    var effectiveSeverities = GetEffectiveSeverities(descriptor, AnalyzerExecutor.Compilation, AnalyzerExecutor.AnalyzerOptions, cancellationToken);
                     var info = new DiagnosticDescriptorErrorLoggerInfo(analyzerExecutionTime, executionPercentage, effectiveSeverities, isDiagnosticIdEverSuppressed);
                     builder.Add((descriptor, info));
                 }
@@ -936,7 +936,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             uniqueDiagnosticIds.Free();
             return builder.ToImmutableAndFree();
 
-            static ImmutableHashSet<ReportDiagnostic> GetEffectiveSeverties(
+            static ImmutableHashSet<ReportDiagnostic> GetEffectiveSeverities(
                 DiagnosticDescriptor descriptor,
                 Compilation compilation,
                 AnalyzerOptions analyzerOptions,

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -927,13 +927,75 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var isDiagnosticIdEverSuppressed = isAnalyzerEverSuppressed ||
                         SuppressedDiagnosticIdsForUnsuppressedAnalyzers.Contains(descriptor.Id);
 
-                    var info = new DiagnosticDescriptorErrorLoggerInfo(analyzerExecutionTime, executionPercentage, isDiagnosticIdEverSuppressed);
+                    var effectiveSeverities = GetEffectiveSeverties(descriptor, AnalyzerExecutor.Compilation, AnalyzerExecutor.AnalyzerOptions, cancellationToken);
+                    var info = new DiagnosticDescriptorErrorLoggerInfo(analyzerExecutionTime, executionPercentage, effectiveSeverities, isDiagnosticIdEverSuppressed);
                     builder.Add((descriptor, info));
                 }
             }
 
             uniqueDiagnosticIds.Free();
             return builder.ToImmutableAndFree();
+
+            static ImmutableHashSet<ReportDiagnostic> GetEffectiveSeverties(
+                DiagnosticDescriptor descriptor,
+                Compilation compilation,
+                AnalyzerOptions analyzerOptions,
+                CancellationToken cancellationToken)
+            {
+                var defaultSeverity = descriptor.IsEnabledByDefault ?
+                    DiagnosticDescriptor.MapSeverityToReport(descriptor.DefaultSeverity) :
+                    ReportDiagnostic.Suppress;
+
+                if (descriptor.IsNotConfigurable())
+                    return ImmutableHashSet.Create(defaultSeverity);
+
+                if (compilation.Options.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out var severity) ||
+                    compilation.Options.SyntaxTreeOptionsProvider?.TryGetGlobalDiagnosticValue(descriptor.Id, cancellationToken, out severity) == true)
+                {
+                    if (severity != ReportDiagnostic.Default)
+                    {
+                        // Handle /warnaserror
+                        if (severity == ReportDiagnostic.Warn &&
+                            compilation.Options.GeneralDiagnosticOption == ReportDiagnostic.Error)
+                        {
+                            severity = ReportDiagnostic.Error;
+                        }
+
+                        defaultSeverity = severity;
+                    }
+                }
+
+                if (compilation.Options.SyntaxTreeOptionsProvider is not { } syntaxTreeProvider ||
+                    compilation.SyntaxTrees.IsEmpty())
+                {
+                    return ImmutableHashSet.Create(defaultSeverity);
+                }
+
+                var builder = ImmutableHashSet.CreateBuilder<ReportDiagnostic>();
+                foreach (var tree in compilation.SyntaxTrees)
+                {
+                    var severityForTree = defaultSeverity;
+
+                    if (syntaxTreeProvider.TryGetDiagnosticValue(tree, descriptor.Id, cancellationToken, out severity) ||
+                        analyzerOptions.TryGetSeverityFromBulkConfiguration(tree, compilation, descriptor, cancellationToken, out severity))
+                    {
+                        Debug.Assert(severity != ReportDiagnostic.Default);
+
+                        // Handle /warnaserror
+                        if (severity == ReportDiagnostic.Warn &&
+                            compilation.Options.GeneralDiagnosticOption == ReportDiagnostic.Error)
+                        {
+                            severity = ReportDiagnostic.Error;
+                        }
+
+                        severityForTree = severity;
+                    }
+
+                    builder.Add(severityForTree);
+                }
+
+                return builder.ToImmutable();
+            }
         }
 
         private SemanticModel GetOrCreateSemanticModel(SyntaxTree tree)

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -417,6 +417,7 @@ namespace Microsoft.CodeAnalysis
 
                 return $@"""invocations"": [
         {{
+          ""executionSuccessful"": true,
           ""ruleConfigurationOverrides"": [{overridesContent}
           ]
         }}

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -100,18 +100,22 @@ namespace Microsoft.CodeAnalysis
                 return expectedText;
             }
 
-            public static string GetExpectedV1ErrorLogResultsAndRulesText(Compilation compilation)
+            public static string GetExpectedV1ErrorLogResultsAndRulesText(Compilation compilation, bool warnAsError = false)
             {
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
                 var filePath = GetUriForPath(tree.FilePath);
+                var effectiveSeverity1 = warnAsError || Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning";
+                var effectiveSeverity2 = warnAsError || Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning";
+                var warningLevelText = warnAsError ? string.Empty : @"
+            """"warningLevel"""": 1,""";
 
                 return @"
       ""results"": [
         {
           ""ruleId"": """ + Descriptor1.Id + @""",
-          ""level"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""level"": """ + effectiveSeverity1 + @""",
           ""message"": """ + Descriptor1.MessageFormat + @""",
           ""locations"": [
             {
@@ -126,13 +130,13 @@ namespace Microsoft.CodeAnalysis
               }
             }
           ],
-          ""properties"": {
-            ""warningLevel"": 1," + GetExpectedPropertiesMapText() + @"
+          ""properties"": {" +
+             warningLevelText + GetExpectedPropertiesMapText() + @"
           }
         },
         {
           ""ruleId"": """ + Descriptor2.Id + @""",
-          ""level"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""level"": """ + effectiveSeverity2 + @""",
           ""message"": """ + Descriptor2.MessageFormat + @""",
           ""properties"": {" +
              GetExpectedPropertiesMapText() + @"
@@ -251,19 +255,23 @@ namespace Microsoft.CodeAnalysis
 }";
             }
 
-            public static string GetExpectedV2ErrorLogResultsText(Compilation compilation)
+            public static string GetExpectedV2ErrorLogResultsText(Compilation compilation, bool warnAsError = false)
             {
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
                 var filePath = GetUriForPath(tree.FilePath);
+                var effectiveSeverity1 = warnAsError || Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning";
+                var effectiveSeverity2 = warnAsError || Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning";
+                var warningLevelText = warnAsError ? string.Empty : @"
+            """"warningLevel"""": 1,""";
 
                 return
 @"      ""results"": [
         {
           ""ruleId"": """ + Descriptor1.Id + @""",
           ""ruleIndex"": 0,
-          ""level"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""level"": """ + effectiveSeverity1 + @""",
           ""message"": {
             ""text"": """ + Descriptor1.MessageFormat + @"""
           },
@@ -282,14 +290,14 @@ namespace Microsoft.CodeAnalysis
               }
             }
           ],
-          ""properties"": {
-            ""warningLevel"": 1," + GetExpectedPropertiesMapText() + @"
+          ""properties"": {" +
+             warningLevelText + GetExpectedPropertiesMapText() + @"
           }
         },
         {
           ""ruleId"": """ + Descriptor2.Id + @""",
           ""ruleIndex"": 1,
-          ""level"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""level"": """ + effectiveSeverity2 + @""",
           ""message"": {
             ""text"": """ + Descriptor2.MessageFormat + @"""
           },

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis
                 ""index"": {index}
               }},
               ""configuration"": {{
-                ""level"": ""{GetLevel(effectiveSeverity)}""
+                {GetConfigurationPropertyString(effectiveSeverity)}
               }}
             }}";
                     }
@@ -425,28 +425,20 @@ namespace Microsoft.CodeAnalysis
       ]";
             }
 
-            private static string GetLevel(ReportDiagnostic severity)
+            private static string GetConfigurationPropertyString(ReportDiagnostic severity)
             {
-                switch (severity)
+                if (severity == ReportDiagnostic.Suppress)
+                    return @"""enabled"": false";
+
+                var severityString = severity switch
                 {
-                    case ReportDiagnostic.Error:
-                        return "error";
+                    ReportDiagnostic.Error => "error",
+                    ReportDiagnostic.Warn => "warning",
+                    ReportDiagnostic.Info or ReportDiagnostic.Hidden => "note",
+                    _ => throw ExceptionUtilities.UnexpectedValue(severity)
+                };
 
-                    case ReportDiagnostic.Warn:
-                        return "warning";
-
-                    case ReportDiagnostic.Info:
-                        return "note";
-
-                    case ReportDiagnostic.Hidden:
-                        goto case ReportDiagnostic.Info;
-
-                    case ReportDiagnostic.Suppress:
-                        return "none";
-
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(severity);
-                }
+                return $@"""level"": ""{severityString}""";
             }
 
             internal static string GetExpectedV2ErrorLogRulesText(

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -372,9 +372,48 @@ namespace Microsoft.CodeAnalysis
                 return string.Empty;
             }
 
+            public static string GetExpectedV2EffectiveSeveritiesTextForRulesSection(ImmutableHashSet<ReportDiagnostic> effectiveSeverities)
+            {
+                if (effectiveSeverities?.Count > 0)
+                {
+                    return @",
+                ""effectiveConfigurationLevels"": [
+                  " + string.Join("," + Environment.NewLine + "                  ", effectiveSeverities.OrderBy(Comparer<ReportDiagnostic>.Default).Select(s => $"\"{GetLevel(s)}\"")) + @"
+                ]";
+                }
+
+                return string.Empty;
+            }
+
+            private static string GetLevel(ReportDiagnostic severity)
+            {
+                switch (severity)
+                {
+                    case ReportDiagnostic.Error:
+                        return "error";
+
+                    case ReportDiagnostic.Warn:
+                        return "warning";
+
+                    case ReportDiagnostic.Info:
+                        return "note";
+
+                    case ReportDiagnostic.Hidden:
+                        goto case ReportDiagnostic.Info;
+
+                    case ReportDiagnostic.Suppress:
+                        return "none";
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(severity);
+                }
+            }
+
             internal static string GetExpectedV2ErrorLogRulesText(
                 ImmutableArray<(DiagnosticDescriptor Descriptor, DiagnosticDescriptorErrorLoggerInfo Info)> descriptorsWithInfo,
                 CultureInfo culture,
+                ImmutableHashSet<ReportDiagnostic> effectiveSeverities1 = null,
+                ImmutableHashSet<ReportDiagnostic> effectiveSeverities2 = null,
                 string[] suppressionKinds1 = null,
                 string[] suppressionKinds2 = null)
             {
@@ -398,7 +437,9 @@ namespace Microsoft.CodeAnalysis
               },
               ""helpUri"": """ + Descriptor1.HelpLinkUri + @""",
               ""properties"": {
-                ""category"": """ + Descriptor1.Category + @"""" + GetExpectedV2SuppressionTextForRulesSection(suppressionKinds1) + @",
+                ""category"": """ + Descriptor1.Category + @"""" +
+                GetExpectedV2EffectiveSeveritiesTextForRulesSection(effectiveSeverities1) +
+                GetExpectedV2SuppressionTextForRulesSection(suppressionKinds1) + @",
                 ""executionTimeInSeconds"": """ + descriptor1ExecutionTime + @""",
                 ""executionTimeInPercentage"": """ + descriptor1ExecutionPercentage + @""",
                 ""tags"": [
@@ -419,7 +460,9 @@ namespace Microsoft.CodeAnalysis
               },
               ""helpUri"": """ + Descriptor2.HelpLinkUri + @""",
               ""properties"": {
-                ""category"": """ + Descriptor2.Category + @"""" + GetExpectedV2SuppressionTextForRulesSection(suppressionKinds2) + @",
+                ""category"": """ + Descriptor2.Category + @"""" +
+                GetExpectedV2EffectiveSeveritiesTextForRulesSection(effectiveSeverities2) +
+                GetExpectedV2SuppressionTextForRulesSection(suppressionKinds2) + @",
                 ""executionTimeInSeconds"": """ + descriptor2ExecutionTime + @""",
                 ""executionTimeInPercentage"": """ + descriptor2ExecutionPercentage + @""",
                 ""tags"": [

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public static string GetExpectedV2ErrorLogInvocationsText(
-                params (int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)[] overriddenEffectiveSeveritiesWithIndex)
+                params (string DescriptorId, int DescriptorIndex, ImmutableHashSet<ReportDiagnostic> EffectiveSeverities)[] overriddenEffectiveSeveritiesWithIndex)
             {
                 if (overriddenEffectiveSeveritiesWithIndex.Length == 0)
                 {
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis
 
                 var first = true;
                 var overridesContent = string.Empty;
-                foreach (var (index, effectiveSeverities) in overriddenEffectiveSeveritiesWithIndex)
+                foreach (var (id, index, effectiveSeverities) in overriddenEffectiveSeveritiesWithIndex)
                 {
                     foreach (var effectiveSeverity in effectiveSeverities.OrderBy(Comparer<ReportDiagnostic>.Default))
                     {
@@ -406,6 +406,7 @@ namespace Microsoft.CodeAnalysis
                         overridesContent += $@"
             {{
               ""descriptor"": {{
+                ""id"": ""{id}"",
                 ""index"": {index}
               }},
               ""configuration"": {{


### PR DESCRIPTION
Closes #67365

~~Add a new custom property array named `effectiveConfigurationLevels` to the `rule` section in sarif v2 error log output.~~ Add a new `invocations` section with `ruleConfigurationOverrides` array, with an entry each for every rule ID severity override configured via options (command line options, editorconfig, globalconfig, rulesets, etc.) for a part or whole of the compilation. See https://github.com/dotnet/roslyn/issues/67365#issuecomment-1641906334 for further details

**Sample error log with this change:** [errorlog.log](https://github.com/dotnet/roslyn/files/12094535/errorlog.log)

