### PR TITLE
External Access EditorConfig generation 

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -559,12 +559,6 @@
   <data name="Perform_additional_code_cleanup_during_formatting" xml:space="preserve">
     <value>Perform additional code cleanup during formatting</value>
   </data>
-  <data name="CSharp_Coding_Conventions" xml:space="preserve">
-    <value>C# Coding Conventions</value>
-  </data>
-  <data name="CSharp_Formatting_Rules" xml:space="preserve">
-    <value>C# Formatting Rules</value>
-  </data>
   <data name="Discard" xml:space="preserve">
     <value>Discard</value>
   </data>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
                 serviceProvider,
                 optionStore,
                 (o, s) => new StyleViewModel(o, s),
-                editorService.GetOptions(LanguageNames.CSharp),
+                editorService.GetDefaultOptions(LanguageNames.CSharp),
                 LanguageNames.CSharp);
         }
     }

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.ExternalAccess.EditorConfig;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
@@ -22,27 +23,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider, OptionStore optionStore)
         {
+            var editorService = (EditorConfigGeneratorService)serviceProvider.GetService(typeof(EditorConfigGeneratorService));
             return new GridOptionPreviewControl(
                 serviceProvider,
                 optionStore,
                 (o, s) => new StyleViewModel(o, s),
-                GetEditorConfigOptions(),
+                editorService.GetOptions(LanguageNames.CSharp),
                 LanguageNames.CSharp);
-        }
-
-        private static ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
-        {
-            var builder = ArrayBuilder<(string, ImmutableArray<IOption2>)>.GetInstance();
-            builder.AddRange(GridOptionPreviewControl.GetLanguageAgnosticEditorConfigOptions());
-            builder.Add((CSharpVSResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.AllOptions));
-            builder.Add((CSharpVSResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.AllOptions));
-            return builder.ToImmutableAndFree();
         }
 
         internal readonly struct TestAccessor
         {
             internal static ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
-                => CodeStylePage.GetEditorConfigOptions();
+                => default;//new CSharpEditorConfigFileGenerator().GetEditorConfigOptions();
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -23,19 +23,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider, OptionStore optionStore)
         {
-            var editorService = (EditorConfigGeneratorService)serviceProvider.GetService(typeof(EditorConfigGeneratorService));
+            var editorService = (EditorConfigGenerator)serviceProvider.GetService(typeof(EditorConfigGenerator));
             return new GridOptionPreviewControl(
                 serviceProvider,
                 optionStore,
                 (o, s) => new StyleViewModel(o, s),
                 editorService.GetOptions(LanguageNames.CSharp),
                 LanguageNames.CSharp);
-        }
-
-        internal readonly struct TestAccessor
-        {
-            internal static ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
-                => default;//new CSharpEditorConfigFileGenerator().GetEditorConfigOptions();
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Konvence kódování v C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Pravidla formátování jazyka C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Při otevření souboru sbalit usings</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">C#-Codierungskonventionen</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C#-Formatierungsregeln</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Reduzieren von Usings beim Öffnen einer Datei</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Convenciones de código de C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Reglas de formato de C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Contraer instrucciones Using al abrir el archivo</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Conventions de codage C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Règles de formatage C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Réduire les utilisations sur le fichier ouvert</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Convenzioni di scrittura codice C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Regole di formattazione C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Comprimi gli utilizzi all'apertura del file</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">C# コーディング規則</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C# 書式ルール</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">ファイルを開くときに usings を折りたたむ</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">C# 코딩 규칙</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C# 서식 설정 규칙</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">파일을 열 때 사용 축소</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Konwencje kodowania w języku C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Reguły formatowania kodu C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Zwiń użycia przy otwieraniu pliku</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Convenções de Codificação em C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Regras de Formatação de C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Recolher os usos no arquivo aberto</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">Рекомендации по написанию кода C#</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">Правила форматирования C#</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Сворачивать директивы using при открытии файлов</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">C# kodlama kuralları</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C# biçimlendirme kuralları</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">Dosya açıkken using'leri daralt</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">c# 编码约定</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C# 格式规则</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">打开文件时折叠 using</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -57,16 +57,6 @@
         <target state="translated">C#</target>
         <note />
       </trans-unit>
-      <trans-unit id="CSharp_Coding_Conventions">
-        <source>C# Coding Conventions</source>
-        <target state="translated">C# 編碼慣例</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CSharp_Formatting_Rules">
-        <source>C# Formatting Rules</source>
-        <target state="translated">C# 格式化規則</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Collapse_usings_on_file_open">
         <source>Collapse usings on file open</source>
         <target state="translated">在檔案開啟時折疊使用</target>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -5,17 +5,12 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -56,12 +51,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _createViewModel = createViewModel;
             _language = language;
             _groupedEditorConfigOptions = groupedEditorConfigOptions;
-        }
-
-        internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions()
-        {
-            yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.Options);
-            yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.AddRange(CodeStyleOptions2.AllOptions));
         }
 
         private void LearnMoreHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
