### PR TITLE
Gracefully handle exceptions from DiagnosticSuppressor.SupportedSuppressions in IDE

### DIFF
--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -39,6 +39,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo> _descriptorsInfo;
 
         /// <summary>
+        /// Supported suppressions of each <see cref="DiagnosticSuppressor"/>. 
+        /// </summary>
+        /// <remarks>
+        /// Holds on <see cref="DiagnosticSuppressor"/> instances weakly so that we don't keep suppressors coming from package references alive.
+        /// They need to be released when the project stops referencing the suppressor.
+        /// 
+        /// The purpose of this map is to avoid multiple calls to <see cref="DiagnosticSuppressor.SupportedSuppressions"/> that might return different values
+        /// (they should not but we need a guarantee to function correctly).
+        /// </remarks>
+        private readonly ConditionalWeakTable<DiagnosticSuppressor, SuppressionDescriptorsInfo> _suppressionsInfo;
+
+        /// <summary>
         /// Lazily populated map from diagnostic IDs to diagnostic descriptor.
         /// If same diagnostic ID is reported by multiple descriptors, a null value is stored in the map for that ID.
         /// </summary>
@@ -49,6 +61,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public readonly ImmutableArray<DiagnosticDescriptor> SupportedDescriptors = supportedDescriptors;
             public readonly bool TelemetryAllowed = telemetryAllowed;
             public readonly bool HasCompilationEndDescriptor = supportedDescriptors.Any(DiagnosticDescriptorExtensions.IsCompilationEnd);
+        }
+
+        private sealed class SuppressionDescriptorsInfo(ImmutableArray<SuppressionDescriptor> supportedSuppressions)
+        {
+            public readonly ImmutableArray<SuppressionDescriptor> SupportedSuppressions = supportedSuppressions;
         }
 
         [Export, Shared]
@@ -66,6 +83,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         internal DiagnosticAnalyzerInfoCache()
         {
             _descriptorsInfo = new ConditionalWeakTable<DiagnosticAnalyzer, DiagnosticDescriptorsInfo>();
+            _suppressionsInfo = new ConditionalWeakTable<DiagnosticSuppressor, SuppressionDescriptorsInfo>();
             _idToDescriptorsMap = new ConcurrentDictionary<string, DiagnosticDescriptor?>();
         }
 
@@ -74,6 +92,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public ImmutableArray<DiagnosticDescriptor> GetDiagnosticDescriptors(DiagnosticAnalyzer analyzer)
             => GetOrCreateDescriptorsInfo(analyzer).SupportedDescriptors;
+
+        /// <summary>
+        /// Returns <see cref="DiagnosticSuppressor.SupportedSuppressions"/> of given <paramref name="suppressor"/>.
+        /// </summary>
+        public ImmutableArray<SuppressionDescriptor> GetDiagnosticSuppressions(DiagnosticSuppressor suppressor)
+            => GetOrCreateSuppressionsInfo(suppressor).SupportedSuppressions;
 
         /// <summary>
         /// Returns <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> of given <paramref name="analyzer"/>
@@ -124,6 +148,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             PopulateIdToDescriptorMap(descriptors);
             var telemetryAllowed = IsTelemetryCollectionAllowed(analyzer, descriptors);
             return new DiagnosticDescriptorsInfo(descriptors, telemetryAllowed);
+        }
+
+        private SuppressionDescriptorsInfo GetOrCreateSuppressionsInfo(DiagnosticSuppressor suppressor)
+            => _suppressionsInfo.GetValue(suppressor, CalculateSuppressionsInfo);
+
+        private SuppressionDescriptorsInfo CalculateSuppressionsInfo(DiagnosticSuppressor suppressor)
+        {
+            ImmutableArray<SuppressionDescriptor> suppressions;
+            try
+            {
+                // SupportedSuppressions is user code and can throw an exception.
+                suppressions = suppressor.SupportedSuppressions.NullToEmpty();
+            }
+            catch
+            {
+                // No need to report the exception to the user.
+                // Eventually, when the suppressor runs the compiler analyzer driver will report a diagnostic.
+                suppressions = ImmutableArray<SuppressionDescriptor>.Empty;
+            }
+
+            return new SuppressionDescriptorsInfo(suppressions);
         }
 
         private static bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticDescriptor> descriptors)

--- a/src/Workspaces/Core/Portable/Diagnostics/SkippedHostAnalyzersInfo.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/SkippedHostAnalyzersInfo.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     if (analyzer is DiagnosticSuppressor suppressor)
                     {
-                        foreach (var descriptor in suppressor.SupportedSuppressions)
+                        foreach (var descriptor in analyzerInfoCache.GetDiagnosticSuppressions(suppressor))
                         {
                             projectSuppressedDiagnosticIds.Add(descriptor.SuppressedDiagnosticId);
                         }
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     // Only execute host suppressor if it does not suppress any diagnostic ID reported by project analyzer
                     // and does not share any suppression ID with a project suppressor.
-                    foreach (var descriptor in suppressor.SupportedSuppressions)
+                    foreach (var descriptor in analyzerInfoCache.GetDiagnosticSuppressions(suppressor))
                     {
                         if (projectAnalyzerDiagnosticIds.Contains(descriptor.SuppressedDiagnosticId) ||
                             projectSuppressedDiagnosticIds.Contains(descriptor.SuppressedDiagnosticId))


### PR DESCRIPTION
Fixes [AB#1844804](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1844804)

Gracefully handle exceptions from `DiagnosticSuppressor.SupportedSuppressions` and also cache these suppression descriptors in the analyzer info cache. Most of the added logic mimics the existing logic for `DiagnosticAnalyzer.SupportedDiagnostics` in this type.