@@ -6,6 +6,7 @@ Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
@@ -147,9 +148,9 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
-                Dim editorConfigOptions = VisualBasic.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
-                Dim options = New OptionStore(workspace.GlobalOptions)
-                Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, options, LanguageNames.VisualBasic)
+                ' Use the default options 
+                Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
+                Dim actualText = editorService.Generate(LanguageNames.VisualBasic)
                 AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
@@ -287,7 +288,8 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
-                Dim editorConfigOptions = VisualBasic.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
+                Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
+                Dim editorConfigOptions = editorService.GetDefaultOptions(LanguageNames.VisualBasic)
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, options, LanguageNames.VisualBasic)
                 AssertEx.EqualOrDiff(expectedText, actualText)
             End Using

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -5,6 +5,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
@@ -249,7 +250,8 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
-                Dim editorConfigOptions = CSharp.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
+                Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
+                Dim editorConfigOptions = editorService.GetOptions(LanguageNames.CSharp)
                 Dim options = New OptionStore(workspace.GlobalOptions)
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, options, LanguageNames.CSharp)
                 AssertEx.EqualOrDiff(expectedText, actualText)
@@ -493,8 +495,8 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
-                Dim editorConfigOptions = CSharp.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
-                Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, options, LanguageNames.CSharp)
+                Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
+                Dim actualText = editorService.Generate(LanguageNames.CSharp)
                 AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -250,10 +250,9 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
+                ' Use the default options
                 Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
-                Dim editorConfigOptions = editorService.GetOptions(LanguageNames.CSharp)
-                Dim options = New OptionStore(workspace.GlobalOptions)
-                Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, options, LanguageNames.CSharp)
+                Dim actualText = editorService.Generate(LanguageNames.CSharp)
                 AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
@@ -496,7 +495,8 @@ dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
                 Dim editorService = workspace.GetService(Of EditorConfigGenerator)()
-                Dim actualText = editorService.Generate(LanguageNames.CSharp)
+                Dim groupedOptions = editorService.GetDefaultOptions(LanguageNames.CSharp)
+                Dim actualText = EditorConfigFileGenerator.Generate(groupedOptions, options, LanguageNames.CSharp)
                 AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub

--- a/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVSResources.resx
@@ -286,9 +286,6 @@
   <data name="In_relational_binary_operators" xml:space="preserve">
     <value>In relational operators:  =   &lt;&gt;   &lt;   &gt;   &lt;=   &gt;=   Like   Is</value>
   </data>
-  <data name="VB_Coding_Conventions" xml:space="preserve">
-    <value>VB Coding Conventions</value>
-  </data>
   <data name="Never" xml:space="preserve">
     <value>Never</value>
   </data>

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -18,12 +18,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider, optionStore As OptionStore) As AbstractOptionPageControl
-            Dim editorService2 = DirectCast(serviceProvider.GetService(GetType(EditorConfigGenerator)), EditorConfigGenerator)
-            'Dim editorService = Me.Site.GetService(GetType(EditorConfigGenerator))
+            Dim editorService = DirectCast(serviceProvider.GetService(GetType(EditorConfigGenerator)), EditorConfigGenerator)
             Return New GridOptionPreviewControl(serviceProvider,
                                                 optionStore,
                                                 Function(o, s) New StyleViewModel(o, s),
-                                                editorService2.GetDefaultOptions(LanguageNames.VisualBasic),
+                                                editorService.GetDefaultOptions(LanguageNames.VisualBasic),
                                                 LanguageNames.VisualBasic)
         End Function
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -5,9 +5,11 @@
 Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
@@ -16,24 +18,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider, optionStore As OptionStore) As AbstractOptionPageControl
+            Dim editorService2 = DirectCast(serviceProvider.GetService(GetType(EditorConfigGenerator)), EditorConfigGenerator)
+            'Dim editorService = Me.Site.GetService(GetType(EditorConfigGenerator))
             Return New GridOptionPreviewControl(serviceProvider,
                                                 optionStore,
                                                 Function(o, s) New StyleViewModel(o, s),
-                                                GetEditorConfigOptions(),
+                                                editorService2.GetDefaultOptions(LanguageNames.VisualBasic),
                                                 LanguageNames.VisualBasic)
         End Function
-
-        Private Shared Function GetEditorConfigOptions() As ImmutableArray(Of (String, ImmutableArray(Of IOption2)))
-            Dim builder = ArrayBuilder(Of (String, ImmutableArray(Of IOption2))).GetInstance()
-            builder.AddRange(GridOptionPreviewControl.GetLanguageAgnosticEditorConfigOptions())
-            builder.Add((BasicVSResources.VB_Coding_Conventions, VisualBasicCodeStyleOptions.AllOptions.As(Of IOption2)))
-            Return builder.ToImmutableAndFree()
-        End Function
-
-        Friend Structure TestAccessor
-            Friend Shared Function GetEditorConfigOptions() As ImmutableArray(Of (String, ImmutableArray(Of IOption2)))
-                Return CodeStylePage.GetEditorConfigOptions()
-            End Function
-        End Structure
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.cs.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Nepoužitá místní</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Konvence kódování ve VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Kontrola hodnot nothing:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Nicht verwendete lokale Variable</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">VB-Codierungskonvention</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Überprüfung auf "nothing":</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Local sin uso</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Convenciones de código de VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Comprobación de "nothing":</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.fr.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Local inutilisé</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Conventions de codage VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Contrôle de 'nothing' :</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.it.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Variabile locale inutilizzata</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Convenzioni di scrittura codice VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Controllo 'nothing':</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ja.xlf
@@ -312,11 +312,6 @@
         <target state="translated">未使用のローカル</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">VB コーディング規約</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'nothing' のチェック中:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ko.xlf
@@ -312,11 +312,6 @@
         <target state="translated">사용하지 않는 로컬</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">VB 코딩 규칙</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'nothing' 검사:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pl.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Nieużywane zmienne lokalne</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Konwencje kodowania w języku VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Sprawdzanie „nothing”:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.pt-BR.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Local não usado</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Convenções do Codificação do VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'verificação de 'nothing':</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Не использовать локальный аргумент</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">Рекомендации по написанию кода VB</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'Проверка значений "nothing":</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.tr.xlf
@@ -312,11 +312,6 @@
         <target state="translated">Kullanılmayan yerel</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">VB kodlama kuralları</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'nothing' denetimi:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hans.xlf
@@ -312,11 +312,6 @@
         <target state="translated">未使用的本地</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">vb 编码约定</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'"nothing" 检查:</target>

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.zh-Hant.xlf
@@ -312,11 +312,6 @@
         <target state="translated">未使用的區域函式</target>
         <note />
       </trans-unit>
-      <trans-unit id="VB_Coding_Conventions">
-        <source>VB Coding Conventions</source>
-        <target state="translated">VB 編碼慣例</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nothing_checking_colon">
         <source>'nothing' checking:</source>
         <target state="translated">'nothing' 檢查:</target>

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigFileGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigFileGenerator.cs
@@ -26,11 +26,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
         {
         }
 
-        public string? GenerateEditorConfig(IOptionsReader options)
-        {
-            return EditorConfigFileGenerator.Generate(GetEditorConfigOptions(), options, LanguageNames.CSharp);
-        }
-
         public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
         {
             var builder = ArrayBuilder<(string, ImmutableArray<IOption2>)>.GetInstance();

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigFileGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigFileGenerator.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
+{
+    [EditorConfigGenerator(LanguageNames.CSharp), Shared]
+    internal class CSharpEditorConfigFileGenerator : IEditorConfigGeneratorCollection
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpEditorConfigFileGenerator()
+        {
+        }
+
+        public string? GenerateEditorConfig(IOptionsReader options)
+        {
+            return EditorConfigFileGenerator.Generate(GetEditorConfigOptions(), options, LanguageNames.CSharp);
+        }
+
+        public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
+        {
+            var builder = ArrayBuilder<(string, ImmutableArray<IOption2>)>.GetInstance();
+            builder.AddRange(CSharpEditorConfigFileGenerator.GetLanguageAgnosticEditorConfigOptions());
+            builder.Add((WorkspacesResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.AllOptions));
+            builder.Add((WorkspacesResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.AllOptions));
+            return builder.ToImmutableAndFree();
+        }
+
+        internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions()
+        {
+            yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.Options);
+            yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.AddRange(CodeStyleOptions2.AllOptions));
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigOptionsGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigOptionsGenerator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 {
     [EditorConfigGenerator(LanguageNames.CSharp), Shared]
     internal class CSharpEditorConfigFileGenerator
-        : IEditorConfigGeneratorCollection
+        : IEditorConfigOptionsCollection
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigOptionsGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpEditorConfigOptionsGenerator.cs
@@ -18,7 +18,8 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 {
     [EditorConfigGenerator(LanguageNames.CSharp), Shared]
-    internal class CSharpEditorConfigFileGenerator : IEditorConfigGeneratorCollection
+    internal class CSharpEditorConfigFileGenerator
+        : IEditorConfigGeneratorCollection
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -29,16 +30,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
         public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions()
         {
             var builder = ArrayBuilder<(string, ImmutableArray<IOption2>)>.GetInstance();
-            builder.AddRange(CSharpEditorConfigFileGenerator.GetLanguageAgnosticEditorConfigOptions());
+            builder.AddRange(EditorConfigFileGenerator.GetLanguageAgnosticEditorConfigOptions());
             builder.Add((WorkspacesResources.CSharp_Coding_Conventions, CSharpCodeStyleOptions.AllOptions));
             builder.Add((WorkspacesResources.CSharp_Formatting_Rules, CSharpFormattingOptions2.AllOptions));
             return builder.ToImmutableAndFree();
-        }
-
-        internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions()
-        {
-            yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.Options);
-            yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.AddRange(CodeStyleOptions2.AllOptions));
         }
     }
 }

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGenerator.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGenerator.cs
@@ -18,13 +18,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 
     {
         private readonly IGlobalOptionService _globalOptions;
-        private readonly ImmutableArray<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> _editorConfigGenerators;
+        private readonly ImmutableArray<Lazy<IEditorConfigOptionsCollection, LanguageMetadata>> _editorConfigGenerators;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public EditorConfigGenerator(
             IGlobalOptionService globalOptions,
-            [ImportMany] IEnumerable<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> generators)
+            [ImportMany] IEnumerable<Lazy<IEditorConfigOptionsCollection, LanguageMetadata>> generators)
         {
             _globalOptions = globalOptions;
             _editorConfigGenerators = generators.ToImmutableArray();

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorAttribute.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
         public string Language { get; }
 
         public EditorConfigGeneratorAttribute(string language)
-            : base(typeof(IEditorConfigGeneratorCollection))
+            : base(typeof(IEditorConfigOptionsCollection))
         {
             this.Language = language ?? throw new ArgumentNullException(nameof(language));
         }

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorAttribute.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
+{
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
+    internal class EditorConfigGeneratorAttribute : ExportAttribute
+    {
+        public string Language { get; }
+
+        public EditorConfigGeneratorAttribute(string language)
+            : base(typeof(IEditorConfigGeneratorCollection))
+        {
+            this.Language = language ?? throw new ArgumentNullException(nameof(language));
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
+{
+    [Export(typeof(EditorConfigGeneratorService)), Shared]
+    internal class EditorConfigGeneratorService
+    {
+        private readonly IGlobalOptionService _globalOptions;
+        private readonly ImmutableArray<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> _editorConfigGenerators;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public EditorConfigGeneratorService(
+            IGlobalOptionService globalOptions,
+            [ImportMany] IEnumerable<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> generators)
+        {
+            _globalOptions = globalOptions;
+            _editorConfigGenerators = generators.ToImmutableArray();
+        }
+
+        public string? Generate(string language)
+        {
+            var generators = _editorConfigGenerators.Where(b => b.Metadata.Language == language);
+            foreach (var generator in generators)
+            {
+                return generator.Value.GenerateEditorConfig(_globalOptions);
+            }
+
+            return null;
+        }
+
+        public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language)
+        {
+            var generators = _editorConfigGenerators.Where(b => b.Metadata.Language == language);
+            foreach (var generator in generators)
+            {
+                return generator.Value.GetEditorConfigOptions();
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
@@ -13,15 +13,16 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 {
-    [Export(typeof(EditorConfigGeneratorService)), Shared]
-    internal class EditorConfigGeneratorService
+    [Export(typeof(EditorConfigGenerator)), Shared]
+    internal class EditorConfigGenerator
+
     {
         private readonly IGlobalOptionService _globalOptions;
         private readonly ImmutableArray<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> _editorConfigGenerators;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public EditorConfigGeneratorService(
+        public EditorConfigGenerator(
             IGlobalOptionService globalOptions,
             [ImportMany] IEnumerable<Lazy<IEditorConfigGeneratorCollection, LanguageMetadata>> generators)
         {
@@ -31,13 +32,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 
         public string? Generate(string language)
         {
-            var generators = _editorConfigGenerators.Where(b => b.Metadata.Language == language);
-            foreach (var generator in generators)
-            {
-                return generator.Value.GenerateEditorConfig(_globalOptions);
-            }
-
-            return null;
+            var groupOptions = GetOptions(language);
+            return EditorConfigFileGenerator.Generate(groupOptions, _globalOptions, language);
         }
 
         public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language)

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/EditorConfigGeneratorService.cs
@@ -32,11 +32,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 
         public string? Generate(string language)
         {
-            var groupOptions = GetOptions(language);
+            var groupOptions = GetDefaultOptions(language);
             return EditorConfigFileGenerator.Generate(groupOptions, _globalOptions, language);
         }
 
-        public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetOptions(string language)
+        public ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetDefaultOptions(string language)
         {
             var generators = _editorConfigGenerators.Where(b => b.Metadata.Language == language);
             foreach (var generator in generators)

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigGeneratorCollection.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigGeneratorCollection.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
+{
+    internal interface IEditorConfigGeneratorCollection
+    {
+        string? GenerateEditorConfig(IOptionsReader options);
+
+        ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions();
+    }
+}

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigGeneratorCollection.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigGeneratorCollection.cs
@@ -9,8 +9,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 {
     internal interface IEditorConfigGeneratorCollection
     {
-        string? GenerateEditorConfig(IOptionsReader options);
-
         ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions();
     }
 }

--- a/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigOptionsCollection.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/EditorConfig/IEditorConfigOptionsCollection.cs
@@ -7,7 +7,8 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
 {
-    internal interface IEditorConfigGeneratorCollection
+    internal interface IEditorConfigOptionsCollection
+
     {
         ImmutableArray<(string feature, ImmutableArray<IOption2> options)> GetEditorConfigOptions();
     }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
@@ -9,6 +9,8 @@ using System.Text;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options
@@ -50,6 +52,12 @@ namespace Microsoft.CodeAnalysis.Options
             }
 
             return editorconfig.ToString();
+        }
+
+        internal static IEnumerable<(string feature, ImmutableArray<IOption2> options)> GetLanguageAgnosticEditorConfigOptions()
+        {
+            yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions2.Options);
+            yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.AddRange(CodeStyleOptions2.AllOptions));
         }
 
         private static void AppendOptionsToEditorConfig(IOptionsReader configOptions, string feature, ImmutableArray<IOption2> options, string language, StringBuilder editorconfig)

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -552,4 +552,10 @@
   <data name="Unexpected_value_0_in_DocumentKinds_array" xml:space="preserve">
     <value>Unexpected value '{0}' in DocumentKinds array.</value>
   </data>
+  <data name="CSharp_Coding_Conventions" xml:space="preserve">
+    <value>C# Coding Conventions</value>
+  </data>
+  <data name="CSharp_Formatting_Rules" xml:space="preserve">
+    <value>C# Formatting Rules</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Došlo k chybě při čtení zadaného konfiguračního souboru: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Soubory C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Beim Lesen der angegebenen Konfigurationsdatei ist ein Fehler aufgetreten: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C#-Dateien</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Error al leer el archivo de configuración especificado: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Archivos de C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Une erreur s'est produite lors de la lecture du fichier de configuration spécifié : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Fichiers C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Si è verificato un errore durante la lettura del file di configurazione specificato: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">File C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -17,6 +17,16 @@
         <target state="translated">指定した構成ファイルの読み取り中にエラーが発生しました: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# ファイル</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -17,6 +17,16 @@
         <target state="translated">지정한 구성 파일을 읽는 동안 오류가 발생했습니다({0}).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# 파일</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Wystąpił błąd podczas odczytywania określonego pliku konfiguracji: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Pliki C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Ocorreu um erro ao ler o arquivo de configuração especificado: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Arquivos C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Произошла ошибка при чтении указанного файла конфигурации: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Файлы C#</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -17,6 +17,16 @@
         <target state="translated">Belirtilen yapılandırma dosyası okunurken bir hata oluştu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# dosyalarını</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -17,6 +17,16 @@
         <target state="translated">读取指定的配置文件时出错: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">c# 文件</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -17,6 +17,16 @@
         <target state="translated">讀取指定的組態檔時發生錯誤: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="CSharp_Coding_Conventions">
+        <source>C# Coding Conventions</source>
+        <target state="new">C# Coding Conventions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CSharp_Formatting_Rules">
+        <source>C# Formatting Rules</source>
+        <target state="new">C# Formatting Rules</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# 檔案</target>

--- a/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicEditorConfigOptionsGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicEditorConfigOptionsGenerator.vb
@@ -1,0 +1,30 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Composition
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.ExternalAccess.EditorConfig
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.PooledObjects
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+    <EditorConfigGenerator(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicEditorConfigOptionsGenerator
+        Implements IEditorConfigGeneratorCollection
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Public Function GetEditorConfigOptions() As ImmutableArray(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigGeneratorCollection.GetEditorConfigOptions
+            Dim builder = ArrayBuilder(Of (String, ImmutableArray(Of IOption2))).GetInstance()
+            builder.AddRange(EditorConfigFileGenerator.GetLanguageAgnosticEditorConfigOptions())
+            builder.Add((VBWorkspaceResources.VB_Coding_Conventions, VisualBasicCodeStyleOptions.AllOptions.As(Of IOption2)))
+            Return builder.ToImmutableAndFree()
+        End Function
+    End Class
+End Namespace

--- a/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicEditorConfigOptionsGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicEditorConfigOptionsGenerator.vb
@@ -13,14 +13,14 @@ Imports Microsoft.CodeAnalysis.PooledObjects
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeStyle
     <EditorConfigGenerator(LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicEditorConfigOptionsGenerator
-        Implements IEditorConfigGeneratorCollection
+        Implements IEditorConfigOptionsCollection
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
         End Sub
 
-        Public Function GetEditorConfigOptions() As ImmutableArray(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigGeneratorCollection.GetEditorConfigOptions
+        Public Function GetEditorConfigOptions() As ImmutableArray(Of (String, ImmutableArray(Of IOption2))) Implements IEditorConfigOptionsCollection.GetEditorConfigOptions
             Dim builder = ArrayBuilder(Of (String, ImmutableArray(Of IOption2))).GetInstance()
             builder.AddRange(EditorConfigFileGenerator.GetLanguageAgnosticEditorConfigOptions())
             builder.Add((VBWorkspaceResources.VB_Coding_Conventions, VisualBasicCodeStyleOptions.AllOptions.As(Of IOption2)))

--- a/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.resx
+++ b/src/Workspaces/VisualBasic/Portable/VBWorkspaceResources.resx
@@ -270,4 +270,7 @@
   <data name="Sort_Imports" xml:space="preserve">
     <value>&amp;Sort Imports</value>
   </data>
+  <data name="VB_Coding_Conventions" xml:space="preserve">
+    <value>VB Coding Conventions</value>
+  </data>
 </root>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.cs.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">&amp;Seřadit importy</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;událost&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.de.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Importe &amp;sortieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;Ereignis&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.es.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Orde&amp;nar instrucciones Import</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;evento&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.fr.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">&amp;Trier les import</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;événement&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.it.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Or&amp;dina import</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;evento&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ja.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">インポートの並べ替え(&amp;S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;event&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ko.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">가져오기 정렬(&amp;S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;event&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.pl.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">&amp;Sortuj importy</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;zdarzenie&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.pt-BR.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Cla&amp;ssificar Importações</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;event&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ru.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">&amp;Сортировать импорты</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;событие&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.tr.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">İçeri Aktarmaları &amp;Sırala</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;event&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.zh-Hans.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">对导入项排序(&amp;S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;事件&gt;</target>

--- a/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.zh-Hant.xlf
+++ b/src/Workspaces/VisualBasic/Portable/xlf/VBWorkspaceResources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">排序 Import(&amp;S)</target>
         <note />
       </trans-unit>
+      <trans-unit id="VB_Coding_Conventions">
+        <source>VB Coding Conventions</source>
+        <target state="new">VB Coding Conventions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="event_">
         <source>&lt;event&gt;</source>
         <target state="translated">&lt;event&gt;</target>


### PR DESCRIPTION
EditorConfig generation is triggered by a few different places. The VS entry points are in an [external repo](https://github.com/dotnet/templates). This refactoring provides external access to an EditorConfig generator, which can generate the EditorConfig file for a .NET language or provide the default options. 

This is a partial fix for [Customer Feedback Item 10220124](https://developercommunity.visualstudio.com/t/Unable-to-add-editorconfig-file-in-VS202/10220124)