### PR TITLE
Use primary constructors in features layer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.7.0-1.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.7.0-3.23329.1</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->

--- a/src/Analyzers/Core/Analyzers/AnalyzerOptionsProvider.cs
+++ b/src/Analyzers/Core/Analyzers/AnalyzerOptionsProvider.cs
@@ -19,26 +19,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 /// <summary>
 /// Provides C# and VB analyzers a convenient access to common editorconfig options with fallback to IDE default values.
 /// </summary>
-internal readonly struct AnalyzerOptionsProvider
+internal readonly struct AnalyzerOptionsProvider(IOptionsReader options, string language, IdeAnalyzerOptions fallbackOptions)
 {
     /// <summary>
     /// Document editorconfig options.
     /// </summary>
-    private readonly IOptionsReader _options;
+    private readonly IOptionsReader _options = options;
 
     /// <summary>
     /// Fallback options - the default options in Code Style layer.
     /// </summary>
-    private readonly IdeAnalyzerOptions _fallbackOptions;
+    private readonly IdeAnalyzerOptions _fallbackOptions = fallbackOptions;
 
-    private readonly string _language;
-
-    public AnalyzerOptionsProvider(IOptionsReader options, string language, IdeAnalyzerOptions fallbackOptions)
-    {
-        _options = options;
-        _language = language;
-        _fallbackOptions = fallbackOptions;
-    }
+    private readonly string _language = language;
 
     public AnalyzerOptionsProvider(IOptionsReader options, string language, AnalyzerOptions fallbackOptions)
         : this(options, language, fallbackOptions.GetIdeOptions())

--- a/src/Analyzers/Core/Analyzers/Helpers/DeserializationConstructorCheck.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DeserializationConstructorCheck.cs
@@ -6,18 +6,11 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
-    internal readonly struct DeserializationConstructorCheck
+    internal readonly struct DeserializationConstructorCheck(Compilation compilation)
     {
-        private readonly INamedTypeSymbol? _iSerializableType;
-        private readonly INamedTypeSymbol? _serializationInfoType;
-        private readonly INamedTypeSymbol? _streamingContextType;
-
-        public DeserializationConstructorCheck(Compilation compilation)
-        {
-            _iSerializableType = compilation.ISerializableType();
-            _serializationInfoType = compilation.SerializationInfoType();
-            _streamingContextType = compilation.StreamingContextType();
-        }
+        private readonly INamedTypeSymbol? _iSerializableType = compilation.ISerializableType();
+        private readonly INamedTypeSymbol? _serializationInfoType = compilation.SerializationInfoType();
+        private readonly INamedTypeSymbol? _streamingContextType = compilation.StreamingContextType();
 
         // True if the method is a constructor adhering to the pattern used for custom
         // deserialization by types that implement System.Runtime.Serialization.ISerializable

--- a/src/Analyzers/Core/Analyzers/Helpers/HashCodeAnalyzer/HashCodeAnalyzer.OperationDeconstructor.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/HashCodeAnalyzer/HashCodeAnalyzer.OperationDeconstructor.cs
@@ -18,24 +18,15 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <see cref="object.GetHashCode"/> patterns and extracting out the field and property
         /// symbols use to compute the hash.
         /// </summary>
-        private struct OperationDeconstructor : IDisposable
+        private struct OperationDeconstructor(
+            HashCodeAnalyzer analyzer, IMethodSymbol method, ILocalSymbol? hashCodeVariable) : IDisposable
         {
-            private readonly HashCodeAnalyzer _analyzer;
-            private readonly IMethodSymbol _method;
-            private readonly ILocalSymbol? _hashCodeVariable;
+            private readonly HashCodeAnalyzer _analyzer = analyzer;
+            private readonly IMethodSymbol _method = method;
+            private readonly ILocalSymbol? _hashCodeVariable = hashCodeVariable;
 
-            private readonly ArrayBuilder<ISymbol> _hashedSymbols;
-            private bool _accessesBase;
-
-            public OperationDeconstructor(
-                HashCodeAnalyzer analyzer, IMethodSymbol method, ILocalSymbol? hashCodeVariable)
-            {
-                _analyzer = analyzer;
-                _method = method;
-                _hashCodeVariable = hashCodeVariable;
-                _hashedSymbols = ArrayBuilder<ISymbol>.GetInstance();
-                _accessesBase = false;
-            }
+            private readonly ArrayBuilder<ISymbol> _hashedSymbols = ArrayBuilder<ISymbol>.GetInstance();
+            private bool _accessesBase = false;
 
             public readonly void Dispose()
                 => _hashedSymbols.Free();

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryAttributeSuppressionsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/AbstractRemoveUnnecessaryAttributeSuppressionsDiagnosticAnalyzer.cs
@@ -64,14 +64,9 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessarySuppressions
             });
         }
 
-        protected sealed class CompilationAnalyzer
+        protected sealed class CompilationAnalyzer(Compilation compilation, INamedTypeSymbol suppressMessageAttributeType)
         {
-            private readonly SuppressMessageAttributeState _state;
-
-            public CompilationAnalyzer(Compilation compilation, INamedTypeSymbol suppressMessageAttributeType)
-            {
-                _state = new SuppressMessageAttributeState(compilation, suppressMessageAttributeType);
-            }
+            private readonly SuppressMessageAttributeState _state = new SuppressMessageAttributeState(compilation, suppressMessageAttributeType);
 
             public void AnalyzeAssemblyOrModuleAttribute(SyntaxNode attributeSyntax, SemanticModel model, Action<Diagnostic> reportDiagnostic, CancellationToken cancellationToken)
             {

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/SuppressMessageAttributeState.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessarySuppressions/SuppressMessageAttributeState.cs
@@ -13,21 +13,15 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    internal partial class SuppressMessageAttributeState
+    internal partial class SuppressMessageAttributeState(Compilation compilation, INamedTypeSymbol suppressMessageAttributeType)
     {
         internal const string SuppressMessageScope = "Scope";
         internal const string SuppressMessageTarget = "Target";
 
         private static readonly ImmutableDictionary<string, TargetScope> s_targetScopesMap = CreateTargetScopesMap();
 
-        private readonly Compilation _compilation;
-        private readonly INamedTypeSymbol _suppressMessageAttributeType;
-
-        public SuppressMessageAttributeState(Compilation compilation, INamedTypeSymbol suppressMessageAttributeType)
-        {
-            _compilation = compilation;
-            _suppressMessageAttributeType = suppressMessageAttributeType;
-        }
+        private readonly Compilation _compilation = compilation;
+        private readonly INamedTypeSymbol _suppressMessageAttributeType = suppressMessageAttributeType;
 
         private static ImmutableDictionary<string, TargetScope> CreateTargetScopesMap()
         {

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -22,42 +22,29 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 {
     internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer : AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer
     {
-        private sealed partial class SymbolStartAnalyzer
+        private sealed partial class SymbolStartAnalyzer(
+            AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer compilationAnalyzer,
+            INamedTypeSymbol eventArgsTypeOpt,
+            ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore,
+            DeserializationConstructorCheck deserializationConstructorCheck,
+            INamedTypeSymbol iCustomMarshaler,
+            SymbolStartAnalysisContext symbolStartAnalysisContext)
         {
-            private readonly AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer _compilationAnalyzer;
+            private readonly AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer _compilationAnalyzer = compilationAnalyzer;
 
-            private readonly INamedTypeSymbol _eventArgsTypeOpt;
-            private readonly ImmutableHashSet<INamedTypeSymbol> _attributeSetForMethodsToIgnore;
-            private readonly DeserializationConstructorCheck _deserializationConstructorCheck;
-            private readonly ConcurrentDictionary<IMethodSymbol, bool> _methodsUsedAsDelegates;
-            private readonly INamedTypeSymbol _iCustomMarshaler;
-            private readonly SymbolStartAnalysisContext _symbolStartAnalysisContext;
+            private readonly INamedTypeSymbol _eventArgsTypeOpt = eventArgsTypeOpt;
+            private readonly ImmutableHashSet<INamedTypeSymbol> _attributeSetForMethodsToIgnore = attributeSetForMethodsToIgnore;
+            private readonly DeserializationConstructorCheck _deserializationConstructorCheck = deserializationConstructorCheck;
+            private readonly ConcurrentDictionary<IMethodSymbol, bool> _methodsUsedAsDelegates = new ConcurrentDictionary<IMethodSymbol, bool>();
+            private readonly INamedTypeSymbol _iCustomMarshaler = iCustomMarshaler;
+            private readonly SymbolStartAnalysisContext _symbolStartAnalysisContext = symbolStartAnalysisContext;
 
             /// <summary>
             /// Map from unused parameters to a boolean value indicating if the parameter has a read reference or not.
             /// For example, a parameter whose initial value is overwritten before any reads
             /// is an unused parameter with read reference(s).
             /// </summary>
-            private readonly ConcurrentDictionary<IParameterSymbol, bool> _unusedParameters;
-
-            public SymbolStartAnalyzer(
-                AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer compilationAnalyzer,
-                INamedTypeSymbol eventArgsTypeOpt,
-                ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore,
-                DeserializationConstructorCheck deserializationConstructorCheck,
-                INamedTypeSymbol iCustomMarshaler,
-                SymbolStartAnalysisContext symbolStartAnalysisContext)
-            {
-                _compilationAnalyzer = compilationAnalyzer;
-
-                _eventArgsTypeOpt = eventArgsTypeOpt;
-                _attributeSetForMethodsToIgnore = attributeSetForMethodsToIgnore;
-                _deserializationConstructorCheck = deserializationConstructorCheck;
-                _unusedParameters = new ConcurrentDictionary<IParameterSymbol, bool>();
-                _methodsUsedAsDelegates = new ConcurrentDictionary<IMethodSymbol, bool>();
-                _iCustomMarshaler = iCustomMarshaler;
-                _symbolStartAnalysisContext = symbolStartAnalysisContext;
-            }
+            private readonly ConcurrentDictionary<IParameterSymbol, bool> _unusedParameters = new ConcurrentDictionary<IParameterSymbol, bool>();
 
             public static void CreateAndRegisterActions(
                 CompilationStartAnalysisContext context,

--- a/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -192,9 +192,9 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        private class AnalyzerImpl
+        private class AnalyzerImpl(SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum, TSimplifierOptions> analyzer)
         {
-            private readonly SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum, TSimplifierOptions> _analyzer;
+            private readonly SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum, TSimplifierOptions> _analyzer = analyzer;
 
             /// <summary>
             /// Tracks the analysis state of syntax trees in a compilation. Each syntax tree has the properties:
@@ -220,9 +220,6 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             /// </summary>
             private readonly ConcurrentDictionary<SyntaxTree, (StrongBox<bool> completed, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? intervalTree)> _codeBlockIntervals
                 = new();
-
-            public AnalyzerImpl(SimplifyTypeNamesDiagnosticAnalyzerBase<TLanguageKindEnum, TSimplifierOptions> analyzer)
-                => _analyzer = analyzer;
 
             public void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
             {

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
@@ -236,27 +236,19 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
         TExpressionSyntax,
         TStatementSyntax,
         TMemberAccessExpressionSyntax,
-        TAssignmentStatementSyntax>
+        TAssignmentStatementSyntax>(
+        TAssignmentStatementSyntax statement,
+        TMemberAccessExpressionSyntax memberAccessExpression,
+        TExpressionSyntax initializer,
+        string memberName)
         where TExpressionSyntax : SyntaxNode
         where TStatementSyntax : SyntaxNode
         where TMemberAccessExpressionSyntax : TExpressionSyntax
         where TAssignmentStatementSyntax : TStatementSyntax
     {
-        public readonly TAssignmentStatementSyntax Statement;
-        public readonly TMemberAccessExpressionSyntax MemberAccessExpression;
-        public readonly TExpressionSyntax Initializer;
-        public readonly string MemberName;
-
-        public Match(
-            TAssignmentStatementSyntax statement,
-            TMemberAccessExpressionSyntax memberAccessExpression,
-            TExpressionSyntax initializer,
-            string memberName)
-        {
-            Statement = statement;
-            MemberAccessExpression = memberAccessExpression;
-            Initializer = initializer;
-            MemberName = memberName;
-        }
+        public readonly TAssignmentStatementSyntax Statement = statement;
+        public readonly TMemberAccessExpressionSyntax MemberAccessExpression = memberAccessExpression;
+        public readonly TExpressionSyntax Initializer = initializer;
+        public readonly string MemberName = memberName;
     }
 }

--- a/src/Analyzers/Core/CodeFixes/AddExplicitCast/InheritanceDistanceComparer.cs
+++ b/src/Analyzers/Core/CodeFixes/AddExplicitCast/InheritanceDistanceComparer.cs
@@ -30,16 +30,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddExplicitCast
     /// 
     /// 'Derived1' is less specific than 'Derived2' compared to 'Base'
     /// </summary>
-    internal sealed class InheritanceDistanceComparer<TExpressionSyntax>
+    internal sealed class InheritanceDistanceComparer<TExpressionSyntax>(SemanticModel semanticModel)
     : IComparer<(TExpressionSyntax syntax, ITypeSymbol symbol)>
     where TExpressionSyntax : SyntaxNode
     {
-        private readonly SemanticModel _semanticModel;
-
-        public InheritanceDistanceComparer(SemanticModel semanticModel)
-        {
-            _semanticModel = semanticModel;
-        }
+        private readonly SemanticModel _semanticModel = semanticModel;
 
         public int Compare((TExpressionSyntax syntax, ITypeSymbol symbol) x,
             (TExpressionSyntax syntax, ITypeSymbol symbol) y)

--- a/src/Analyzers/Core/CodeFixes/AddParameter/ArgumentInsertPositionData.cs
+++ b/src/Analyzers/Core/CodeFixes/AddParameter/ArgumentInsertPositionData.cs
@@ -4,17 +4,10 @@
 
 namespace Microsoft.CodeAnalysis.AddParameter
 {
-    internal readonly struct ArgumentInsertPositionData<TArgumentSyntax> where TArgumentSyntax : SyntaxNode
+    internal readonly struct ArgumentInsertPositionData<TArgumentSyntax>(IMethodSymbol methodToUpdate, TArgumentSyntax argumentToInsert, int argumentInsertionIndex) where TArgumentSyntax : SyntaxNode
     {
-        public ArgumentInsertPositionData(IMethodSymbol methodToUpdate, TArgumentSyntax argumentToInsert, int argumentInsertionIndex)
-        {
-            MethodToUpdate = methodToUpdate;
-            ArgumentToInsert = argumentToInsert;
-            ArgumentInsertionIndex = argumentInsertionIndex;
-        }
-
-        public IMethodSymbol MethodToUpdate { get; }
-        public TArgumentSyntax ArgumentToInsert { get; }
-        public int ArgumentInsertionIndex { get; }
+        public IMethodSymbol MethodToUpdate { get; } = methodToUpdate;
+        public TArgumentSyntax ArgumentToInsert { get; } = argumentToInsert;
+        public int ArgumentInsertionIndex { get; } = argumentInsertionIndex;
     }
 }

--- a/src/Analyzers/Core/CodeFixes/AddParameter/CodeFixData.cs
+++ b/src/Analyzers/Core/CodeFixes/AddParameter/CodeFixData.cs
@@ -8,31 +8,25 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.AddParameter
 {
-    internal readonly struct CodeFixData
+    internal readonly struct CodeFixData(
+        IMethodSymbol method,
+        Func<CancellationToken, Task<Solution>> createChangedSolutionNonCascading,
+        Func<CancellationToken, Task<Solution>>? createChangedSolutionCascading)
     {
-        public CodeFixData(
-            IMethodSymbol method,
-            Func<CancellationToken, Task<Solution>> createChangedSolutionNonCascading,
-            Func<CancellationToken, Task<Solution>>? createChangedSolutionCascading)
-        {
-            Method = method ?? throw new ArgumentNullException(nameof(method));
-            CreateChangedSolutionNonCascading = createChangedSolutionNonCascading ?? throw new ArgumentNullException(nameof(createChangedSolutionNonCascading));
-            CreateChangedSolutionCascading = createChangedSolutionCascading;
-        }
 
         /// <summary>
         /// The overload to fix.
         /// </summary>
-        public IMethodSymbol Method { get; }
+        public IMethodSymbol Method { get; } = method ?? throw new ArgumentNullException(nameof(method));
 
         /// <summary>
         /// A mandatory fix for the overload without cascading.
         /// </summary>
-        public Func<CancellationToken, Task<Solution>> CreateChangedSolutionNonCascading { get; }
+        public Func<CancellationToken, Task<Solution>> CreateChangedSolutionNonCascading { get; } = createChangedSolutionNonCascading ?? throw new ArgumentNullException(nameof(createChangedSolutionNonCascading));
 
         /// <summary>
         /// An optional fix for the overload with cascading.
         /// </summary>
-        public Func<CancellationToken, Task<Solution>>? CreateChangedSolutionCascading { get; }
+        public Func<CancellationToken, Task<Solution>>? CreateChangedSolutionCascading { get; } = createChangedSolutionCascading;
     }
 }

--- a/src/Analyzers/Core/CodeFixes/AddParameter/RegisterFixData.cs
+++ b/src/Analyzers/Core/CodeFixes/AddParameter/RegisterFixData.cs
@@ -6,22 +6,15 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.AddParameter
 {
-    internal class RegisterFixData<TArgumentSyntax>
+    internal class RegisterFixData<TArgumentSyntax>(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates, bool isConstructorInitializer)
         where TArgumentSyntax : SyntaxNode
     {
         public RegisterFixData() : this(new SeparatedSyntaxList<TArgumentSyntax>(), ImmutableArray<IMethodSymbol>.Empty, false)
         {
         }
 
-        public RegisterFixData(SeparatedSyntaxList<TArgumentSyntax> arguments, ImmutableArray<IMethodSymbol> methodCandidates, bool isConstructorInitializer)
-        {
-            Arguments = arguments;
-            MethodCandidates = methodCandidates;
-            IsConstructorInitializer = isConstructorInitializer;
-        }
-
-        public SeparatedSyntaxList<TArgumentSyntax> Arguments { get; }
-        public ImmutableArray<IMethodSymbol> MethodCandidates { get; }
-        public bool IsConstructorInitializer { get; }
+        public SeparatedSyntaxList<TArgumentSyntax> Arguments { get; } = arguments;
+        public ImmutableArray<IMethodSymbol> MethodCandidates { get; } = methodCandidates;
+        public bool IsConstructorInitializer { get; } = isConstructorInitializer;
     }
 }

--- a/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
@@ -930,27 +930,17 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 referencedSymbols.Single().Locations.IsEmpty();
         }
 
-        protected sealed class UniqueVariableNameGenerator : IDisposable
+        protected sealed class UniqueVariableNameGenerator(
+            SyntaxNode memberDeclaration,
+            SemanticModel semanticModel,
+            ISemanticFactsService semanticFacts,
+            CancellationToken cancellationToken) : IDisposable
         {
-            private readonly SyntaxNode _memberDeclaration;
-            private readonly SemanticModel _semanticModel;
-            private readonly ISemanticFactsService _semanticFacts;
-            private readonly CancellationToken _cancellationToken;
-            private readonly PooledHashSet<string> _usedNames;
-
-            public UniqueVariableNameGenerator(
-                SyntaxNode memberDeclaration,
-                SemanticModel semanticModel,
-                ISemanticFactsService semanticFacts,
-                CancellationToken cancellationToken)
-            {
-                _memberDeclaration = memberDeclaration;
-                _semanticModel = semanticModel;
-                _semanticFacts = semanticFacts;
-                _cancellationToken = cancellationToken;
-
-                _usedNames = PooledHashSet<string>.GetInstance();
-            }
+            private readonly SyntaxNode _memberDeclaration = memberDeclaration;
+            private readonly SemanticModel _semanticModel = semanticModel;
+            private readonly ISemanticFactsService _semanticFacts = semanticFacts;
+            private readonly CancellationToken _cancellationToken = cancellationToken;
+            private readonly PooledHashSet<string> _usedNames = PooledHashSet<string>.GetInstance();
 
             public SyntaxToken GenerateUniqueNameAtSpanStart(SyntaxNode node)
             {

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParameterResult.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParameterResult.cs
@@ -8,21 +8,14 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 {
     internal partial class AddConstructorParametersFromMembersCodeRefactoringProvider
     {
-        private readonly struct AddConstructorParameterResult
+        private readonly struct AddConstructorParameterResult(
+            ImmutableArray<AddConstructorParametersCodeAction> requiredParameterActions,
+            ImmutableArray<AddConstructorParametersCodeAction> optionalParameterActions,
+            bool useSubMenu)
         {
-            internal readonly ImmutableArray<AddConstructorParametersCodeAction> RequiredParameterActions;
-            internal readonly ImmutableArray<AddConstructorParametersCodeAction> OptionalParameterActions;
-            internal readonly bool UseSubMenu;
-
-            public AddConstructorParameterResult(
-                ImmutableArray<AddConstructorParametersCodeAction> requiredParameterActions,
-                ImmutableArray<AddConstructorParametersCodeAction> optionalParameterActions,
-                bool useSubMenu)
-            {
-                RequiredParameterActions = requiredParameterActions;
-                OptionalParameterActions = optionalParameterActions;
-                UseSubMenu = useSubMenu;
-            }
+            internal readonly ImmutableArray<AddConstructorParametersCodeAction> RequiredParameterActions = requiredParameterActions;
+            internal readonly ImmutableArray<AddConstructorParametersCodeAction> OptionalParameterActions = optionalParameterActions;
+            internal readonly bool UseSubMenu = useSubMenu;
         }
     }
 }

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParametersCodeAction.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParametersCodeAction.cs
@@ -19,36 +19,26 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 {
     internal partial class AddConstructorParametersFromMembersCodeRefactoringProvider
     {
-        private class AddConstructorParametersCodeAction : CodeAction
+        private class AddConstructorParametersCodeAction(
+            Document document,
+            CodeGenerationContextInfo info,
+            ConstructorCandidate constructorCandidate,
+            ISymbol containingType,
+            ImmutableArray<IParameterSymbol> missingParameters,
+            bool useSubMenuName) : CodeAction
         {
-            private readonly Document _document;
-            private readonly CodeGenerationContextInfo _info;
-            private readonly ConstructorCandidate _constructorCandidate;
-            private readonly ISymbol _containingType;
-            private readonly ImmutableArray<IParameterSymbol> _missingParameters;
+            private readonly Document _document = document;
+            private readonly CodeGenerationContextInfo _info = info;
+            private readonly ConstructorCandidate _constructorCandidate = constructorCandidate;
+            private readonly ISymbol _containingType = containingType;
+            private readonly ImmutableArray<IParameterSymbol> _missingParameters = missingParameters;
 
             /// <summary>
             /// If there is more than one constructor, the suggested actions will be split into two sub menus,
             /// one for regular parameters and one for optional. This boolean is used by the Title property
             /// to determine if the code action should be given the complete title or the sub menu title
             /// </summary>
-            private readonly bool _useSubMenuName;
-
-            public AddConstructorParametersCodeAction(
-                Document document,
-                CodeGenerationContextInfo info,
-                ConstructorCandidate constructorCandidate,
-                ISymbol containingType,
-                ImmutableArray<IParameterSymbol> missingParameters,
-                bool useSubMenuName)
-            {
-                _document = document;
-                _info = info;
-                _constructorCandidate = constructorCandidate;
-                _containingType = containingType;
-                _missingParameters = missingParameters;
-                _useSubMenuName = useSubMenuName;
-            }
+            private readonly bool _useSubMenuName = useSubMenuName;
 
             protected override Task<Solution?> GetChangedSolutionAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.ConstructorCandidate.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.ConstructorCandidate.cs
@@ -8,18 +8,11 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 {
     internal partial class AddConstructorParametersFromMembersCodeRefactoringProvider
     {
-        private readonly struct ConstructorCandidate
+        private readonly struct ConstructorCandidate(IMethodSymbol constructor, ImmutableArray<ISymbol> missingMembers, ImmutableArray<IParameterSymbol> missingParameters)
         {
-            public readonly IMethodSymbol Constructor;
-            public readonly ImmutableArray<ISymbol> MissingMembers;
-            public readonly ImmutableArray<IParameterSymbol> MissingParameters;
-
-            public ConstructorCandidate(IMethodSymbol constructor, ImmutableArray<ISymbol> missingMembers, ImmutableArray<IParameterSymbol> missingParameters)
-            {
-                Constructor = constructor;
-                MissingMembers = missingMembers;
-                MissingParameters = missingParameters;
-            }
+            public readonly IMethodSymbol Constructor = constructor;
+            public readonly ImmutableArray<ISymbol> MissingMembers = missingMembers;
+            public readonly ImmutableArray<IParameterSymbol> MissingParameters = missingParameters;
         }
     }
 }

--- a/src/Features/Core/Portable/AddImport/AddImportFixData.cs
+++ b/src/Features/Core/Portable/AddImport/AddImportFixData.cs
@@ -14,10 +14,23 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.AddImport
 {
     [DataContract]
-    internal sealed class AddImportFixData
+    internal sealed class AddImportFixData(
+        AddImportFixKind kind,
+        ImmutableArray<TextChange> textChanges,
+        string title = null,
+        ImmutableArray<string> tags = default,
+        CodeActionPriority priority = default,
+        ProjectId projectReferenceToAdd = null,
+        ProjectId portableExecutableReferenceProjectId = null,
+        string portableExecutableReferenceFilePathToAdd = null,
+        string assemblyReferenceAssemblyName = null,
+        string assemblyReferenceFullyQualifiedTypeName = null,
+        string packageSource = null,
+        string packageName = null,
+        string packageVersionOpt = null)
     {
         [DataMember(Order = 0)]
-        public AddImportFixKind Kind { get; }
+        public AddImportFixKind Kind { get; } = kind;
 
         /// <summary>
         /// Text changes to make to the document.  Usually just the import to add.  May also
@@ -26,25 +39,25 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// add a project/metadata reference.
         /// </summary>
         [DataMember(Order = 1)]
-        public readonly ImmutableArray<TextChange> TextChanges;
+        public readonly ImmutableArray<TextChange> TextChanges = textChanges;
 
         /// <summary>
         /// String to display in the lightbulb menu.
         /// </summary>
         [DataMember(Order = 2)]
-        public readonly string Title;
+        public readonly string Title = title;
 
         /// <summary>
         /// Tags that control what glyph is displayed in the lightbulb menu.
         /// </summary>
         [DataMember(Order = 3)]
-        public readonly ImmutableArray<string> Tags;
+        public readonly ImmutableArray<string> Tags = tags;
 
         /// <summary>
         /// The priority this item should have in the lightbulb list.
         /// </summary>
         [DataMember(Order = 4)]
-        public readonly CodeActionPriority Priority;
+        public readonly CodeActionPriority Priority = priority;
 
         #region When adding P2P references.
 
@@ -52,7 +65,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// The optional id for a <see cref="Project"/> we'd like to add a reference to.
         /// </summary>
         [DataMember(Order = 5)]
-        public readonly ProjectId ProjectReferenceToAdd;
+        public readonly ProjectId ProjectReferenceToAdd = projectReferenceToAdd;
 
         #endregion
 
@@ -64,70 +77,39 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// referenced from.
         /// </summary>
         [DataMember(Order = 6)]
-        public readonly ProjectId PortableExecutableReferenceProjectId;
+        public readonly ProjectId PortableExecutableReferenceProjectId = portableExecutableReferenceProjectId;
 
         /// <summary>
         /// If we want to add a <see cref="PortableExecutableReference"/> metadata reference, this 
         /// is the <see cref="PortableExecutableReference.FilePath"/> for it.
         /// </summary>
         [DataMember(Order = 7)]
-        public readonly string PortableExecutableReferenceFilePathToAdd;
+        public readonly string PortableExecutableReferenceFilePathToAdd = portableExecutableReferenceFilePathToAdd;
 
         #endregion
 
         #region When adding an assembly reference
 
         [DataMember(Order = 8)]
-        public readonly string AssemblyReferenceAssemblyName;
+        public readonly string AssemblyReferenceAssemblyName = assemblyReferenceAssemblyName;
 
         [DataMember(Order = 9)]
-        public readonly string AssemblyReferenceFullyQualifiedTypeName;
+        public readonly string AssemblyReferenceFullyQualifiedTypeName = assemblyReferenceFullyQualifiedTypeName;
 
         #endregion
 
         #region When adding a package reference
 
         [DataMember(Order = 10)]
-        public readonly string PackageSource;
+        public readonly string PackageSource = packageSource;
 
         [DataMember(Order = 11)]
-        public readonly string PackageName;
+        public readonly string PackageName = packageName;
 
         [DataMember(Order = 12)]
-        public readonly string PackageVersionOpt;
+        public readonly string PackageVersionOpt = packageVersionOpt;
 
         #endregion
-
-        // Must be public since it's used for deserialization.
-        public AddImportFixData(
-            AddImportFixKind kind,
-            ImmutableArray<TextChange> textChanges,
-            string title = null,
-            ImmutableArray<string> tags = default,
-            CodeActionPriority priority = default,
-            ProjectId projectReferenceToAdd = null,
-            ProjectId portableExecutableReferenceProjectId = null,
-            string portableExecutableReferenceFilePathToAdd = null,
-            string assemblyReferenceAssemblyName = null,
-            string assemblyReferenceFullyQualifiedTypeName = null,
-            string packageSource = null,
-            string packageName = null,
-            string packageVersionOpt = null)
-        {
-            Kind = kind;
-            TextChanges = textChanges;
-            Title = title;
-            Tags = tags;
-            Priority = priority;
-            ProjectReferenceToAdd = projectReferenceToAdd;
-            PortableExecutableReferenceProjectId = portableExecutableReferenceProjectId;
-            PortableExecutableReferenceFilePathToAdd = portableExecutableReferenceFilePathToAdd;
-            AssemblyReferenceAssemblyName = assemblyReferenceAssemblyName;
-            AssemblyReferenceFullyQualifiedTypeName = assemblyReferenceFullyQualifiedTypeName;
-            PackageSource = packageSource;
-            PackageName = packageName;
-            PackageVersionOpt = packageVersionOpt;
-        }
 
         public static AddImportFixData CreateForProjectSymbol(ImmutableArray<TextChange> textChanges, string title, ImmutableArray<string> tags, CodeActionPriority priority, ProjectId projectReferenceToAdd)
             => new(AddImportFixKind.ProjectSymbol,

--- a/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
@@ -56,21 +56,14 @@ namespace Microsoft.CodeAnalysis.AddImport
                 }
             }
 
-            private sealed class AddAssemblyReferenceCodeActionOperation : CodeActionOperation
+            private sealed class AddAssemblyReferenceCodeActionOperation(
+                string assemblyReferenceAssemblyName,
+                string assemblyReferenceFullyQualifiedTypeName,
+                Project newProject) : CodeActionOperation
             {
-                private readonly string _assemblyReferenceAssemblyName;
-                private readonly string _assemblyReferenceFullyQualifiedTypeName;
-                private readonly Project _newProject;
-
-                public AddAssemblyReferenceCodeActionOperation(
-                    string assemblyReferenceAssemblyName,
-                    string assemblyReferenceFullyQualifiedTypeName,
-                    Project newProject)
-                {
-                    _assemblyReferenceAssemblyName = assemblyReferenceAssemblyName;
-                    _assemblyReferenceFullyQualifiedTypeName = assemblyReferenceFullyQualifiedTypeName;
-                    _newProject = newProject;
-                }
+                private readonly string _assemblyReferenceAssemblyName = assemblyReferenceAssemblyName;
+                private readonly string _assemblyReferenceFullyQualifiedTypeName = assemblyReferenceFullyQualifiedTypeName;
+                private readonly Project _newProject = newProject;
 
                 internal override bool ApplyDuringTests => true;
 

--- a/src/Features/Core/Portable/AddImport/CodeActions/InstallPackageAndAddImportCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/InstallPackageAndAddImportCodeAction.cs
@@ -96,24 +96,16 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
         }
 
-        private class InstallPackageAndAddImportOperation : CodeActionOperation
+        private class InstallPackageAndAddImportOperation(
+            DocumentId changedDocumentId,
+            SourceText oldText,
+            SourceText newText,
+            InstallPackageDirectlyCodeActionOperation item2) : CodeActionOperation
         {
-            private readonly DocumentId _changedDocumentId;
-            private readonly SourceText _oldText;
-            private readonly SourceText _newText;
-            private readonly InstallPackageDirectlyCodeActionOperation _installPackageOperation;
-
-            public InstallPackageAndAddImportOperation(
-                DocumentId changedDocumentId,
-                SourceText oldText,
-                SourceText newText,
-                InstallPackageDirectlyCodeActionOperation item2)
-            {
-                _changedDocumentId = changedDocumentId;
-                _oldText = oldText;
-                _newText = newText;
-                _installPackageOperation = item2;
-            }
+            private readonly DocumentId _changedDocumentId = changedDocumentId;
+            private readonly SourceText _oldText = oldText;
+            private readonly SourceText _newText = newText;
+            private readonly InstallPackageDirectlyCodeActionOperation _installPackageOperation = item2;
 
             internal override bool ApplyDuringTests => _installPackageOperation.ApplyDuringTests;
             public override string Title => _installPackageOperation.Title;

--- a/src/Features/Core/Portable/AddImport/CodeActions/InstallWithPackageManagerCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/InstallWithPackageManagerCodeAction.cs
@@ -15,18 +15,12 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private class InstallWithPackageManagerCodeAction : CodeAction
+        private class InstallWithPackageManagerCodeAction(
+            IPackageInstallerService installerService,
+            string packageName) : CodeAction
         {
-            private readonly IPackageInstallerService _installerService;
-            private readonly string _packageName;
-
-            public InstallWithPackageManagerCodeAction(
-                IPackageInstallerService installerService,
-                string packageName)
-            {
-                _installerService = installerService;
-                _packageName = packageName;
-            }
+            private readonly IPackageInstallerService _installerService = installerService;
+            private readonly string _packageName = packageName;
 
             public override string Title => FeaturesResources.Install_with_package_manager;
 
@@ -36,18 +30,12 @@ namespace Microsoft.CodeAnalysis.AddImport
                     new InstallWithPackageManagerCodeActionOperation(_installerService, _packageName)));
             }
 
-            private class InstallWithPackageManagerCodeActionOperation : CodeActionOperation
+            private class InstallWithPackageManagerCodeActionOperation(
+                IPackageInstallerService installerService,
+                string packageName) : CodeActionOperation
             {
-                private readonly IPackageInstallerService _installerService;
-                private readonly string _packageName;
-
-                public InstallWithPackageManagerCodeActionOperation(
-                    IPackageInstallerService installerService,
-                    string packageName)
-                {
-                    _installerService = installerService;
-                    _packageName = packageName;
-                }
+                private readonly IPackageInstallerService _installerService = installerService;
+                private readonly string _packageName = packageName;
 
                 public override string Title => FeaturesResources.Install_with_package_manager;
 

--- a/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
@@ -53,18 +53,11 @@ namespace Microsoft.CodeAnalysis.AddImport
                 return Task.FromResult<CodeActionOperation?>(new AddProjectReferenceCodeActionOperation(OriginalDocument.Project.Id, FixData.ProjectReferenceToAdd, applyOperation));
             }
 
-            private sealed class AddProjectReferenceCodeActionOperation : CodeActionOperation
+            private sealed class AddProjectReferenceCodeActionOperation(ProjectId referencingProject, ProjectId referencedProject, ApplyChangesOperation applyOperation) : CodeActionOperation
             {
-                private readonly ProjectId _referencingProject;
-                private readonly ProjectId _referencedProject;
-                private readonly ApplyChangesOperation _applyOperation;
-
-                public AddProjectReferenceCodeActionOperation(ProjectId referencingProject, ProjectId referencedProject, ApplyChangesOperation applyOperation)
-                {
-                    _referencingProject = referencingProject;
-                    _referencedProject = referencedProject;
-                    _applyOperation = applyOperation;
-                }
+                private readonly ProjectId _referencingProject = referencingProject;
+                private readonly ProjectId _referencedProject = referencedProject;
+                private readonly ApplyChangesOperation _applyOperation = applyOperation;
 
                 internal override bool ApplyDuringTests => true;
 

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -15,18 +15,12 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private partial class AssemblyReference : Reference
+        private partial class AssemblyReference(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            SearchResult searchResult,
+            ReferenceAssemblyWithTypeResult referenceAssemblyWithType) : Reference(provider, searchResult)
         {
-            private readonly ReferenceAssemblyWithTypeResult _referenceAssemblyWithType;
-
-            public AssemblyReference(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                SearchResult searchResult,
-                ReferenceAssemblyWithTypeResult referenceAssemblyWithType)
-                : base(provider, searchResult)
-            {
-                _referenceAssemblyWithType = referenceAssemblyWithType;
-            }
+            private readonly ReferenceAssemblyWithTypeResult _referenceAssemblyWithType = referenceAssemblyWithType;
 
             public override async Task<AddImportFixData> TryGetFixDataAsync(
                 Document document, SyntaxNode node, CodeCleanupOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/References/MetadataSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/MetadataSymbolReference.cs
@@ -19,21 +19,14 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private partial class MetadataSymbolReference : SymbolReference
+        private partial class MetadataSymbolReference(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            SymbolResult<INamespaceOrTypeSymbol> symbolResult,
+            ProjectId referenceProjectId,
+            PortableExecutableReference reference) : SymbolReference(provider, symbolResult)
         {
-            private readonly ProjectId _referenceProjectId;
-            private readonly PortableExecutableReference _reference;
-
-            public MetadataSymbolReference(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                SymbolResult<INamespaceOrTypeSymbol> symbolResult,
-                ProjectId referenceProjectId,
-                PortableExecutableReference reference)
-                : base(provider, symbolResult)
-            {
-                _referenceProjectId = referenceProjectId;
-                _reference = reference;
-            }
+            private readonly ProjectId _referenceProjectId = referenceProjectId;
+            private readonly PortableExecutableReference _reference = reference;
 
             /// <summary>
             /// If we're adding a metadata-reference, then we always offer to do the add,

--- a/src/Features/Core/Portable/AddImport/References/PackageReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/PackageReference.cs
@@ -14,24 +14,16 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private partial class PackageReference : Reference
+        private partial class PackageReference(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            SearchResult searchResult,
+            string source,
+            string packageName,
+            string versionOpt) : Reference(provider, searchResult)
         {
-            private readonly string _source;
-            private readonly string _packageName;
-            private readonly string _versionOpt;
-
-            public PackageReference(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                SearchResult searchResult,
-                string source,
-                string packageName,
-                string versionOpt)
-                : base(provider, searchResult)
-            {
-                _source = source;
-                _packageName = packageName;
-                _versionOpt = versionOpt;
-            }
+            private readonly string _source = source;
+            private readonly string _packageName = packageName;
+            private readonly string _versionOpt = versionOpt;
 
             public override async Task<AddImportFixData> TryGetFixDataAsync(
                 Document document, SyntaxNode node, CodeCleanupOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
@@ -26,18 +26,12 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// light bulb and we say "(from ProjectXXX)" to make it clear that this will do more than
         /// just add a using/import.
         /// </summary>
-        private partial class ProjectSymbolReference : SymbolReference
+        private partial class ProjectSymbolReference(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            SymbolResult<INamespaceOrTypeSymbol> symbolResult,
+            Project project) : SymbolReference(provider, symbolResult)
         {
-            private readonly Project _project;
-
-            public ProjectSymbolReference(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                SymbolResult<INamespaceOrTypeSymbol> symbolResult,
-                Project project)
-                : base(provider, symbolResult)
-            {
-                _project = project;
-            }
+            private readonly Project _project = project;
 
             protected override ImmutableArray<string> GetTags(Document document)
             {

--- a/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
@@ -19,19 +19,13 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private abstract partial class SymbolReference : Reference
+        private abstract partial class SymbolReference(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            SymbolResult<INamespaceOrTypeSymbol> symbolResult) : Reference(provider, new SearchResult(symbolResult))
         {
-            public readonly SymbolResult<INamespaceOrTypeSymbol> SymbolResult;
+            public readonly SymbolResult<INamespaceOrTypeSymbol> SymbolResult = symbolResult;
 
             protected abstract bool ShouldAddWithExistingImport(Document document);
-
-            public SymbolReference(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                SymbolResult<INamespaceOrTypeSymbol> symbolResult)
-                : base(provider, new SearchResult(symbolResult))
-            {
-                SymbolResult = symbolResult;
-            }
 
             protected abstract ImmutableArray<string> GetTags(Document document);
 

--- a/src/Features/Core/Portable/AddImport/SearchScopes/AllSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/AllSymbolsProjectSearchScope.cs
@@ -16,16 +16,11 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// i.e. the symbols created from source *and* symbols from references (both project and
         /// metadata).
         /// </summary>
-        private class AllSymbolsProjectSearchScope : ProjectSearchScope
+        private class AllSymbolsProjectSearchScope(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            Project project,
+            bool exact) : ProjectSearchScope(provider, project, exact)
         {
-            public AllSymbolsProjectSearchScope(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                Project project,
-                bool exact)
-                : base(provider, project, exact)
-            {
-            }
-
             protected override async Task<ImmutableArray<ISymbol>> FindDeclarationsAsync(
                 SymbolFilter filter, SearchQuery searchQuery, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/AddImport/SearchScopes/MetadataSymbolsSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/MetadataSymbolsSearchScope.cs
@@ -12,24 +12,16 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private class MetadataSymbolsSearchScope : SearchScope
+        private class MetadataSymbolsSearchScope(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            Project assemblyProject,
+            IAssemblySymbol assembly,
+            PortableExecutableReference metadataReference,
+            bool exact) : SearchScope(provider, exact)
         {
-            private readonly Project _assemblyProject;
-            private readonly IAssemblySymbol _assembly;
-            private readonly PortableExecutableReference _metadataReference;
-
-            public MetadataSymbolsSearchScope(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                Project assemblyProject,
-                IAssemblySymbol assembly,
-                PortableExecutableReference metadataReference,
-                bool exact)
-                : base(provider, exact)
-            {
-                _assemblyProject = assemblyProject;
-                _assembly = assembly;
-                _metadataReference = metadataReference;
-            }
+            private readonly Project _assemblyProject = assemblyProject;
+            private readonly IAssemblySymbol _assembly = assembly;
+            private readonly PortableExecutableReference _metadataReference = metadataReference;
 
             public override SymbolReference CreateReference<T>(SymbolResult<T> searchResult)
             {

--- a/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
@@ -19,18 +19,12 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// SearchScope used for searching *only* the source symbols contained within a project/compilation.
         /// i.e. symbols from metadata will not be searched.
         /// </summary>
-        private class SourceSymbolsProjectSearchScope : ProjectSearchScope
+        private class SourceSymbolsProjectSearchScope(
+            AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
+            ConcurrentDictionary<Project, AsyncLazy<IAssemblySymbol?>> projectToAssembly,
+            Project project, bool ignoreCase) : ProjectSearchScope(provider, project, ignoreCase)
         {
-            private readonly ConcurrentDictionary<Project, AsyncLazy<IAssemblySymbol?>> _projectToAssembly;
-
-            public SourceSymbolsProjectSearchScope(
-                AbstractAddImportFeatureService<TSimpleNameSyntax> provider,
-                ConcurrentDictionary<Project, AsyncLazy<IAssemblySymbol?>> projectToAssembly,
-                Project project, bool ignoreCase)
-                : base(provider, project, ignoreCase)
-            {
-                _projectToAssembly = projectToAssembly;
-            }
+            private readonly ConcurrentDictionary<Project, AsyncLazy<IAssemblySymbol?>> _projectToAssembly = projectToAssembly;
 
             protected override async Task<ImmutableArray<ISymbol>> FindDeclarationsAsync(
                 SymbolFilter filter, SearchQuery searchQuery, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/SymbolResult.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolResult.cs
@@ -12,31 +12,23 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal abstract partial class AbstractAddImportFeatureService<TSimpleNameSyntax>
     {
-        private readonly struct SearchResult
+        private readonly struct SearchResult(string? desiredName, TSimpleNameSyntax nameNode, IReadOnlyList<string> nameParts, double weight)
         {
-            public readonly IReadOnlyList<string> NameParts;
+            public readonly IReadOnlyList<string> NameParts = nameParts;
 
             // How good a match this was.  0 means it was a perfect match.  Larger numbers are less 
             // and less good.
-            public readonly double Weight;
+            public readonly double Weight = weight;
 
             // The desired name to change the user text to if this was a fuzzy (spell-checking) match.
-            public readonly string? DesiredName;
+            public readonly string? DesiredName = desiredName;
 
             // The node to convert to the desired name
-            public readonly TSimpleNameSyntax NameNode;
+            public readonly TSimpleNameSyntax NameNode = nameNode;
 
             public SearchResult(SymbolResult<INamespaceOrTypeSymbol> result)
                 : this(result.DesiredName, result.NameNode, INamespaceOrTypeSymbolExtensions.GetNameParts(result.Symbol), result.Weight)
             {
-            }
-
-            public SearchResult(string? desiredName, TSimpleNameSyntax nameNode, IReadOnlyList<string> nameParts, double weight)
-            {
-                DesiredName = desiredName;
-                Weight = weight;
-                NameNode = nameNode;
-                NameParts = nameParts;
             }
 
             public bool DesiredNameDiffersFromSourceName()
@@ -75,28 +67,20 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
         }
 
-        private readonly struct SymbolResult<T> where T : ISymbol
+        private readonly struct SymbolResult<T>(string desiredName, TSimpleNameSyntax nameNode, T symbol, double weight) where T : ISymbol
         {
             // The symbol that matched the string being searched for.
-            public readonly T Symbol;
+            public readonly T Symbol = symbol;
 
             // How good a match this was.  0 means it was a perfect match.  Larger numbers are less 
             // and less good.
-            public readonly double Weight;
+            public readonly double Weight = weight;
 
             // The desired name to change the user text to if this was a fuzzy (spell-checking) match.
-            public readonly string DesiredName;
+            public readonly string DesiredName = desiredName;
 
             // The node to convert to the desired name
-            public readonly TSimpleNameSyntax NameNode;
-
-            public SymbolResult(string desiredName, TSimpleNameSyntax nameNode, T symbol, double weight)
-            {
-                DesiredName = desiredName;
-                Symbol = symbol;
-                Weight = weight;
-                NameNode = nameNode;
-            }
+            public readonly TSimpleNameSyntax NameNode = nameNode;
 
             public SymbolResult<T2> WithSymbol<T2>(T2 symbol) where T2 : ISymbol
                 => new(DesiredName, NameNode, symbol, Weight);

--- a/src/Features/Core/Portable/AddMissingReference/AddMissingReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddMissingReference/AddMissingReferenceCodeAction.cs
@@ -14,27 +14,19 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddMissingReference
 {
-    internal class AddMissingReferenceCodeAction : CodeAction
+    internal class AddMissingReferenceCodeAction(Project project, string title, ProjectReference? projectReferenceToAdd, AssemblyIdentity missingAssemblyIdentity) : CodeAction
     {
-        private readonly Project _project;
-        private readonly ProjectReference? _projectReferenceToAdd;
-        private readonly AssemblyIdentity _missingAssemblyIdentity;
+        private readonly Project _project = project;
+        private readonly ProjectReference? _projectReferenceToAdd = projectReferenceToAdd;
+        private readonly AssemblyIdentity _missingAssemblyIdentity = missingAssemblyIdentity;
 
-        public override string Title { get; }
+        public override string Title { get; } = title;
 
         /// <summary>
         /// This code action only works by adding references.  As such, it requires a non document change (and is
         /// thus restricted in which hosts it can run).
         /// </summary>
         public override ImmutableArray<string> Tags => RequiresNonDocumentChangeTags;
-
-        public AddMissingReferenceCodeAction(Project project, string title, ProjectReference? projectReferenceToAdd, AssemblyIdentity missingAssemblyIdentity)
-        {
-            _project = project;
-            Title = title;
-            _projectReferenceToAdd = projectReferenceToAdd;
-            _missingAssemblyIdentity = missingAssemblyIdentity;
-        }
 
         public static async Task<CodeAction> CreateAsync(Project project, AssemblyIdentity missingAssemblyIdentity, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
@@ -13,31 +13,24 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddPackage
 {
-    internal class InstallPackageDirectlyCodeAction : CodeAction
+    internal class InstallPackageDirectlyCodeAction(
+        IPackageInstallerService installerService,
+        Document document,
+        string source,
+        string packageName,
+        string versionOpt,
+        bool includePrerelease,
+        bool isLocal) : CodeAction
     {
-        private readonly CodeActionOperation _installPackageOperation;
+        private readonly CodeActionOperation _installPackageOperation = new InstallPackageDirectlyCodeActionOperation(
+                installerService, document, source, packageName,
+                versionOpt, includePrerelease, isLocal);
 
-        public override string Title { get; }
-
-        public InstallPackageDirectlyCodeAction(
-            IPackageInstallerService installerService,
-            Document document,
-            string source,
-            string packageName,
-            string versionOpt,
-            bool includePrerelease,
-            bool isLocal)
-        {
-            Title = versionOpt == null
+        public override string Title { get; } = versionOpt == null
                 ? FeaturesResources.Find_and_install_latest_version
                 : isLocal
                     ? string.Format(FeaturesResources.Use_local_version_0, versionOpt)
                     : string.Format(FeaturesResources.Install_version_0, versionOpt);
-
-            _installPackageOperation = new InstallPackageDirectlyCodeActionOperation(
-                installerService, document, source, packageName,
-                versionOpt, includePrerelease, isLocal);
-        }
 
         protected override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
             => Task.FromResult(SpecializedCollections.SingletonEnumerable(_installPackageOperation));

--- a/src/Features/Core/Portable/AddPackage/InstallPackageParentCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageParentCodeAction.cs
@@ -18,31 +18,26 @@ namespace Microsoft.CodeAnalysis.AddPackage
     /// the lightbulb.  It will have children to 'Install Latest', 
     /// 'Install Version 'X' ..., and 'Install with package manager'.
     /// </summary>
-    internal class InstallPackageParentCodeAction : CodeAction.CodeActionWithNestedActions
+    /// <remarks>
+    /// Even though we have child actions, we mark ourselves as explicitly non-inlinable.
+    /// We want to the experience of having the top level item the user has to see and
+    /// navigate through, and we don't want our child items confusingly being added to the
+    /// top level light-bulb where it's not clear what effect they would have if invoked.
+    /// </remarks>
+    internal class InstallPackageParentCodeAction(
+        IPackageInstallerService installerService,
+        string source,
+        string packageName,
+        bool includePrerelease,
+        Document document) : CodeAction.CodeActionWithNestedActions(string.Format(FeaturesResources.Install_package_0, packageName),
+               CreateNestedActions(installerService, source, packageName, includePrerelease, document),
+               isInlinable: false)
     {
         /// <summary>
         /// This code action only works by installing a package.  As such, it requires a non document change (and is
         /// thus restricted in which hosts it can run).
         /// </summary>
         public override ImmutableArray<string> Tags => RequiresNonDocumentChangeTags;
-
-        /// <summary>
-        /// Even though we have child actions, we mark ourselves as explicitly non-inlinable.
-        /// We want to the experience of having the top level item the user has to see and
-        /// navigate through, and we don't want our child items confusingly being added to the
-        /// top level light-bulb where it's not clear what effect they would have if invoked.
-        /// </summary>
-        public InstallPackageParentCodeAction(
-            IPackageInstallerService installerService,
-            string source,
-            string packageName,
-            bool includePrerelease,
-            Document document)
-            : base(string.Format(FeaturesResources.Install_package_0, packageName),
-                   CreateNestedActions(installerService, source, packageName, includePrerelease, document),
-                   isInlinable: false)
-        {
-        }
 
         private static ImmutableArray<CodeAction> CreateNestedActions(
             IPackageInstallerService installerService,

--- a/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallWithPackageManagerCodeAction.cs
@@ -13,17 +13,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddPackage
 {
-    internal class InstallWithPackageManagerCodeAction : CodeAction
+    internal class InstallWithPackageManagerCodeAction(
+        IPackageInstallerService installerService, string packageName) : CodeAction
     {
-        private readonly IPackageInstallerService _installerService;
-        private readonly string _packageName;
-
-        public InstallWithPackageManagerCodeAction(
-            IPackageInstallerService installerService, string packageName)
-        {
-            _installerService = installerService;
-            _packageName = packageName;
-        }
+        private readonly IPackageInstallerService _installerService = installerService;
+        private readonly string _packageName = packageName;
 
         public override string Title => FeaturesResources.Install_with_package_manager;
 
@@ -33,15 +27,10 @@ namespace Microsoft.CodeAnalysis.AddPackage
                 new InstallWithPackageManagerCodeActionOperation(this)));
         }
 
-        private class InstallWithPackageManagerCodeActionOperation : CodeActionOperation
+        private class InstallWithPackageManagerCodeActionOperation(
+            InstallWithPackageManagerCodeAction codeAction) : CodeActionOperation
         {
-            private readonly InstallWithPackageManagerCodeAction _codeAction;
-
-            public InstallWithPackageManagerCodeActionOperation(
-                InstallWithPackageManagerCodeAction codeAction)
-            {
-                _codeAction = codeAction;
-            }
+            private readonly InstallWithPackageManagerCodeAction _codeAction = codeAction;
 
             public override string Title => FeaturesResources.Install_with_package_manager;
 

--- a/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
+++ b/src/Features/Core/Portable/BraceCompletion/IBraceCompletionService.cs
@@ -72,13 +72,13 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
         bool AllowOverType(BraceCompletionContext braceCompletionContext, CancellationToken cancellationToken);
     }
 
-    internal readonly struct BraceCompletionResult
+    internal readonly struct BraceCompletionResult(ImmutableArray<TextChange> textChanges, LinePosition caretLocation)
     {
         /// <summary>
         /// The set of text changes that should be applied to the input text to retrieve the
         /// brace completion result.
         /// </summary>
-        public ImmutableArray<TextChange> TextChanges { get; }
+        public ImmutableArray<TextChange> TextChanges { get; } = textChanges;
 
         /// <summary>
         /// The caret location in the new text created by applying all <see cref="TextChanges"/>
@@ -88,32 +88,18 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
         /// For example, placing the character in virtual space (when suppported)
         /// or inserting an appropriate number of spaces into the document".
         /// </summary>
-        public LinePosition CaretLocation { get; }
-
-        public BraceCompletionResult(ImmutableArray<TextChange> textChanges, LinePosition caretLocation)
-        {
-            CaretLocation = caretLocation;
-            TextChanges = textChanges;
-        }
+        public LinePosition CaretLocation { get; } = caretLocation;
     }
 
-    internal readonly struct BraceCompletionContext
+    internal readonly struct BraceCompletionContext(ParsedDocument document, int openingPoint, int closingPoint, int caretLocation)
     {
-        public ParsedDocument Document { get; }
+        public ParsedDocument Document { get; } = document;
 
-        public int OpeningPoint { get; }
+        public int OpeningPoint { get; } = openingPoint;
 
-        public int ClosingPoint { get; }
+        public int ClosingPoint { get; } = closingPoint;
 
-        public int CaretLocation { get; }
-
-        public BraceCompletionContext(ParsedDocument document, int openingPoint, int closingPoint, int caretLocation)
-        {
-            Document = document;
-            OpeningPoint = openingPoint;
-            ClosingPoint = closingPoint;
-            CaretLocation = caretLocation;
-        }
+        public int CaretLocation { get; } = caretLocation;
 
         public bool HasCompletionForOpeningBrace(char openingBrace)
             => ClosingPoint >= 1 && Document.Text[OpeningPoint] == openingBrace;

--- a/src/Features/Core/Portable/BraceMatching/BraceCharacterAndKind.cs
+++ b/src/Features/Core/Portable/BraceMatching/BraceCharacterAndKind.cs
@@ -6,15 +6,9 @@ using Microsoft;
 
 namespace Microsoft.CodeAnalysis.BraceMatching
 {
-    internal readonly struct BraceCharacterAndKind
+    internal readonly struct BraceCharacterAndKind(char character, int kind)
     {
-        public char Character { get; }
-        public int Kind { get; }
-
-        public BraceCharacterAndKind(char character, int kind)
-        {
-            this.Character = character;
-            this.Kind = kind;
-        }
+        public char Character { get; } = character;
+        public int Kind { get; } = kind;
     }
 }

--- a/src/Features/Core/Portable/BraceMatching/BraceMatchingService.cs
+++ b/src/Features/Core/Portable/BraceMatching/BraceMatchingService.cs
@@ -16,17 +16,12 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.BraceMatching
 {
     [Export(typeof(IBraceMatchingService)), Shared]
-    internal class BraceMatchingService : IBraceMatchingService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class BraceMatchingService(
+        [ImportMany] IEnumerable<Lazy<IBraceMatcher, LanguageMetadata>> braceMatchers) : IBraceMatchingService
     {
-        private readonly ImmutableArray<Lazy<IBraceMatcher, LanguageMetadata>> _braceMatchers;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public BraceMatchingService(
-            [ImportMany] IEnumerable<Lazy<IBraceMatcher, LanguageMetadata>> braceMatchers)
-        {
-            _braceMatchers = braceMatchers.ToImmutableArray();
-        }
+        private readonly ImmutableArray<Lazy<IBraceMatcher, LanguageMetadata>> _braceMatchers = braceMatchers.ToImmutableArray();
 
         public async Task<BraceMatchingResult?> GetMatchingBracesAsync(Document document, int position, BraceMatchingOptions options, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/BraceMatching/ExportBraceMatcherAttribute.cs
+++ b/src/Features/Core/Portable/BraceMatching/ExportBraceMatcherAttribute.cs
@@ -11,14 +11,8 @@ namespace Microsoft.CodeAnalysis.BraceMatching
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class ExportBraceMatcherAttribute : ExportAttribute
+    internal sealed class ExportBraceMatcherAttribute(string language) : ExportAttribute(typeof(IBraceMatcher))
     {
-        public string Language { get; }
-
-        public ExportBraceMatcherAttribute(string language)
-            : base(typeof(IBraceMatcher))
-        {
-            this.Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
     }
 }

--- a/src/Features/Core/Portable/BraceMatching/ExportEmbeddedLanguageBraceMatcherAttribute.cs
+++ b/src/Features/Core/Portable/BraceMatching/ExportEmbeddedLanguageBraceMatcherAttribute.cs
@@ -9,17 +9,12 @@ namespace Microsoft.CodeAnalysis.BraceMatching
     /// <summary>
     /// Use this attribute to export a <see cref="IEmbeddedLanguageBraceMatcher"/>.
     /// </summary>
-    internal class ExportEmbeddedLanguageBraceMatcherAttribute : ExportEmbeddedLanguageFeatureServiceAttribute
+    internal class ExportEmbeddedLanguageBraceMatcherAttribute(
+        string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers) : ExportEmbeddedLanguageFeatureServiceAttribute(typeof(IEmbeddedLanguageBraceMatcher), name, languages, supportsUnannotatedAPIs, identifiers)
     {
         public ExportEmbeddedLanguageBraceMatcherAttribute(
             string name, string[] languages, params string[] identifiers)
             : this(name, languages, supportsUnannotatedAPIs: false, identifiers)
-        {
-        }
-
-        public ExportEmbeddedLanguageBraceMatcherAttribute(
-            string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers)
-            : base(typeof(IEmbeddedLanguageBraceMatcher), name, languages, supportsUnannotatedAPIs, identifiers)
         {
         }
     }

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureAnalyzedContext.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureAnalyzedContext.cs
@@ -10,34 +10,20 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
     {
     }
 
-    internal sealed class ChangeSignatureAnalysisSucceededContext : ChangeSignatureAnalyzedContext
+    internal sealed class ChangeSignatureAnalysisSucceededContext(
+        Document document, int positionForTypeBinding, ISymbol symbol, ParameterConfiguration parameterConfiguration, CodeCleanupOptionsProvider fallbackOptions) : ChangeSignatureAnalyzedContext
     {
-        public readonly Document Document;
-        public readonly ISymbol Symbol;
-        public readonly ParameterConfiguration ParameterConfiguration;
-        public readonly int PositionForTypeBinding;
-        public readonly CodeCleanupOptionsProvider FallbackOptions;
-
-        public ChangeSignatureAnalysisSucceededContext(
-            Document document, int positionForTypeBinding, ISymbol symbol, ParameterConfiguration parameterConfiguration, CodeCleanupOptionsProvider fallbackOptions)
-        {
-            Document = document;
-            Symbol = symbol;
-            ParameterConfiguration = parameterConfiguration;
-            PositionForTypeBinding = positionForTypeBinding;
-            FallbackOptions = fallbackOptions;
-        }
+        public readonly Document Document = document;
+        public readonly ISymbol Symbol = symbol;
+        public readonly ParameterConfiguration ParameterConfiguration = parameterConfiguration;
+        public readonly int PositionForTypeBinding = positionForTypeBinding;
+        public readonly CodeCleanupOptionsProvider FallbackOptions = fallbackOptions;
 
         public Solution Solution => Document.Project.Solution;
     }
 
-    internal sealed class CannotChangeSignatureAnalyzedContext : ChangeSignatureAnalyzedContext
+    internal sealed class CannotChangeSignatureAnalyzedContext(ChangeSignatureFailureKind reason) : ChangeSignatureAnalyzedContext
     {
-        public readonly ChangeSignatureFailureKind CannotChangeSignatureReason;
-
-        public CannotChangeSignatureAnalyzedContext(ChangeSignatureFailureKind reason)
-        {
-            CannotChangeSignatureReason = reason;
-        }
+        public readonly ChangeSignatureFailureKind CannotChangeSignatureReason = reason;
     }
 }

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -14,22 +14,16 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ChangeSignature
 {
-    internal class ChangeSignatureCodeAction : CodeActionWithOptions
+    internal class ChangeSignatureCodeAction(AbstractChangeSignatureService changeSignatureService, ChangeSignatureAnalysisSucceededContext context) : CodeActionWithOptions
     {
-        private readonly AbstractChangeSignatureService _changeSignatureService;
-        private readonly ChangeSignatureAnalysisSucceededContext _context;
+        private readonly AbstractChangeSignatureService _changeSignatureService = changeSignatureService;
+        private readonly ChangeSignatureAnalysisSucceededContext _context = context;
 
         /// <summary>
         /// This code action currently pops up a confirmation dialog to the user.  As such, it does more than make
         /// document changes (and is thus restricted in which hosts it can run).
         /// </summary>
         public override ImmutableArray<string> Tags => RequiresNonDocumentChangeTags;
-
-        public ChangeSignatureCodeAction(AbstractChangeSignatureService changeSignatureService, ChangeSignatureAnalysisSucceededContext context)
-        {
-            _changeSignatureService = changeSignatureService;
-            _context = context;
-        }
 
         public override string Title => FeaturesResources.Change_signature;
 

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeActionOperation.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeActionOperation.cs
@@ -17,17 +17,11 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
     /// This is used instead of <see cref="ApplyChangesOperation"/> as we need to show a confirmation
     /// dialog to the user before applying the change.
     /// </summary>
-    internal sealed class ChangeSignatureCodeActionOperation : CodeActionOperation
+    internal sealed class ChangeSignatureCodeActionOperation(Solution changedSolution, string? confirmationMessage) : CodeActionOperation
     {
-        public Solution ChangedSolution { get; }
+        public Solution ChangedSolution { get; } = changedSolution ?? throw new ArgumentNullException(nameof(changedSolution));
 
-        public string? ConfirmationMessage { get; }
-
-        public ChangeSignatureCodeActionOperation(Solution changedSolution, string? confirmationMessage)
-        {
-            ChangedSolution = changedSolution ?? throw new ArgumentNullException(nameof(changedSolution));
-            ConfirmationMessage = confirmationMessage;
-        }
+        public string? ConfirmationMessage { get; } = confirmationMessage;
 
         internal override bool ApplyDuringTests => true;
 

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureOptionsResult.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureOptionsResult.cs
@@ -7,15 +7,9 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
     /// <summary>
     /// A value of null indicates that the operation has been cancelled.
     /// </summary>
-    internal sealed class ChangeSignatureOptionsResult
+    internal sealed class ChangeSignatureOptionsResult(SignatureChange updatedSignature, bool previewChanges)
     {
-        public readonly bool PreviewChanges;
-        public readonly SignatureChange UpdatedSignature;
-
-        public ChangeSignatureOptionsResult(SignatureChange updatedSignature, bool previewChanges)
-        {
-            UpdatedSignature = updatedSignature;
-            PreviewChanges = previewChanges;
-        }
+        public readonly bool PreviewChanges = previewChanges;
+        public readonly SignatureChange UpdatedSignature = updatedSignature;
     }
 }

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureResult.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureResult.cs
@@ -6,37 +6,26 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.ChangeSignature
 {
-    internal sealed class ChangeSignatureResult
+    internal sealed class ChangeSignatureResult(
+        bool succeeded,
+        Solution? updatedSolution = null,
+        string? name = null,
+        Glyph? glyph = null,
+        bool previewChanges = false,
+        ChangeSignatureFailureKind? changeSignatureFailureKind = null,
+        string? confirmationMessage = null)
     {
         [MemberNotNullWhen(true, nameof(UpdatedSolution))]
-        public bool Succeeded { get; }
-        public Solution? UpdatedSolution { get; }
-        public Glyph? Glyph { get; }
-        public bool PreviewChanges { get; }
-        public ChangeSignatureFailureKind? ChangeSignatureFailureKind { get; }
-        public string? ConfirmationMessage { get; }
+        public bool Succeeded { get; } = succeeded;
+        public Solution? UpdatedSolution { get; } = updatedSolution;
+        public Glyph? Glyph { get; } = glyph;
+        public bool PreviewChanges { get; } = previewChanges;
+        public ChangeSignatureFailureKind? ChangeSignatureFailureKind { get; } = changeSignatureFailureKind;
+        public string? ConfirmationMessage { get; } = confirmationMessage;
 
         /// <summary>
         /// Name of the symbol. Needed here for the Preview Changes dialog.
         /// </summary>
-        public string? Name { get; }
-
-        public ChangeSignatureResult(
-            bool succeeded,
-            Solution? updatedSolution = null,
-            string? name = null,
-            Glyph? glyph = null,
-            bool previewChanges = false,
-            ChangeSignatureFailureKind? changeSignatureFailureKind = null,
-            string? confirmationMessage = null)
-        {
-            Succeeded = succeeded;
-            UpdatedSolution = updatedSolution;
-            Name = name;
-            Glyph = glyph;
-            PreviewChanges = previewChanges;
-            ChangeSignatureFailureKind = changeSignatureFailureKind;
-            ConfirmationMessage = confirmationMessage;
-        }
+        public string? Name { get; } = name;
     }
 }

--- a/src/Features/Core/Portable/ChangeSignature/Parameter.cs
+++ b/src/Features/Core/Portable/ChangeSignature/Parameter.cs
@@ -16,14 +16,9 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         public abstract string Name { get; }
     }
 
-    internal sealed class ExistingParameter : Parameter
+    internal sealed class ExistingParameter(IParameterSymbol param) : Parameter
     {
-        public IParameterSymbol Symbol { get; }
-
-        public ExistingParameter(IParameterSymbol param)
-        {
-            Symbol = param;
-        }
+        public IParameterSymbol Symbol { get; } = param;
 
         public override bool HasDefaultValue => Symbol.HasExplicitDefaultValue;
         public override string Name => Symbol.Name;

--- a/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
@@ -8,27 +8,18 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.ChangeSignature
 {
-    internal sealed class ParameterConfiguration
+    internal sealed class ParameterConfiguration(
+        ExistingParameter? thisParameter,
+        ImmutableArray<Parameter> parametersWithoutDefaultValues,
+        ImmutableArray<Parameter> remainingEditableParameters,
+        ExistingParameter? paramsParameter,
+        int selectedIndex)
     {
-        public readonly ExistingParameter? ThisParameter;
-        public readonly ImmutableArray<Parameter> ParametersWithoutDefaultValues;
-        public readonly ImmutableArray<Parameter> RemainingEditableParameters;
-        public readonly ExistingParameter? ParamsParameter;
-        public readonly int SelectedIndex;
-
-        public ParameterConfiguration(
-            ExistingParameter? thisParameter,
-            ImmutableArray<Parameter> parametersWithoutDefaultValues,
-            ImmutableArray<Parameter> remainingEditableParameters,
-            ExistingParameter? paramsParameter,
-            int selectedIndex)
-        {
-            ThisParameter = thisParameter;
-            ParametersWithoutDefaultValues = parametersWithoutDefaultValues;
-            RemainingEditableParameters = remainingEditableParameters;
-            ParamsParameter = paramsParameter;
-            SelectedIndex = selectedIndex;
-        }
+        public readonly ExistingParameter? ThisParameter = thisParameter;
+        public readonly ImmutableArray<Parameter> ParametersWithoutDefaultValues = parametersWithoutDefaultValues;
+        public readonly ImmutableArray<Parameter> RemainingEditableParameters = remainingEditableParameters;
+        public readonly ExistingParameter? ParamsParameter = paramsParameter;
+        public readonly int SelectedIndex = selectedIndex;
 
         public static ParameterConfiguration Create(ImmutableArray<Parameter> parameters, bool isExtensionMethod, int selectedIndex)
         {

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpan.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpan.cs
@@ -9,19 +9,13 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
-    internal readonly struct ClassifiedSpansAndHighlightSpan
+    internal readonly struct ClassifiedSpansAndHighlightSpan(
+        ImmutableArray<ClassifiedSpan> classifiedSpans,
+        TextSpan highlightSpan)
     {
         public const string Key = nameof(ClassifiedSpansAndHighlightSpan);
 
-        public readonly ImmutableArray<ClassifiedSpan> ClassifiedSpans;
-        public readonly TextSpan HighlightSpan;
-
-        public ClassifiedSpansAndHighlightSpan(
-            ImmutableArray<ClassifiedSpan> classifiedSpans,
-            TextSpan highlightSpan)
-        {
-            ClassifiedSpans = classifiedSpans;
-            HighlightSpan = highlightSpan;
-        }
+        public readonly ImmutableArray<ClassifiedSpan> ClassifiedSpans = classifiedSpans;
+        public readonly TextSpan HighlightSpan = highlightSpan;
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixCollection.cs
@@ -13,33 +13,23 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// Represents a collection of <see cref="CodeFix"/>es supplied by a given fix provider
     /// (such as <see cref="CodeFixProvider"/> or <see cref="IConfigurationFixProvider"/>).
     /// </summary>
-    internal class CodeFixCollection
+    internal class CodeFixCollection(
+        object provider,
+        TextSpan span,
+        ImmutableArray<CodeFix> fixes,
+        FixAllState fixAllState,
+        ImmutableArray<FixAllScope> supportedScopes,
+        Diagnostic firstDiagnostic)
     {
-        public object Provider { get; }
-        public TextSpan TextSpan { get; }
-        public ImmutableArray<CodeFix> Fixes { get; }
+        public object Provider { get; } = provider;
+        public TextSpan TextSpan { get; } = span;
+        public ImmutableArray<CodeFix> Fixes { get; } = fixes.NullToEmpty();
 
         /// <summary>
         /// Optional fix all context, which is non-null if the given <see cref="Provider"/> supports fix all occurrences code fix.
         /// </summary>
-        public FixAllState FixAllState { get; }
-        public ImmutableArray<FixAllScope> SupportedScopes { get; }
-        public Diagnostic FirstDiagnostic { get; }
-
-        public CodeFixCollection(
-            object provider,
-            TextSpan span,
-            ImmutableArray<CodeFix> fixes,
-            FixAllState fixAllState,
-            ImmutableArray<FixAllScope> supportedScopes,
-            Diagnostic firstDiagnostic)
-        {
-            Provider = provider;
-            TextSpan = span;
-            Fixes = fixes.NullToEmpty();
-            FixAllState = fixAllState;
-            SupportedScopes = supportedScopes.NullToEmpty();
-            FirstDiagnostic = firstDiagnostic;
-        }
+        public FixAllState FixAllState { get; } = fixAllState;
+        public ImmutableArray<FixAllScope> SupportedScopes { get; } = supportedScopes.NullToEmpty();
+        public Diagnostic FirstDiagnostic { get; } = firstDiagnostic;
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelBulkConfigureSeverityCodeAction.cs
@@ -9,20 +9,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 {
     internal sealed partial class ConfigureSeverityLevelCodeFixProvider : IConfigurationFixProvider
     {
-        private sealed class TopLevelBulkConfigureSeverityCodeAction : AbstractConfigurationActionWithNestedActions
-        {
-            public TopLevelBulkConfigureSeverityCodeAction(ImmutableArray<CodeAction> nestedActions, string? category)
-                : base(nestedActions,
-                      category != null
+        private sealed class TopLevelBulkConfigureSeverityCodeAction(ImmutableArray<CodeAction> nestedActions, string? category) : AbstractConfigurationActionWithNestedActions(nestedActions,
+                  category != null
                         ? string.Format(FeaturesResources.Configure_severity_for_all_0_analyzers, category)
                         : FeaturesResources.Configure_severity_for_all_analyzers)
-            {
-                // Ensure that 'Category' based bulk configuration actions are shown above
-                // the 'All analyzer diagnostics' bulk configuration actions.
-                AdditionalPriority = category != null ? CodeActionPriority.Low : CodeActionPriority.Lowest;
-            }
-
-            internal override CodeActionPriority AdditionalPriority { get; }
+        {
+            internal override CodeActionPriority AdditionalPriority { get; } = category != null ? CodeActionPriority.Low : CodeActionPriority.Lowest;
 
             internal override bool IsBulkConfigurationAction => true;
         }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelConfigureSeverityCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.TopLevelConfigureSeverityCodeAction.cs
@@ -11,12 +11,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 {
     internal sealed partial class ConfigureSeverityLevelCodeFixProvider : IConfigurationFixProvider
     {
-        private sealed class TopLevelConfigureSeverityCodeAction : AbstractConfigurationActionWithNestedActions
+        private sealed class TopLevelConfigureSeverityCodeAction(Diagnostic diagnostic, ImmutableArray<CodeAction> nestedActions) : AbstractConfigurationActionWithNestedActions(nestedActions, string.Format(FeaturesResources.Configure_0_severity, diagnostic.Id))
         {
-            public TopLevelConfigureSeverityCodeAction(Diagnostic diagnostic, ImmutableArray<CodeAction> nestedActions)
-                : base(nestedActions, string.Format(FeaturesResources.Configure_0_severity, diagnostic.Id))
-            {
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/FirstFixResult.cs
+++ b/src/Features/Core/Portable/CodeFixes/FirstFixResult.cs
@@ -6,18 +6,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CodeFixes
 {
-    internal readonly struct FirstFixResult
+    internal readonly struct FirstFixResult(bool upToDate, CodeFixCollection? codeFixCollection)
     {
-        public readonly bool UpToDate;
-        public readonly CodeFixCollection? CodeFixCollection;
+        public readonly bool UpToDate = upToDate;
+        public readonly CodeFixCollection? CodeFixCollection = codeFixCollection;
 
         [MemberNotNullWhen(true, nameof(CodeFixCollection))]
         public bool HasFix => CodeFixCollection != null;
-
-        public FirstFixResult(bool upToDate, CodeFixCollection? codeFixCollection)
-        {
-            UpToDate = upToDate;
-            CodeFixCollection = codeFixCollection;
-        }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixMultipleCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixMultipleCodeAction.cs
@@ -8,20 +8,13 @@ using Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
 
 namespace Microsoft.CodeAnalysis.CodeFixes
 {
-    internal partial class FixMultipleCodeAction : AbstractFixAllCodeFixCodeAction
+    internal partial class FixMultipleCodeAction(
+        IFixAllState fixAllState,
+        string title,
+        string computingFixWaitDialogMessage) : AbstractFixAllCodeFixCodeAction(fixAllState, showPreviewChangesDialog: false)
     {
-        private readonly string _title;
-        private readonly string _computingFixWaitDialogMessage;
-
-        public FixMultipleCodeAction(
-            IFixAllState fixAllState,
-            string title,
-            string computingFixWaitDialogMessage)
-            : base(fixAllState, showPreviewChangesDialog: false)
-        {
-            _title = title;
-            _computingFixWaitDialogMessage = computingFixWaitDialogMessage;
-        }
+        private readonly string _title = title;
+        private readonly string _computingFixWaitDialogMessage = computingFixWaitDialogMessage;
 
         public override string Title => _title;
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
@@ -15,25 +15,16 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 {
     internal abstract partial class AbstractSuppressionCodeFixProvider : IConfigurationFixProvider
     {
-        internal sealed class GlobalSuppressMessageCodeAction : AbstractGlobalSuppressMessageCodeAction
+        internal sealed class GlobalSuppressMessageCodeAction(
+            ISymbol targetSymbol, INamedTypeSymbol suppressMessageAttribute,
+            Project project, Diagnostic diagnostic,
+            AbstractSuppressionCodeFixProvider fixer,
+            CodeActionOptionsProvider fallbackOptions) : AbstractGlobalSuppressMessageCodeAction(fixer, project)
         {
-            private readonly ISymbol _targetSymbol;
-            private readonly INamedTypeSymbol _suppressMessageAttribute;
-            private readonly Diagnostic _diagnostic;
-            private readonly CodeActionOptionsProvider _fallbackOptions;
-
-            public GlobalSuppressMessageCodeAction(
-                ISymbol targetSymbol, INamedTypeSymbol suppressMessageAttribute,
-                Project project, Diagnostic diagnostic,
-                AbstractSuppressionCodeFixProvider fixer,
-                CodeActionOptionsProvider fallbackOptions)
-                : base(fixer, project)
-            {
-                _targetSymbol = targetSymbol;
-                _suppressMessageAttribute = suppressMessageAttribute;
-                _diagnostic = diagnostic;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly ISymbol _targetSymbol = targetSymbol;
+            private readonly INamedTypeSymbol _suppressMessageAttribute = suppressMessageAttribute;
+            private readonly Diagnostic _diagnostic = diagnostic;
+            private readonly CodeActionOptionsProvider _fallbackOptions = fallbackOptions;
 
             protected override async Task<Document> GetChangedSuppressionDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageFixAllCodeAction.cs
@@ -56,13 +56,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                     equivalenceKey: title);
             }
 
-            private class GlobalSuppressionSolutionChangeAction : SolutionChangeAction
+            private class GlobalSuppressionSolutionChangeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey) : SolutionChangeAction(title, createChangedSolution, equivalenceKey)
             {
-                public GlobalSuppressionSolutionChangeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey)
-                    : base(title, createChangedSolution, equivalenceKey)
-                {
-                }
-
                 protected override Task<Document> PostProcessChangesAsync(Document document, CancellationToken cancellationToken)
                 {
                     // PERF: We don't to formatting on the entire global suppressions document, but instead do it for each attribute individual in the fixer.

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.LocalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.LocalSuppressMessageCodeAction.cs
@@ -11,31 +11,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 {
     internal abstract partial class AbstractSuppressionCodeFixProvider : IConfigurationFixProvider
     {
-        internal sealed class LocalSuppressMessageCodeAction : AbstractSuppressionCodeAction
+        internal sealed class LocalSuppressMessageCodeAction(
+            AbstractSuppressionCodeFixProvider fixer,
+            ISymbol targetSymbol,
+            INamedTypeSymbol suppressMessageAttribute,
+            SyntaxNode targetNode,
+            Document document,
+            Diagnostic diagnostic) : AbstractSuppressionCodeAction(fixer, FeaturesResources.in_Source_attribute)
         {
-            private readonly AbstractSuppressionCodeFixProvider _fixer;
-            private readonly ISymbol _targetSymbol;
-            private readonly INamedTypeSymbol _suppressMessageAttribute;
-            private readonly SyntaxNode _targetNode;
-            private readonly Document _document;
-            private readonly Diagnostic _diagnostic;
-
-            public LocalSuppressMessageCodeAction(
-                AbstractSuppressionCodeFixProvider fixer,
-                ISymbol targetSymbol,
-                INamedTypeSymbol suppressMessageAttribute,
-                SyntaxNode targetNode,
-                Document document,
-                Diagnostic diagnostic)
-                : base(fixer, FeaturesResources.in_Source_attribute)
-            {
-                _fixer = fixer;
-                _targetSymbol = targetSymbol;
-                _suppressMessageAttribute = suppressMessageAttribute;
-                _targetNode = targetNode;
-                _document = document;
-                _diagnostic = diagnostic;
-            }
+            private readonly AbstractSuppressionCodeFixProvider _fixer = fixer;
+            private readonly ISymbol _targetSymbol = targetSymbol;
+            private readonly INamedTypeSymbol _suppressMessageAttribute = suppressMessageAttribute;
+            private readonly SyntaxNode _targetNode = targetNode;
+            private readonly Document _document = document;
+            private readonly Diagnostic _diagnostic = diagnostic;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.PragmaWarningBatchFixAllProvider.cs
@@ -20,12 +20,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         /// <summary>
         /// Batch fixer for pragma suppress code action.
         /// </summary>
-        internal sealed class PragmaWarningBatchFixAllProvider : AbstractSuppressionBatchFixAllProvider
+        internal sealed class PragmaWarningBatchFixAllProvider(AbstractSuppressionCodeFixProvider suppressionFixProvider) : AbstractSuppressionBatchFixAllProvider
         {
-            private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider;
-
-            public PragmaWarningBatchFixAllProvider(AbstractSuppressionCodeFixProvider suppressionFixProvider)
-                => _suppressionFixProvider = suppressionFixProvider;
+            private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider = suppressionFixProvider;
 
             protected override async Task AddDocumentFixesAsync(
                 Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
@@ -26,12 +26,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             /// <summary>
             /// Batch fixer for pragma suppression removal code action.
             /// </summary>
-            private sealed class RemoveSuppressionBatchFixAllProvider : AbstractSuppressionBatchFixAllProvider
+            private sealed class RemoveSuppressionBatchFixAllProvider(AbstractSuppressionCodeFixProvider suppressionFixProvider) : AbstractSuppressionBatchFixAllProvider
             {
-                private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider;
-
-                public RemoveSuppressionBatchFixAllProvider(AbstractSuppressionCodeFixProvider suppressionFixProvider)
-                    => _suppressionFixProvider = suppressionFixProvider;
+                private readonly AbstractSuppressionCodeFixProvider _suppressionFixProvider = suppressionFixProvider;
 
                 protected override async Task AddDocumentFixesAsync(
                     Document document, ImmutableArray<Diagnostic> diagnostics,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/TopLevelSuppressionCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/TopLevelSuppressionCodeAction.cs
@@ -9,11 +9,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 {
-    internal sealed class TopLevelSuppressionCodeAction : AbstractConfigurationActionWithNestedActions
+    internal sealed class TopLevelSuppressionCodeAction(Diagnostic diagnostic, ImmutableArray<NestedSuppressionCodeAction> nestedActions) : AbstractConfigurationActionWithNestedActions(ImmutableArray<CodeAction>.CastUp(nestedActions), string.Format(FeaturesResources.Suppress_0, diagnostic.Id))
     {
-        public TopLevelSuppressionCodeAction(Diagnostic diagnostic, ImmutableArray<NestedSuppressionCodeAction> nestedActions)
-            : base(ImmutableArray<CodeAction>.CastUp(nestedActions), string.Format(FeaturesResources.Suppress_0, diagnostic.Id))
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -11,16 +11,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 {
-    internal sealed class WrapperCodeFixProvider : CodeFixProvider
+    internal sealed class WrapperCodeFixProvider(IConfigurationFixProvider suppressionFixProvider, IEnumerable<string> diagnosticIds) : CodeFixProvider
     {
-        private readonly ImmutableArray<string> _originalDiagnosticIds;
-        private readonly IConfigurationFixProvider _suppressionFixProvider;
-
-        public WrapperCodeFixProvider(IConfigurationFixProvider suppressionFixProvider, IEnumerable<string> diagnosticIds)
-        {
-            _suppressionFixProvider = suppressionFixProvider;
-            _originalDiagnosticIds = diagnosticIds.Distinct().ToImmutableArray();
-        }
+        private readonly ImmutableArray<string> _originalDiagnosticIds = diagnosticIds.Distinct().ToImmutableArray();
+        private readonly IConfigurationFixProvider _suppressionFixProvider = suppressionFixProvider;
 
         public IConfigurationFixProvider SuppressionFixProvider => _suppressionFixProvider;
         public override ImmutableArray<string> FixableDiagnosticIds => _originalDiagnosticIds;

--- a/src/Features/Core/Portable/CodeFixesAndRefactorings/CodeActionRequestPriorityProvider.cs
+++ b/src/Features/Core/Portable/CodeFixesAndRefactorings/CodeActionRequestPriorityProvider.cs
@@ -97,17 +97,12 @@ namespace Microsoft.CodeAnalysis.CodeActions
         }
     }
 
-    internal sealed class DefaultCodeActionRequestPriorityProvider : ICodeActionRequestPriorityProvider
+    internal sealed class DefaultCodeActionRequestPriorityProvider(CodeActionRequestPriority priority = CodeActionRequestPriority.None) : ICodeActionRequestPriorityProvider
     {
         private readonly object _gate = new();
         private HashSet<DiagnosticAnalyzer>? _lowPriorityAnalyzers;
 
-        public DefaultCodeActionRequestPriorityProvider(CodeActionRequestPriority priority = CodeActionRequestPriority.None)
-        {
-            Priority = priority;
-        }
-
-        public CodeActionRequestPriority Priority { get; }
+        public CodeActionRequestPriority Priority { get; } = priority;
 
         public void AddDeprioritizedAnalyzerWithLowPriority(DiagnosticAnalyzer analyzer)
         {

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -23,17 +23,21 @@ namespace Microsoft.CodeAnalysis.CodeLens
     /// <remarks>
     /// All public methods of this type could be called from multiple threads.
     /// </remarks>
-    internal sealed class CodeLensFindReferencesProgress : IFindReferencesProgress, IDisposable
+    internal sealed class CodeLensFindReferencesProgress(
+        ISymbol queriedDefinition,
+        SyntaxNode queriedNode,
+        int searchCap,
+        CancellationToken cancellationToken) : IFindReferencesProgress, IDisposable
     {
-        private readonly CancellationTokenSource _aggregateCancellationTokenSource;
-        private readonly SyntaxNode _queriedNode;
-        private readonly ISymbol _queriedSymbol;
-        private readonly ConcurrentSet<Location> _locations;
+        private readonly CancellationTokenSource _aggregateCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        private readonly SyntaxNode _queriedNode = queriedNode;
+        private readonly ISymbol _queriedSymbol = queriedDefinition;
+        private readonly ConcurrentSet<Location> _locations = new ConcurrentSet<Location>(LocationComparer.Instance);
 
         /// <remarks>
         /// If the cap is 0, then there is no cap.
         /// </remarks>
-        public int SearchCap { get; }
+        public int SearchCap { get; } = searchCap;
 
         /// <summary>
         /// The cancellation token that aggregates the original cancellation token + this progress
@@ -45,20 +49,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
         public int ReferencesCount => _locations.Count;
 
         public ImmutableArray<Location> Locations => _locations.ToImmutableArray();
-
-        public CodeLensFindReferencesProgress(
-            ISymbol queriedDefinition,
-            SyntaxNode queriedNode,
-            int searchCap,
-            CancellationToken cancellationToken)
-        {
-            _queriedSymbol = queriedDefinition;
-            _queriedNode = queriedNode;
-            _aggregateCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _locations = new ConcurrentSet<Location>(LocationComparer.Instance);
-
-            SearchCap = searchCap;
-        }
 
         public void OnStarted()
         {

--- a/src/Features/Core/Portable/CodeLens/ReferenceCount.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceCount.cs
@@ -12,29 +12,22 @@ namespace Microsoft.CodeAnalysis.CodeLens
     /// Represents the result of a FindReferences Count operation.
     /// </summary>
     [DataContract]
-    internal readonly struct ReferenceCount : IEquatable<ReferenceCount>
+    internal readonly struct ReferenceCount(int count, bool isCapped, string version) : IEquatable<ReferenceCount>
     {
         /// <summary>
         /// Represents the number of references to a given symbol.
         /// </summary>
         [DataMember(Order = 0)]
-        public int Count { get; }
+        public int Count { get; } = count;
 
         /// <summary>
         /// Represents if the count is capped by a certain maximum.
         /// </summary>
         [DataMember(Order = 1)]
-        public bool IsCapped { get; }
+        public bool IsCapped { get; } = isCapped;
 
         [DataMember(Order = 2)]
-        public string Version { get; }
-
-        public ReferenceCount(int count, bool isCapped, string version)
-        {
-            Count = count;
-            IsCapped = isCapped;
-            Version = version;
-        }
+        public string Version { get; } = version;
 
         public static bool operator ==(ReferenceCount left, ReferenceCount right)
         {

--- a/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
@@ -13,141 +13,119 @@ namespace Microsoft.CodeAnalysis.CodeLens
     /// Holds information required to display and navigate to individual references
     /// </summary>
     [DataContract]
-    internal sealed class ReferenceLocationDescriptor
+    internal sealed class ReferenceLocationDescriptor(
+        string longDescription,
+        string language,
+        Glyph? glyph,
+        int spanStart,
+        int spanLength,
+        int lineNumber,
+        int columnNumber,
+        Guid projectGuid,
+        Guid documentGuid,
+        string filePath,
+        string referenceLineText,
+        int referenceStart,
+        int referenceLength,
+        string beforeReferenceText1,
+        string beforeReferenceText2,
+        string afterReferenceText1,
+        string afterReferenceText2)
     {
         /// <summary>
         /// Fully qualified name of the symbol containing the reference location
         /// </summary>
         [DataMember(Order = 0)]
-        public string LongDescription { get; }
+        public string LongDescription { get; } = longDescription;
 
         /// <summary>
         /// Language of the reference location
         /// </summary>
         [DataMember(Order = 1)]
-        public string Language { get; }
+        public string Language { get; } = language;
 
         /// <summary>
         /// The kind of symbol containing the reference location (such as type, method, property, etc.)
         /// </summary>
         [DataMember(Order = 2)]
-        public Glyph? Glyph { get; }
+        public Glyph? Glyph { get; } = glyph;
 
         /// <summary>
         /// Reference's span start based on the document content
         /// </summary>
         [DataMember(Order = 3)]
-        public int SpanStart { get; }
+        public int SpanStart { get; } = spanStart;
 
         /// <summary>
         /// Reference's span length based on the document content
         /// </summary>
         [DataMember(Order = 4)]
-        public int SpanLength { get; }
+        public int SpanLength { get; } = spanLength;
 
         /// <summary>
         /// Reference's line based on the document content
         /// </summary>
         [DataMember(Order = 5)]
-        public int LineNumber { get; }
+        public int LineNumber { get; } = lineNumber;
 
         /// <summary>
         /// Reference's character based on the document content
         /// </summary>
         [DataMember(Order = 6)]
-        public int ColumnNumber { get; }
+        public int ColumnNumber { get; } = columnNumber;
 
         [DataMember(Order = 7)]
-        public Guid ProjectGuid { get; }
+        public Guid ProjectGuid { get; } = projectGuid;
 
         [DataMember(Order = 8)]
-        public Guid DocumentGuid { get; }
+        public Guid DocumentGuid { get; } = documentGuid;
 
         /// <summary>
         /// Document's file path
         /// </summary>
         [DataMember(Order = 9)]
-        public string FilePath { get; }
+        public string FilePath { get; } = filePath;
 
         /// <summary>
         /// the full line of source that contained the reference
         /// </summary>
         [DataMember(Order = 10)]
-        public string ReferenceLineText { get; }
+        public string ReferenceLineText { get; } = referenceLineText;
 
         /// <summary>
         /// the beginning of the span within reference text that was the use of the reference
         /// </summary>
         [DataMember(Order = 11)]
-        public int ReferenceStart { get; }
+        public int ReferenceStart { get; } = referenceStart;
 
         /// <summary>
         /// the length of the span of the reference
         /// </summary>
         [DataMember(Order = 12)]
-        public int ReferenceLength { get; }
+        public int ReferenceLength { get; } = referenceLength;
 
         /// <summary>
         /// Text above the line with the reference
         /// </summary>
         [DataMember(Order = 13)]
-        public string BeforeReferenceText1 { get; }
+        public string BeforeReferenceText1 { get; } = beforeReferenceText1;
 
         /// <summary>
         /// Text above the line with the reference
         /// </summary>
         [DataMember(Order = 14)]
-        public string BeforeReferenceText2 { get; }
+        public string BeforeReferenceText2 { get; } = beforeReferenceText2;
 
         /// <summary>
         /// Text below the line with the reference
         /// </summary>
         [DataMember(Order = 15)]
-        public string AfterReferenceText1 { get; }
+        public string AfterReferenceText1 { get; } = afterReferenceText1;
 
         /// <summary>
         /// Text below the line with the reference
         /// </summary>
         [DataMember(Order = 16)]
-        public string AfterReferenceText2 { get; }
-
-        public ReferenceLocationDescriptor(
-            string longDescription,
-            string language,
-            Glyph? glyph,
-            int spanStart,
-            int spanLength,
-            int lineNumber,
-            int columnNumber,
-            Guid projectGuid,
-            Guid documentGuid,
-            string filePath,
-            string referenceLineText,
-            int referenceStart,
-            int referenceLength,
-            string beforeReferenceText1,
-            string beforeReferenceText2,
-            string afterReferenceText1,
-            string afterReferenceText2)
-        {
-            LongDescription = longDescription;
-            Language = language;
-            Glyph = glyph;
-            SpanStart = spanStart;
-            SpanLength = spanLength;
-            LineNumber = lineNumber;
-            ColumnNumber = columnNumber;
-            // We want to keep track of the location's document if it comes from a file in your solution.
-            ProjectGuid = projectGuid;
-            DocumentGuid = documentGuid;
-            FilePath = filePath;
-            ReferenceLineText = referenceLineText;
-            ReferenceStart = referenceStart;
-            ReferenceLength = referenceLength;
-            BeforeReferenceText1 = beforeReferenceText1;
-            BeforeReferenceText2 = beforeReferenceText2;
-            AfterReferenceText1 = afterReferenceText1;
-            AfterReferenceText2 = afterReferenceText2;
-        }
+        public string AfterReferenceText2 { get; } = afterReferenceText2;
     }
 }

--- a/src/Features/Core/Portable/CodeLens/ReferenceMethodDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceMethodDescriptor.cs
@@ -12,40 +12,24 @@ namespace Microsoft.CodeAnalysis.CodeLens
     /// A caller method of a callee
     /// </summary>
     [DataContract]
-    internal sealed class ReferenceMethodDescriptor
+    internal sealed class ReferenceMethodDescriptor(string fullName, string filePath, string outputFilePath)
     {
         /// <summary>
         ///  Returns method's fully quilified name without parameters
         /// </summary>
         [DataMember(Order = 0)]
-        public string FullName { get; private set; }
+        public string FullName { get; private set; } = fullName;
 
         /// <summary>
         /// Returns method's file path.
         /// </summary>
         [DataMember(Order = 1)]
-        public string FilePath { get; private set; }
+        public string FilePath { get; private set; } = filePath;
 
         /// <summary>
         /// Returns output file path for the project containing the method.
         /// </summary>
         [DataMember(Order = 2)]
-        public string OutputFilePath { get; private set; }
-
-        /// <summary>
-        /// Describe a caller method of a callee
-        /// </summary>
-        /// <param name="fullName">Method's fully qualified name</param>
-        /// <param name="filePath">Method full path</param>
-        /// <remarks>
-        ///  Method full name is expected to be in the .NET full name type convention. That is,
-        ///  namespace/type is delimited by '.' and nested type is delimited by '+'
-        /// </remarks>
-        public ReferenceMethodDescriptor(string fullName, string filePath, string outputFilePath)
-        {
-            FullName = fullName;
-            FilePath = filePath;
-            OutputFilePath = outputFilePath;
-        }
+        public string OutputFilePath { get; private set; } = outputFilePath;
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -238,12 +238,9 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             return (projectChanges, textChanges);
         }
 
-        protected sealed class CleanUpNewLinesFormatter : AbstractFormattingRule
+        protected sealed class CleanUpNewLinesFormatter(SourceText text) : AbstractFormattingRule
         {
-            private readonly SourceText _text;
-
-            public CleanUpNewLinesFormatter(SourceText text)
-                => _text = text;
+            private readonly SourceText _text = text;
 
             public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -13,13 +13,10 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.AddMissingImports
 {
-    internal abstract class AbstractAddMissingImportsRefactoringProvider : CodeRefactoringProvider
+    internal abstract class AbstractAddMissingImportsRefactoringProvider(IPasteTrackingService? pasteTrackingService) : CodeRefactoringProvider
     {
-        private readonly IPasteTrackingService? _pasteTrackingService;
+        private readonly IPasteTrackingService? _pasteTrackingService = pasteTrackingService;
         protected abstract string CodeActionTitle { get; }
-
-        public AbstractAddMissingImportsRefactoringProvider(IPasteTrackingService? pasteTrackingService)
-            => _pasteTrackingService = pasteTrackingService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AddMissingImportsAnalysisResult.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AddMissingImportsAnalysisResult.cs
@@ -7,15 +7,10 @@ using Microsoft.CodeAnalysis.AddImport;
 
 namespace Microsoft.CodeAnalysis.AddMissingImports
 {
-    internal sealed class AddMissingImportsAnalysisResult
+    internal sealed class AddMissingImportsAnalysisResult(
+        ImmutableArray<AddImportFixData> addImportFixData)
     {
-        public ImmutableArray<AddImportFixData> AddImportFixData { get; }
+        public ImmutableArray<AddImportFixData> AddImportFixData { get; } = addImportFixData;
         public bool CanAddMissingImports => !AddImportFixData.IsEmpty;
-
-        public AddMissingImportsAnalysisResult(
-            ImmutableArray<AddImportFixData> addImportFixData)
-        {
-            AddImportFixData = addImportFixData;
-        }
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/FixAllOccurences/FixAllCodeRefactoringCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/FixAllOccurences/FixAllCodeRefactoringCodeAction.cs
@@ -11,13 +11,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     /// <summary>
     /// Fix all code action for a code action registered by a <see cref="CodeRefactoringProvider"/>.
     /// </summary>
-    internal sealed class FixAllCodeRefactoringCodeAction : AbstractFixAllCodeAction
+    internal sealed class FixAllCodeRefactoringCodeAction(IFixAllState fixAllState) : AbstractFixAllCodeAction(fixAllState, showPreviewChangesDialog: true)
     {
-        public FixAllCodeRefactoringCodeAction(IFixAllState fixAllState)
-            : base(fixAllState, showPreviewChangesDialog: true)
-        {
-        }
-
         protected override IFixAllContext CreateFixAllContext(IFixAllState fixAllState, IProgressTracker progressTracker, CancellationToken cancellationToken)
             => new FixAllContext((FixAllState)fixAllState, progressTracker, cancellationToken);
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.Editor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.Editor.cs
@@ -18,24 +18,16 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
         /// <summary>
         /// An abstract class for different edits performed by the Move Type Code Action.
         /// </summary>
-        private abstract class Editor
+        private abstract class Editor(
+            TService service,
+            State state,
+            string fileName,
+            CancellationToken cancellationToken)
         {
-            public Editor(
-                TService service,
-                State state,
-                string fileName,
-                CancellationToken cancellationToken)
-            {
-                State = state;
-                Service = service;
-                FileName = fileName;
-                CancellationToken = cancellationToken;
-            }
-
-            protected State State { get; }
-            protected TService Service { get; }
-            protected string FileName { get; }
-            protected CancellationToken CancellationToken { get; }
+            protected State State { get; } = state;
+            protected TService Service { get; } = service;
+            protected string FileName { get; } = fileName;
+            protected CancellationToken CancellationToken { get; } = cancellationToken;
             protected SemanticDocument SemanticDocument => State.SemanticDocument;
 
             /// <summary>

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -22,15 +22,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 {
     internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarationSyntax, TNamespaceDeclarationSyntax, TMemberDeclarationSyntax, TCompilationUnitSyntax>
     {
-        private sealed class MoveTypeEditor : Editor
+        private sealed class MoveTypeEditor(
+            TService service,
+            State state,
+            string fileName,
+            CancellationToken cancellationToken) : Editor(service, state, fileName, cancellationToken)
         {
-            public MoveTypeEditor(
-                TService service,
-                State state,
-                string fileName,
-                CancellationToken cancellationToken) : base(service, state, fileName, cancellationToken)
-            {
-            }
 
             /// <summary>
             /// Given a document and a type contained in it, moves the type

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeNamespaceScopeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeNamespaceScopeEditor.cs
@@ -21,13 +21,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
         /// Editor that takes a type in a scope and creates a scope beside it. For example, if the type is contained within a namespace 
         /// it will evaluate if the namespace scope needs to be closed and reopened to create a new scope. 
         /// </summary>
-        private class MoveTypeNamespaceScopeEditor : Editor
+        private class MoveTypeNamespaceScopeEditor(TService service, State state, string fileName, CancellationToken cancellationToken) : Editor(service, state, fileName, cancellationToken)
         {
-            public MoveTypeNamespaceScopeEditor(TService service, State state, string fileName, CancellationToken cancellationToken)
-                : base(service, state, fileName, cancellationToken)
-            {
-            }
-
             public override async Task<Solution> GetModifiedSolutionAsync()
             {
                 var node = State.TypeNode;

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
@@ -13,13 +13,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 {
     internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarationSyntax, TNamespaceDeclarationSyntax, TMemberDeclarationSyntax, TCompilationUnitSyntax>
     {
-        private class RenameFileEditor : Editor
+        private class RenameFileEditor(TService service, State state, string fileName, CancellationToken cancellationToken) : Editor(service, state, fileName, cancellationToken)
         {
-            public RenameFileEditor(TService service, State state, string fileName, CancellationToken cancellationToken)
-                : base(service, state, fileName, cancellationToken)
-            {
-            }
-
             public override Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync()
                 => Task.FromResult(RenameFileToMatchTypeName());
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameTypeEditor.cs
@@ -12,12 +12,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 {
     internal abstract partial class AbstractMoveTypeService<TService, TTypeDeclarationSyntax, TNamespaceDeclarationSyntax, TMemberDeclarationSyntax, TCompilationUnitSyntax>
     {
-        private class RenameTypeEditor : Editor
+        private class RenameTypeEditor(TService service, State state, string fileName, CancellationToken cancellationToken) : Editor(service, state, fileName, cancellationToken)
         {
-            public RenameTypeEditor(TService service, State state, string fileName, CancellationToken cancellationToken)
-                : base(service, state, fileName, cancellationToken)
-            {
-            }
 
             /// <summary>
             /// Renames a type to match its containing file name.

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -498,17 +498,11 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             return originalSolution;
         }
 
-        private readonly struct LocationForAffectedSymbol
+        private readonly struct LocationForAffectedSymbol(ReferenceLocation location, bool isReferenceToExtensionMethod)
         {
-            public LocationForAffectedSymbol(ReferenceLocation location, bool isReferenceToExtensionMethod)
-            {
-                ReferenceLocation = location;
-                IsReferenceToExtensionMethod = isReferenceToExtensionMethod;
-            }
+            public ReferenceLocation ReferenceLocation { get; } = location;
 
-            public ReferenceLocation ReferenceLocation { get; }
-
-            public bool IsReferenceToExtensionMethod { get; }
+            public bool IsReferenceToExtensionMethod { get; } = isReferenceToExtensionMethod;
 
             public Document Document => ReferenceLocation.Document;
         }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.MoveFileCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.MoveFileCodeAction.cs
@@ -23,21 +23,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
         where TCompilationUnitSyntax : SyntaxNode
         where TMemberDeclarationSyntax : SyntaxNode
     {
-        private class MoveFileCodeAction : CodeAction
+        private class MoveFileCodeAction(State state, ImmutableArray<string> newFolders) : CodeAction
         {
-            private readonly State _state;
-            private readonly ImmutableArray<string> _newfolders;
+            private readonly State _state = state;
+            private readonly ImmutableArray<string> _newfolders = newFolders;
 
             public override string Title
                 => _newfolders.Length > 0
                 ? string.Format(FeaturesResources.Move_file_to_0, string.Join(PathUtilities.DirectorySeparatorStr, _newfolders))
                 : FeaturesResources.Move_file_to_project_root_folder;
-
-            public MoveFileCodeAction(State state, ImmutableArray<string> newFolders)
-            {
-                _state = state;
-                _newfolders = newFolders;
-            }
 
             protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/Common/DocumentNavigationOperation.cs
+++ b/src/Features/Core/Portable/Common/DocumentNavigationOperation.cs
@@ -18,16 +18,10 @@ namespace Microsoft.CodeAnalysis.CodeActions
     /// <see cref="Document"/> using this operation.
     /// </summary>
 #pragma warning restore RS0030 // Do not used banned APIs
-    public class DocumentNavigationOperation : CodeActionOperation
+    public class DocumentNavigationOperation(DocumentId documentId, int position = 0) : CodeActionOperation
     {
-        internal DocumentId DocumentId { get; }
-        internal int Position { get; }
-
-        public DocumentNavigationOperation(DocumentId documentId, int position = 0)
-        {
-            DocumentId = documentId ?? throw new ArgumentNullException(nameof(documentId));
-            Position = position;
-        }
+        internal DocumentId DocumentId { get; } = documentId ?? throw new ArgumentNullException(nameof(documentId));
+        internal int Position { get; } = position;
 
         public override void Apply(Workspace workspace, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Common/UpdatedEventArgs.cs
+++ b/src/Features/Core/Portable/Common/UpdatedEventArgs.cs
@@ -6,34 +6,26 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Common
 {
-    internal class UpdatedEventArgs : EventArgs
+    internal class UpdatedEventArgs(object id, Workspace workspace, ProjectId? projectId, DocumentId? documentId) : EventArgs
     {
         /// <summary>
         /// The identity of update group. 
         /// </summary>
-        public object Id { get; }
+        public object Id { get; } = id;
 
         /// <summary>
         /// <see cref="Workspace"/> this update is associated with.
         /// </summary>
-        public Workspace Workspace { get; }
+        public Workspace Workspace { get; } = workspace;
 
         /// <summary>
         /// <see cref="ProjectId"/> this update is associated with, or <see langword="null"/>.
         /// </summary>
-        public ProjectId? ProjectId { get; }
+        public ProjectId? ProjectId { get; } = projectId;
 
         /// <summary>
         /// <see cref="DocumentId"/> this update is associated with, or <see langword="null"/>.
         /// </summary>
-        public DocumentId? DocumentId { get; }
-
-        public UpdatedEventArgs(object id, Workspace workspace, ProjectId? projectId, DocumentId? documentId)
-        {
-            Id = id;
-            Workspace = workspace;
-            ProjectId = projectId;
-            DocumentId = documentId;
-        }
+        public DocumentId? DocumentId { get; } = documentId;
     }
 }

--- a/src/Features/Core/Portable/Completion/ArgumentContext.cs
+++ b/src/Features/Core/Portable/Completion/ArgumentContext.cs
@@ -11,40 +11,30 @@ namespace Microsoft.CodeAnalysis.Completion
     /// <summary>
     /// Provides context information for argument completion.
     /// </summary>
-    internal sealed class ArgumentContext
+    internal sealed class ArgumentContext(
+        ArgumentProvider provider,
+        SemanticModel semanticModel,
+        int position,
+        IParameterSymbol parameter,
+        string? previousValue,
+        CancellationToken cancellationToken)
     {
-        public ArgumentContext(
-            ArgumentProvider provider,
-            SemanticModel semanticModel,
-            int position,
-            IParameterSymbol parameter,
-            string? previousValue,
-            CancellationToken cancellationToken)
-        {
-            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
-            SemanticModel = semanticModel ?? throw new ArgumentNullException(nameof(semanticModel));
-            Position = position;
-            Parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
-            PreviousValue = previousValue;
-            CancellationToken = cancellationToken;
-        }
-
-        internal ArgumentProvider Provider { get; }
+        internal ArgumentProvider Provider { get; } = provider ?? throw new ArgumentNullException(nameof(provider));
 
         /// <summary>
         /// Gets the semantic model where argument completion is requested.
         /// </summary>
-        public SemanticModel SemanticModel { get; }
+        public SemanticModel SemanticModel { get; } = semanticModel ?? throw new ArgumentNullException(nameof(semanticModel));
 
         /// <summary>
         /// Gets the position within <see cref="SemanticModel"/> where argument completion is requested.
         /// </summary>
-        public int Position { get; }
+        public int Position { get; } = position;
 
         /// <summary>
         /// Gets the symbol for the parameter for which an argument value is requested.
         /// </summary>
-        public IParameterSymbol Parameter { get; }
+        public IParameterSymbol Parameter { get; } = parameter ?? throw new ArgumentNullException(nameof(parameter));
 
         /// <summary>
         /// Gets the previously-provided argument value for this parameter.
@@ -53,12 +43,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// The existing text of the argument value, if the argument is already in code; otherwise,
         /// <see langword="null"/> when requesting a new argument value.
         /// </value>
-        public string? PreviousValue { get; }
+        public string? PreviousValue { get; } = previousValue;
 
         /// <summary>
         /// Gets a cancellation token that argument providers may observe.
         /// </summary>
-        public CancellationToken CancellationToken { get; }
+        public CancellationToken CancellationToken { get; } = cancellationToken;
 
         /// <summary>
         /// Gets or sets the default argument value.

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -11,15 +11,12 @@ using Microsoft.CodeAnalysis.Tags;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
-    internal sealed class CompletionHelper
+    internal sealed class CompletionHelper(bool isCaseSensitive)
     {
         private static CompletionHelper CaseSensitiveInstance { get; } = new CompletionHelper(isCaseSensitive: true);
         private static CompletionHelper CaseInsensitiveInstance { get; } = new CompletionHelper(isCaseSensitive: false);
 
-        private readonly bool _isCaseSensitive;
-
-        public CompletionHelper(bool isCaseSensitive)
-            => _isCaseSensitive = isCaseSensitive;
+        private readonly bool _isCaseSensitive = isCaseSensitive;
 
         public static CompletionHelper GetHelper(Document document)
         {

--- a/src/Features/Core/Portable/Completion/CompletionProviderMetadata.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProviderMetadata.cs
@@ -8,15 +8,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
-    internal sealed class CompletionProviderMetadata : OrderableLanguageMetadata
+    internal sealed class CompletionProviderMetadata(IDictionary<string, object> data) : OrderableLanguageMetadata(data)
     {
-        public string[]? Roles { get; }
-
-        public CompletionProviderMetadata(IDictionary<string, object> data)
-            : base(data)
-        {
-            Roles = (string[]?)data.GetValueOrDefault("Roles")
+        public string[]? Roles { get; } = (string[]?)data.GetValueOrDefault("Roles")
                 ?? (string[]?)data.GetValueOrDefault("TextViewRoles");
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
@@ -269,14 +269,9 @@ namespace Microsoft.CodeAnalysis.Completion
             internal TestAccessor GetTestAccessor()
                 => new(this);
 
-            internal readonly struct TestAccessor
+            internal readonly struct TestAccessor(ProviderManager providerManager)
             {
-                private readonly ProviderManager _providerManager;
-
-                public TestAccessor(ProviderManager providerManager)
-                {
-                    _providerManager = providerManager;
-                }
+                private readonly ProviderManager _providerManager = providerManager;
 
                 public ImmutableArray<CompletionProvider> GetImportedAndBuiltInProviders(ImmutableHashSet<string> roles)
                 {

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -351,12 +351,9 @@ namespace Microsoft.CodeAnalysis.Completion
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(CompletionService completionServiceWithProviders)
         {
-            private readonly CompletionService _completionServiceWithProviders;
-
-            public TestAccessor(CompletionService completionServiceWithProviders)
-                => _completionServiceWithProviders = completionServiceWithProviders;
+            private readonly CompletionService _completionServiceWithProviders = completionServiceWithProviders;
 
             public ImmutableArray<CompletionProvider> GetImportedAndBuiltInProviders(ImmutableHashSet<string> roles)
                 => _completionServiceWithProviders._providerManager.GetTestAccessor().GetImportedAndBuiltInProviders(roles);

--- a/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService_GetCompletions.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return context;
         }
 
-        private class DisplayNameToItemsMap : IEnumerable<CompletionItem>, IDisposable
+        private class DisplayNameToItemsMap(CompletionService service) : IEnumerable<CompletionItem>, IDisposable
         {
             // We might need to handle large amount of items with import completion enabled,
             // so use a dedicated pool to minimize array allocations. Set the size of pool to a small
@@ -331,16 +331,10 @@ namespace Microsoft.CodeAnalysis.Completion
             private static readonly ObjectPool<Dictionary<string, object>> s_uniqueSourcesPool = new(factory: () => new Dictionary<string, object>(), size: 5);
             private static readonly ObjectPool<List<CompletionItem>> s_sortListPool = new(factory: () => new List<CompletionItem>(), size: 5);
 
-            private readonly Dictionary<string, object> _displayNameToItemsMap;
-            private readonly CompletionService _service;
+            private readonly Dictionary<string, object> _displayNameToItemsMap = s_uniqueSourcesPool.Allocate();
+            private readonly CompletionService _service = service;
 
             public int Count { get; private set; }
-
-            public DisplayNameToItemsMap(CompletionService service)
-            {
-                _service = service;
-                _displayNameToItemsMap = s_uniqueSourcesPool.Allocate();
-            }
 
             public SegmentedList<CompletionItem> SortToSegmentedList()
             {

--- a/src/Features/Core/Portable/Completion/ExportArgumentProviderAttribute.cs
+++ b/src/Features/Core/Portable/Completion/ExportArgumentProviderAttribute.cs
@@ -9,18 +9,10 @@ namespace Microsoft.CodeAnalysis.Completion
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class ExportArgumentProviderAttribute : ExportAttribute
+    internal sealed class ExportArgumentProviderAttribute(string name, string language) : ExportAttribute(typeof(ArgumentProvider))
     {
-        public string Name { get; }
-        public string Language { get; }
-        public string[] Roles { get; set; }
-
-        public ExportArgumentProviderAttribute(string name, string language)
-            : base(typeof(ArgumentProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Language = language ?? throw new ArgumentNullException(nameof(language));
-            Roles = Array.Empty<string>();
-        }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
+        public string[] Roles { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/Features/Core/Portable/Completion/ExportCompletionProviderAttribute.cs
+++ b/src/Features/Core/Portable/Completion/ExportCompletionProviderAttribute.cs
@@ -13,17 +13,10 @@ namespace Microsoft.CodeAnalysis.Completion
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class ExportCompletionProviderAttribute : ExportAttribute
+    public sealed class ExportCompletionProviderAttribute(string name, string language) : ExportAttribute(typeof(CompletionProvider))
     {
-        public string Name { get; }
-        public string Language { get; }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
         public string[]? Roles { get; set; }
-
-        public ExportCompletionProviderAttribute(string name, string language)
-            : base(typeof(CompletionProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/FileSystemCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/FileSystemCompletionHelper.cs
@@ -256,12 +256,9 @@ namespace Microsoft.CodeAnalysis.Completion
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(FileSystemCompletionHelper fileSystemCompletionHelper)
         {
-            private readonly FileSystemCompletionHelper _fileSystemCompletionHelper;
-
-            public TestAccessor(FileSystemCompletionHelper fileSystemCompletionHelper)
-                => _fileSystemCompletionHelper = fileSystemCompletionHelper;
+            private readonly FileSystemCompletionHelper _fileSystemCompletionHelper = fileSystemCompletionHelper;
 
             internal ImmutableArray<CompletionItem> GetItems(string directoryPath, CancellationToken cancellationToken)
                 => _fileSystemCompletionHelper.GetItems(directoryPath, cancellationToken);

--- a/src/Features/Core/Portable/Completion/MatchResult.cs
+++ b/src/Features/Core/Portable/Completion/MatchResult.cs
@@ -7,52 +7,42 @@ using Microsoft.CodeAnalysis.PatternMatching;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
-    internal readonly struct MatchResult
+    internal readonly struct MatchResult(
+        CompletionItem completionItem,
+        bool shouldBeConsideredMatchingFilterText,
+        PatternMatch? patternMatch,
+        int index,
+        string? matchedAdditionalFilterText,
+        int recentItemIndex = -1)
     {
         /// <summary>
         /// The CompletionItem used to create this MatchResult.
         /// </summary>
-        public readonly CompletionItem CompletionItem;
+        public readonly CompletionItem CompletionItem = completionItem;
 
-        public readonly PatternMatch? PatternMatch;
+        public readonly PatternMatch? PatternMatch = patternMatch;
 
         // The value of `ShouldBeConsideredMatchingFilterText` doesn't 100% reflect the actual PatternMatch result.
         // In certain cases, there'd be no match but we'd still want to consider it a match (e.g. when the item is in MRU list,)
         // and this is why PatternMatch can be null. There's also cases it's a match but we want to consider it a non-match
         // (e.g. when not a prefix match in deletion scenario).
-        public readonly bool ShouldBeConsideredMatchingFilterText;
+        public readonly bool ShouldBeConsideredMatchingFilterText = shouldBeConsideredMatchingFilterText;
 
         public string FilterTextUsed => MatchedAdditionalFilterText ?? CompletionItem.FilterText;
 
         // We want to preserve the original alphabetical order for items with same pattern match score,
         // but `ArrayBuilder.Sort` we currently use isn't stable. So we have to add a monotonically increasing 
         // integer to achieve this.
-        public readonly int IndexInOriginalSortedOrder;
-        public readonly int RecentItemIndex;
+        public readonly int IndexInOriginalSortedOrder = index;
+        public readonly int RecentItemIndex = recentItemIndex;
 
         /// <summary>
         /// If `CompletionItem.AdditionalFilterTexts` was used to create this MatchResult, then this is set to the one that was used.
         /// Otherwise this is set to null.
         /// </summary>
-        public readonly string? MatchedAdditionalFilterText;
+        public readonly string? MatchedAdditionalFilterText = matchedAdditionalFilterText;
 
         public bool MatchedWithAdditionalFilterTexts => MatchedAdditionalFilterText is not null;
-
-        public MatchResult(
-            CompletionItem completionItem,
-            bool shouldBeConsideredMatchingFilterText,
-            PatternMatch? patternMatch,
-            int index,
-            string? matchedAdditionalFilterText,
-            int recentItemIndex = -1)
-        {
-            CompletionItem = completionItem;
-            ShouldBeConsideredMatchingFilterText = shouldBeConsideredMatchingFilterText;
-            PatternMatch = patternMatch;
-            IndexInOriginalSortedOrder = index;
-            RecentItemIndex = recentItemIndex;
-            MatchedAdditionalFilterText = matchedAdditionalFilterText;
-        }
 
         public static IComparer<MatchResult> SortingComparer { get; } = new Comparer();
 

--- a/src/Features/Core/Portable/Completion/PatternMatchHelper.cs
+++ b/src/Features/Core/Portable/Completion/PatternMatchHelper.cs
@@ -16,19 +16,14 @@ namespace Microsoft.CodeAnalysis.Completion
     /// This type is not thread safe due to the restriction of underlying PatternMatcher. 
     /// Must be disposed after use.
     /// </summary>
-    internal sealed class PatternMatchHelper : IDisposable
+    internal sealed class PatternMatchHelper(string pattern) : IDisposable
     {
         private readonly object _gate = new();
         private readonly Dictionary<(CultureInfo, bool includeMatchedSpans), PatternMatcher> _patternMatcherMap = new();
 
         private static readonly CultureInfo EnUSCultureInfo = new("en-US");
 
-        public string Pattern { get; }
-
-        public PatternMatchHelper(string pattern)
-        {
-            Pattern = pattern;
-        }
+        public string Pattern { get; } = pattern;
 
         public ImmutableArray<TextSpan> GetHighlightedSpans(string text, CultureInfo culture)
         {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionCacheServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionCacheServiceFactory.cs
@@ -65,23 +65,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             _projectItemsCache.Clear();
         }
 
-        private class ImportCompletionCacheService : IImportCompletionCacheService<TProjectCacheEntry, TMetadataCacheEntry>
+        private class ImportCompletionCacheService(
+            ConcurrentDictionary<string, TMetadataCacheEntry> peCache,
+            ConcurrentDictionary<ProjectId, TProjectCacheEntry> projectCache,
+            AsyncBatchingWorkQueue<Project> workQueue) : IImportCompletionCacheService<TProjectCacheEntry, TMetadataCacheEntry>
         {
-            public IDictionary<string, TMetadataCacheEntry> PEItemsCache { get; }
+            public IDictionary<string, TMetadataCacheEntry> PEItemsCache { get; } = peCache;
 
-            public IDictionary<ProjectId, TProjectCacheEntry> ProjectItemsCache { get; }
+            public IDictionary<ProjectId, TProjectCacheEntry> ProjectItemsCache { get; } = projectCache;
 
-            public AsyncBatchingWorkQueue<Project> WorkQueue { get; }
-
-            public ImportCompletionCacheService(
-                ConcurrentDictionary<string, TMetadataCacheEntry> peCache,
-                ConcurrentDictionary<ProjectId, TProjectCacheEntry> projectCache,
-                AsyncBatchingWorkQueue<Project> workQueue)
-            {
-                PEItemsCache = peCache;
-                ProjectItemsCache = projectCache;
-                WorkQueue = workQueue;
-            }
+            public AsyncBatchingWorkQueue<Project> WorkQueue { get; } = workQueue;
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -294,21 +294,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
         }
 
-        private readonly struct TypeOverloadInfo
+        private readonly struct TypeOverloadInfo(INamedTypeSymbol nonGenericOverload, INamedTypeSymbol bestGenericOverload, bool containsPublicGenericOverload)
         {
-            public TypeOverloadInfo(INamedTypeSymbol nonGenericOverload, INamedTypeSymbol bestGenericOverload, bool containsPublicGenericOverload)
-            {
-                NonGenericOverload = nonGenericOverload;
-                BestGenericOverload = bestGenericOverload;
-                ContainsPublicGenericOverload = containsPublicGenericOverload;
-            }
-
-            public INamedTypeSymbol NonGenericOverload { get; }
+            public INamedTypeSymbol NonGenericOverload { get; } = nonGenericOverload;
 
             // Generic with fewest type parameters is considered best symbol to show in description.
-            public INamedTypeSymbol BestGenericOverload { get; }
+            public INamedTypeSymbol BestGenericOverload { get; } = bestGenericOverload;
 
-            public bool ContainsPublicGenericOverload { get; }
+            public bool ContainsPublicGenericOverload { get; } = containsPublicGenericOverload;
 
             public TypeOverloadInfo Aggregate(INamedTypeSymbol type)
             {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/DefaultExtensionMethodImportCompletionCacheServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/DefaultExtensionMethodImportCompletionCacheServiceFactory.cs
@@ -14,14 +14,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     /// We don't use PE cache from the service, so just pass in type `object` for PE entries.
     /// </summary>
     [ExportWorkspaceServiceFactory(typeof(IImportCompletionCacheService<ExtensionMethodImportCompletionCacheEntry, object>), ServiceLayer.Default), Shared]
-    internal sealed class DefaultExtensionMethodImportCompletionCacheServiceFactory
-        : AbstractImportCompletionCacheServiceFactory<ExtensionMethodImportCompletionCacheEntry, object>
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class DefaultExtensionMethodImportCompletionCacheServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
+                : AbstractImportCompletionCacheServiceFactory<ExtensionMethodImportCompletionCacheEntry, object>(listenerProvider, ExtensionMethodImportCompletionHelper.BatchUpdateCacheAsync, CancellationToken.None)
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultExtensionMethodImportCompletionCacheServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
-            : base(listenerProvider, ExtensionMethodImportCompletionHelper.BatchUpdateCacheAsync, CancellationToken.None)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/DefaultTypeImportCompletionCacheServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/DefaultTypeImportCompletionCacheServiceFactory.cs
@@ -11,14 +11,10 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     [ExportWorkspaceServiceFactory(typeof(IImportCompletionCacheService<TypeImportCompletionCacheEntry, TypeImportCompletionCacheEntry>), ServiceLayer.Default), Shared]
-    internal sealed class DefaultTypeImportCompletionCacheServiceFactory
-        : AbstractImportCompletionCacheServiceFactory<TypeImportCompletionCacheEntry, TypeImportCompletionCacheEntry>
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class DefaultTypeImportCompletionCacheServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
+                : AbstractImportCompletionCacheServiceFactory<TypeImportCompletionCacheEntry, TypeImportCompletionCacheEntry>(listenerProvider, AbstractTypeImportCompletionService.BatchUpdateCacheAsync, CancellationToken.None)
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultTypeImportCompletionCacheServiceFactory(IAsynchronousOperationListenerProvider listenerProvider)
-            : base(listenerProvider, AbstractTypeImportCompletionService.BatchUpdateCacheAsync, CancellationToken.None)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionCacheEntry.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionCacheEntry.cs
@@ -30,20 +30,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             ReceiverTypeNameToExtensionMethodMap = receiverTypeNameToExtensionMethodMap;
         }
 
-        public class Builder
+        public class Builder(Checksum checksum, string langauge, IEqualityComparer<string> comparer)
         {
-            private readonly Checksum _checksum;
-            private readonly string _language;
+            private readonly Checksum _checksum = checksum;
+            private readonly string _language = langauge;
 
-            private readonly MultiDictionary<string, DeclaredSymbolInfo> _mapBuilder;
-
-            public Builder(Checksum checksum, string langauge, IEqualityComparer<string> comparer)
-            {
-                _checksum = checksum;
-                _language = langauge;
-
-                _mapBuilder = new MultiDictionary<string, DeclaredSymbolInfo>(comparer);
-            }
+            private readonly MultiDictionary<string, DeclaredSymbolInfo> _mapBuilder = new MultiDictionary<string, DeclaredSymbolInfo>(comparer);
 
             public ExtensionMethodImportCompletionCacheEntry ToCacheEntry()
             {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableImportCompletionItem.cs
@@ -7,38 +7,27 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     [DataContract]
-    internal readonly struct SerializableImportCompletionItem
+    internal readonly struct SerializableImportCompletionItem(string symbolKeyData, string name, int arity, Glyph glyph, string containingNamespace, int additionalOverloadCount, bool includedInTargetTypeCompletion)
     {
         [DataMember(Order = 0)]
-        public readonly string SymbolKeyData;
+        public readonly string SymbolKeyData = symbolKeyData;
 
         [DataMember(Order = 1)]
-        public readonly string Name;
+        public readonly string Name = name;
 
         [DataMember(Order = 2)]
-        public readonly int Arity;
+        public readonly int Arity = arity;
 
         [DataMember(Order = 3)]
-        public readonly Glyph Glyph;
+        public readonly Glyph Glyph = glyph;
 
         [DataMember(Order = 4)]
-        public readonly string ContainingNamespace;
+        public readonly string ContainingNamespace = containingNamespace;
 
         [DataMember(Order = 5)]
-        public readonly int AdditionalOverloadCount;
+        public readonly int AdditionalOverloadCount = additionalOverloadCount;
 
         [DataMember(Order = 6)]
-        public readonly bool IncludedInTargetTypeCompletion;
-
-        public SerializableImportCompletionItem(string symbolKeyData, string name, int arity, Glyph glyph, string containingNamespace, int additionalOverloadCount, bool includedInTargetTypeCompletion)
-        {
-            SymbolKeyData = symbolKeyData;
-            Arity = arity;
-            Name = name;
-            Glyph = glyph;
-            ContainingNamespace = containingNamespace;
-            AdditionalOverloadCount = additionalOverloadCount;
-            IncludedInTargetTypeCompletion = includedInTargetTypeCompletion;
-        }
+        public readonly bool IncludedInTargetTypeCompletion = includedInTargetTypeCompletion;
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
@@ -9,35 +9,26 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
     [DataContract]
-    internal sealed class SerializableUnimportedExtensionMethods
+    internal sealed class SerializableUnimportedExtensionMethods(
+        ImmutableArray<SerializableImportCompletionItem> completionItems,
+        bool isPartialResult,
+        TimeSpan getSymbolsTime,
+        TimeSpan createItemsTime,
+        TimeSpan? remoteAssetSyncTime)
     {
         [DataMember(Order = 0)]
-        public readonly ImmutableArray<SerializableImportCompletionItem> CompletionItems;
+        public readonly ImmutableArray<SerializableImportCompletionItem> CompletionItems = completionItems;
 
         [DataMember(Order = 1)]
-        public readonly bool IsPartialResult;
+        public readonly bool IsPartialResult = isPartialResult;
 
         [DataMember(Order = 2)]
-        public TimeSpan GetSymbolsTime { get; set; }
+        public TimeSpan GetSymbolsTime { get; set; } = getSymbolsTime;
 
         [DataMember(Order = 3)]
-        public readonly TimeSpan CreateItemsTime;
+        public readonly TimeSpan CreateItemsTime = createItemsTime;
 
         [DataMember(Order = 4)]
-        public readonly TimeSpan? RemoteAssetSyncTime;
-
-        public SerializableUnimportedExtensionMethods(
-            ImmutableArray<SerializableImportCompletionItem> completionItems,
-            bool isPartialResult,
-            TimeSpan getSymbolsTime,
-            TimeSpan createItemsTime,
-            TimeSpan? remoteAssetSyncTime)
-        {
-            CompletionItems = completionItems;
-            IsPartialResult = isPartialResult;
-            GetSymbolsTime = getSymbolsTime;
-            CreateItemsTime = createItemsTime;
-            RemoteAssetSyncTime = remoteAssetSyncTime;
-        }
+        public readonly TimeSpan? RemoteAssetSyncTime = remoteAssetSyncTime;
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionCacheEntry.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionCacheEntry.cs
@@ -143,29 +143,18 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
         }
 
-        public class Builder : IDisposable
+        public class Builder(SymbolKey assemblySymbolKey, Checksum checksum, string language, string genericTypeSuffix, EditorBrowsableInfo editorBrowsableInfo) : IDisposable
         {
-            private readonly SymbolKey _assemblySymbolKey;
-            private readonly string _language;
-            private readonly string _genericTypeSuffix;
-            private readonly Checksum _checksum;
-            private readonly EditorBrowsableInfo _editorBrowsableInfo;
+            private readonly SymbolKey _assemblySymbolKey = assemblySymbolKey;
+            private readonly string _language = language;
+            private readonly string _genericTypeSuffix = genericTypeSuffix;
+            private readonly Checksum _checksum = checksum;
+            private readonly EditorBrowsableInfo _editorBrowsableInfo = editorBrowsableInfo;
 
             private int _publicItemCount;
             private bool _hasEnumBaseTypes;
 
-            private readonly ArrayBuilder<TypeImportCompletionItemInfo> _itemsBuilder;
-
-            public Builder(SymbolKey assemblySymbolKey, Checksum checksum, string language, string genericTypeSuffix, EditorBrowsableInfo editorBrowsableInfo)
-            {
-                _assemblySymbolKey = assemblySymbolKey;
-                _checksum = checksum;
-                _language = language;
-                _genericTypeSuffix = genericTypeSuffix;
-                _editorBrowsableInfo = editorBrowsableInfo;
-
-                _itemsBuilder = ArrayBuilder<TypeImportCompletionItemInfo>.GetInstance();
-            }
+            private readonly ArrayBuilder<TypeImportCompletionItemInfo> _itemsBuilder = ArrayBuilder<TypeImportCompletionItemInfo>.GetInstance();
 
             public TypeImportCompletionCacheEntry ToReferenceCacheEntry()
             {
@@ -224,21 +213,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 => _itemsBuilder.Free();
         }
 
-        private readonly struct TypeImportCompletionItemInfo
+        private readonly struct TypeImportCompletionItemInfo(CompletionItem item, bool isPublic, bool isGeneric, bool isAttribute, bool isEditorBrowsableStateAdvanced, bool isEnumBaseType)
         {
-            private readonly ItemPropertyKind _properties;
-
-            public TypeImportCompletionItemInfo(CompletionItem item, bool isPublic, bool isGeneric, bool isAttribute, bool isEditorBrowsableStateAdvanced, bool isEnumBaseType)
-            {
-                Item = item;
-                _properties = (isPublic ? ItemPropertyKind.IsPublic : 0)
+            private readonly ItemPropertyKind _properties = (isPublic ? ItemPropertyKind.IsPublic : 0)
                             | (isGeneric ? ItemPropertyKind.IsGeneric : 0)
                             | (isAttribute ? ItemPropertyKind.IsAttribute : 0)
                             | (isEnumBaseType ? ItemPropertyKind.IsEnumBaseType : 0)
                             | (isEditorBrowsableStateAdvanced ? ItemPropertyKind.IsEditorBrowsableStateAdvanced : 0);
-            }
 
-            public CompletionItem Item { get; }
+            public CompletionItem Item { get; } = item;
 
             public bool IsPublic
                 => (_properties & ItemPropertyKind.IsPublic) != 0;

--- a/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
+++ b/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
@@ -9,14 +9,20 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
-    internal sealed class RecommendedKeyword
+    internal sealed class RecommendedKeyword(
+        string keyword,
+         Glyph glyph,
+          Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> descriptionFactory,
+          bool isIntrinsic = false,
+          bool shouldFormatOnCommit = false,
+          int? matchPriority = null)
     {
-        public Glyph Glyph { get; }
-        public string Keyword { get; }
-        public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; }
-        public bool IsIntrinsic { get; }
-        public bool ShouldFormatOnCommit { get; }
-        public int MatchPriority { get; }
+        public Glyph Glyph { get; } = glyph;
+        public string Keyword { get; } = keyword;
+        public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; } = descriptionFactory;
+        public bool IsIntrinsic { get; } = isIntrinsic;
+        public bool ShouldFormatOnCommit { get; } = shouldFormatOnCommit;
+        public int MatchPriority { get; } = matchPriority ?? Completion.MatchPriority.Default;
 
         public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false, int? matchPriority = null)
             : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit, matchPriority)
@@ -35,22 +41,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
 
             return textContentBuilder.ToImmutableArray();
-        }
-
-        public RecommendedKeyword(
-            string keyword,
-             Glyph glyph,
-              Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> descriptionFactory,
-              bool isIntrinsic = false,
-              bool shouldFormatOnCommit = false,
-              int? matchPriority = null)
-        {
-            Keyword = keyword;
-            Glyph = glyph;
-            DescriptionFactory = descriptionFactory;
-            IsIntrinsic = isIntrinsic;
-            ShouldFormatOnCommit = shouldFormatOnCommit;
-            MatchPriority = matchPriority ?? Completion.MatchPriority.Default;
         }
     }
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedActiveStatementDebugInfo.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedActiveStatementDebugInfo.cs
@@ -9,51 +9,37 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// Active statement debug information retrieved from the runtime and the PDB.
     /// </summary>
     [DataContract]
-    internal readonly struct ManagedActiveStatementDebugInfo
+    internal readonly struct ManagedActiveStatementDebugInfo(
+        ManagedInstructionId activeInstruction,
+        string? documentName,
+        SourceSpan sourceSpan,
+        ActiveStatementFlags flags)
     {
-        /// <summary>
-        /// Creates a ManagedActiveStatementDebugInfo.
-        /// </summary>
-        /// <param name="activeInstruction">Instruction of the active statement that is being executed.</param>
-        /// <param name="documentName">Document name as found in the PDB, if the active statement location was determined.</param>
-        /// <param name="sourceSpan">Location of the closest non-hidden sequence point from the active statement.</param>
-        /// <param name="flags">Active statement flags shared across all threads that own the active statement.</param>
-        public ManagedActiveStatementDebugInfo(
-            ManagedInstructionId activeInstruction,
-            string? documentName,
-            SourceSpan sourceSpan,
-            ActiveStatementFlags flags)
-        {
-            ActiveInstruction = activeInstruction;
-            DocumentName = documentName;
-            SourceSpan = sourceSpan;
-            Flags = flags;
-        }
 
         /// <summary>
         /// The instruction of the active statement that is being executed.
         /// </summary>
         [DataMember(Name = "activeInstruction")]
-        public ManagedInstructionId ActiveInstruction { get; }
+        public ManagedInstructionId ActiveInstruction { get; } = activeInstruction;
 
         /// <summary>
         /// Document name as found in the PDB, or null if the debugger can't determine the location of the active statement.
         /// </summary>
         [DataMember(Name = "documentName")]
-        public string? DocumentName { get; }
+        public string? DocumentName { get; } = documentName;
 
         /// <summary>
         /// Location of the closest non-hidden sequence point retrieved from the PDB, 
         /// or default(<see cref="SourceSpan"/>) if the debugger can't determine the location of the active statement.
         /// </summary>
         [DataMember(Name = "sourceSpan")]
-        public SourceSpan SourceSpan { get; }
+        public SourceSpan SourceSpan { get; } = sourceSpan;
 
         /// <summary>
         /// Aggregated across any threads that own the active instruction.
         /// </summary>
         [DataMember(Name = "flags")]
-        public ActiveStatementFlags Flags { get; }
+        public ActiveStatementFlags Flags { get; } = flags;
 
         public bool HasSourceLocation => DocumentName != null;
     }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedActiveStatementUpdate.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedActiveStatementUpdate.cs
@@ -10,41 +10,29 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// This is used when remapping the instruction pointer to the appropriate location.
     /// </summary>
     [DataContract]
-    internal readonly struct ManagedActiveStatementUpdate
+    internal readonly struct ManagedActiveStatementUpdate(
+        ManagedModuleMethodId method,
+        int ilOffset,
+        SourceSpan newSpan)
     {
-        /// <summary>
-        /// Creates a ManagedActiveStatementUpdate.
-        /// </summary>
-        /// <param name="method">Method information before the change was made.</param>
-        /// <param name="ilOffset">Old IL offset of the active statement.</param>
-        /// <param name="newSpan">Updated text span for the active statement.</param>
-        public ManagedActiveStatementUpdate(
-            ManagedModuleMethodId method,
-            int ilOffset,
-            SourceSpan newSpan)
-        {
-            Method = method;
-            ILOffset = ilOffset;
-            NewSpan = newSpan;
-        }
 
         /// <summary>
         /// Method ID. It has the token for the method that contains the active statement
         /// and the version when the change was made.
         /// </summary>
         [DataMember(Name = "method")]
-        public ManagedModuleMethodId Method { get; }
+        public ManagedModuleMethodId Method { get; } = method;
 
         /// <summary>
         /// Old IL offset for the active statement.
         /// </summary>
         [DataMember(Name = "ilOffset")]
-        public int ILOffset { get; }
+        public int ILOffset { get; } = ilOffset;
 
         /// <summary>
         /// Updated text span for the active statement after the edit was made.
         /// </summary>
         [DataMember(Name = "newSpan")]
-        public SourceSpan NewSpan { get; }
+        public SourceSpan NewSpan { get; } = newSpan;
     }
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedExceptionRegionUpdate.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedExceptionRegionUpdate.cs
@@ -9,30 +9,18 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// Exception region affected by a managed update.
     /// </summary>
     [DataContract]
-    internal readonly struct ManagedExceptionRegionUpdate
+    internal readonly struct ManagedExceptionRegionUpdate(
+        ManagedModuleMethodId method,
+        int delta,
+        SourceSpan newSpan)
     {
-        /// <summary>
-        /// Creates an ExceptionRegionUpdate.
-        /// </summary>
-        /// <param name="method">Method information before the change was made.</param>
-        /// <param name="delta">Total of lines modified after the update.</param>
-        /// <param name="newSpan">Updated text span for the active statement.</param>
-        public ManagedExceptionRegionUpdate(
-            ManagedModuleMethodId method,
-            int delta,
-            SourceSpan newSpan)
-        {
-            Method = method;
-            Delta = delta;
-            NewSpan = newSpan;
-        }
 
         /// <summary>
         /// Method ID. It has the token for the method that contains the exception region
         /// and the version when the change was made.
         /// </summary>
         [DataMember(Name = "method")]
-        public ManagedModuleMethodId Method { get; }
+        public ManagedModuleMethodId Method { get; } = method;
 
         /// <summary>
         /// The delta is the total of lines modified after the update. This value is inverse:
@@ -43,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
         /// For example, if 2 new lines were added preceding the exception region, this value will be -2.
         /// </summary>
         [DataMember(Name = "delta")]
-        public int Delta { get; }
+        public int Delta { get; } = delta;
 
         /// <summary>
         /// Specifies where the exception region starts and ends after the update. This value is 0-based.
@@ -55,6 +43,6 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
         /// The new span is expected to be: [PreviousExceptionRegionSpan] + [Delta of updated lines].
         /// </remarks>
         [DataMember(Name = "newSpan")]
-        public SourceSpan NewSpan { get; }
+        public SourceSpan NewSpan { get; } = newSpan;
     }
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadAvailability.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadAvailability.cs
@@ -10,26 +10,21 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// Managed hot reload availability information.
     /// </summary>
     [DataContract]
-    internal readonly struct ManagedHotReloadAvailability
+    internal readonly struct ManagedHotReloadAvailability(
+        ManagedHotReloadAvailabilityStatus status,
+        string? localizedMessage = null)
     {
-        public ManagedHotReloadAvailability(
-            ManagedHotReloadAvailabilityStatus status,
-            string? localizedMessage = null)
-        {
-            Status = status;
-            LocalizedMessage = localizedMessage;
-        }
 
         /// <summary>
         /// Status for the managed hot reload session.
         /// </summary>
         [DataMember(Name = "status")]
-        public ManagedHotReloadAvailabilityStatus Status { get; }
+        public ManagedHotReloadAvailabilityStatus Status { get; } = status;
 
         /// <summary>
         /// [Optional] Localized message for <see cref="Status"/>.
         /// </summary>
         [DataMember(Name = "localizedMessage")]
-        public string? LocalizedMessage { get; }
+        public string? LocalizedMessage { get; } = localizedMessage;
     }
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadDiagnostic.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadDiagnostic.cs
@@ -10,58 +10,42 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// Diagnostic information about a particular edit made through hot reload.
     /// </summary>
     [DataContract]
-    internal readonly struct ManagedHotReloadDiagnostic
+    internal readonly struct ManagedHotReloadDiagnostic(
+        string id,
+        string message,
+        ManagedHotReloadDiagnosticSeverity severity,
+        string filePath,
+        SourceSpan span)
     {
-        /// <summary>
-        /// Creates a new <see cref="ManagedHotReloadDiagnostic"/> for an edit made by the user.
-        /// </summary>
-        /// <param name="id">Diagnostic information identifier.</param>
-        /// <param name="message">User message.</param>
-        /// <param name="severity">Severity of the edit, whether it's an error or a warning.</param>
-        /// <param name="filePath">File path for the target edit.</param>
-        /// <param name="span">Source span of the edit.</param>
-        public ManagedHotReloadDiagnostic(
-            string id,
-            string message,
-            ManagedHotReloadDiagnosticSeverity severity,
-            string filePath,
-            SourceSpan span)
-        {
-            Id = id;
-            Message = message;
-            Severity = severity;
-            FilePath = filePath;
-            Span = span;
-        }
 
         /// <summary>
         /// Diagnostic information identifier.
         /// </summary>
         [DataMember(Name = "id")]
-        public string Id { get; }
+        public string Id { get; } = id;
 
         /// <summary>
         /// User message which will be displayed for the edit.
         /// </summary>
         [DataMember(Name = "message")]
-        public string Message { get; }
+        public string Message { get; } = message;
 
         /// <summary>
         /// Severity of the diagnostic information.
         /// </summary>
         [DataMember(Name = "severity")]
-        public ManagedHotReloadDiagnosticSeverity Severity { get; }
+        public ManagedHotReloadDiagnosticSeverity Severity { get; } = severity;
 
         /// <summary>
         /// File path where the edit was made.
         /// </summary>
         [DataMember(Name = "filePath")]
-        public string FilePath { get; }
+        public string FilePath { get; } = filePath;
 
         /// <summary>
         /// Source span for the edit.
         /// </summary>
         [DataMember(Name = "span")]
-        public SourceSpan Span { get; }
+        public SourceSpan Span { get; } = span;
     }
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdate.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdate.cs
@@ -9,64 +9,49 @@ using System.Collections.Immutable;
 namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 
 [DataContract]
-internal readonly struct ManagedHotReloadUpdate
+internal readonly struct ManagedHotReloadUpdate(
+    Guid module,
+    string moduleName,
+    ImmutableArray<byte> ilDelta,
+    ImmutableArray<byte> metadataDelta,
+    ImmutableArray<byte> pdbDelta,
+    ImmutableArray<int> updatedTypes,
+    ImmutableArray<string> requiredCapabilities,
+    ImmutableArray<int> updatedMethods,
+    ImmutableArray<SequencePointUpdates> sequencePoints,
+    ImmutableArray<ManagedActiveStatementUpdate> activeStatements,
+    ImmutableArray<ManagedExceptionRegionUpdate> exceptionRegions)
 {
     [DataMember(Name = "module")]
-    public Guid Module { get; }
+    public Guid Module { get; } = module;
 
     [DataMember(Name = "moduleName")]
-    public string ModuleName { get; }
+    public string ModuleName { get; } = moduleName;
 
     [DataMember(Name = "ilDelta")]
-    public ImmutableArray<byte> ILDelta { get; }
+    public ImmutableArray<byte> ILDelta { get; } = ilDelta;
 
     [DataMember(Name = "metadataDelta")]
-    public ImmutableArray<byte> MetadataDelta { get; }
+    public ImmutableArray<byte> MetadataDelta { get; } = metadataDelta;
 
     [DataMember(Name = "pdbDelta")]
-    public ImmutableArray<byte> PdbDelta { get; }
+    public ImmutableArray<byte> PdbDelta { get; } = pdbDelta;
 
     [DataMember(Name = "updatedTypes")]
-    public ImmutableArray<int> UpdatedTypes { get; }
+    public ImmutableArray<int> UpdatedTypes { get; } = updatedTypes;
 
     [DataMember(Name = "requiredCapabilities")]
-    public ImmutableArray<string> RequiredCapabilities { get; }
+    public ImmutableArray<string> RequiredCapabilities { get; } = requiredCapabilities;
 
     [DataMember(Name = "updatedMethods")]
-    public ImmutableArray<int> UpdatedMethods { get; }
+    public ImmutableArray<int> UpdatedMethods { get; } = updatedMethods;
 
     [DataMember(Name = "sequencePoints")]
-    public ImmutableArray<SequencePointUpdates> SequencePoints { get; }
+    public ImmutableArray<SequencePointUpdates> SequencePoints { get; } = sequencePoints;
 
     [DataMember(Name = "activeStatements")]
-    public ImmutableArray<ManagedActiveStatementUpdate> ActiveStatements { get; }
+    public ImmutableArray<ManagedActiveStatementUpdate> ActiveStatements { get; } = activeStatements;
 
     [DataMember(Name = "exceptionRegions")]
-    public ImmutableArray<ManagedExceptionRegionUpdate> ExceptionRegions { get; }
-
-    public ManagedHotReloadUpdate(
-        Guid module,
-        string moduleName,
-        ImmutableArray<byte> ilDelta,
-        ImmutableArray<byte> metadataDelta,
-        ImmutableArray<byte> pdbDelta,
-        ImmutableArray<int> updatedTypes,
-        ImmutableArray<string> requiredCapabilities,
-        ImmutableArray<int> updatedMethods,
-        ImmutableArray<SequencePointUpdates> sequencePoints,
-        ImmutableArray<ManagedActiveStatementUpdate> activeStatements,
-        ImmutableArray<ManagedExceptionRegionUpdate> exceptionRegions)
-    {
-        Module = module;
-        ModuleName = moduleName;
-        ILDelta = ilDelta;
-        MetadataDelta = metadataDelta;
-        PdbDelta = pdbDelta;
-        SequencePoints = sequencePoints;
-        UpdatedMethods = updatedMethods;
-        UpdatedTypes = updatedTypes;
-        ActiveStatements = activeStatements;
-        ExceptionRegions = exceptionRegions;
-        RequiredCapabilities = requiredCapabilities;
-    }
+    public ImmutableArray<ManagedExceptionRegionUpdate> ExceptionRegions { get; } = exceptionRegions;
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdates.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedHotReloadUpdates.cs
@@ -8,17 +8,11 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 
 [DataContract]
-internal readonly struct ManagedHotReloadUpdates
+internal readonly struct ManagedHotReloadUpdates(ImmutableArray<ManagedHotReloadUpdate> updates, ImmutableArray<ManagedHotReloadDiagnostic> diagnostics)
 {
     [DataMember(Name = "updates")]
-    public ImmutableArray<ManagedHotReloadUpdate> Updates { get; }
+    public ImmutableArray<ManagedHotReloadUpdate> Updates { get; } = updates;
 
     [DataMember(Name = "diagnostics")]
-    public ImmutableArray<ManagedHotReloadDiagnostic> Diagnostics { get; }
-
-    public ManagedHotReloadUpdates(ImmutableArray<ManagedHotReloadUpdate> updates, ImmutableArray<ManagedHotReloadDiagnostic> diagnostics)
-    {
-        Updates = updates;
-        Diagnostics = diagnostics;
-    }
+    public ImmutableArray<ManagedHotReloadDiagnostic> Diagnostics { get; } = diagnostics;
 }

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedInstructionId.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedInstructionId.cs
@@ -15,32 +15,22 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal readonly struct ManagedInstructionId : IEquatable<ManagedInstructionId>
+    internal readonly struct ManagedInstructionId(
+        ManagedMethodId method,
+        int ilOffset) : IEquatable<ManagedInstructionId>
     {
-        /// <summary>
-        /// Creates an ActiveInstructionId.
-        /// </summary>
-        /// <param name="method">Method which the instruction is scoped to.</param>
-        /// <param name="ilOffset">IL offset for the instruction.</param>
-        public ManagedInstructionId(
-            ManagedMethodId method,
-            int ilOffset)
-        {
-            Method = method;
-            ILOffset = ilOffset;
-        }
 
         /// <summary>
         /// Method which the instruction is scoped to.
         /// </summary>
         [DataMember(Name = "method")]
-        public ManagedMethodId Method { get; }
+        public ManagedMethodId Method { get; } = method;
 
         /// <summary>
         /// The IL offset for the instruction.
         /// </summary>
         [DataMember(Name = "ilOffset")]
-        public int ILOffset { get; }
+        public int ILOffset { get; } = ilOffset;
 
         public bool Equals(ManagedInstructionId other)
         {

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedMethodId.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/ManagedMethodId.cs
@@ -15,21 +15,10 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal readonly struct ManagedMethodId : IEquatable<ManagedMethodId>
+    internal readonly struct ManagedMethodId(
+        Guid module,
+        ManagedModuleMethodId method) : IEquatable<ManagedMethodId>
     {
-        /// <summary>
-        /// Creates a ManagedMethodId.
-        /// </summary>
-        /// <param name="module">Module version ID in which the method exists.</param>
-        /// <param name="method">Method ID.</param>
-        public ManagedMethodId(
-            Guid module,
-            ManagedModuleMethodId method)
-        {
-            Module = module;
-            Method = method;
-        }
-
         public ManagedMethodId(Guid module, int token, int version)
             : this(module, new(token, version))
         {
@@ -39,13 +28,13 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
         /// The module version ID in which the method exists.
         /// </summary>
         [DataMember(Name = "module")]
-        public Guid Module { get; }
+        public Guid Module { get; } = module;
 
         /// <summary>
         /// The unique identifier for the method within <see cref="Module"/>.
         /// </summary>
         [DataMember(Name = "method")]
-        public ManagedModuleMethodId Method { get; }
+        public ManagedModuleMethodId Method { get; } = method;
 
         public int Token => Method.Token;
 

--- a/src/Features/Core/Portable/Contracts/EditAndContinue/SequencePointUpdates.cs
+++ b/src/Features/Core/Portable/Contracts/EditAndContinue/SequencePointUpdates.cs
@@ -11,31 +11,21 @@ namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
     /// Sequence points affected by an update on a specified file.
     /// </summary>
     [DataContract]
-    internal readonly struct SequencePointUpdates
+    internal readonly struct SequencePointUpdates(
+        string fileName,
+        ImmutableArray<SourceLineUpdate> lineUpdates)
     {
-        /// <summary>
-        /// Creates a SequencePointsUpdate.
-        /// </summary>
-        /// <param name="fileName">Name of the file which was modified.</param>
-        /// <param name="lineUpdates">Collection of the file lines affected by the update.</param>
-        public SequencePointUpdates(
-            string fileName,
-            ImmutableArray<SourceLineUpdate> lineUpdates)
-        {
-            FileName = fileName;
-            LineUpdates = lineUpdates;
-        }
 
         /// <summary>
         /// Name of the modified file as stored in PDB.
         /// </summary>
         [DataMember(Name = "fileName")]
-        public string FileName { get; }
+        public string FileName { get; } = fileName;
 
         /// <summary>
         /// Collection of the file lines affected by the update.
         /// </summary>
         [DataMember(Name = "lineUpdates")]
-        public ImmutableArray<SourceLineUpdate> LineUpdates { get; }
+        public ImmutableArray<SourceLineUpdate> LineUpdates { get; } = lineUpdates;
     }
 }

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -425,34 +425,19 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
             return document.WithSyntaxRoot(newRoot);
         }
 
-        protected sealed class ForEachInfo
+        protected sealed class ForEachInfo(
+            ISemanticFactsService semanticFacts, string collectionNameSuggestion, string countName,
+            ITypeSymbol? explicitCastInterface, ITypeSymbol forEachElementType,
+            bool requireCollectionStatement, TForEachStatement forEachStatement)
         {
-            public ForEachInfo(
-                ISemanticFactsService semanticFacts, string collectionNameSuggestion, string countName,
-                ITypeSymbol? explicitCastInterface, ITypeSymbol forEachElementType,
-                bool requireCollectionStatement, TForEachStatement forEachStatement)
-            {
-                SemanticFacts = semanticFacts;
+            public ISemanticFactsService SemanticFacts { get; } = semanticFacts;
 
-                CollectionNameSuggestion = collectionNameSuggestion;
-                CountName = countName;
-
-                ExplicitCastInterface = explicitCastInterface;
-                ForEachElementType = forEachElementType;
-
-                RequireCollectionStatement = requireCollectionStatement || (explicitCastInterface != null);
-
-                ForEachStatement = forEachStatement;
-            }
-
-            public ISemanticFactsService SemanticFacts { get; }
-
-            public string CollectionNameSuggestion { get; }
-            public string CountName { get; }
-            public ITypeSymbol? ExplicitCastInterface { get; }
-            public ITypeSymbol ForEachElementType { get; }
-            public bool RequireCollectionStatement { get; }
-            public TForEachStatement ForEachStatement { get; }
+            public string CollectionNameSuggestion { get; } = collectionNameSuggestion;
+            public string CountName { get; } = countName;
+            public ITypeSymbol? ExplicitCastInterface { get; } = explicitCastInterface;
+            public ITypeSymbol ForEachElementType { get; } = forEachElementType;
+            public bool RequireCollectionStatement { get; } = requireCollectionStatement || (explicitCastInterface != null);
+            public TForEachStatement ForEachStatement { get; } = forEachStatement;
         }
     }
 }

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.AnalyzedNodes.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.AnalyzedNodes.cs
@@ -21,34 +21,21 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
         /// Represents a switch-section constructed from a series of
         /// if-conditions, possibly combined with logical-or operator
         /// </summary>
-        internal sealed class AnalyzedSwitchSection
+        internal sealed class AnalyzedSwitchSection(ImmutableArray<AnalyzedSwitchLabel> labels, IOperation body, SyntaxNode syntaxToRemove)
         {
-            public readonly ImmutableArray<AnalyzedSwitchLabel> Labels;
-            public readonly IOperation Body;
-            public readonly SyntaxNode SyntaxToRemove;
-
-            public AnalyzedSwitchSection(ImmutableArray<AnalyzedSwitchLabel> labels, IOperation body, SyntaxNode syntaxToRemove)
-            {
-                Labels = labels;
-                Body = body;
-                SyntaxToRemove = syntaxToRemove;
-            }
+            public readonly ImmutableArray<AnalyzedSwitchLabel> Labels = labels;
+            public readonly IOperation Body = body;
+            public readonly SyntaxNode SyntaxToRemove = syntaxToRemove;
         }
 
         /// <summary>
         /// Represents a switch-label constructed from a series of
         /// if-conditions, possibly combined by logical-and operator
         /// </summary>
-        internal sealed class AnalyzedSwitchLabel
+        internal sealed class AnalyzedSwitchLabel(AnalyzedPattern pattern, ImmutableArray<TExpressionSyntax> guards)
         {
-            public readonly AnalyzedPattern Pattern;
-            public readonly ImmutableArray<TExpressionSyntax> Guards;
-
-            public AnalyzedSwitchLabel(AnalyzedPattern pattern, ImmutableArray<TExpressionSyntax> guards)
-            {
-                Pattern = pattern;
-                Guards = guards;
-            }
+            public readonly AnalyzedPattern Pattern = pattern;
+            public readonly ImmutableArray<TExpressionSyntax> Guards = guards;
         }
 
         /// <summary>
@@ -63,79 +50,52 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             /// <summary>
             /// Represents a type-pattern, constructed from is-expression
             /// </summary>
-            internal sealed class Type : AnalyzedPattern
+            internal sealed class Type(TIsExpressionSyntax expression) : AnalyzedPattern
             {
-                public readonly TIsExpressionSyntax IsExpressionSyntax;
-
-                public Type(TIsExpressionSyntax expression)
-                    => IsExpressionSyntax = expression;
+                public readonly TIsExpressionSyntax IsExpressionSyntax = expression;
             }
 
             /// <summary>
             /// Represents a source-pattern constructed from C# patterns
             /// </summary>
-            internal sealed class Source : AnalyzedPattern
+            internal sealed class Source(TPatternSyntax patternSyntax) : AnalyzedPattern
             {
-                public readonly TPatternSyntax PatternSyntax;
-
-                public Source(TPatternSyntax patternSyntax)
-                    => PatternSyntax = patternSyntax;
+                public readonly TPatternSyntax PatternSyntax = patternSyntax;
             }
 
             /// <summary>
             /// Represents a constant-pattern constructed from an equality check
             /// </summary>
-            internal sealed class Constant : AnalyzedPattern
+            internal sealed class Constant(TExpressionSyntax expression) : AnalyzedPattern
             {
-                public readonly TExpressionSyntax ExpressionSyntax;
-
-                public Constant(TExpressionSyntax expression)
-                    => ExpressionSyntax = expression;
+                public readonly TExpressionSyntax ExpressionSyntax = expression;
             }
 
             /// <summary>
             /// Represents a relational-pattern constructed from comparison operators
             /// </summary>
-            internal sealed class Relational : AnalyzedPattern
+            internal sealed class Relational(BinaryOperatorKind operatorKind, TExpressionSyntax value) : AnalyzedPattern
             {
-                public readonly BinaryOperatorKind OperatorKind;
-                public readonly TExpressionSyntax Value;
-
-                public Relational(BinaryOperatorKind operatorKind, TExpressionSyntax value)
-                {
-                    OperatorKind = operatorKind;
-                    Value = value;
-                }
+                public readonly BinaryOperatorKind OperatorKind = operatorKind;
+                public readonly TExpressionSyntax Value = value;
             }
 
             /// <summary>
             /// Represents a range-pattern constructed from a couple of comparison operators
             /// </summary>
-            internal sealed class Range : AnalyzedPattern
+            internal sealed class Range(TExpressionSyntax lowerBound, TExpressionSyntax higherBound) : AnalyzedPattern
             {
-                public readonly TExpressionSyntax LowerBound;
-                public readonly TExpressionSyntax HigherBound;
-
-                public Range(TExpressionSyntax lowerBound, TExpressionSyntax higherBound)
-                {
-                    LowerBound = lowerBound;
-                    HigherBound = higherBound;
-                }
+                public readonly TExpressionSyntax LowerBound = lowerBound;
+                public readonly TExpressionSyntax HigherBound = higherBound;
             }
 
             /// <summary>
             /// Represents an and-pattern, constructed from two other patterns.
             /// </summary>
-            internal sealed class And : AnalyzedPattern
+            internal sealed class And(AnalyzedPattern leftPattern, AnalyzedPattern rightPattern) : AnalyzedPattern
             {
-                public readonly AnalyzedPattern LeftPattern;
-                public readonly AnalyzedPattern RightPattern;
-
-                public And(AnalyzedPattern leftPattern, AnalyzedPattern rightPattern)
-                {
-                    LeftPattern = leftPattern;
-                    RightPattern = rightPattern;
-                }
+                public readonly AnalyzedPattern LeftPattern = leftPattern;
+                public readonly AnalyzedPattern RightPattern = rightPattern;
             }
         }
     }

--- a/src/Features/Core/Portable/ConvertLinq/AbstractConvertLinqQueryToForEachProvider.cs
+++ b/src/Features/Core/Portable/ConvertLinq/AbstractConvertLinqQueryToForEachProvider.cs
@@ -56,19 +56,13 @@ namespace Microsoft.CodeAnalysis.ConvertLinq
         /// <summary>
         /// Handles information about updating the document with the refactoring.
         /// </summary>
-        internal sealed class DocumentUpdateInfo
+        internal sealed class DocumentUpdateInfo(TStatement source, IEnumerable<TStatement> destinations)
         {
-            public readonly TStatement Source;
-            public readonly ImmutableArray<TStatement> Destinations;
+            public readonly TStatement Source = source;
+            public readonly ImmutableArray<TStatement> Destinations = ImmutableArray.CreateRange(destinations);
 
             public DocumentUpdateInfo(TStatement source, TStatement destination) : this(source, new[] { destination })
             {
-            }
-
-            public DocumentUpdateInfo(TStatement source, IEnumerable<TStatement> destinations)
-            {
-                Source = source;
-                Destinations = ImmutableArray.CreateRange(destinations);
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ExtendedSyntaxNode.cs
+++ b/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ExtendedSyntaxNode.cs
@@ -8,13 +8,16 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.ConvertLinq.ConvertForEachToLinqQuery
 {
-    internal readonly struct ExtendedSyntaxNode
+    internal readonly struct ExtendedSyntaxNode(
+        SyntaxNode node,
+        IEnumerable<SyntaxTrivia> extraLeadingComments,
+        IEnumerable<SyntaxTrivia> extraTrailingComments)
     {
-        public SyntaxNode Node { get; }
+        public SyntaxNode Node { get; } = node;
 
-        public ImmutableArray<SyntaxTrivia> ExtraLeadingComments { get; }
+        public ImmutableArray<SyntaxTrivia> ExtraLeadingComments { get; } = extraLeadingComments.ToImmutableArray();
 
-        public ImmutableArray<SyntaxTrivia> ExtraTrailingComments { get; }
+        public ImmutableArray<SyntaxTrivia> ExtraTrailingComments { get; } = extraTrailingComments.ToImmutableArray();
 
         public ExtendedSyntaxNode(
             SyntaxNode node,
@@ -22,16 +25,6 @@ namespace Microsoft.CodeAnalysis.ConvertLinq.ConvertForEachToLinqQuery
             IEnumerable<SyntaxToken> extraTrailingTokens)
             : this(node, extraLeadingTokens.GetTrivia(), extraTrailingTokens.GetTrivia())
         {
-        }
-
-        public ExtendedSyntaxNode(
-            SyntaxNode node,
-            IEnumerable<SyntaxTrivia> extraLeadingComments,
-            IEnumerable<SyntaxTrivia> extraTrailingComments)
-        {
-            Node = node;
-            ExtraLeadingComments = extraLeadingComments.ToImmutableArray();
-            ExtraTrailingComments = extraTrailingComments.ToImmutableArray();
         }
     }
 }

--- a/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ForEachInfo.cs
+++ b/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/ForEachInfo.cs
@@ -8,38 +8,27 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ConvertLinq.ConvertForEachToLinqQuery
 {
-    internal readonly struct ForEachInfo<TForEachStatement, TStatement>
+    internal readonly struct ForEachInfo<TForEachStatement, TStatement>(
+        TForEachStatement forEachStatement,
+        SemanticModel semanticModel,
+        ImmutableArray<ExtendedSyntaxNode> convertingExtendedNodes,
+        ImmutableArray<SyntaxToken> identifiers,
+        ImmutableArray<TStatement> statements,
+        ImmutableArray<SyntaxToken> leadingTokens,
+        ImmutableArray<SyntaxToken> trailingTokens)
     {
-        public TForEachStatement ForEachStatement { get; }
+        public TForEachStatement ForEachStatement { get; } = forEachStatement;
 
-        public SemanticModel SemanticModel { get; }
+        public SemanticModel SemanticModel { get; } = semanticModel;
 
-        public ImmutableArray<ExtendedSyntaxNode> ConvertingExtendedNodes { get; }
+        public ImmutableArray<ExtendedSyntaxNode> ConvertingExtendedNodes { get; } = convertingExtendedNodes;
 
-        public ImmutableArray<SyntaxToken> Identifiers { get; }
+        public ImmutableArray<SyntaxToken> Identifiers { get; } = identifiers;
 
-        public ImmutableArray<TStatement> Statements { get; }
+        public ImmutableArray<TStatement> Statements { get; } = statements;
 
-        public ImmutableArray<SyntaxToken> LeadingTokens { get; }
+        public ImmutableArray<SyntaxToken> LeadingTokens { get; } = leadingTokens;
 
-        public ImmutableArray<SyntaxToken> TrailingTokens { get; }
-
-        public ForEachInfo(
-            TForEachStatement forEachStatement,
-            SemanticModel semanticModel,
-            ImmutableArray<ExtendedSyntaxNode> convertingExtendedNodes,
-            ImmutableArray<SyntaxToken> identifiers,
-            ImmutableArray<TStatement> statements,
-            ImmutableArray<SyntaxToken> leadingTokens,
-            ImmutableArray<SyntaxToken> trailingTokens)
-        {
-            ForEachStatement = forEachStatement;
-            SemanticModel = semanticModel;
-            ConvertingExtendedNodes = convertingExtendedNodes;
-            Identifiers = identifiers;
-            Statements = statements;
-            LeadingTokens = leadingTokens;
-            TrailingTokens = trailingTokens;
-        }
+        public ImmutableArray<SyntaxToken> TrailingTokens { get; } = trailingTokens;
     }
 }

--- a/src/Features/Core/Portable/ConvertTupleToStruct/DocumentToUpdate.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/DocumentToUpdate.cs
@@ -6,23 +6,17 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
 {
-    internal readonly struct DocumentToUpdate
+    internal readonly struct DocumentToUpdate(Document document, ImmutableArray<SyntaxNode> nodesToUpdate)
     {
         /// <summary>
         /// The document to update.
         /// </summary>
-        public readonly Document Document;
+        public readonly Document Document = document;
 
         /// <summary>
         /// The subnodes in this document to walk and update.  If empty, the entire document
         /// should be walked.
         /// </summary>
-        public readonly ImmutableArray<SyntaxNode> NodesToUpdate;
-
-        public DocumentToUpdate(Document document, ImmutableArray<SyntaxNode> nodesToUpdate)
-        {
-            Document = document;
-            NodesToUpdate = nodesToUpdate;
-        }
+        public readonly ImmutableArray<SyntaxNode> NodesToUpdate = nodesToUpdate;
     }
 }

--- a/src/Features/Core/Portable/ConvertTupleToStruct/IRemoteConvertTupleToStructCodeRefactoringService.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/IRemoteConvertTupleToStructCodeRefactoringService.cs
@@ -49,20 +49,14 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
     }
 
     [DataContract]
-    internal readonly struct SerializableConvertTupleToStructResult
+    internal readonly struct SerializableConvertTupleToStructResult(
+        ImmutableArray<(DocumentId, ImmutableArray<TextChange>)> documentTextChanges,
+        (DocumentId, TextSpan) renamedToken)
     {
         [DataMember(Order = 0)]
-        public readonly ImmutableArray<(DocumentId, ImmutableArray<TextChange>)> DocumentTextChanges;
+        public readonly ImmutableArray<(DocumentId, ImmutableArray<TextChange>)> DocumentTextChanges = documentTextChanges;
 
         [DataMember(Order = 1)]
-        public readonly (DocumentId, TextSpan) RenamedToken;
-
-        public SerializableConvertTupleToStructResult(
-            ImmutableArray<(DocumentId, ImmutableArray<TextChange>)> documentTextChanges,
-            (DocumentId, TextSpan) renamedToken)
-        {
-            DocumentTextChanges = documentTextChanges;
-            RenamedToken = renamedToken;
-        }
+        public readonly (DocumentId, TextSpan) RenamedToken = renamedToken;
     }
 }

--- a/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.NameAndArity.cs
+++ b/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.NameAndArity.cs
@@ -8,16 +8,10 @@ namespace Microsoft.CodeAnalysis.Debugging
 {
     internal partial class AbstractBreakpointResolver
     {
-        protected struct NameAndArity
+        protected struct NameAndArity(string name, int arity)
         {
-            public string Name;
-            public int Arity;
-
-            public NameAndArity(string name, int arity)
-            {
-                Name = name;
-                Arity = arity;
-            }
+            public string Name = name;
+            public int Arity = arity;
         }
     }
 }

--- a/src/Features/Core/Portable/Debugging/DebugDataTipInfo.cs
+++ b/src/Features/Core/Portable/Debugging/DebugDataTipInfo.cs
@@ -6,16 +6,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Debugging
 {
-    internal readonly struct DebugDataTipInfo
+    internal readonly struct DebugDataTipInfo(TextSpan span, string text)
     {
-        public readonly TextSpan Span;
-        public readonly string Text;
-
-        public DebugDataTipInfo(TextSpan span, string text)
-        {
-            Span = span;
-            Text = text;
-        }
+        public readonly TextSpan Span = span;
+        public readonly string Text = text;
 
         public bool IsDefault
             => Span.Length == 0 && Span.Start == 0 && Text == null;

--- a/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
+++ b/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
@@ -39,12 +39,9 @@ namespace Microsoft.CodeAnalysis.Debugging
                 => throw ExceptionUtilities.Unreachable();
         }
 
-        private sealed class Portable : DebugInformationReaderProvider
+        private sealed class Portable(MetadataReaderProvider pdbReaderProvider) : DebugInformationReaderProvider
         {
-            private readonly MetadataReaderProvider _pdbReaderProvider;
-
-            public Portable(MetadataReaderProvider pdbReaderProvider)
-                => _pdbReaderProvider = pdbReaderProvider;
+            private readonly MetadataReaderProvider _pdbReaderProvider = pdbReaderProvider;
 
             public override EditAndContinueMethodDebugInfoReader CreateEditAndContinueMethodDebugInfoReader()
                 => EditAndContinueMethodDebugInfoReader.Create(_pdbReaderProvider.GetMetadataReader());
@@ -65,18 +62,11 @@ namespace Microsoft.CodeAnalysis.Debugging
                 => _pdbReaderProvider.Dispose();
         }
 
-        private sealed class Native : DebugInformationReaderProvider
+        private sealed class Native(Stream stream, ISymUnmanagedReader5 symReader, int version) : DebugInformationReaderProvider
         {
-            private readonly Stream _stream;
-            private readonly int _version;
-            private ISymUnmanagedReader5 _symReader;
-
-            public Native(Stream stream, ISymUnmanagedReader5 symReader, int version)
-            {
-                _stream = stream;
-                _symReader = symReader;
-                _version = version;
-            }
+            private readonly Stream _stream = stream;
+            private readonly int _version = version;
+            private ISymUnmanagedReader5 _symReader = symReader;
 
             public override EditAndContinueMethodDebugInfoReader CreateEditAndContinueMethodDebugInfoReader()
                 => EditAndContinueMethodDebugInfoReader.Create(_symReader, _version);

--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -25,7 +25,9 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.DesignerAttribute
 {
     [ExportWorkspaceService(typeof(IDesignerAttributeDiscoveryService)), Shared]
-    internal sealed partial class DesignerAttributeDiscoveryService : IDesignerAttributeDiscoveryService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed partial class DesignerAttributeDiscoveryService(IAsynchronousOperationListenerProvider listenerProvider) : IDesignerAttributeDiscoveryService
     {
         /// <summary>
         /// Cache from the individual references a project has, to a boolean specifying if reference knows about the
@@ -33,7 +35,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
         /// </summary>
         private static readonly ConditionalWeakTable<MetadataId, AsyncLazy<bool>> s_metadataIdToDesignerAttributeInfo = new();
 
-        private readonly IAsynchronousOperationListener _listener;
+        private readonly IAsynchronousOperationListener _listener = listenerProvider.GetListener(FeatureAttribute.DesignerAttributes);
 
         /// <summary>
         /// Protects mutable state in this type.
@@ -45,13 +47,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
         /// don't change.
         /// </summary>
         private readonly ConcurrentDictionary<DocumentId, (string? category, VersionStamp projectVersion)> _documentToLastReportedInformation = new();
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DesignerAttributeDiscoveryService(IAsynchronousOperationListenerProvider listenerProvider)
-        {
-            _listener = listenerProvider.GetListener(FeatureAttribute.DesignerAttributes);
-        }
 
         private static async ValueTask<bool> HasDesignerCategoryTypeAsync(Project project, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -146,12 +146,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(AbstractHostDiagnosticUpdateSource abstractHostDiagnosticUpdateSource)
         {
-            private readonly AbstractHostDiagnosticUpdateSource _abstractHostDiagnosticUpdateSource;
-
-            public TestAccessor(AbstractHostDiagnosticUpdateSource abstractHostDiagnosticUpdateSource)
-                => _abstractHostDiagnosticUpdateSource = abstractHostDiagnosticUpdateSource;
+            private readonly AbstractHostDiagnosticUpdateSource _abstractHostDiagnosticUpdateSource = abstractHostDiagnosticUpdateSource;
 
             internal ImmutableArray<DiagnosticData> GetReportedDiagnostics()
                 => _abstractHostDiagnosticUpdateSource._analyzerHostDiagnosticsMap.Values.Flatten().ToImmutableArray();
@@ -167,16 +164,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private sealed class HostArgsId : AnalyzerUpdateArgsId
+        private sealed class HostArgsId(AbstractHostDiagnosticUpdateSource source, DiagnosticAnalyzer analyzer, ProjectId? projectId) : AnalyzerUpdateArgsId(analyzer)
         {
-            private readonly AbstractHostDiagnosticUpdateSource _source;
-            private readonly ProjectId? _projectId;
-
-            public HostArgsId(AbstractHostDiagnosticUpdateSource source, DiagnosticAnalyzer analyzer, ProjectId? projectId) : base(analyzer)
-            {
-                _source = source;
-                _projectId = projectId;
-            }
+            private readonly AbstractHostDiagnosticUpdateSource _source = source;
+            private readonly ProjectId? _projectId = projectId;
 
             public override bool Equals(object? obj)
             {

--- a/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
+++ b/src/Features/Core/Portable/Diagnostics/BuildToolId.cs
@@ -13,12 +13,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         public abstract string BuildTool { get; }
 
-        internal abstract class Base<T> : BuildToolId
+        internal abstract class Base<T>(T? field) : BuildToolId
         {
-            protected readonly T? _Field1;
-
-            public Base(T? field)
-                => _Field1 = field;
+            protected readonly T? _Field1 = field;
 
             public override bool Equals(object? obj)
             {
@@ -34,12 +31,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 => _Field1?.GetHashCode() ?? 0;
         }
 
-        internal abstract class Base<T1, T2> : Base<T2>
+        internal abstract class Base<T1, T2>(T1? field1, T2? field2) : Base<T2>(field2)
         {
-            private readonly T1? _Field2;
-
-            public Base(T1? field1, T2? field2) : base(field2)
-                => _Field2 = field1;
+            private readonly T1? _Field2 = field1;
 
             public override bool Equals(object? obj)
             {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerTelemetry.cs
@@ -19,52 +19,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal sealed class DiagnosticAnalyzerTelemetry
     {
-        private readonly struct Data
+        private readonly struct Data(AnalyzerTelemetryInfo analyzerTelemetryInfo, bool isTelemetryCollectionAllowed)
         {
-            public readonly int CompilationStartActionsCount;
-            public readonly int CompilationEndActionsCount;
-            public readonly int CompilationActionsCount;
-            public readonly int SyntaxTreeActionsCount;
-            public readonly int AdditionalFileActionsCount;
-            public readonly int SemanticModelActionsCount;
-            public readonly int SymbolActionsCount;
-            public readonly int SymbolStartActionsCount;
-            public readonly int SymbolEndActionsCount;
-            public readonly int SyntaxNodeActionsCount;
-            public readonly int CodeBlockStartActionsCount;
-            public readonly int CodeBlockEndActionsCount;
-            public readonly int CodeBlockActionsCount;
-            public readonly int OperationActionsCount;
-            public readonly int OperationBlockStartActionsCount;
-            public readonly int OperationBlockEndActionsCount;
-            public readonly int OperationBlockActionsCount;
-            public readonly int SuppressionActionsCount;
+            public readonly int CompilationStartActionsCount = analyzerTelemetryInfo.CompilationStartActionsCount;
+            public readonly int CompilationEndActionsCount = analyzerTelemetryInfo.CompilationEndActionsCount;
+            public readonly int CompilationActionsCount = analyzerTelemetryInfo.CompilationActionsCount;
+            public readonly int SyntaxTreeActionsCount = analyzerTelemetryInfo.SyntaxTreeActionsCount;
+            public readonly int AdditionalFileActionsCount = analyzerTelemetryInfo.AdditionalFileActionsCount;
+            public readonly int SemanticModelActionsCount = analyzerTelemetryInfo.SemanticModelActionsCount;
+            public readonly int SymbolActionsCount = analyzerTelemetryInfo.SymbolActionsCount;
+            public readonly int SymbolStartActionsCount = analyzerTelemetryInfo.SymbolStartActionsCount;
+            public readonly int SymbolEndActionsCount = analyzerTelemetryInfo.SymbolEndActionsCount;
+            public readonly int SyntaxNodeActionsCount = analyzerTelemetryInfo.SyntaxNodeActionsCount;
+            public readonly int CodeBlockStartActionsCount = analyzerTelemetryInfo.CodeBlockStartActionsCount;
+            public readonly int CodeBlockEndActionsCount = analyzerTelemetryInfo.CodeBlockEndActionsCount;
+            public readonly int CodeBlockActionsCount = analyzerTelemetryInfo.CodeBlockActionsCount;
+            public readonly int OperationActionsCount = analyzerTelemetryInfo.OperationActionsCount;
+            public readonly int OperationBlockStartActionsCount = analyzerTelemetryInfo.OperationBlockStartActionsCount;
+            public readonly int OperationBlockEndActionsCount = analyzerTelemetryInfo.OperationBlockEndActionsCount;
+            public readonly int OperationBlockActionsCount = analyzerTelemetryInfo.OperationBlockActionsCount;
+            public readonly int SuppressionActionsCount = analyzerTelemetryInfo.SuppressionActionsCount;
 
-            public readonly bool IsTelemetryCollectionAllowed;
-
-            public Data(AnalyzerTelemetryInfo analyzerTelemetryInfo, bool isTelemetryCollectionAllowed)
-            {
-                CodeBlockActionsCount = analyzerTelemetryInfo.CodeBlockActionsCount;
-                CodeBlockEndActionsCount = analyzerTelemetryInfo.CodeBlockEndActionsCount;
-                CodeBlockStartActionsCount = analyzerTelemetryInfo.CodeBlockStartActionsCount;
-                CompilationActionsCount = analyzerTelemetryInfo.CompilationActionsCount;
-                CompilationEndActionsCount = analyzerTelemetryInfo.CompilationEndActionsCount;
-                CompilationStartActionsCount = analyzerTelemetryInfo.CompilationStartActionsCount;
-                SemanticModelActionsCount = analyzerTelemetryInfo.SemanticModelActionsCount;
-                SymbolActionsCount = analyzerTelemetryInfo.SymbolActionsCount;
-                SyntaxNodeActionsCount = analyzerTelemetryInfo.SyntaxNodeActionsCount;
-                SyntaxTreeActionsCount = analyzerTelemetryInfo.SyntaxTreeActionsCount;
-                AdditionalFileActionsCount = analyzerTelemetryInfo.AdditionalFileActionsCount;
-                OperationActionsCount = analyzerTelemetryInfo.OperationActionsCount;
-                OperationBlockActionsCount = analyzerTelemetryInfo.OperationBlockActionsCount;
-                OperationBlockEndActionsCount = analyzerTelemetryInfo.OperationBlockEndActionsCount;
-                OperationBlockStartActionsCount = analyzerTelemetryInfo.OperationBlockStartActionsCount;
-                SymbolStartActionsCount = analyzerTelemetryInfo.SymbolStartActionsCount;
-                SymbolEndActionsCount = analyzerTelemetryInfo.SymbolEndActionsCount;
-                SuppressionActionsCount = analyzerTelemetryInfo.SuppressionActionsCount;
-
-                IsTelemetryCollectionAllowed = isTelemetryCollectionAllowed;
-            }
+            public readonly bool IsTelemetryCollectionAllowed = isTelemetryCollectionAllowed;
         }
 
         private readonly object _guard = new();

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticBucket.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticBucket.cs
@@ -4,34 +4,26 @@
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    internal readonly struct DiagnosticBucket
+    internal readonly struct DiagnosticBucket(object id, Workspace workspace, ProjectId? projectId, DocumentId? documentId)
     {
         /// <summary>
         /// The identity of bucket group. 
         /// </summary>
-        public readonly object Id;
+        public readonly object Id = id;
 
         /// <summary>
         /// <see cref="Workspace"/> this bucket is associated with.
         /// </summary>
-        public readonly Workspace Workspace;
+        public readonly Workspace Workspace = workspace;
 
         /// <summary>
         /// <see cref="ProjectId"/> this bucket is associated with, or <see langword="null"/>.
         /// </summary>
-        public readonly ProjectId? ProjectId;
+        public readonly ProjectId? ProjectId = projectId;
 
         /// <summary>
         /// <see cref="DocumentId"/> this bucket is associated with, or <see langword="null"/>.
         /// </summary>
-        public readonly DocumentId? DocumentId;
-
-        public DiagnosticBucket(object id, Workspace workspace, ProjectId? projectId, DocumentId? documentId)
-        {
-            Id = id;
-            Workspace = workspace;
-            ProjectId = projectId;
-            DocumentId = documentId;
-        }
+        public readonly DocumentId? DocumentId = documentId;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticProviderMetadata.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticProviderMetadata.cs
@@ -10,15 +10,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    internal class DiagnosticProviderMetadata : ILanguageMetadata
+    internal class DiagnosticProviderMetadata(IDictionary<string, object> data) : ILanguageMetadata
     {
-        public string Name { get; }
-        public string Language { get; }
-
-        public DiagnosticProviderMetadata(IDictionary<string, object> data)
-        {
-            Name = (string)data.GetValueOrDefault("Name");
-            Language = (string)data.GetValueOrDefault("Language");
-        }
+        public string Name { get; } = (string)data.GetValueOrDefault("Name");
+        public string Language { get; } = (string)data.GetValueOrDefault("Language");
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -23,22 +23,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     }
 
     [DataContract]
-    internal readonly struct AnalyzerPerformanceInfo
+    internal readonly struct AnalyzerPerformanceInfo(string analyzerId, bool builtIn, TimeSpan timeSpan)
     {
         [DataMember(Order = 0)]
-        public readonly string AnalyzerId;
+        public readonly string AnalyzerId = analyzerId;
 
         [DataMember(Order = 1)]
-        public readonly bool BuiltIn;
+        public readonly bool BuiltIn = builtIn;
 
         [DataMember(Order = 2)]
-        public readonly TimeSpan TimeSpan;
-
-        public AnalyzerPerformanceInfo(string analyzerId, bool builtIn, TimeSpan timeSpan)
-        {
-            AnalyzerId = analyzerId;
-            BuiltIn = builtIn;
-            TimeSpan = timeSpan;
-        }
+        public readonly TimeSpan TimeSpan = timeSpan;
     }
 }

--- a/src/Features/Core/Portable/DocumentHighlighting/ExportEmbeddedLanguageDocumentHighlighterAttribute.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/ExportEmbeddedLanguageDocumentHighlighterAttribute.cs
@@ -9,17 +9,12 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
     /// <summary>
     /// Use this attribute to export a <see cref="IEmbeddedLanguageDocumentHighlighter"/>.
     /// </summary>
-    internal class ExportEmbeddedLanguageDocumentHighlighterAttribute : ExportEmbeddedLanguageFeatureServiceAttribute
+    internal class ExportEmbeddedLanguageDocumentHighlighterAttribute(
+        string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers) : ExportEmbeddedLanguageFeatureServiceAttribute(typeof(IEmbeddedLanguageDocumentHighlighter), name, languages, supportsUnannotatedAPIs, identifiers)
     {
         public ExportEmbeddedLanguageDocumentHighlighterAttribute(
             string name, string[] languages, params string[] identifiers)
             : this(name, languages, supportsUnannotatedAPIs: false, identifiers)
-        {
-        }
-
-        public ExportEmbeddedLanguageDocumentHighlighterAttribute(
-            string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers)
-            : base(typeof(IEmbeddedLanguageDocumentHighlighter), name, languages, supportsUnannotatedAPIs, identifiers)
         {
         }
     }

--- a/src/Features/Core/Portable/DocumentHighlighting/IDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IDocumentHighlightsService.cs
@@ -35,16 +35,10 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
         }
     }
 
-    internal readonly struct DocumentHighlights
+    internal readonly struct DocumentHighlights(Document document, ImmutableArray<HighlightSpan> highlightSpans)
     {
-        public Document Document { get; }
-        public ImmutableArray<HighlightSpan> HighlightSpans { get; }
-
-        public DocumentHighlights(Document document, ImmutableArray<HighlightSpan> highlightSpans)
-        {
-            Document = document;
-            HighlightSpans = highlightSpans;
-        }
+        public Document Document { get; } = document;
+        public ImmutableArray<HighlightSpan> HighlightSpans { get; } = highlightSpans;
     }
 
     /// <summary>

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlightsService.cs
@@ -17,19 +17,13 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
     }
 
     [DataContract]
-    internal readonly struct SerializableDocumentHighlights
+    internal readonly struct SerializableDocumentHighlights(DocumentId documentId, ImmutableArray<HighlightSpan> highlightSpans)
     {
         [DataMember(Order = 0)]
-        public readonly DocumentId DocumentId;
+        public readonly DocumentId DocumentId = documentId;
 
         [DataMember(Order = 1)]
-        public readonly ImmutableArray<HighlightSpan> HighlightSpans;
-
-        public SerializableDocumentHighlights(DocumentId documentId, ImmutableArray<HighlightSpan> highlightSpans)
-        {
-            DocumentId = documentId;
-            HighlightSpans = highlightSpans;
-        }
+        public readonly ImmutableArray<HighlightSpan> HighlightSpans = highlightSpans;
 
         public async ValueTask<DocumentHighlights> RehydrateAsync(Solution solution)
             => new(await solution.GetRequiredDocumentAsync(DocumentId, includeSourceGenerated: true).ConfigureAwait(false), HighlightSpans);

--- a/src/Features/Core/Portable/DocumentIdSpan.cs
+++ b/src/Features/Core/Portable/DocumentIdSpan.cs
@@ -15,18 +15,12 @@ namespace Microsoft.CodeAnalysis
     /// very stale <see cref="Solution"/> snapshot that may keep around a lot of memory in a host.
     /// </summary>
     [DataContract]
-    internal readonly struct DocumentIdSpan
+    internal readonly struct DocumentIdSpan(DocumentId documentId, TextSpan sourceSpan)
     {
         [DataMember(Order = 0)]
-        public readonly DocumentId DocumentId;
+        public readonly DocumentId DocumentId = documentId;
         [DataMember(Order = 1)]
-        public readonly TextSpan SourceSpan;
-
-        public DocumentIdSpan(DocumentId documentId, TextSpan sourceSpan)
-        {
-            DocumentId = documentId;
-            SourceSpan = sourceSpan;
-        }
+        public readonly TextSpan SourceSpan = sourceSpan;
 
         public static implicit operator DocumentIdSpan(DocumentSpan documentSpan)
             => new(documentSpan.Document.Id, documentSpan.SourceSpan);

--- a/src/Features/Core/Portable/DocumentSpan.cs
+++ b/src/Features/Core/Portable/DocumentSpan.cs
@@ -12,29 +12,22 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Represents a <see cref="TextSpan"/> location in a <see cref="Document"/>.
     /// </summary>
-    internal readonly struct DocumentSpan : IEquatable<DocumentSpan>
+    internal readonly struct DocumentSpan(
+        Document document,
+        TextSpan sourceSpan,
+        ImmutableDictionary<string, object>? properties) : IEquatable<DocumentSpan>
     {
-        public Document Document { get; }
-        public TextSpan SourceSpan { get; }
+        public Document Document { get; } = document;
+        public TextSpan SourceSpan { get; } = sourceSpan;
 
         /// <summary>
         /// Additional information attached to a document span by it creator.
         /// </summary>
-        public ImmutableDictionary<string, object>? Properties { get; }
+        public ImmutableDictionary<string, object>? Properties { get; } = properties ?? ImmutableDictionary<string, object>.Empty;
 
         public DocumentSpan(Document document, TextSpan sourceSpan)
             : this(document, sourceSpan, properties: null)
         {
-        }
-
-        public DocumentSpan(
-            Document document,
-            TextSpan sourceSpan,
-            ImmutableDictionary<string, object>? properties)
-        {
-            Document = document;
-            SourceSpan = sourceSpan;
-            Properties = properties ?? ImmutableDictionary<string, object>.Empty;
         }
 
         public override bool Equals(object? obj)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -891,22 +891,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        internal readonly struct ActiveNode
+        internal readonly struct ActiveNode(int activeStatementIndex, SyntaxNode oldNode, SyntaxNode? enclosingLambdaBody, int statementPart, SyntaxNode? newTrackedNode)
         {
-            public readonly int ActiveStatementIndex;
-            public readonly SyntaxNode OldNode;
-            public readonly SyntaxNode? NewTrackedNode;
-            public readonly SyntaxNode? EnclosingLambdaBody;
-            public readonly int StatementPart;
-
-            public ActiveNode(int activeStatementIndex, SyntaxNode oldNode, SyntaxNode? enclosingLambdaBody, int statementPart, SyntaxNode? newTrackedNode)
-            {
-                ActiveStatementIndex = activeStatementIndex;
-                OldNode = oldNode;
-                NewTrackedNode = newTrackedNode;
-                EnclosingLambdaBody = enclosingLambdaBody;
-                StatementPart = statementPart;
-            }
+            public readonly int ActiveStatementIndex = activeStatementIndex;
+            public readonly SyntaxNode OldNode = oldNode;
+            public readonly SyntaxNode? NewTrackedNode = newTrackedNode;
+            public readonly SyntaxNode? EnclosingLambdaBody = enclosingLambdaBody;
+            public readonly int StatementPart = statementPart;
         }
 
         /// <summary>
@@ -2369,27 +2360,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Aggregates information needed to emit updates of constructors that contain member initialization.
         /// </summary>
-        private sealed class MemberInitializationUpdates
+        private sealed class MemberInitializationUpdates(INamedTypeSymbol oldType)
         {
-            public readonly INamedTypeSymbol OldType;
+            public readonly INamedTypeSymbol OldType = oldType;
 
             /// <summary>
             /// Contains syntax maps for all changed data member initializers or constructor declarations (of constructors emitting initializers)
             /// in the currently analyzed document. The key is the new declaration of the member.
             /// </summary>
-            public readonly Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode?>?> ChangedDeclarations;
+            public readonly Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode?>?> ChangedDeclarations = new Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode?>?>();
 
             /// <summary>
             /// True if a member initializer has been deleted
             /// (<see cref="ChangedDeclarations"/> only contains syntax nodes of new declarations, which are not available for deleted members).
             /// </summary>
             public bool HasDeletedMemberInitializer;
-
-            public MemberInitializationUpdates(INamedTypeSymbol oldType)
-            {
-                OldType = oldType;
-                ChangedDeclarations = new Dictionary<SyntaxNode, Func<SyntaxNode, SyntaxNode?>?>();
-            }
         }
 
         private async Task<ImmutableArray<SemanticEditInfo>> AnalyzeSemanticsAsync(
@@ -6708,12 +6693,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(AbstractEditAndContinueAnalyzer abstractEditAndContinueAnalyzer)
         {
-            private readonly AbstractEditAndContinueAnalyzer _abstractEditAndContinueAnalyzer;
-
-            public TestAccessor(AbstractEditAndContinueAnalyzer abstractEditAndContinueAnalyzer)
-                => _abstractEditAndContinueAnalyzer = abstractEditAndContinueAnalyzer;
+            private readonly AbstractEditAndContinueAnalyzer _abstractEditAndContinueAnalyzer = abstractEditAndContinueAnalyzer;
 
             internal void ReportTopLevelSyntacticRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, EditScript<SyntaxNode> syntacticEdits, Dictionary<SyntaxNode, EditKind> editMap)
                 => _abstractEditAndContinueAnalyzer.ReportTopLevelSyntacticRudeEdits(diagnostics, syntacticEdits, editMap);

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementId.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementId.cs
@@ -6,15 +6,9 @@
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal readonly struct ActiveStatementId
+    internal readonly struct ActiveStatementId(DocumentId documentId, int ordinal)
     {
-        public readonly DocumentId DocumentId;
-        public readonly int Ordinal;
-
-        public ActiveStatementId(DocumentId documentId, int ordinal)
-        {
-            DocumentId = documentId;
-            Ordinal = ordinal;
-        }
+        public readonly DocumentId DocumentId = documentId;
+        public readonly int Ordinal = ordinal;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -823,12 +823,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(DebuggingSession instance)
         {
-            private readonly DebuggingSession _instance;
-
-            public TestAccessor(DebuggingSession instance)
-                => _instance = instance;
+            private readonly DebuggingSession _instance = instance;
 
             public ImmutableHashSet<Guid> GetModulesPreparedForUpdate()
             {

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
@@ -10,35 +10,22 @@ using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal sealed class DebuggingSessionTelemetry
+    internal sealed class DebuggingSessionTelemetry(Guid solutionSessionId)
     {
-        internal readonly struct Data
+        internal readonly struct Data(DebuggingSessionTelemetry telemetry)
         {
-            public readonly Guid SolutionSessionId;
-            public readonly ImmutableArray<EditSessionTelemetry.Data> EditSessionData;
-            public readonly int EmptyEditSessionCount;
-            public readonly int EmptyHotReloadEditSessionCount;
-
-            public Data(DebuggingSessionTelemetry telemetry)
-            {
-                SolutionSessionId = telemetry._solutionSessionId;
-                EditSessionData = telemetry._editSessionData.ToImmutableArray();
-                EmptyEditSessionCount = telemetry._emptyEditSessionCount;
-                EmptyHotReloadEditSessionCount = telemetry._emptyHotReloadEditSessionCount;
-            }
+            public readonly Guid SolutionSessionId = telemetry._solutionSessionId;
+            public readonly ImmutableArray<EditSessionTelemetry.Data> EditSessionData = telemetry._editSessionData.ToImmutableArray();
+            public readonly int EmptyEditSessionCount = telemetry._emptyEditSessionCount;
+            public readonly int EmptyHotReloadEditSessionCount = telemetry._emptyHotReloadEditSessionCount;
         }
 
         private readonly object _guard = new();
 
-        private readonly Guid _solutionSessionId;
+        private readonly Guid _solutionSessionId = solutionSessionId;
         private readonly List<EditSessionTelemetry.Data> _editSessionData = new();
         private int _emptyEditSessionCount;
         private int _emptyHotReloadEditSessionCount;
-
-        public DebuggingSessionTelemetry(Guid solutionSessionId)
-        {
-            _solutionSessionId = solutionSessionId;
-        }
 
         public Data GetDataAndClear()
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilitiesGrantor.cs
@@ -7,17 +7,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     /// <summary>
     /// Grants capabilities. 
     /// </summary>
-    internal sealed class EditAndContinueCapabilitiesGrantor
+    internal sealed class EditAndContinueCapabilitiesGrantor(EditAndContinueCapabilities availableCapabilities)
     {
-        private readonly EditAndContinueCapabilities _availableCapabilities;
+        private readonly EditAndContinueCapabilities _availableCapabilities = availableCapabilities;
 
-        public EditAndContinueCapabilities GrantedCapabilities { get; private set; }
-
-        public EditAndContinueCapabilitiesGrantor(EditAndContinueCapabilities availableCapabilities)
-        {
-            _availableCapabilities = availableCapabilities;
-            GrantedCapabilities = 0;
-        }
+        public EditAndContinueCapabilities GrantedCapabilities { get; private set; } = 0;
 
         public bool Grant(EditAndContinueCapabilities capabilities)
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -22,18 +22,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     /// The work is triggered by an incremental analyzer on idle or explicitly when "continue" operation is executed.
     /// Contains analyses of the latest observed document versions.
     /// </summary>
-    internal sealed class EditAndContinueDocumentAnalysesCache
+    internal sealed class EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveStatementsMap> baseActiveStatements, AsyncLazy<EditAndContinueCapabilities> capabilities)
     {
         private readonly object _guard = new();
         private readonly Dictionary<DocumentId, (AsyncLazy<DocumentAnalysisResults> results, Project baseProject, Document document, ImmutableArray<LinePositionSpan> activeStatementSpans)> _analyses = new();
-        private readonly AsyncLazy<ActiveStatementsMap> _baseActiveStatements;
-        private readonly AsyncLazy<EditAndContinueCapabilities> _capabilities;
-
-        public EditAndContinueDocumentAnalysesCache(AsyncLazy<ActiveStatementsMap> baseActiveStatements, AsyncLazy<EditAndContinueCapabilities> capabilities)
-        {
-            _baseActiveStatements = baseActiveStatements;
-            _capabilities = capabilities;
-        }
+        private readonly AsyncLazy<ActiveStatementsMap> _baseActiveStatements = baseActiveStatements;
+        private readonly AsyncLazy<EditAndContinueCapabilities> _capabilities = capabilities;
 
         public async ValueTask<ImmutableArray<DocumentAnalysisResults>> GetDocumentAnalysesAsync(
             CommittedSolution oldSolution,

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
@@ -109,12 +109,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 => TryGetDocumentChecksum(_symReader, documentPath, out checksum, out algorithmId);
         }
 
-        private sealed class Portable : EditAndContinueMethodDebugInfoReader
+        private sealed class Portable(MetadataReader pdbReader) : EditAndContinueMethodDebugInfoReader
         {
-            private readonly MetadataReader _pdbReader;
-
-            public Portable(MetadataReader pdbReader)
-                => _pdbReader = pdbReader;
+            private readonly MetadataReader _pdbReader = pdbReader;
 
             public override bool IsPortable => true;
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs
@@ -27,14 +27,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     internal sealed class EditAndContinueService : IEditAndContinueService
     {
         [ExportWorkspaceService(typeof(IEditAndContinueWorkspaceService)), Shared]
-        internal sealed class WorkspaceService : IEditAndContinueWorkspaceService
+        [method: ImportingConstructor]
+        [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        internal sealed class WorkspaceService(IEditAndContinueService service) : IEditAndContinueWorkspaceService
         {
-            public IEditAndContinueService Service { get; }
-
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public WorkspaceService(IEditAndContinueService service)
-                => Service = service;
+            public IEditAndContinueService Service { get; } = service;
         }
 
         internal static readonly TraceLog Log;
@@ -263,14 +260,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal TestAccessor GetTestAccessor()
             => new(this);
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(EditAndContinueService service)
         {
-            private readonly EditAndContinueService _service;
-
-            public TestAccessor(EditAndContinueService service)
-            {
-                _service = service;
-            }
+            private readonly EditAndContinueService _service = service;
 
             public void SetOutputProvider(Func<Project, CompilationOutputs> value)
                 => _service._compilationOutputsProvider = value;

--- a/src/Features/Core/Portable/EditAndContinue/NonRemappableRegion.cs
+++ b/src/Features/Core/Portable/EditAndContinue/NonRemappableRegion.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal readonly struct NonRemappableRegion : IEquatable<NonRemappableRegion>
+    internal readonly struct NonRemappableRegion(SourceFileSpan oldSpan, SourceFileSpan newSpan, bool isExceptionRegion) : IEquatable<NonRemappableRegion>
     {
         /// <summary>
         /// PDB span in pre-remap method version.
@@ -19,24 +19,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// its active statement needs to be mapped from <see cref="OldSpan"/> in the old version 
         /// to <see cref="NewSpan"/> in the new version of the method.
         /// </remarks>
-        public readonly SourceFileSpan OldSpan;
+        public readonly SourceFileSpan OldSpan = oldSpan;
 
         /// <summary>
         /// PDB span in the new method version.
         /// </summary>
-        public readonly SourceFileSpan NewSpan;
+        public readonly SourceFileSpan NewSpan = newSpan;
 
         /// <summary>
         /// True if the region represents an exception region, false if it represents an active statement.
         /// </summary>
-        public readonly bool IsExceptionRegion;
-
-        public NonRemappableRegion(SourceFileSpan oldSpan, SourceFileSpan newSpan, bool isExceptionRegion)
-        {
-            OldSpan = oldSpan;
-            NewSpan = newSpan;
-            IsExceptionRegion = isExceptionRegion;
-        }
+        public readonly bool IsExceptionRegion = isExceptionRegion;
 
         public override bool Equals(object? obj)
             => obj is NonRemappableRegion region && Equals(region);

--- a/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/PendingSolutionUpdate.cs
@@ -9,34 +9,21 @@ using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal abstract class PendingUpdate
+    internal abstract class PendingUpdate(
+        ImmutableArray<ProjectBaseline> projectBaselines,
+        ImmutableArray<ManagedHotReloadUpdate> deltas)
     {
-        public readonly ImmutableArray<ProjectBaseline> ProjectBaselines;
-        public readonly ImmutableArray<ManagedHotReloadUpdate> Deltas;
-
-        public PendingUpdate(
-            ImmutableArray<ProjectBaseline> projectBaselines,
-            ImmutableArray<ManagedHotReloadUpdate> deltas)
-        {
-            ProjectBaselines = projectBaselines;
-            Deltas = deltas;
-        }
+        public readonly ImmutableArray<ProjectBaseline> ProjectBaselines = projectBaselines;
+        public readonly ImmutableArray<ManagedHotReloadUpdate> Deltas = deltas;
     }
 
-    internal sealed class PendingSolutionUpdate : PendingUpdate
+    internal sealed class PendingSolutionUpdate(
+        Solution solution,
+        ImmutableArray<ProjectBaseline> projectBaselines,
+        ImmutableArray<ManagedHotReloadUpdate> deltas,
+        ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions) : PendingUpdate(projectBaselines, deltas)
     {
-        public readonly Solution Solution;
-        public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)> Regions)> NonRemappableRegions;
-
-        public PendingSolutionUpdate(
-            Solution solution,
-            ImmutableArray<ProjectBaseline> projectBaselines,
-            ImmutableArray<ManagedHotReloadUpdate> deltas,
-            ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions)
-            : base(projectBaselines, deltas)
-        {
-            Solution = solution;
-            NonRemappableRegions = nonRemappableRegions;
-        }
+        public readonly Solution Solution = solution;
+        public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)> Regions)> NonRemappableRegions = nonRemappableRegions;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/ProjectBaseline.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ProjectBaseline.cs
@@ -6,16 +6,9 @@ using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue;
 
-internal sealed class ProjectBaseline
+internal sealed class ProjectBaseline(ProjectId projectId, EmitBaseline emitBaseline, int generation)
 {
-    public ProjectId ProjectId { get; }
-    public EmitBaseline EmitBaseline { get; }
-    public int Generation { get; }
-
-    public ProjectBaseline(ProjectId projectId, EmitBaseline emitBaseline, int generation)
-    {
-        ProjectId = projectId;
-        EmitBaseline = emitBaseline;
-        Generation = generation;
-    }
+    public ProjectId ProjectId { get; } = projectId;
+    public EmitBaseline EmitBaseline { get; } = emitBaseline;
+    public int Generation { get; } = generation;
 }

--- a/src/Features/Core/Portable/EditAndContinue/Remote/ActiveStatementSpanProviderCallback.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/ActiveStatementSpanProviderCallback.cs
@@ -10,12 +10,9 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal sealed class ActiveStatementSpanProviderCallback
+    internal sealed class ActiveStatementSpanProviderCallback(ActiveStatementSpanProvider provider)
     {
-        private readonly ActiveStatementSpanProvider _provider;
-
-        public ActiveStatementSpanProviderCallback(ActiveStatementSpanProvider provider)
-            => _provider = provider;
+        private readonly ActiveStatementSpanProvider _provider = provider;
 
         /// <summary>
         /// Remote API.

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -17,18 +17,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal sealed class RemoteDebuggingSessionProxy : IActiveStatementSpanProvider, IDisposable
+    internal sealed class RemoteDebuggingSessionProxy(Workspace workspace, IDisposable? connection, DebuggingSessionId sessionId) : IActiveStatementSpanProvider, IDisposable
     {
-        private readonly IDisposable? _connection;
-        private readonly DebuggingSessionId _sessionId;
-        private readonly Workspace _workspace;
-
-        public RemoteDebuggingSessionProxy(Workspace workspace, IDisposable? connection, DebuggingSessionId sessionId)
-        {
-            _connection = connection;
-            _sessionId = sessionId;
-            _workspace = workspace;
-        }
+        private readonly IDisposable? _connection = connection;
+        private readonly DebuggingSessionId _sessionId = sessionId;
+        private readonly Workspace _workspace = workspace;
 
         public void Dispose()
         {

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     /// Encapsulates all RPC logic as well as dispatching to the local service if the remote service is disabled.
     /// THe facade is useful for targeted testing of serialization/deserialization of EnC service calls.
     /// </summary>
-    internal readonly partial struct RemoteEditAndContinueServiceProxy
+    internal readonly partial struct RemoteEditAndContinueServiceProxy(Workspace workspace)
     {
         [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteEditAndContinueService)), Shared]
         internal sealed class CallbackDispatcher : RemoteServiceCallbackDispatcher, IRemoteEditAndContinueService.ICallback
@@ -53,16 +53,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 => ((DebuggingSessionCallback)GetCallback(callbackId)).PrepareModuleForUpdateAsync(mvid, cancellationToken);
         }
 
-        private sealed class DebuggingSessionCallback
+        private sealed class DebuggingSessionCallback(IManagedHotReloadService debuggerService, IPdbMatchingSourceTextProvider sourceTextProvider)
         {
-            private readonly IManagedHotReloadService _debuggerService;
-            private readonly IPdbMatchingSourceTextProvider _sourceTextProvider;
-
-            public DebuggingSessionCallback(IManagedHotReloadService debuggerService, IPdbMatchingSourceTextProvider sourceTextProvider)
-            {
-                _debuggerService = debuggerService;
-                _sourceTextProvider = sourceTextProvider;
-            }
+            private readonly IManagedHotReloadService _debuggerService = debuggerService;
+            private readonly IPdbMatchingSourceTextProvider _sourceTextProvider = sourceTextProvider;
 
             public async ValueTask<string?> TryGetMatchingSourceTextAsync(string filePath, ImmutableArray<byte> requiredChecksum, SourceHashAlgorithm checksumAlgorithm, CancellationToken cancellationToken)
             {
@@ -125,12 +119,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        public readonly Workspace Workspace;
-
-        public RemoteEditAndContinueServiceProxy(Workspace workspace)
-        {
-            Workspace = workspace;
-        }
+        public readonly Workspace Workspace = workspace;
 
         private IEditAndContinueService GetLocalService()
             => Workspace.Services.GetRequiredService<IEditAndContinueWorkspaceService>().Service;

--- a/src/Features/Core/Portable/EditAndContinue/SemanticEditInfo.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SemanticEditInfo.cs
@@ -7,12 +7,18 @@ using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal readonly struct SemanticEditInfo
+    internal readonly struct SemanticEditInfo(
+        SemanticEditKind kind,
+        SymbolKey symbol,
+        Func<SyntaxNode, SyntaxNode?>? syntaxMap,
+        SyntaxTree? syntaxMapTree,
+        SymbolKey? partialType,
+        SymbolKey? deletedSymbolContainer = null)
     {
         /// <summary>
         /// <see cref="SemanticEditKind.Insert"/> or <see cref="SemanticEditKind.Update"/> or <see cref="SemanticEditKind.Delete"/>.
         /// </summary>
-        public SemanticEditKind Kind { get; }
+        public SemanticEditKind Kind { get; } = kind;
 
         /// <summary>
         /// If <see cref="Kind"/> is <see cref="SemanticEditKind.Insert"/> represents the inserted symbol in the new compilation.
@@ -23,7 +29,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// since different semantic edits might have been calculated against different solution snapshot and thus symbols are not directly comparable.
         /// When the edits are processed we map the <see cref="SymbolKey"/> to the current compilation.
         /// </summary>
-        public SymbolKey Symbol { get; }
+        public SymbolKey Symbol { get; } = symbol;
 
         /// <summary>
         /// If <see cref="Kind"/> is <see cref="SemanticEditKind.Delete"/> represents the containing symbol in the new compilation.
@@ -32,41 +38,25 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// since different semantic edits might have been calculated against different solution snapshot and thus symbols are not directly comparable.
         /// When the edits are processed we map the <see cref="SymbolKey"/> to the current compilation.
         /// </summary>
-        public SymbolKey? DeletedSymbolContainer { get; }
+        public SymbolKey? DeletedSymbolContainer { get; } = deletedSymbolContainer;
 
         /// <summary>
         /// The syntax map for nodes in the tree for this edit, which will be merged with other maps from other trees for this type.
         /// Only available when <see cref="PartialType"/> is not null.
         /// </summary>
-        public Func<SyntaxNode, SyntaxNode?>? SyntaxMap { get; }
+        public Func<SyntaxNode, SyntaxNode?>? SyntaxMap { get; } = syntaxMap;
 
         /// <summary>
         /// The tree <see cref="SyntaxMap"/> operates on (the new tree, since the map is mapping from new nodes to old nodes).
         /// Only available when <see cref="PartialType"/> is not null.
         /// </summary>
-        public SyntaxTree? SyntaxMapTree { get; }
+        public SyntaxTree? SyntaxMapTree { get; } = syntaxMapTree;
 
         /// <summary>
         /// Specified if the edit needs to be merged with other edits of the same <see cref="PartialType"/>.
         /// 
         /// If specified, the <see cref="SyntaxMap"/> is either null or incomplete: it only provides mapping of the changed members of a single partial type declaration.
         /// </summary>
-        public SymbolKey? PartialType { get; }
-
-        public SemanticEditInfo(
-            SemanticEditKind kind,
-            SymbolKey symbol,
-            Func<SyntaxNode, SyntaxNode?>? syntaxMap,
-            SyntaxTree? syntaxMapTree,
-            SymbolKey? partialType,
-            SymbolKey? deletedSymbolContainer = null)
-        {
-            Kind = kind;
-            Symbol = symbol;
-            SyntaxMap = syntaxMap;
-            SyntaxMapTree = syntaxMapTree;
-            PartialType = partialType;
-            DeletedSymbolContainer = deletedSymbolContainer;
-        }
+        public SymbolKey? PartialType { get; } = partialType;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SolutionUpdate.cs
@@ -9,30 +9,20 @@ using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal readonly struct SolutionUpdate
+    internal readonly struct SolutionUpdate(
+        ModuleUpdates moduleUpdates,
+        ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
+        ImmutableArray<ProjectBaseline> projectBaselines,
+        ImmutableArray<ProjectDiagnostics> diagnostics,
+        ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits,
+        Diagnostic? syntaxError)
     {
-        public readonly ModuleUpdates ModuleUpdates;
-        public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> NonRemappableRegions;
-        public readonly ImmutableArray<ProjectBaseline> ProjectBaselines;
-        public readonly ImmutableArray<ProjectDiagnostics> Diagnostics;
-        public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits;
-        public readonly Diagnostic? SyntaxError;
-
-        public SolutionUpdate(
-            ModuleUpdates moduleUpdates,
-            ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> nonRemappableRegions,
-            ImmutableArray<ProjectBaseline> projectBaselines,
-            ImmutableArray<ProjectDiagnostics> diagnostics,
-            ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> documentsWithRudeEdits,
-            Diagnostic? syntaxError)
-        {
-            ModuleUpdates = moduleUpdates;
-            NonRemappableRegions = nonRemappableRegions;
-            ProjectBaselines = projectBaselines;
-            Diagnostics = diagnostics;
-            DocumentsWithRudeEdits = documentsWithRudeEdits;
-            SyntaxError = syntaxError;
-        }
+        public readonly ModuleUpdates ModuleUpdates = moduleUpdates;
+        public readonly ImmutableArray<(Guid ModuleId, ImmutableArray<(ManagedModuleMethodId Method, NonRemappableRegion Region)>)> NonRemappableRegions = nonRemappableRegions;
+        public readonly ImmutableArray<ProjectBaseline> ProjectBaselines = projectBaselines;
+        public readonly ImmutableArray<ProjectDiagnostics> Diagnostics = diagnostics;
+        public readonly ImmutableArray<(DocumentId DocumentId, ImmutableArray<RudeEditDiagnostic> Diagnostics)> DocumentsWithRudeEdits = documentsWithRudeEdits;
+        public readonly Diagnostic? SyntaxError = syntaxError;
 
         public static SolutionUpdate Blocked(
             ImmutableArray<ProjectDiagnostics> diagnostics,

--- a/src/Features/Core/Portable/EditAndContinue/SourceFileSpan.cs
+++ b/src/Features/Core/Portable/EditAndContinue/SourceFileSpan.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     /// An alternative for <see cref="FileLinePositionSpan"/> without <see cref="FileLinePositionSpan.HasMappedPath"/> bit.
     /// </summary>
     [DataContract]
-    internal readonly struct SourceFileSpan : IEquatable<SourceFileSpan>
+    internal readonly struct SourceFileSpan(string path, LinePositionSpan span) : IEquatable<SourceFileSpan>
     {
         /// <summary>
         /// Path, or null if the span represents an invalid value.
@@ -23,25 +23,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Path may be <see cref="string.Empty"/> if not available.
         /// </remarks>
         [DataMember(Order = 0)]
-        public string Path { get; }
+        public string Path { get; } = path ?? throw new ArgumentNullException(nameof(path));
 
         /// <summary>
         /// Gets the span.
         /// </summary>
         [DataMember(Order = 1)]
-        public LinePositionSpan Span { get; }
-
-        /// <summary>
-        /// Initializes the <see cref="SourceFileSpan"/> instance.
-        /// </summary>
-        /// <param name="path">The file identifier - typically a relative or absolute path.</param>
-        /// <param name="span">The span.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
-        public SourceFileSpan(string path, LinePositionSpan span)
-        {
-            Path = path ?? throw new ArgumentNullException(nameof(path));
-            Span = span;
-        }
+        public LinePositionSpan Span { get; } = span;
 
         public SourceFileSpan WithSpan(LinePositionSpan span)
             => new(Path, span);

--- a/src/Features/Core/Portable/EditAndContinue/UnmappedActiveStatement.cs
+++ b/src/Features/Core/Portable/EditAndContinue/UnmappedActiveStatement.cs
@@ -9,30 +9,23 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal readonly struct UnmappedActiveStatement
+    internal readonly struct UnmappedActiveStatement(TextSpan unmappedSpan, ActiveStatement statement, ActiveStatementExceptionRegions exceptionRegions)
     {
         /// <summary>
         /// Unmapped span of the active statement
         /// (span within the file that contains #line directive that has an effect on the active statement, if there is any).
         /// </summary>
-        public TextSpan UnmappedSpan { get; }
+        public TextSpan UnmappedSpan { get; } = unmappedSpan;
 
         /// <summary>
         /// Active statement - its <see cref="ActiveStatement.FileSpan"/> is mapped.
         /// </summary>
-        public ActiveStatement Statement { get; }
+        public ActiveStatement Statement { get; } = statement;
 
         /// <summary>
         /// Mapped exception regions around the active statement.
         /// </summary>
-        public ActiveStatementExceptionRegions ExceptionRegions { get; }
-
-        public UnmappedActiveStatement(TextSpan unmappedSpan, ActiveStatement statement, ActiveStatementExceptionRegions exceptionRegions)
-        {
-            UnmappedSpan = unmappedSpan;
-            Statement = statement;
-            ExceptionRegions = exceptionRegions;
-        }
+        public ActiveStatementExceptionRegions ExceptionRegions { get; } = exceptionRegions;
 
         public void Deconstruct(out TextSpan unmappedSpan, out ActiveStatement statement, out ActiveStatementExceptionRegions exceptionRegions)
         {

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -53,33 +53,22 @@ namespace Microsoft.CodeAnalysis.Classification
             worker.VisitTokens(root);
         }
 
-        private readonly ref struct Worker
+        private readonly ref struct Worker(
+            AbstractEmbeddedLanguageClassificationService service,
+            Project project,
+            SemanticModel semanticModel,
+            TextSpan textSpan,
+            ClassificationOptions options,
+            SegmentedList<ClassifiedSpan> result,
+            CancellationToken cancellationToken)
         {
-            private readonly AbstractEmbeddedLanguageClassificationService _owner;
-            private readonly Project _project;
-            private readonly SemanticModel _semanticModel;
-            private readonly TextSpan _textSpan;
-            private readonly ClassificationOptions _options;
-            private readonly SegmentedList<ClassifiedSpan> _result;
-            private readonly CancellationToken _cancellationToken;
-
-            public Worker(
-                AbstractEmbeddedLanguageClassificationService service,
-                Project project,
-                SemanticModel semanticModel,
-                TextSpan textSpan,
-                ClassificationOptions options,
-                SegmentedList<ClassifiedSpan> result,
-                CancellationToken cancellationToken)
-            {
-                _owner = service;
-                _project = project;
-                _semanticModel = semanticModel;
-                _textSpan = textSpan;
-                _options = options;
-                _result = result;
-                _cancellationToken = cancellationToken;
-            }
+            private readonly AbstractEmbeddedLanguageClassificationService _owner = service;
+            private readonly Project _project = project;
+            private readonly SemanticModel _semanticModel = semanticModel;
+            private readonly TextSpan _textSpan = textSpan;
+            private readonly ClassificationOptions _options = options;
+            private readonly SegmentedList<ClassifiedSpan> _result = result;
+            private readonly CancellationToken _cancellationToken = cancellationToken;
 
             public void VisitTokens(SyntaxNode node)
             {

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/ExportEmbeddedLanguageClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/ExportEmbeddedLanguageClassifier.cs
@@ -9,17 +9,12 @@ namespace Microsoft.CodeAnalysis.Classification
     /// <summary>
     /// Use this attribute to export a <see cref="IEmbeddedLanguageClassifier"/>.
     /// </summary>
-    internal class ExportEmbeddedLanguageClassifierAttribute : ExportEmbeddedLanguageFeatureServiceAttribute
+    internal class ExportEmbeddedLanguageClassifierAttribute(
+        string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers) : ExportEmbeddedLanguageFeatureServiceAttribute(typeof(IEmbeddedLanguageClassifier), name, languages, supportsUnannotatedAPIs, identifiers)
     {
         public ExportEmbeddedLanguageClassifierAttribute(
             string name, string[] languages, params string[] identifiers)
             : this(name, languages, supportsUnannotatedAPIs: false, identifiers)
-        {
-        }
-
-        public ExportEmbeddedLanguageClassifierAttribute(
-            string name, string[] languages, bool supportsUnannotatedAPIs, params string[] identifiers)
-            : base(typeof(IEmbeddedLanguageClassifier), name, languages, supportsUnannotatedAPIs, identifiers)
         {
         }
     }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -16,7 +16,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 {
-    internal sealed partial class DateAndTimeEmbeddedCompletionProvider : EmbeddedLanguageCompletionProvider
+    internal sealed partial class DateAndTimeEmbeddedCompletionProvider(DateAndTimeEmbeddedLanguage language) : EmbeddedLanguageCompletionProvider
     {
         private const string StartKey = nameof(StartKey);
         private const string LengthKey = nameof(LengthKey);
@@ -28,10 +28,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
             CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.SoftSelection)
                                        .WithFilterCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, new char[] { }));
 
-        private readonly DateAndTimeEmbeddedLanguage _language;
-
-        public DateAndTimeEmbeddedCompletionProvider(DateAndTimeEmbeddedLanguage language)
-            => _language = language;
+        private readonly DateAndTimeEmbeddedLanguage _language = language;
 
         public override ImmutableHashSet<char> TriggerCharacters { get; } = ImmutableHashSet.Create('"', ':');
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeItem.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeItem.cs
@@ -8,23 +8,14 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 {
     internal partial class DateAndTimeEmbeddedCompletionProvider
     {
-        private readonly struct DateAndTimeItem
+        private readonly struct DateAndTimeItem(
+            string displayText, string inlineDescription, string fullDescription, CompletionChange change, bool isDefault)
         {
-            public readonly string DisplayText;
-            public readonly string InlineDescription;
-            public readonly string FullDescription;
-            public readonly CompletionChange Change;
-            public readonly bool IsDefault;
-
-            public DateAndTimeItem(
-                string displayText, string inlineDescription, string fullDescription, CompletionChange change, bool isDefault)
-            {
-                DisplayText = displayText;
-                InlineDescription = inlineDescription;
-                FullDescription = fullDescription;
-                Change = change;
-                IsDefault = isDefault;
-            }
+            public readonly string DisplayText = displayText;
+            public readonly string InlineDescription = inlineDescription;
+            public readonly string FullDescription = fullDescription;
+            public readonly CompletionChange Change = change;
+            public readonly bool IsDefault = isDefault;
         }
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
@@ -19,7 +19,10 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime.Language
     /// Helper class to detect <see cref="System.DateTime"/> and <see cref="DateTimeOffset"/> format
     /// strings in a document efficiently.
     /// </summary>
-    internal sealed class DateAndTimeLanguageDetector : AbstractLanguageDetector<DateAndTimeOptions, DateTimeTree>
+    internal sealed class DateAndTimeLanguageDetector(
+        EmbeddedLanguageInfo info,
+        INamedTypeSymbol? dateTimeType,
+        INamedTypeSymbol? dateTimeOffsetType) : AbstractLanguageDetector<DateAndTimeOptions, DateTimeTree>(info, LanguageIdentifiers)
     {
         public static readonly ImmutableArray<string> LanguageIdentifiers = ImmutableArray.Create("Date", "Time", "DateTime", "DateTimeFormat");
 
@@ -32,18 +35,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime.Language
         /// </summary>
         private static readonly ConditionalWeakTable<Compilation, DateAndTimeLanguageDetector> s_compilationToDetector = new();
 
-        private readonly INamedTypeSymbol? _dateTimeType;
-        private readonly INamedTypeSymbol? _dateTimeOffsetType;
-
-        public DateAndTimeLanguageDetector(
-            EmbeddedLanguageInfo info,
-            INamedTypeSymbol? dateTimeType,
-            INamedTypeSymbol? dateTimeOffsetType)
-            : base(info, LanguageIdentifiers)
-        {
-            _dateTimeType = dateTimeType;
-            _dateTimeOffsetType = dateTimeOffsetType;
-        }
+        private readonly INamedTypeSymbol? _dateTimeType = dateTimeType;
+        private readonly INamedTypeSymbol? _dateTimeOffsetType = dateTimeOffsetType;
 
         protected override bool TryGetOptions(SemanticModel semanticModel, ITypeSymbol exprType, SyntaxNode expr, CancellationToken cancellationToken, out DateAndTimeOptions options)
         {

--- a/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageDetector.cs
@@ -13,20 +13,13 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages
 {
-    internal readonly struct EmbeddedLanguageDetector
+    internal readonly struct EmbeddedLanguageDetector(
+        EmbeddedLanguageInfo info,
+        ImmutableArray<string> languageIdentifiers)
     {
-        private readonly EmbeddedLanguageInfo Info;
-        private readonly HashSet<string> LanguageIdentifiers;
-        private readonly EmbeddedLanguageCommentDetector _commentDetector;
-
-        public EmbeddedLanguageDetector(
-            EmbeddedLanguageInfo info,
-            ImmutableArray<string> languageIdentifiers)
-        {
-            Info = info;
-            LanguageIdentifiers = new HashSet<string>(languageIdentifiers, StringComparer.OrdinalIgnoreCase);
-            _commentDetector = new EmbeddedLanguageCommentDetector(languageIdentifiers);
-        }
+        private readonly EmbeddedLanguageInfo Info = info;
+        private readonly HashSet<string> LanguageIdentifiers = new HashSet<string>(languageIdentifiers, StringComparer.OrdinalIgnoreCase);
+        private readonly EmbeddedLanguageCommentDetector _commentDetector = new EmbeddedLanguageCommentDetector(languageIdentifiers);
 
         /// <summary>
         /// Determines if <paramref name="token"/> is an embedded language token.  If the token is, the specific

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonNodes.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonNodes.cs
@@ -186,15 +186,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json
             => visitor.Visit(this);
     }
 
-    internal sealed class JsonLiteralNode : JsonValueNode
+    internal sealed class JsonLiteralNode(JsonToken literalToken) : JsonValueNode(JsonKind.Literal)
     {
-        public JsonLiteralNode(JsonToken literalToken)
-            : base(JsonKind.Literal)
-        {
-            LiteralToken = literalToken;
-        }
-
-        public JsonToken LiteralToken { get; }
+        public JsonToken LiteralToken { get; } = literalToken;
 
         internal override int ChildCount => 1;
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonTree.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/JsonTree.cs
@@ -8,13 +8,10 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
 namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json
 {
-    internal sealed class JsonTree : EmbeddedSyntaxTree<JsonKind, JsonNode, JsonCompilationUnit>
+    internal sealed class JsonTree(
+        VirtualCharSequence text,
+        JsonCompilationUnit root,
+        ImmutableArray<EmbeddedDiagnostic> diagnostics) : EmbeddedSyntaxTree<JsonKind, JsonNode, JsonCompilationUnit>(text, root, diagnostics)
     {
-        public JsonTree(
-            VirtualCharSequence text,
-            JsonCompilationUnit root,
-            ImmutableArray<EmbeddedDiagnostic> diagnostics) : base(text, root, diagnostics)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/JsonLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/JsonLanguageDetector.cs
@@ -20,7 +20,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
     /// <summary>
     /// Helper class to detect json in string tokens in a document efficiently.
     /// </summary>
-    internal class JsonLanguageDetector : AbstractLanguageDetector<JsonOptions, JsonTree>
+    internal class JsonLanguageDetector(
+        EmbeddedLanguageInfo info,
+        ISet<INamedTypeSymbol> typesOfInterest) : AbstractLanguageDetector<JsonOptions, JsonTree>(info, LanguageIdentifiers)
     {
         public static readonly ImmutableArray<string> LanguageIdentifiers = ImmutableArray.Create("Json");
 
@@ -37,15 +39,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
         private static readonly ConditionalWeakTable<Compilation, JsonLanguageDetector> s_compilationToDetector = new();
 
-        private readonly ISet<INamedTypeSymbol> _typesOfInterest;
-
-        public JsonLanguageDetector(
-            EmbeddedLanguageInfo info,
-            ISet<INamedTypeSymbol> typesOfInterest)
-            : base(info, LanguageIdentifiers)
-        {
-            _typesOfInterest = typesOfInterest;
-        }
+        private readonly ISet<INamedTypeSymbol> _typesOfInterest = typesOfInterest;
 
         public static JsonLanguageDetector GetOrCreate(
             Compilation compilation, EmbeddedLanguageInfo info)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedCompletionProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
     using static FeaturesResources;
     using RegexToken = EmbeddedSyntaxToken<RegexKind>;
 
-    internal sealed partial class RegexEmbeddedCompletionProvider : EmbeddedLanguageCompletionProvider
+    internal sealed partial class RegexEmbeddedCompletionProvider(RegexEmbeddedLanguage language) : EmbeddedLanguageCompletionProvider
     {
         private const string StartKey = nameof(StartKey);
         private const string LengthKey = nameof(LengthKey);
@@ -35,10 +35,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
             CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.SoftSelection)
                                        .WithFilterCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, Array.Empty<char>()));
 
-        private readonly RegexEmbeddedLanguage _language;
-
-        public RegexEmbeddedCompletionProvider(RegexEmbeddedLanguage language)
-            => _language = language;
+        private readonly RegexEmbeddedLanguage _language = language;
 
         public override ImmutableHashSet<char> TriggerCharacters { get; } = ImmutableHashSet.Create(
             '\\', // any escape

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexItem.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexItem.cs
@@ -8,21 +8,13 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 {
     internal partial class RegexEmbeddedCompletionProvider
     {
-        private readonly struct RegexItem
+        private readonly struct RegexItem(
+            string displayText, string inlineDescription, string fullDescription, CompletionChange change)
         {
-            public readonly string DisplayText;
-            public readonly string InlineDescription;
-            public readonly string FullDescription;
-            public readonly CompletionChange Change;
-
-            public RegexItem(
-                string displayText, string inlineDescription, string fullDescription, CompletionChange change)
-            {
-                DisplayText = displayText;
-                InlineDescription = inlineDescription;
-                FullDescription = fullDescription;
-                Change = change;
-            }
+            public readonly string DisplayText = displayText;
+            public readonly string InlineDescription = inlineDescription;
+            public readonly string FullDescription = fullDescription;
+            public readonly CompletionChange Change = change;
         }
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexLanguageDetector.cs
@@ -22,7 +22,10 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
     /// <summary>
     /// Helper class to detect regex pattern tokens in a document efficiently.
     /// </summary>
-    internal sealed class RegexLanguageDetector : AbstractLanguageDetector<RegexOptions, RegexTree>
+    internal sealed class RegexLanguageDetector(
+        EmbeddedLanguageInfo info,
+        INamedTypeSymbol? regexType,
+        HashSet<string> methodNamesOfInterest) : AbstractLanguageDetector<RegexOptions, RegexTree>(info, LanguageIdentifiers)
     {
         public static readonly ImmutableArray<string> LanguageIdentifiers = ImmutableArray.Create("Regex", "Regexp");
 
@@ -35,18 +38,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
         /// </summary>
         private static readonly ConditionalWeakTable<Compilation, RegexLanguageDetector> _modelToDetector = new();
 
-        private readonly INamedTypeSymbol? _regexType;
-        private readonly HashSet<string> _methodNamesOfInterest;
-
-        public RegexLanguageDetector(
-            EmbeddedLanguageInfo info,
-            INamedTypeSymbol? regexType,
-            HashSet<string> methodNamesOfInterest)
-            : base(info, LanguageIdentifiers)
-        {
-            _regexType = regexType;
-            _methodNamesOfInterest = methodNamesOfInterest;
-        }
+        private readonly INamedTypeSymbol? _regexType = regexType;
+        private readonly HashSet<string> _methodNamesOfInterest = methodNamesOfInterest;
 
         public static RegexLanguageDetector GetOrCreate(
             Compilation compilation, EmbeddedLanguageInfo info)

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNodes.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexNodes.cs
@@ -55,17 +55,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// This does not deviate from Roslyn principles.  While nodes for empty text are rare, they
     /// are allowed (for example, OmittedTypeArgument in C#).
     /// </summary>
-    internal sealed class RegexSequenceNode : RegexExpressionNode
+    internal sealed class RegexSequenceNode(ImmutableArray<RegexExpressionNode> children) : RegexExpressionNode(RegexKind.Sequence)
     {
-        public ImmutableArray<RegexExpressionNode> Children { get; }
+        public ImmutableArray<RegexExpressionNode> Children { get; } = children;
 
         internal override int ChildCount => Children.Length;
-
-        public RegexSequenceNode(ImmutableArray<RegexExpressionNode> children)
-            : base(RegexKind.Sequence)
-        {
-            this.Children = children;
-        }
 
         internal override RegexNodeOrToken ChildAt(int index)
             => Children[index];
@@ -126,14 +120,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// [...] node.
     /// </summary>
-    internal sealed class RegexCharacterClassNode : RegexBaseCharacterClassNode
+    internal sealed class RegexCharacterClassNode(
+        RegexToken openBracketToken, RegexSequenceNode components, RegexToken closeBracketToken) : RegexBaseCharacterClassNode(RegexKind.CharacterClass, openBracketToken, components, closeBracketToken)
     {
-        public RegexCharacterClassNode(
-            RegexToken openBracketToken, RegexSequenceNode components, RegexToken closeBracketToken)
-            : base(RegexKind.CharacterClass, openBracketToken, components, closeBracketToken)
-        {
-        }
-
         internal override int ChildCount => 3;
 
         internal override RegexNodeOrToken ChildAt(int index)
@@ -499,14 +488,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```a{5}```
     /// </summary>
-    internal sealed class RegexExactNumericQuantifierNode : RegexNumericQuantifierNode
+    internal sealed class RegexExactNumericQuantifierNode(
+        RegexPrimaryExpressionNode expression, RegexToken openBraceToken, RegexToken numberToken, RegexToken closeBraceToken) : RegexNumericQuantifierNode(RegexKind.ExactNumericQuantifier, expression, openBraceToken, numberToken, closeBraceToken)
     {
-        public RegexExactNumericQuantifierNode(
-            RegexPrimaryExpressionNode expression, RegexToken openBraceToken, RegexToken numberToken, RegexToken closeBraceToken)
-            : base(RegexKind.ExactNumericQuantifier, expression, openBraceToken, numberToken, closeBraceToken)
-        {
-        }
-
         internal override int ChildCount => 4;
 
         internal override RegexNodeOrToken ChildAt(int index)
@@ -727,14 +711,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```(?inmsx)``` node.  Changes options in a sequence for all subsequence nodes.
     /// </summary>
-    internal sealed class RegexSimpleOptionsGroupingNode : RegexOptionsGroupingNode
+    internal sealed class RegexSimpleOptionsGroupingNode(
+        RegexToken openParenToken, RegexToken questionToken, RegexToken optionsToken, RegexToken closeParenToken) : RegexOptionsGroupingNode(RegexKind.SimpleOptionsGrouping, openParenToken, questionToken, optionsToken, closeParenToken)
     {
-        public RegexSimpleOptionsGroupingNode(
-            RegexToken openParenToken, RegexToken questionToken, RegexToken optionsToken, RegexToken closeParenToken)
-            : base(RegexKind.SimpleOptionsGrouping, openParenToken, questionToken, optionsToken, closeParenToken)
-        {
-        }
-
         internal override int ChildCount => 4;
 
         internal override RegexNodeOrToken ChildAt(int index)
@@ -1256,13 +1235,8 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// One of \b \B \A \G \z \Z
     /// </summary>
-    internal sealed class RegexAnchorEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexAnchorEscapeNode(RegexToken backslashToken, RegexToken typeToken) : RegexTypeEscapeNode(RegexKind.AnchorEscape, backslashToken, typeToken)
     {
-        public RegexAnchorEscapeNode(RegexToken backslashToken, RegexToken typeToken)
-            : base(RegexKind.AnchorEscape, backslashToken, typeToken)
-        {
-        }
-
         internal override int ChildCount => 2;
 
         internal override RegexNodeOrToken ChildAt(int index)
@@ -1280,13 +1254,8 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// One of \s \S \d \D \w \W
     /// </summary>
-    internal sealed class RegexCharacterClassEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexCharacterClassEscapeNode(RegexToken backslashToken, RegexToken typeToken) : RegexTypeEscapeNode(RegexKind.CharacterClassEscape, backslashToken, typeToken)
     {
-        public RegexCharacterClassEscapeNode(RegexToken backslashToken, RegexToken typeToken)
-            : base(RegexKind.CharacterClassEscape, backslashToken, typeToken)
-        {
-        }
-
         internal override int ChildCount => 2;
 
         internal override RegexNodeOrToken ChildAt(int index)
@@ -1304,17 +1273,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\cX``` escape
     /// </summary>
-    internal sealed class RegexControlEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexControlEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken controlToken) : RegexTypeEscapeNode(RegexKind.ControlEscape, backslashToken, typeToken)
     {
-        public RegexControlEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken controlToken)
-            : base(RegexKind.ControlEscape, backslashToken, typeToken)
-        {
-            ControlToken = controlToken;
-        }
-
         internal override int ChildCount => 3;
 
-        public RegexToken ControlToken { get; }
+        public RegexToken ControlToken { get; } = controlToken;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch
@@ -1332,17 +1295,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\xFF``` escape.
     /// </summary>
-    internal sealed class RegexHexEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexHexEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken hexText) : RegexTypeEscapeNode(RegexKind.HexEscape, backslashToken, typeToken)
     {
-        public RegexHexEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken hexText)
-            : base(RegexKind.HexEscape, backslashToken, typeToken)
-        {
-            HexText = hexText;
-        }
-
         internal override int ChildCount => 3;
 
-        public RegexToken HexText { get; }
+        public RegexToken HexText { get; } = hexText;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch
@@ -1360,17 +1317,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\uFFFF``` escape.
     /// </summary>
-    internal sealed class RegexUnicodeEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexUnicodeEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken hexText) : RegexTypeEscapeNode(RegexKind.UnicodeEscape, backslashToken, typeToken)
     {
-        public RegexUnicodeEscapeNode(RegexToken backslashToken, RegexToken typeToken, RegexToken hexText)
-            : base(RegexKind.UnicodeEscape, backslashToken, typeToken)
-        {
-            HexText = hexText;
-        }
-
         internal override int ChildCount => 3;
 
-        public RegexToken HexText { get; }
+        public RegexToken HexText { get; } = hexText;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch
@@ -1388,22 +1339,14 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\'name'``` or ```\&lt;name&gt;``` escape.
     /// </summary>
-    internal sealed class RegexCaptureEscapeNode : RegexEscapeNode
+    internal sealed class RegexCaptureEscapeNode(
+        RegexToken backslashToken, RegexToken openToken, RegexToken captureToken, RegexToken closeToken) : RegexEscapeNode(RegexKind.CaptureEscape, backslashToken)
     {
-        public RegexCaptureEscapeNode(
-            RegexToken backslashToken, RegexToken openToken, RegexToken captureToken, RegexToken closeToken)
-            : base(RegexKind.CaptureEscape, backslashToken)
-        {
-            OpenToken = openToken;
-            CaptureToken = captureToken;
-            CloseToken = closeToken;
-        }
-
         internal override int ChildCount => 4;
 
-        public RegexToken OpenToken { get; }
-        public RegexToken CaptureToken { get; }
-        public RegexToken CloseToken { get; }
+        public RegexToken OpenToken { get; } = openToken;
+        public RegexToken CaptureToken { get; } = captureToken;
+        public RegexToken CloseToken { get; } = closeToken;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch
@@ -1422,23 +1365,15 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\k'name'``` or ```\k&lt;name&gt;``` escape.
     /// </summary>
-    internal sealed class RegexKCaptureEscapeNode : RegexTypeEscapeNode
+    internal sealed class RegexKCaptureEscapeNode(
+        RegexToken backslashToken, RegexToken typeToken,
+        RegexToken openToken, RegexToken captureToken, RegexToken closeToken) : RegexTypeEscapeNode(RegexKind.KCaptureEscape, backslashToken, typeToken)
     {
-        public RegexKCaptureEscapeNode(
-            RegexToken backslashToken, RegexToken typeToken,
-            RegexToken openToken, RegexToken captureToken, RegexToken closeToken)
-            : base(RegexKind.KCaptureEscape, backslashToken, typeToken)
-        {
-            OpenToken = openToken;
-            CaptureToken = captureToken;
-            CloseToken = closeToken;
-        }
-
         internal override int ChildCount => 5;
 
-        public RegexToken OpenToken { get; }
-        public RegexToken CaptureToken { get; }
-        public RegexToken CloseToken { get; }
+        public RegexToken OpenToken { get; } = openToken;
+        public RegexToken CaptureToken { get; } = captureToken;
+        public RegexToken CloseToken { get; } = closeToken;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch
@@ -1458,17 +1393,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\1``` escape. In contexts where back-references are not allowed.
     /// </summary>
-    internal sealed class RegexOctalEscapeNode : RegexEscapeNode
+    internal sealed class RegexOctalEscapeNode(RegexToken backslashToken, RegexToken octalText) : RegexEscapeNode(RegexKind.OctalEscape, backslashToken)
     {
-        public RegexOctalEscapeNode(RegexToken backslashToken, RegexToken octalText)
-            : base(RegexKind.OctalEscape, backslashToken)
-        {
-            OctalText = octalText;
-        }
-
         internal override int ChildCount => 2;
 
-        public RegexToken OctalText { get; }
+        public RegexToken OctalText { get; } = octalText;
 
         internal override RegexNodeOrToken ChildAt(int index)
         {
@@ -1488,17 +1417,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
     /// <summary>
     /// ```\1```
     /// </summary>
-    internal sealed class RegexBackreferenceEscapeNode : RegexEscapeNode
+    internal sealed class RegexBackreferenceEscapeNode(RegexToken backslashToken, RegexToken numberToken) : RegexEscapeNode(RegexKind.BackreferenceEscape, backslashToken)
     {
-        public RegexBackreferenceEscapeNode(RegexToken backslashToken, RegexToken numberToken)
-            : base(RegexKind.BackreferenceEscape, backslashToken)
-        {
-            NumberToken = numberToken;
-        }
-
         internal override int ChildCount => 2;
 
-        public RegexToken NumberToken { get; }
+        public RegexToken NumberToken { get; } = numberToken;
 
         internal override RegexNodeOrToken ChildAt(int index)
             => index switch

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexTree.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexTree.cs
@@ -11,21 +11,14 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
 {
-    internal sealed class RegexTree : EmbeddedSyntaxTree<RegexKind, RegexNode, RegexCompilationUnit>
+    internal sealed class RegexTree(
+        VirtualCharSequence text,
+        RegexCompilationUnit root,
+        ImmutableArray<EmbeddedDiagnostic> diagnostics,
+        ImmutableDictionary<string, TextSpan> captureNamesToSpan,
+        ImmutableDictionary<int, TextSpan> captureNumbersToSpan) : EmbeddedSyntaxTree<RegexKind, RegexNode, RegexCompilationUnit>(text, root, diagnostics)
     {
-        public readonly ImmutableDictionary<string, TextSpan> CaptureNamesToSpan;
-        public readonly ImmutableDictionary<int, TextSpan> CaptureNumbersToSpan;
-
-        public RegexTree(
-            VirtualCharSequence text,
-            RegexCompilationUnit root,
-            ImmutableArray<EmbeddedDiagnostic> diagnostics,
-            ImmutableDictionary<string, TextSpan> captureNamesToSpan,
-            ImmutableDictionary<int, TextSpan> captureNumbersToSpan)
-            : base(text, root, diagnostics)
-        {
-            CaptureNamesToSpan = captureNamesToSpan;
-            CaptureNumbersToSpan = captureNumbersToSpan;
-        }
+        public readonly ImmutableDictionary<string, TextSpan> CaptureNamesToSpan = captureNamesToSpan;
+        public readonly ImmutableDictionary<int, TextSpan> CaptureNumbersToSpan = captureNumbersToSpan;
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameCompilationUnit.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameCompilationUnit.cs
@@ -16,33 +16,25 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
     /// Any leading "at " is considered trivia of <see cref="MethodDeclaration"/>, and " in " is put as trivia for the <see cref="FileInformationExpression"/>.
     /// Remaining unparsable text is put as leading trivia on the <see cref="EndOfLineToken"/>
     /// </summary>
-    internal class StackFrameCompilationUnit : StackFrameNode
+    internal class StackFrameCompilationUnit(StackFrameMethodDeclarationNode methodDeclaration, StackFrameFileInformationNode? fileInformationExpression, StackFrameToken endOfLineToken) : StackFrameNode(StackFrameKind.CompilationUnit)
     {
         /// <summary>
         /// Represents the method declaration for a stack frame. Requires at least a member 
         /// access and argument list with no parameters to be considered valid
         /// </summary>
-        public readonly StackFrameMethodDeclarationNode MethodDeclaration;
+        public readonly StackFrameMethodDeclarationNode MethodDeclaration = methodDeclaration;
 
         /// <summary>
         /// File information for a stack frame. May be optionally contained. If available, represents
         /// the file path of a stackframe and optionally the line number. This is available as hint information
         /// and may be useful for a user, but is not always accurate when mapping back to source.
         /// </summary>
-        public readonly StackFrameFileInformationNode? FileInformationExpression;
+        public readonly StackFrameFileInformationNode? FileInformationExpression = fileInformationExpression;
 
         /// <summary>
         /// The end token of a frame. Any trailing text is added as leading trivia of this token.
         /// </summary>
-        public readonly StackFrameToken EndOfLineToken;
-
-        public StackFrameCompilationUnit(StackFrameMethodDeclarationNode methodDeclaration, StackFrameFileInformationNode? fileInformationExpression, StackFrameToken endOfLineToken)
-            : base(StackFrameKind.CompilationUnit)
-        {
-            MethodDeclaration = methodDeclaration;
-            FileInformationExpression = fileInformationExpression;
-            EndOfLineToken = endOfLineToken;
-        }
+        public readonly StackFrameToken EndOfLineToken = endOfLineToken;
 
         internal override int ChildCount => 3;
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
@@ -30,22 +30,14 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         }
     }
 
-    internal sealed class StackFrameMethodDeclarationNode : StackFrameDeclarationNode
+    internal sealed class StackFrameMethodDeclarationNode(
+        StackFrameQualifiedNameNode memberAccessExpression,
+        StackFrameTypeArgumentList? typeArguments,
+        StackFrameParameterList argumentList) : StackFrameDeclarationNode(StackFrameKind.MethodDeclaration)
     {
-        public readonly StackFrameQualifiedNameNode MemberAccessExpression;
-        public readonly StackFrameTypeArgumentList? TypeArguments;
-        public readonly StackFrameParameterList ArgumentList;
-
-        public StackFrameMethodDeclarationNode(
-            StackFrameQualifiedNameNode memberAccessExpression,
-            StackFrameTypeArgumentList? typeArguments,
-            StackFrameParameterList argumentList)
-            : base(StackFrameKind.MethodDeclaration)
-        {
-            MemberAccessExpression = memberAccessExpression;
-            TypeArguments = typeArguments;
-            ArgumentList = argumentList;
-        }
+        public readonly StackFrameQualifiedNameNode MemberAccessExpression = memberAccessExpression;
+        public readonly StackFrameTypeArgumentList? TypeArguments = typeArguments;
+        public readonly StackFrameParameterList ArgumentList = argumentList;
 
         internal override int ChildCount => 3;
 
@@ -137,14 +129,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
     /// <summary>
     /// The simplest identifier node, which wraps a <see cref="StackFrameKind.IdentifierToken" />
     /// </summary>
-    internal sealed class StackFrameIdentifierNameNode : StackFrameSimpleNameNode
+    internal sealed class StackFrameIdentifierNameNode(StackFrameToken identifier) : StackFrameSimpleNameNode(identifier, StackFrameKind.TypeIdentifier)
     {
         internal override int ChildCount => 1;
-
-        public StackFrameIdentifierNameNode(StackFrameToken identifier)
-            : base(identifier, StackFrameKind.TypeIdentifier)
-        {
-        }
 
         public override void Accept(IStackFrameNodeVisitor visitor)
             => visitor.Visit(this);

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameTree.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameTree.cs
@@ -8,11 +8,7 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
 {
-    internal class StackFrameTree : EmbeddedSyntaxTree<StackFrameKind, StackFrameNode, StackFrameCompilationUnit>
+    internal class StackFrameTree(VirtualCharSequence text, StackFrameCompilationUnit root) : EmbeddedSyntaxTree<StackFrameKind, StackFrameNode, StackFrameCompilationUnit>(text, root, ImmutableArray<EmbeddedDiagnostic>.Empty)
     {
-        public StackFrameTree(VirtualCharSequence text, StackFrameCompilationUnit root)
-            : base(text, root, ImmutableArray<EmbeddedDiagnostic>.Empty)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
+++ b/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldResult.cs
@@ -11,18 +11,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EncapsulateField
 {
-    internal class EncapsulateFieldResult
+    internal class EncapsulateFieldResult(string name, Glyph glyph, Func<CancellationToken, Task<Solution>> getSolutionAsync)
     {
-        public readonly string Name;
-        public readonly Glyph Glyph;
-        private readonly AsyncLazy<Solution> _lazySolution;
-
-        public EncapsulateFieldResult(string name, Glyph glyph, Func<CancellationToken, Task<Solution>> getSolutionAsync)
-        {
-            Name = name;
-            Glyph = glyph;
-            _lazySolution = AsyncLazy.Create(getSolutionAsync);
-        }
+        public readonly string Name = name;
+        public readonly Glyph Glyph = glyph;
+        private readonly AsyncLazy<Solution> _lazySolution = AsyncLazy.Create(getSolutionAsync);
 
         public Task<Solution> GetSolutionAsync(CancellationToken cancellationToken)
             => _lazySolution.GetValueAsync(cancellationToken);

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/NewUnitTestingIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/NewUnitTestingIncrementalAnalyzer.cs
@@ -12,12 +12,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api;
 
 internal sealed partial class NewUnitTestingIncrementalAnalyzerProvider
 {
-    private sealed class NewUnitTestingIncrementalAnalyzer : IUnitTestingIncrementalAnalyzer
+    private sealed class NewUnitTestingIncrementalAnalyzer(INewUnitTestingIncrementalAnalyzerImplementation implementation) : IUnitTestingIncrementalAnalyzer
     {
-        private readonly INewUnitTestingIncrementalAnalyzerImplementation _implementation;
-
-        public NewUnitTestingIncrementalAnalyzer(INewUnitTestingIncrementalAnalyzerImplementation implementation)
-            => _implementation = implementation;
+        private readonly INewUnitTestingIncrementalAnalyzerImplementation _implementation = implementation;
 
         public Task AnalyzeDocumentAsync(
             Document document,

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingDefinitionItemWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingDefinitionItemWrapper.cs
@@ -4,13 +4,8 @@
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
-    internal readonly struct UnitTestingDefinitionItemWrapper
+    internal readonly struct UnitTestingDefinitionItemWrapper(FindUsages.DefinitionItem definition)
     {
-        internal FindUsages.DefinitionItem UnderlyingObject { get; }
-
-        public UnitTestingDefinitionItemWrapper(FindUsages.DefinitionItem definition)
-        {
-            UnderlyingObject = definition;
-        }
+        internal FindUsages.DefinitionItem UnderlyingObject { get; } = definition;
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingInvocationReasons.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingInvocationReasons.cs
@@ -10,20 +10,17 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     [DataContract]
-    internal partial struct UnitTestingInvocationReasons : IEnumerable<string>
+    internal partial struct UnitTestingInvocationReasons(ImmutableHashSet<string> reasons) : IEnumerable<string>
     {
         public static readonly UnitTestingInvocationReasons Empty = new(ImmutableHashSet<string>.Empty);
 
         [DataMember(Order = 0)]
-        private readonly ImmutableHashSet<string> _reasons;
+        private readonly ImmutableHashSet<string> _reasons = reasons ?? ImmutableHashSet<string>.Empty;
 
         public UnitTestingInvocationReasons(string reason)
             : this(ImmutableHashSet.Create(reason))
         {
         }
-
-        public UnitTestingInvocationReasons(ImmutableHashSet<string> reasons)
-            => _reasons = reasons ?? ImmutableHashSet<string>.Empty;
 
         public bool IsEmpty => _reasons.IsEmpty;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingParsedFrameWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingParsedFrameWrapper.cs
@@ -6,13 +6,8 @@ using Microsoft.CodeAnalysis.StackTraceExplorer;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
-    internal readonly struct UnitTestingParsedFrameWrapper
+    internal readonly struct UnitTestingParsedFrameWrapper(ParsedFrame parsedFrame)
     {
-        internal ParsedFrame UnderlyingObject { get; }
-
-        public UnitTestingParsedFrameWrapper(ParsedFrame parsedFrame)
-        {
-            UnderlyingObject = parsedFrame;
-        }
+        internal ParsedFrame UnderlyingObject { get; } = parsedFrame;
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/IRemoteUnitTestingSearchService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/IRemoteUnitTestingSearchService.cs
@@ -19,18 +19,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
     }
 
     [DataContract]
-    internal readonly struct UnitTestingSourceLocation
+    internal readonly struct UnitTestingSourceLocation(DocumentIdSpan documentIdSpan, FileLinePositionSpan span)
     {
         [DataMember(Order = 0)]
-        public readonly DocumentIdSpan DocumentIdSpan;
+        public readonly DocumentIdSpan DocumentIdSpan = documentIdSpan;
         [DataMember(Order = 1)]
-        public readonly FileLinePositionSpan Span;
-
-        public UnitTestingSourceLocation(DocumentIdSpan documentIdSpan, FileLinePositionSpan span)
-        {
-            DocumentIdSpan = documentIdSpan;
-            Span = span;
-        }
+        public readonly FileLinePositionSpan Span = span;
 
         public async Task<UnitTestingDocumentSpan?> TryRehydrateAsync(Solution solution, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingDocumentDifferenceService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingDocumentDifferenceService.cs
@@ -9,16 +9,10 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
 {
-    internal class UnitTestingDocumentDifferenceResult
+    internal class UnitTestingDocumentDifferenceResult(UnitTestingInvocationReasons changeType, SyntaxNode? changedMember = null)
     {
-        public UnitTestingInvocationReasons ChangeType { get; }
-        public SyntaxNode? ChangedMember { get; }
-
-        public UnitTestingDocumentDifferenceResult(UnitTestingInvocationReasons changeType, SyntaxNode? changedMember = null)
-        {
-            ChangeType = changeType;
-            ChangedMember = changedMember;
-        }
+        public UnitTestingInvocationReasons ChangeType { get; } = changeType;
+        public SyntaxNode? ChangedMember { get; } = changedMember;
     }
 
     internal interface IUnitTestingDocumentDifferenceService : ILanguageService

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerProgressReporter.cs
@@ -25,21 +25,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
         event EventHandler<UnitTestingProgressData> ProgressChanged;
     }
 
-    internal readonly struct UnitTestingProgressData
+    internal readonly struct UnitTestingProgressData(UnitTestingProgressStatus type, int? pendingItemCount)
     {
-        public UnitTestingProgressStatus Status { get; }
+        public UnitTestingProgressStatus Status { get; } = type;
 
         /// <summary>
         /// number of pending work item in the queue. 
         /// null means N/A for the associated <see cref="Status"/>
         /// </summary>
-        public int? PendingItemCount { get; }
-
-        public UnitTestingProgressData(UnitTestingProgressStatus type, int? pendingItemCount)
-        {
-            Status = type;
-            PendingItemCount = pendingItemCount;
-        }
+        public int? PendingItemCount { get; } = pendingItemCount;
     }
 
     internal enum UnitTestingProgressStatus

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerRegistrationService.cs
@@ -319,28 +319,19 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
 #endif
         }
 
-        internal sealed class UnitTestingRegistration
+        internal sealed class UnitTestingRegistration(
+            UnitTestingSolutionCrawlerRegistrationService owner,
+            int correlationId,
+            string workspaceKind,
+            SolutionServices solutionServices,
+            UnitTestingSolutionCrawlerProgressReporter progressReporter)
         {
-            private readonly UnitTestingSolutionCrawlerRegistrationService _owner;
+            private readonly UnitTestingSolutionCrawlerRegistrationService _owner = owner;
 
-            public readonly int CorrelationId;
-            public readonly string WorkspaceKind;
-            public readonly SolutionServices Services;
-            public readonly UnitTestingSolutionCrawlerProgressReporter ProgressReporter;
-
-            public UnitTestingRegistration(
-                UnitTestingSolutionCrawlerRegistrationService owner,
-                int correlationId,
-                string workspaceKind,
-                SolutionServices solutionServices,
-                UnitTestingSolutionCrawlerProgressReporter progressReporter)
-            {
-                _owner = owner;
-                CorrelationId = correlationId;
-                WorkspaceKind = workspaceKind;
-                Services = solutionServices;
-                ProgressReporter = progressReporter;
-            }
+            public readonly int CorrelationId = correlationId;
+            public readonly string WorkspaceKind = workspaceKind;
+            public readonly SolutionServices Services = solutionServices;
+            public readonly UnitTestingSolutionCrawlerProgressReporter ProgressReporter = progressReporter;
 
             public Solution GetSolutionToAnalyze()
             {

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncDocumentWorkItemQueue.cs
@@ -14,14 +14,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
     {
         internal partial class UnitTestingWorkCoordinator
         {
-            private class UnitTestingAsyncDocumentWorkItemQueue : UnitTestingAsyncWorkItemQueue<DocumentId>
+            private class UnitTestingAsyncDocumentWorkItemQueue(UnitTestingSolutionCrawlerProgressReporter progressReporter) : UnitTestingAsyncWorkItemQueue<DocumentId>(progressReporter)
             {
                 private readonly Dictionary<ProjectId, Dictionary<DocumentId, UnitTestingWorkItem>> _documentWorkQueue = new();
-
-                public UnitTestingAsyncDocumentWorkItemQueue(UnitTestingSolutionCrawlerProgressReporter progressReporter)
-                    : base(progressReporter)
-                {
-                }
 
                 protected override int WorkItemCount_NoLock => _documentWorkQueue.Count;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncProjectWorkItemQueue.cs
@@ -15,14 +15,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
     {
         internal partial class UnitTestingWorkCoordinator
         {
-            private sealed class UnitTestingAsyncProjectWorkItemQueue : UnitTestingAsyncWorkItemQueue<ProjectId>
+            private sealed class UnitTestingAsyncProjectWorkItemQueue(UnitTestingSolutionCrawlerProgressReporter progressReporter) : UnitTestingAsyncWorkItemQueue<ProjectId>(progressReporter)
             {
                 private readonly Dictionary<ProjectId, UnitTestingWorkItem> _projectWorkQueue = new();
-
-                public UnitTestingAsyncProjectWorkItemQueue(UnitTestingSolutionCrawlerProgressReporter progressReporter)
-                    : base(progressReporter)
-                {
-                }
 
                 protected override int WorkItemCount_NoLock => _projectWorkQueue.Count;
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingAsyncWorkItemQueue.cs
@@ -17,24 +17,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
     {
         internal partial class UnitTestingWorkCoordinator
         {
-            private abstract class UnitTestingAsyncWorkItemQueue<TKey> : IDisposable
+            private abstract class UnitTestingAsyncWorkItemQueue<TKey>(UnitTestingSolutionCrawlerProgressReporter progressReporter) : IDisposable
                 where TKey : class
             {
                 private readonly object _gate = new();
-                private readonly SemaphoreSlim _semaphore;
+                private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(initialCount: 0);
                 private bool _disposed;
 
-                private readonly UnitTestingSolutionCrawlerProgressReporter _progressReporter;
+                private readonly UnitTestingSolutionCrawlerProgressReporter _progressReporter = progressReporter;
 
                 // map containing cancellation source for the item given out.
                 private readonly Dictionary<object, CancellationTokenSource> _cancellationMap = new();
-
-                public UnitTestingAsyncWorkItemQueue(UnitTestingSolutionCrawlerProgressReporter progressReporter)
-                {
-                    _semaphore = new SemaphoreSlim(initialCount: 0);
-
-                    _progressReporter = progressReporter;
-                }
 
                 protected abstract int WorkItemCount_NoLock { get; }
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingIncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingIncrementalAnalyzerProcessor.cs
@@ -456,9 +456,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
                     }
                 }
 
-                private class UnitTestingAnalyzersGetter
+                private class UnitTestingAnalyzersGetter(IEnumerable<Lazy<IUnitTestingIncrementalAnalyzerProvider, UnitTestingIncrementalAnalyzerProviderMetadata>> analyzerProviders)
                 {
-                    private readonly List<Lazy<IUnitTestingIncrementalAnalyzerProvider, UnitTestingIncrementalAnalyzerProviderMetadata>> _analyzerProviders;
+                    private readonly List<Lazy<IUnitTestingIncrementalAnalyzerProvider, UnitTestingIncrementalAnalyzerProviderMetadata>> _analyzerProviders = analyzerProviders.ToList();
                     private readonly Dictionary<(string workspaceKind, SolutionServices services), ImmutableArray<
 #if false // Not used in unit testing crawling
                         (IUnitTestingIncrementalAnalyzer analyzer, bool highPriorityForActiveFile)
@@ -466,11 +466,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
                         IUnitTestingIncrementalAnalyzer
 #endif
                         >> _analyzerMap = new();
-
-                    public UnitTestingAnalyzersGetter(IEnumerable<Lazy<IUnitTestingIncrementalAnalyzerProvider, UnitTestingIncrementalAnalyzerProviderMetadata>> analyzerProviders)
-                    {
-                        _analyzerProviders = analyzerProviders.ToList();
-                    }
 
                     public ImmutableArray<IUnitTestingIncrementalAnalyzer> GetOrderedAnalyzers(string workspaceKind, SolutionServices services, bool onlyHighPriorityAnalyzer)
                     {

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingSemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingWorkCoordinator.UnitTestingSemanticChangeProcessor.cs
@@ -305,23 +305,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
                     return graph.GetProjectsThatDirectlyDependOnThisProject(projectId).Concat(projectId);
                 }
 
-                private readonly struct UnitTestingData
+                private readonly struct UnitTestingData(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
                 {
-                    private readonly DocumentId _documentId;
-                    private readonly Document? _document;
+                    private readonly DocumentId _documentId = documentId;
+                    private readonly Document? _document = document;
 
-                    public readonly Project Project;
-                    public readonly SyntaxPath? ChangedMember;
-                    public readonly IAsyncToken AsyncToken;
-
-                    public UnitTestingData(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
-                    {
-                        _documentId = documentId;
-                        _document = document;
-                        Project = project;
-                        ChangedMember = changedMember;
-                        AsyncToken = asyncToken;
-                    }
+                    public readonly Project Project = project;
+                    public readonly SyntaxPath? ChangedMember = changedMember;
+                    public readonly IAsyncToken AsyncToken = asyncToken;
 
                     public Document GetRequiredDocument()
                         => UnitTestingWorkCoordinator.GetRequiredDocument(Project, _documentId, _document);
@@ -445,18 +436,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
                             await EnqueueWorkItemAsync(project, documentId, document: null).ConfigureAwait(false);
                     }
 
-                    private readonly struct UnitTestingData
+                    private readonly struct UnitTestingData(ProjectId projectId, bool needDependencyTracking, IAsyncToken asyncToken)
                     {
-                        public readonly IAsyncToken AsyncToken;
-                        public readonly ProjectId ProjectId;
-                        public readonly bool NeedDependencyTracking;
-
-                        public UnitTestingData(ProjectId projectId, bool needDependencyTracking, IAsyncToken asyncToken)
-                        {
-                            AsyncToken = asyncToken;
-                            ProjectId = projectId;
-                            NeedDependencyTracking = needDependencyTracking;
-                        }
+                        public readonly IAsyncToken AsyncToken = asyncToken;
+                        public readonly ProjectId ProjectId = projectId;
+                        public readonly bool NeedDependencyTracking = needDependencyTracking;
                     }
                 }
             }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
@@ -13,16 +13,11 @@ using Microsoft.CodeAnalysis.StackTraceExplorer;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
 {
-    internal class UnitTestingStackTraceServiceAccessor : IUnitTestingStackTraceServiceAccessor
+    [method: Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
+    internal class UnitTestingStackTraceServiceAccessor(
+        IStackTraceExplorerService stackTraceExplorerService) : IUnitTestingStackTraceServiceAccessor
     {
-        private readonly IStackTraceExplorerService _stackTraceExplorerService;
-
-        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
-        public UnitTestingStackTraceServiceAccessor(
-            IStackTraceExplorerService stackTraceExplorerService)
-        {
-            _stackTraceExplorerService = stackTraceExplorerService;
-        }
+        private readonly IStackTraceExplorerService _stackTraceExplorerService = stackTraceExplorerService;
 
         public (Document? document, int lineNumber) GetDocumentAndLine(Workspace workspace, UnitTestingParsedFrameWrapper parsedFrame)
             => _stackTraceExplorerService.GetDocumentAndLine(workspace.CurrentSolution, parsedFrame.UnderlyingObject);

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/IVSTypeScriptTodoCommentDataServiceImplementation.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/IVSTypeScriptTodoCommentDataServiceImplementation.cs
@@ -9,18 +9,11 @@ using Microsoft.CodeAnalysis.TaskList;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 
-internal readonly struct VSTypeScriptTaskListItem
+internal readonly struct VSTypeScriptTaskListItem(VSTypeScriptTaskListItemDescriptorWrapper descriptor, string message, int position)
 {
-    public VSTypeScriptTaskListItem(VSTypeScriptTaskListItemDescriptorWrapper descriptor, string message, int position)
-    {
-        Descriptor = descriptor;
-        Message = message;
-        Position = position;
-    }
-
-    public VSTypeScriptTaskListItemDescriptorWrapper Descriptor { get; }
-    public string Message { get; }
-    public int Position { get; }
+    public VSTypeScriptTaskListItemDescriptorWrapper Descriptor { get; } = descriptor;
+    public string Message { get; } = message;
+    public int Position { get; } = position;
 }
 
 internal readonly struct VSTypeScriptTaskListItemDescriptorWrapper

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticsUpdatedArgsWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticsUpdatedArgsWrapper.cs
@@ -6,12 +6,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
-    internal readonly struct VSTypeScriptDiagnosticsUpdatedArgsWrapper
+    internal readonly struct VSTypeScriptDiagnosticsUpdatedArgsWrapper(DiagnosticsUpdatedArgs underlyingObject)
     {
-        internal readonly DiagnosticsUpdatedArgs UnderlyingObject;
-
-        public VSTypeScriptDiagnosticsUpdatedArgsWrapper(DiagnosticsUpdatedArgs underlyingObject)
-            => UnderlyingObject = underlyingObject;
+        internal readonly DiagnosticsUpdatedArgs UnderlyingObject = underlyingObject;
 
         public Solution? Solution
             => UnderlyingObject.Solution;

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDocumentNavigationServiceWrapper.cs
@@ -10,18 +10,12 @@ using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
-    internal readonly struct VSTypeScriptDocumentNavigationServiceWrapper
+    internal readonly struct VSTypeScriptDocumentNavigationServiceWrapper(
+        IDocumentNavigationService underlyingObject,
+        IWorkspaceThreadingServiceProvider threadingProvider)
     {
-        private readonly IDocumentNavigationService _underlyingObject;
-        private readonly IWorkspaceThreadingServiceProvider _threadingProvider;
-
-        public VSTypeScriptDocumentNavigationServiceWrapper(
-            IDocumentNavigationService underlyingObject,
-            IWorkspaceThreadingServiceProvider threadingProvider)
-        {
-            _underlyingObject = underlyingObject;
-            _threadingProvider = threadingProvider;
-        }
+        private readonly IDocumentNavigationService _underlyingObject = underlyingObject;
+        private readonly IWorkspaceThreadingServiceProvider _threadingProvider = threadingProvider;
 
         public static VSTypeScriptDocumentNavigationServiceWrapper Create(Workspace workspace)
             => new(workspace.Services.GetRequiredService<IDocumentNavigationService>(),

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerLanguageService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerLanguageService.cs
@@ -12,16 +12,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
     [Shared]
     [ExportLanguageService(typeof(VSTypeScriptDiagnosticAnalyzerLanguageService), InternalLanguageNames.TypeScript)]
-    internal sealed class VSTypeScriptDiagnosticAnalyzerLanguageService : ILanguageService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class VSTypeScriptDiagnosticAnalyzerLanguageService(
+        [Import(AllowDefault = true)] IVSTypeScriptDiagnosticAnalyzerImplementation? implementation = null) : ILanguageService
     {
-        internal readonly IVSTypeScriptDiagnosticAnalyzerImplementation? Implementation;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VSTypeScriptDiagnosticAnalyzerLanguageService(
-            [Import(AllowDefault = true)] IVSTypeScriptDiagnosticAnalyzerImplementation? implementation = null)
-        {
-            Implementation = implementation;
-        }
+        internal readonly IVSTypeScriptDiagnosticAnalyzerImplementation? Implementation = implementation;
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptDiagnosticAnalyzerService.cs
@@ -13,14 +13,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
     [Shared]
     [Export(typeof(IVSTypeScriptDiagnosticAnalyzerService))]
-    internal sealed class VSTypeScriptAnalyzerService : IVSTypeScriptDiagnosticAnalyzerService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class VSTypeScriptAnalyzerService(IDiagnosticAnalyzerService service) : IVSTypeScriptDiagnosticAnalyzerService
     {
-        private readonly IDiagnosticAnalyzerService _service;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VSTypeScriptAnalyzerService(IDiagnosticAnalyzerService service)
-            => _service = service;
+        private readonly IDiagnosticAnalyzerService _service = service;
 
         public void Reanalyze(Workspace workspace, IEnumerable<ProjectId>? projectIds = null, IEnumerable<DocumentId>? documentIds = null, bool highPriority = false)
             => _service.Reanalyze(workspace, projectIds, documentIds, highPriority);

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptFormattingService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptFormattingService.cs
@@ -16,14 +16,11 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
     [ExportLanguageService(typeof(IFormattingService), InternalLanguageNames.TypeScript), Shared]
-    internal sealed class VSTypeScriptFormattingService : IFormattingService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class VSTypeScriptFormattingService([Import(AllowDefault = true)] IVSTypeScriptFormattingServiceImplementation impl) : IFormattingService
     {
-        private readonly IVSTypeScriptFormattingServiceImplementation _impl;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VSTypeScriptFormattingService([Import(AllowDefault = true)] IVSTypeScriptFormattingServiceImplementation impl)
-            => _impl = impl ?? throw new ArgumentNullException(nameof(impl));
+        private readonly IVSTypeScriptFormattingServiceImplementation _impl = impl ?? throw new ArgumentNullException(nameof(impl));
 
         public Task<Document> FormatAsync(Document document, IEnumerable<TextSpan>? spans, LineFormattingOptions lineFormattingOptions, SyntaxFormattingOptions? syntaxFormattingOptions, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigableItemWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigableItemWrapper.cs
@@ -9,16 +9,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    internal sealed class VSTypeScriptNavigableItemWrapper : INavigableItem
+    internal sealed class VSTypeScriptNavigableItemWrapper(IVSTypeScriptNavigableItem navigableItem) : INavigableItem
     {
-        private readonly IVSTypeScriptNavigableItem _navigableItem;
-        private readonly INavigableItem.NavigableDocument _navigableDocument;
-
-        public VSTypeScriptNavigableItemWrapper(IVSTypeScriptNavigableItem navigableItem)
-        {
-            _navigableItem = navigableItem;
-            _navigableDocument = INavigableItem.NavigableDocument.FromDocument(navigableItem.Document);
-        }
+        private readonly IVSTypeScriptNavigableItem _navigableItem = navigableItem;
+        private readonly INavigableItem.NavigableDocument _navigableDocument = INavigableItem.NavigableDocument.FromDocument(navigableItem.Document);
 
         public Glyph Glyph => _navigableItem.Glyph;
 

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptNavigateToSearchService.cs
@@ -20,17 +20,12 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
     [ExportLanguageService(typeof(INavigateToSearchService), InternalLanguageNames.TypeScript), Shared]
-    internal sealed class VSTypeScriptNavigateToSearchService : INavigateToSearchService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class VSTypeScriptNavigateToSearchService(
+        [Import(AllowDefault = true)] IVSTypeScriptNavigateToSearchService? searchService) : INavigateToSearchService
     {
-        private readonly IVSTypeScriptNavigateToSearchService? _searchService;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VSTypeScriptNavigateToSearchService(
-            [Import(AllowDefault = true)] IVSTypeScriptNavigateToSearchService? searchService)
-        {
-            _searchService = searchService;
-        }
+        private readonly IVSTypeScriptNavigateToSearchService? _searchService = searchService;
 
         public IImmutableSet<string> KindsProvided => _searchService?.KindsProvided ?? ImmutableHashSet<string>.Empty;
 
@@ -97,14 +92,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
         private static INavigateToSearchResult Convert(IVSTypeScriptNavigateToSearchResult result)
             => new WrappedNavigateToSearchResult(result);
 
-        private class WrappedNavigateToSearchResult : INavigateToSearchResult
+        private class WrappedNavigateToSearchResult(IVSTypeScriptNavigateToSearchResult result) : INavigateToSearchResult
         {
-            private readonly IVSTypeScriptNavigateToSearchResult _result;
-
-            public WrappedNavigateToSearchResult(IVSTypeScriptNavigateToSearchResult result)
-            {
-                _result = result;
-            }
+            private readonly IVSTypeScriptNavigateToSearchResult _result = result;
 
             public string AdditionalInformation => _result.AdditionalInformation;
 

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptTaskListService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptTaskListService.cs
@@ -15,16 +15,11 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript;
 
 [ExportLanguageService(typeof(ITaskListService), InternalLanguageNames.TypeScript), Shared]
-internal sealed class VSTypeScriptTaskListService : ITaskListService
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class VSTypeScriptTaskListService([Import(AllowDefault = true)] IVSTypeScriptTaskListServiceImplementation impl) : ITaskListService
 {
-    private readonly IVSTypeScriptTaskListServiceImplementation? _impl;
-
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public VSTypeScriptTaskListService([Import(AllowDefault = true)] IVSTypeScriptTaskListServiceImplementation impl)
-    {
-        _impl = impl;
-    }
+    private readonly IVSTypeScriptTaskListServiceImplementation? _impl = impl;
 
     public async Task<ImmutableArray<TaskListItem>> GetTaskListItemsAsync(Document document, ImmutableArray<TaskListItemDescriptor> descriptors, CancellationToken cancellationToken)
     {

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -16,12 +16,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
 {
     internal sealed class WatchHotReloadService
     {
-        private sealed class DebuggerService : IManagedHotReloadService
+        private sealed class DebuggerService(ImmutableArray<string> capabilities) : IManagedHotReloadService
         {
-            private readonly ImmutableArray<string> _capabilities;
-
-            public DebuggerService(ImmutableArray<string> capabilities)
-                => _capabilities = capabilities;
+            private readonly ImmutableArray<string> _capabilities = capabilities;
 
             public ValueTask<ImmutableArray<ManagedActiveStatementDebugInfo>> GetActiveStatementsAsync(CancellationToken cancellationToken)
                 => ValueTaskFactory.FromResult(ImmutableArray<ManagedActiveStatementDebugInfo>.Empty);

--- a/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
@@ -16,14 +16,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractClass
 {
-    internal abstract class AbstractExtractClassRefactoringProvider : CodeRefactoringProvider
+    internal abstract class AbstractExtractClassRefactoringProvider(IExtractClassOptionsService? service) : CodeRefactoringProvider
     {
-        private readonly IExtractClassOptionsService? _optionsService;
-
-        public AbstractExtractClassRefactoringProvider(IExtractClassOptionsService? service)
-        {
-            _optionsService = service;
-        }
+        private readonly IExtractClassOptionsService? _optionsService = service;
 
         protected abstract Task<ImmutableArray<SyntaxNode>> GetSelectedNodesAsync(CodeRefactoringContext context);
         protected abstract Task<SyntaxNode?> GetSelectedClassDeclarationAsync(CodeRefactoringContext context);

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassOptions.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassOptions.cs
@@ -9,44 +9,30 @@ using Microsoft.CodeAnalysis.PullMemberUp;
 
 namespace Microsoft.CodeAnalysis.ExtractClass
 {
-    internal class ExtractClassOptions
+    internal class ExtractClassOptions(
+        string fileName,
+        string typeName,
+        bool sameFile,
+        ImmutableArray<ExtractClassMemberAnalysisResult> memberAnalysisResults)
     {
-        public string FileName { get; }
-        public string TypeName { get; }
-        public bool SameFile { get; }
-        public ImmutableArray<ExtractClassMemberAnalysisResult> MemberAnalysisResults { get; }
-
-        public ExtractClassOptions(
-            string fileName,
-            string typeName,
-            bool sameFile,
-            ImmutableArray<ExtractClassMemberAnalysisResult> memberAnalysisResults)
-        {
-            FileName = fileName;
-            TypeName = typeName;
-            MemberAnalysisResults = memberAnalysisResults;
-            SameFile = sameFile;
-        }
+        public string FileName { get; } = fileName;
+        public string TypeName { get; } = typeName;
+        public bool SameFile { get; } = sameFile;
+        public ImmutableArray<ExtractClassMemberAnalysisResult> MemberAnalysisResults { get; } = memberAnalysisResults;
     }
 
-    internal class ExtractClassMemberAnalysisResult
+    internal class ExtractClassMemberAnalysisResult(
+        ISymbol member,
+        bool makeAbstract)
     {
         /// <summary>
         /// The member needs to be pulled up.
         /// </summary>
-        public ISymbol Member { get; }
+        public ISymbol Member { get; } = member;
 
         /// <summary>
         /// Whether to make the member abstract when added to the new class
         /// </summary>
-        public bool MakeAbstract { get; }
-
-        public ExtractClassMemberAnalysisResult(
-            ISymbol member,
-            bool makeAbstract)
-        {
-            Member = member;
-            MakeAbstract = makeAbstract;
-        }
+        public bool MakeAbstract { get; } = makeAbstract;
     }
 }

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -22,44 +22,28 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractClass
 {
-    internal class ExtractClassWithDialogCodeAction : CodeActionWithOptions
+    internal class ExtractClassWithDialogCodeAction(
+        Document document,
+        TextSpan span,
+        IExtractClassOptionsService service,
+        INamedTypeSymbol selectedType,
+        SyntaxNode selectedTypeDeclarationNode,
+        CleanCodeGenerationOptionsProvider fallbackOptions,
+        ImmutableArray<ISymbol> selectedMembers) : CodeActionWithOptions
     {
-        private readonly Document _document;
-        private readonly ImmutableArray<ISymbol> _selectedMembers;
-        private readonly INamedTypeSymbol _selectedType;
-        private readonly SyntaxNode _selectedTypeDeclarationNode;
-        private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
-        private readonly IExtractClassOptionsService _service;
+        private readonly Document _document = document;
+        private readonly ImmutableArray<ISymbol> _selectedMembers = selectedMembers;
+        private readonly INamedTypeSymbol _selectedType = selectedType;
+        private readonly SyntaxNode _selectedTypeDeclarationNode = selectedTypeDeclarationNode;
+        private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
+        private readonly IExtractClassOptionsService _service = service;
 
-        public TextSpan Span { get; }
+        public TextSpan Span { get; } = span;
         public override string Title => _selectedType.IsRecord
             ? FeaturesResources.Extract_base_record
             : FeaturesResources.Extract_base_class;
 
-        internal override CodeActionPriority Priority { get; }
-
-        public ExtractClassWithDialogCodeAction(
-            Document document,
-            TextSpan span,
-            IExtractClassOptionsService service,
-            INamedTypeSymbol selectedType,
-            SyntaxNode selectedTypeDeclarationNode,
-            CleanCodeGenerationOptionsProvider fallbackOptions,
-            ImmutableArray<ISymbol> selectedMembers)
-        {
-            _document = document;
-            _service = service;
-            _selectedType = selectedType;
-            _selectedTypeDeclarationNode = selectedTypeDeclarationNode;
-            _fallbackOptions = fallbackOptions;
-            _selectedMembers = selectedMembers;
-            Span = span;
-
-            // If the user brought up the lightbulb on a class itself, it's more likely that they want to extract a base
-            // class.  on a member however, we deprioritize this as there are likely more member-specific operations
-            // they'd prefer to invoke instead.
-            Priority = selectedMembers.IsEmpty ? CodeActionPriority.Medium : CodeActionPriority.Low;
-        }
+        internal override CodeActionPriority Priority { get; } = selectedMembers.IsEmpty ? CodeActionPriority.Medium : CodeActionPriority.Low;
 
         public override object? GetOptions(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
@@ -10,16 +10,10 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractInterface
 {
-    internal class ExtractInterfaceCodeAction : CodeActionWithOptions
+    internal class ExtractInterfaceCodeAction(AbstractExtractInterfaceService extractInterfaceService, ExtractInterfaceTypeAnalysisResult typeAnalysisResult) : CodeActionWithOptions
     {
-        private readonly ExtractInterfaceTypeAnalysisResult _typeAnalysisResult;
-        private readonly AbstractExtractInterfaceService _extractInterfaceService;
-
-        public ExtractInterfaceCodeAction(AbstractExtractInterfaceService extractInterfaceService, ExtractInterfaceTypeAnalysisResult typeAnalysisResult)
-        {
-            _extractInterfaceService = extractInterfaceService;
-            _typeAnalysisResult = typeAnalysisResult;
-        }
+        private readonly ExtractInterfaceTypeAnalysisResult _typeAnalysisResult = typeAnalysisResult;
+        private readonly AbstractExtractInterfaceService _extractInterfaceService = extractInterfaceService;
 
         public override object GetOptions(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceResult.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceResult.cs
@@ -6,17 +6,10 @@
 
 namespace Microsoft.CodeAnalysis.ExtractInterface
 {
-    internal sealed class ExtractInterfaceResult
+    internal sealed class ExtractInterfaceResult(bool succeeded, Solution updatedSolution = null, DocumentId navigationDocumentId = null)
     {
-        public bool Succeeded { get; }
-        public Solution UpdatedSolution { get; }
-        public DocumentId NavigationDocumentId { get; }
-
-        public ExtractInterfaceResult(bool succeeded, Solution updatedSolution = null, DocumentId navigationDocumentId = null)
-        {
-            Succeeded = succeeded;
-            UpdatedSolution = updatedSolution;
-            NavigationDocumentId = navigationDocumentId;
-        }
+        public bool Succeeded { get; } = succeeded;
+        public Solution UpdatedSolution { get; } = updatedSolution;
+        public DocumentId NavigationDocumentId { get; } = navigationDocumentId;
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/FailedExtractMethodResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/FailedExtractMethodResult.cs
@@ -7,11 +7,7 @@ using Microsoft.CodeAnalysis.Formatting.Rules;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod
 {
-    internal class FailedExtractMethodResult : ExtractMethodResult
+    internal class FailedExtractMethodResult(OperationStatus status) : ExtractMethodResult(status.Flag, status.Reasons, null, ImmutableArray<AbstractFormattingRule>.Empty, default, null)
     {
-        public FailedExtractMethodResult(OperationStatus status)
-            : base(status.Flag, status.Reasons, null, ImmutableArray<AbstractFormattingRule>.Empty, default, null)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.AnalyzerResult.cs
@@ -15,38 +15,23 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 {
     internal abstract partial class MethodExtractor
     {
-        protected class AnalyzerResult
+        protected class AnalyzerResult(
+            SemanticDocument document,
+            IEnumerable<ITypeParameterSymbol> typeParametersInDeclaration,
+            IEnumerable<ITypeParameterSymbol> typeParametersInConstraintList,
+            ImmutableArray<VariableInfo> variables,
+            VariableInfo variableToUseAsReturnValue,
+            ITypeSymbol returnType,
+            bool awaitTaskReturn,
+            bool instanceMemberIsUsed,
+            bool shouldBeReadOnly,
+            bool endOfSelectionReachable,
+            OperationStatus status)
         {
-            private readonly IList<ITypeParameterSymbol> _typeParametersInDeclaration;
-            private readonly IList<ITypeParameterSymbol> _typeParametersInConstraintList;
-            private readonly ImmutableArray<VariableInfo> _variables;
-            private readonly VariableInfo _variableToUseAsReturnValue;
-
-            public AnalyzerResult(
-                SemanticDocument document,
-                IEnumerable<ITypeParameterSymbol> typeParametersInDeclaration,
-                IEnumerable<ITypeParameterSymbol> typeParametersInConstraintList,
-                ImmutableArray<VariableInfo> variables,
-                VariableInfo variableToUseAsReturnValue,
-                ITypeSymbol returnType,
-                bool awaitTaskReturn,
-                bool instanceMemberIsUsed,
-                bool shouldBeReadOnly,
-                bool endOfSelectionReachable,
-                OperationStatus status)
-            {
-                UseInstanceMember = instanceMemberIsUsed;
-                ShouldBeReadOnly = shouldBeReadOnly;
-                EndOfSelectionReachable = endOfSelectionReachable;
-                AwaitTaskReturn = awaitTaskReturn;
-                SemanticDocument = document;
-                _typeParametersInDeclaration = typeParametersInDeclaration.ToList();
-                _typeParametersInConstraintList = typeParametersInConstraintList.ToList();
-                _variables = variables;
-                ReturnType = returnType;
-                _variableToUseAsReturnValue = variableToUseAsReturnValue;
-                Status = status;
-            }
+            private readonly IList<ITypeParameterSymbol> _typeParametersInDeclaration = typeParametersInDeclaration.ToList();
+            private readonly IList<ITypeParameterSymbol> _typeParametersInConstraintList = typeParametersInConstraintList.ToList();
+            private readonly ImmutableArray<VariableInfo> _variables = variables;
+            private readonly VariableInfo _variableToUseAsReturnValue = variableToUseAsReturnValue;
 
             public AnalyzerResult With(SemanticDocument document)
             {
@@ -72,37 +57,37 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             /// <summary>
             /// used to determine whether static can be used
             /// </summary>
-            public bool UseInstanceMember { get; }
+            public bool UseInstanceMember { get; } = instanceMemberIsUsed;
 
             /// <summary>
             /// Indicates whether the extracted method should have a 'readonly' modifier.
             /// </summary>
-            public bool ShouldBeReadOnly { get; }
+            public bool ShouldBeReadOnly { get; } = shouldBeReadOnly;
 
             /// <summary>
             /// used to determine whether "return" statement needs to be inserted
             /// </summary>
-            public bool EndOfSelectionReachable { get; }
+            public bool EndOfSelectionReachable { get; } = endOfSelectionReachable;
 
             /// <summary>
             /// document this result is based on
             /// </summary>
-            public SemanticDocument SemanticDocument { get; }
+            public SemanticDocument SemanticDocument { get; } = document;
 
             /// <summary>
             /// flag to show whether task return type is due to await
             /// </summary>
-            public bool AwaitTaskReturn { get; }
+            public bool AwaitTaskReturn { get; } = awaitTaskReturn;
 
             /// <summary>
             /// return type
             /// </summary>
-            public ITypeSymbol ReturnType { get; }
+            public ITypeSymbol ReturnType { get; } = returnType;
 
             /// <summary>
             /// analyzer result operation status
             /// </summary>
-            public OperationStatus Status { get; }
+            public OperationStatus Status { get; } = status;
 
             public ReadOnlyCollection<ITypeParameterSymbol> MethodTypeParametersInDeclaration
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TriviaResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TriviaResult.cs
@@ -15,26 +15,17 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 {
     internal abstract partial class MethodExtractor
     {
-        protected abstract class TriviaResult
+        protected abstract class TriviaResult(SemanticDocument document, ITriviaSavedResult result, int endOfLineKind, int whitespaceKind)
         {
-            private readonly int _endOfLineKind;
-            private readonly int _whitespaceKind;
+            private readonly int _endOfLineKind = endOfLineKind;
+            private readonly int _whitespaceKind = whitespaceKind;
 
-            private readonly ITriviaSavedResult _result;
-
-            public TriviaResult(SemanticDocument document, ITriviaSavedResult result, int endOfLineKind, int whitespaceKind)
-            {
-                SemanticDocument = document;
-
-                _result = result;
-                _endOfLineKind = endOfLineKind;
-                _whitespaceKind = whitespaceKind;
-            }
+            private readonly ITriviaSavedResult _result = result;
 
             protected abstract AnnotationResolver GetAnnotationResolver(SyntaxNode callsite, SyntaxNode methodDefinition);
             protected abstract TriviaResolver GetTriviaResolver(SyntaxNode methodDefinition);
 
-            public SemanticDocument SemanticDocument { get; }
+            public SemanticDocument SemanticDocument { get; } = document;
 
             public async Task<OperationStatus<SemanticDocument>> ApplyAsync(GeneratedCode generatedCode, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -15,21 +15,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 {
     internal abstract partial class MethodExtractor
     {
-        protected class VariableInfo
+        protected class VariableInfo(
+            VariableSymbol variableSymbol,
+            VariableStyle variableStyle,
+            bool useAsReturnValue = false)
         {
-            private readonly VariableSymbol _variableSymbol;
-            private readonly VariableStyle _variableStyle;
-            private readonly bool _useAsReturnValue;
-
-            public VariableInfo(
-                VariableSymbol variableSymbol,
-                VariableStyle variableStyle,
-                bool useAsReturnValue = false)
-            {
-                _variableSymbol = variableSymbol;
-                _variableStyle = variableStyle;
-                _useAsReturnValue = useAsReturnValue;
-            }
+            private readonly VariableSymbol _variableSymbol = variableSymbol;
+            private readonly VariableStyle _variableStyle = variableStyle;
+            private readonly bool _useAsReturnValue = useAsReturnValue;
 
             public bool UseAsReturnValue
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -77,13 +77,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
         }
 
-        protected abstract class NotMovableVariableSymbol : VariableSymbol
+        protected abstract class NotMovableVariableSymbol(Compilation compilation, ITypeSymbol type) : VariableSymbol(compilation, type)
         {
-            public NotMovableVariableSymbol(Compilation compilation, ITypeSymbol type)
-                : base(compilation, type)
-            {
-            }
-
             public override bool GetUseSaferDeclarationBehavior(CancellationToken cancellationToken)
             {
                 // decl never get moved

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus`1.cs
@@ -9,16 +9,10 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     /// <summary>
     /// operation status paired with data
     /// </summary>
-    internal class OperationStatus<T>
+    internal class OperationStatus<T>(OperationStatus status, T data)
     {
-        public OperationStatus(OperationStatus status, T data)
-        {
-            Status = status;
-            Data = data;
-        }
-
-        public OperationStatus Status { get; }
-        public T Data { get; }
+        public OperationStatus Status { get; } = status;
+        public T Data { get; } = data;
 
         public OperationStatus<T> With(OperationStatus status)
             => new(status, Data);

--- a/src/Features/Core/Portable/ExtractMethod/SelectionValidator.NullSelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionValidator.NullSelectionResult.cs
@@ -36,12 +36,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 => throw new InvalidOperationException();
         }
 
-        protected class ErrorSelectionResult : NullSelectionResult
+        protected class ErrorSelectionResult(OperationStatus status) : NullSelectionResult(status.MakeFail())
         {
-            public ErrorSelectionResult(OperationStatus status)
-                : base(status.MakeFail())
-            {
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/SimpleExtractMethodResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SimpleExtractMethodResult.cs
@@ -7,16 +7,12 @@ using Microsoft.CodeAnalysis.Formatting.Rules;
 
 namespace Microsoft.CodeAnalysis.ExtractMethod
 {
-    internal class SimpleExtractMethodResult : ExtractMethodResult
+    internal class SimpleExtractMethodResult(
+        OperationStatus status,
+        Document documentWithoutFinalFormatting,
+        ImmutableArray<AbstractFormattingRule> formattingRules,
+        SyntaxToken invocationNameToken,
+        SyntaxNode methodDefinition) : ExtractMethodResult(status.Flag, status.Reasons, documentWithoutFinalFormatting, formattingRules, invocationNameToken, methodDefinition)
     {
-        public SimpleExtractMethodResult(
-            OperationStatus status,
-            Document documentWithoutFinalFormatting,
-            ImmutableArray<AbstractFormattingRule> formattingRules,
-            SyntaxToken invocationNameToken,
-            SyntaxNode methodDefinition)
-            : base(status.Flag, status.Reasons, documentWithoutFinalFormatting, formattingRules, invocationNameToken, methodDefinition)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
@@ -21,14 +21,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// definitions found to third parties in case they want to add any additional definitions
         /// to the results we present.
         /// </summary>
-        private sealed class DefinitionTrackingContext : IFindUsagesContext
+        private sealed class DefinitionTrackingContext(IFindUsagesContext underlyingContext) : IFindUsagesContext
         {
-            private readonly IFindUsagesContext _underlyingContext;
+            private readonly IFindUsagesContext _underlyingContext = underlyingContext;
             private readonly object _gate = new();
             private readonly List<DefinitionItem> _definitions = new();
-
-            public DefinitionTrackingContext(IFindUsagesContext underlyingContext)
-                => _underlyingContext = underlyingContext;
 
             public ValueTask<FindUsagesOptions> GetOptionsAsync(string language, CancellationToken cancellationToken)
                 => _underlyingContext.GetOptionsAsync(language, cancellationToken);

--- a/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/Features/Core/Portable/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -24,20 +24,14 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// Forwards <see cref="IStreamingFindLiteralReferencesProgress"/> calls to an
         /// <see cref="IFindUsagesContext"/> instance.
         /// </summary>
-        private sealed class FindLiteralsProgressAdapter : IStreamingFindLiteralReferencesProgress
+        private sealed class FindLiteralsProgressAdapter(
+            IFindUsagesContext context, DefinitionItem definition) : IStreamingFindLiteralReferencesProgress
         {
-            private readonly IFindUsagesContext _context;
-            private readonly DefinitionItem _definition;
+            private readonly IFindUsagesContext _context = context;
+            private readonly DefinitionItem _definition = definition;
 
             public IStreamingProgressTracker ProgressTracker
                 => _context.ProgressTracker;
-
-            public FindLiteralsProgressAdapter(
-                IFindUsagesContext context, DefinitionItem definition)
-            {
-                _context = context;
-                _definition = definition;
-            }
 
             public async ValueTask OnReferenceFoundAsync(Document document, TextSpan span, CancellationToken cancellationToken)
             {
@@ -54,11 +48,12 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// <summary>
         /// Forwards IFindReferencesProgress calls to an IFindUsagesContext instance.
         /// </summary>
-        private sealed class FindReferencesProgressAdapter : IStreamingFindReferencesProgress
+        private sealed class FindReferencesProgressAdapter(
+            Solution solution, IFindUsagesContext context, FindReferencesSearchOptions options) : IStreamingFindReferencesProgress
         {
-            private readonly Solution _solution;
-            private readonly IFindUsagesContext _context;
-            private readonly FindReferencesSearchOptions _options;
+            private readonly Solution _solution = solution;
+            private readonly IFindUsagesContext _context = context;
+            private readonly FindReferencesSearchOptions _options = options;
 
             /// <summary>
             /// We will hear about definition symbols many times while performing FAR.  We'll
@@ -76,14 +71,6 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
             public IStreamingProgressTracker ProgressTracker
                 => _context.ProgressTracker;
-
-            public FindReferencesProgressAdapter(
-                Solution solution, IFindUsagesContext context, FindReferencesSearchOptions options)
-            {
-                _solution = solution;
-                _context = context;
-                _options = options;
-            }
 
             // Do nothing functions.  The streaming far service doesn't care about
             // any of these.

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
@@ -19,23 +19,18 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// <see cref="DocumentSpan"/>.
         /// </summary>
         // internal for testing purposes.
-        internal sealed class DefaultDefinitionItem : DefinitionItem
+        internal sealed class DefaultDefinitionItem(
+            ImmutableArray<string> tags,
+            ImmutableArray<TaggedText> displayParts,
+            ImmutableArray<TaggedText> nameDisplayParts,
+            ImmutableArray<TaggedText> originationParts,
+            ImmutableArray<DocumentSpan> sourceSpans,
+            ImmutableDictionary<string, string>? properties,
+            ImmutableDictionary<string, string>? displayableProperties,
+            bool displayIfNoReferences) : DefinitionItem(tags, displayParts, nameDisplayParts, originationParts,
+                   sourceSpans, properties, displayableProperties, displayIfNoReferences)
         {
             internal sealed override bool IsExternal => false;
-
-            public DefaultDefinitionItem(
-                ImmutableArray<string> tags,
-                ImmutableArray<TaggedText> displayParts,
-                ImmutableArray<TaggedText> nameDisplayParts,
-                ImmutableArray<TaggedText> originationParts,
-                ImmutableArray<DocumentSpan> sourceSpans,
-                ImmutableDictionary<string, string>? properties,
-                ImmutableDictionary<string, string>? displayableProperties,
-                bool displayIfNoReferences)
-                : base(tags, displayParts, nameDisplayParts, originationParts,
-                       sourceSpans, properties, displayableProperties, displayIfNoReferences)
-            {
-            }
 
             public override async Task<INavigableLocation?> GetNavigableLocationAsync(Workspace workspace, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DetachedDefinitionItem.cs
@@ -15,46 +15,34 @@ using static Microsoft.CodeAnalysis.FindUsages.DefinitionItem;
 namespace Microsoft.CodeAnalysis.FindUsages
 {
     [DataContract]
-    internal sealed class DetachedDefinitionItem : IEquatable<DetachedDefinitionItem>
+    internal sealed class DetachedDefinitionItem(
+        ImmutableArray<string> tags,
+        ImmutableArray<TaggedText> displayParts,
+        ImmutableArray<TaggedText> nameDisplayParts,
+        ImmutableArray<TaggedText> originationParts,
+        ImmutableArray<DocumentIdSpan> sourceSpans,
+        ImmutableDictionary<string, string> properties,
+        ImmutableDictionary<string, string> displayableProperties,
+        bool displayIfNoReferences) : IEquatable<DetachedDefinitionItem>
     {
         [DataMember(Order = 0)]
-        public readonly ImmutableArray<string> Tags;
+        public readonly ImmutableArray<string> Tags = tags;
         [DataMember(Order = 1)]
-        public readonly ImmutableArray<TaggedText> DisplayParts;
+        public readonly ImmutableArray<TaggedText> DisplayParts = displayParts;
         [DataMember(Order = 2)]
-        public readonly ImmutableArray<TaggedText> NameDisplayParts;
+        public readonly ImmutableArray<TaggedText> NameDisplayParts = nameDisplayParts;
         [DataMember(Order = 3)]
-        public readonly ImmutableArray<TaggedText> OriginationParts;
+        public readonly ImmutableArray<TaggedText> OriginationParts = originationParts;
         [DataMember(Order = 4)]
-        public readonly ImmutableArray<DocumentIdSpan> SourceSpans;
+        public readonly ImmutableArray<DocumentIdSpan> SourceSpans = sourceSpans;
         [DataMember(Order = 5)]
-        public readonly ImmutableDictionary<string, string> Properties;
+        public readonly ImmutableDictionary<string, string> Properties = properties;
         [DataMember(Order = 6)]
-        public readonly ImmutableDictionary<string, string> DisplayableProperties;
+        public readonly ImmutableDictionary<string, string> DisplayableProperties = displayableProperties;
         [DataMember(Order = 7)]
-        public readonly bool DisplayIfNoReferences;
+        public readonly bool DisplayIfNoReferences = displayIfNoReferences;
 
         private int _hashCode;
-
-        public DetachedDefinitionItem(
-            ImmutableArray<string> tags,
-            ImmutableArray<TaggedText> displayParts,
-            ImmutableArray<TaggedText> nameDisplayParts,
-            ImmutableArray<TaggedText> originationParts,
-            ImmutableArray<DocumentIdSpan> sourceSpans,
-            ImmutableDictionary<string, string> properties,
-            ImmutableDictionary<string, string> displayableProperties,
-            bool displayIfNoReferences)
-        {
-            Tags = tags;
-            DisplayParts = displayParts;
-            NameDisplayParts = nameDisplayParts;
-            OriginationParts = originationParts;
-            Properties = properties;
-            DisplayableProperties = displayableProperties;
-            DisplayIfNoReferences = displayIfNoReferences;
-            SourceSpans = sourceSpans;
-        }
 
         public override bool Equals(object? obj)
             => Equals(obj as DetachedDefinitionItem);

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -84,17 +84,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
             => GetCallback(callbackId).SetSearchTitleAsync(title, cancellationToken);
     }
 
-    internal sealed class FindUsagesServerCallback
+    internal sealed class FindUsagesServerCallback(Solution solution, IFindUsagesContext context)
     {
-        private readonly Solution _solution;
-        private readonly IFindUsagesContext _context;
+        private readonly Solution _solution = solution;
+        private readonly IFindUsagesContext _context = context;
         private readonly Dictionary<int, DefinitionItem> _idToDefinition = new();
-
-        public FindUsagesServerCallback(Solution solution, IFindUsagesContext context)
-        {
-            _solution = solution;
-            _context = context;
-        }
 
         public ValueTask<FindUsagesOptions> GetOptionsAsync(string language, CancellationToken cancellationToken)
             => _context.GetOptionsAsync(language, cancellationToken);
@@ -158,19 +152,13 @@ namespace Microsoft.CodeAnalysis.FindUsages
     }
 
     [DataContract]
-    internal readonly struct SerializableDocumentSpan
+    internal readonly struct SerializableDocumentSpan(DocumentId documentId, TextSpan sourceSpan)
     {
         [DataMember(Order = 0)]
-        public readonly DocumentId DocumentId;
+        public readonly DocumentId DocumentId = documentId;
 
         [DataMember(Order = 1)]
-        public readonly TextSpan SourceSpan;
-
-        public SerializableDocumentSpan(DocumentId documentId, TextSpan sourceSpan)
-        {
-            DocumentId = documentId;
-            SourceSpan = sourceSpan;
-        }
+        public readonly TextSpan SourceSpan = sourceSpan;
 
         public static SerializableDocumentSpan Dehydrate(DocumentSpan documentSpan)
             => new(documentSpan.Document.Id, documentSpan.SourceSpan);
@@ -185,56 +173,43 @@ namespace Microsoft.CodeAnalysis.FindUsages
     }
 
     [DataContract]
-    internal readonly struct SerializableDefinitionItem
+    internal readonly struct SerializableDefinitionItem(
+        int id,
+        ImmutableArray<string> tags,
+        ImmutableArray<TaggedText> displayParts,
+        ImmutableArray<TaggedText> nameDisplayParts,
+        ImmutableArray<TaggedText> originationParts,
+        ImmutableArray<SerializableDocumentSpan> sourceSpans,
+        ImmutableDictionary<string, string> properties,
+        ImmutableDictionary<string, string> displayableProperties,
+        bool displayIfNoReferences)
     {
         [DataMember(Order = 0)]
-        public readonly int Id;
+        public readonly int Id = id;
 
         [DataMember(Order = 1)]
-        public readonly ImmutableArray<string> Tags;
+        public readonly ImmutableArray<string> Tags = tags;
 
         [DataMember(Order = 2)]
-        public readonly ImmutableArray<TaggedText> DisplayParts;
+        public readonly ImmutableArray<TaggedText> DisplayParts = displayParts;
 
         [DataMember(Order = 3)]
-        public readonly ImmutableArray<TaggedText> NameDisplayParts;
+        public readonly ImmutableArray<TaggedText> NameDisplayParts = nameDisplayParts;
 
         [DataMember(Order = 4)]
-        public readonly ImmutableArray<TaggedText> OriginationParts;
+        public readonly ImmutableArray<TaggedText> OriginationParts = originationParts;
 
         [DataMember(Order = 5)]
-        public readonly ImmutableArray<SerializableDocumentSpan> SourceSpans;
+        public readonly ImmutableArray<SerializableDocumentSpan> SourceSpans = sourceSpans;
 
         [DataMember(Order = 6)]
-        public readonly ImmutableDictionary<string, string> Properties;
+        public readonly ImmutableDictionary<string, string> Properties = properties;
 
         [DataMember(Order = 7)]
-        public readonly ImmutableDictionary<string, string> DisplayableProperties;
+        public readonly ImmutableDictionary<string, string> DisplayableProperties = displayableProperties;
 
         [DataMember(Order = 8)]
-        public readonly bool DisplayIfNoReferences;
-
-        public SerializableDefinitionItem(
-            int id,
-            ImmutableArray<string> tags,
-            ImmutableArray<TaggedText> displayParts,
-            ImmutableArray<TaggedText> nameDisplayParts,
-            ImmutableArray<TaggedText> originationParts,
-            ImmutableArray<SerializableDocumentSpan> sourceSpans,
-            ImmutableDictionary<string, string> properties,
-            ImmutableDictionary<string, string> displayableProperties,
-            bool displayIfNoReferences)
-        {
-            Id = id;
-            Tags = tags;
-            DisplayParts = displayParts;
-            NameDisplayParts = nameDisplayParts;
-            OriginationParts = originationParts;
-            SourceSpans = sourceSpans;
-            Properties = properties;
-            DisplayableProperties = displayableProperties;
-            DisplayIfNoReferences = displayIfNoReferences;
-        }
+        public readonly bool DisplayIfNoReferences = displayIfNoReferences;
 
         public static SerializableDefinitionItem Dehydrate(int id, DefinitionItem item)
             => new(id,
@@ -264,31 +239,23 @@ namespace Microsoft.CodeAnalysis.FindUsages
     }
 
     [DataContract]
-    internal readonly struct SerializableSourceReferenceItem
+    internal readonly struct SerializableSourceReferenceItem(
+        int definitionId,
+        SerializableDocumentSpan sourceSpan,
+        SymbolUsageInfo symbolUsageInfo,
+        ImmutableDictionary<string, string> additionalProperties)
     {
         [DataMember(Order = 0)]
-        public readonly int DefinitionId;
+        public readonly int DefinitionId = definitionId;
 
         [DataMember(Order = 1)]
-        public readonly SerializableDocumentSpan SourceSpan;
+        public readonly SerializableDocumentSpan SourceSpan = sourceSpan;
 
         [DataMember(Order = 2)]
-        public readonly SymbolUsageInfo SymbolUsageInfo;
+        public readonly SymbolUsageInfo SymbolUsageInfo = symbolUsageInfo;
 
         [DataMember(Order = 3)]
-        public readonly ImmutableDictionary<string, string> AdditionalProperties;
-
-        public SerializableSourceReferenceItem(
-            int definitionId,
-            SerializableDocumentSpan sourceSpan,
-            SymbolUsageInfo symbolUsageInfo,
-            ImmutableDictionary<string, string> additionalProperties)
-        {
-            DefinitionId = definitionId;
-            SourceSpan = sourceSpan;
-            SymbolUsageInfo = symbolUsageInfo;
-            AdditionalProperties = additionalProperties;
-        }
+        public readonly ImmutableDictionary<string, string> AdditionalProperties = additionalProperties;
 
         public static SerializableSourceReferenceItem Dehydrate(int definitionId, SourceReferenceItem item)
             => new(definitionId,

--- a/src/Features/Core/Portable/Formatting/ExportNewDocumentFormattingProviderAttribute.cs
+++ b/src/Features/Core/Portable/Formatting/ExportNewDocumentFormattingProviderAttribute.cs
@@ -9,14 +9,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal class ExportNewDocumentFormattingProviderAttribute : ExportAttribute
+    internal class ExportNewDocumentFormattingProviderAttribute(string languageName) : ExportAttribute(typeof(INewDocumentFormattingProvider))
     {
-        public ExportNewDocumentFormattingProviderAttribute(string languageName)
-            : base(typeof(INewDocumentFormattingProvider))
-        {
-            Language = languageName;
-        }
-
-        public string Language { get; }
+        public string Language { get; } = languageName;
     }
 }

--- a/src/Features/Core/Portable/FullyQualify/IFullyQualifyService.cs
+++ b/src/Features/Core/Portable/FullyQualify/IFullyQualifyService.cs
@@ -12,34 +12,22 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify;
 
 [DataContract]
-internal readonly struct FullyQualifyFixData
+internal readonly struct FullyQualifyFixData(string name, ImmutableArray<FullyQualifyIndividualFixData> individualFixData)
 {
     [DataMember(Order = 0)]
-    public readonly string Name;
+    public readonly string Name = name;
 
     [DataMember(Order = 1)]
-    public readonly ImmutableArray<FullyQualifyIndividualFixData> IndividualFixData;
-
-    public FullyQualifyFixData(string name, ImmutableArray<FullyQualifyIndividualFixData> individualFixData)
-    {
-        Name = name;
-        IndividualFixData = individualFixData;
-    }
+    public readonly ImmutableArray<FullyQualifyIndividualFixData> IndividualFixData = individualFixData;
 }
 
 [DataContract]
-internal readonly struct FullyQualifyIndividualFixData
+internal readonly struct FullyQualifyIndividualFixData(string title, ImmutableArray<TextChange> textChanges)
 {
     [DataMember(Order = 0)]
-    public readonly string Title;
+    public readonly string Title = title;
     [DataMember(Order = 1)]
-    public readonly ImmutableArray<TextChange> TextChanges;
-
-    public FullyQualifyIndividualFixData(string title, ImmutableArray<TextChange> textChanges)
-    {
-        Title = title;
-        TextChanges = textChanges;
-    }
+    public readonly ImmutableArray<TextChange> TextChanges = textChanges;
 }
 
 internal interface IFullyQualifyService : ILanguageService

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
@@ -18,27 +18,18 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 {
     internal abstract partial class AbstractGenerateConstructorFromMembersCodeRefactoringProvider
     {
-        private sealed class ConstructorDelegatingCodeAction : CodeAction
+        private sealed class ConstructorDelegatingCodeAction(
+            AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
+            Document document,
+            State state,
+            bool addNullChecks,
+            CleanCodeGenerationOptionsProvider fallbackOptions) : CodeAction
         {
-            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service;
-            private readonly Document _document;
-            private readonly State _state;
-            private readonly bool _addNullChecks;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
-
-            public ConstructorDelegatingCodeAction(
-                AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
-                Document document,
-                State state,
-                bool addNullChecks,
-                CleanCodeGenerationOptionsProvider fallbackOptions)
-            {
-                _service = service;
-                _document = document;
-                _state = state;
-                _addNullChecks = addNullChecks;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service = service;
+            private readonly Document _document = document;
+            private readonly State _state = state;
+            private readonly bool _addNullChecks = addNullChecks;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
@@ -15,27 +15,18 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 {
     internal abstract partial class AbstractGenerateConstructorFromMembersCodeRefactoringProvider
     {
-        private sealed class FieldDelegatingCodeAction : CodeAction
+        private sealed class FieldDelegatingCodeAction(
+            AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
+            Document document,
+            State state,
+            bool addNullChecks,
+            CleanCodeGenerationOptionsProvider fallbackOptions) : CodeAction
         {
-            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service;
-            private readonly Document _document;
-            private readonly State _state;
-            private readonly bool _addNullChecks;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
-
-            public FieldDelegatingCodeAction(
-                AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
-                Document document,
-                State state,
-                bool addNullChecks,
-                CleanCodeGenerationOptionsProvider fallbackOptions)
-            {
-                _service = service;
-                _document = document;
-                _state = state;
-                _addNullChecks = addNullChecks;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service = service;
+            private readonly Document _document = document;
+            private readonly State _state = state;
+            private readonly bool _addNullChecks = addNullChecks;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
@@ -21,39 +21,27 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 {
     internal abstract partial class AbstractGenerateConstructorFromMembersCodeRefactoringProvider : AbstractGenerateFromMembersCodeRefactoringProvider
     {
-        private class GenerateConstructorWithDialogCodeAction : CodeActionWithOptions
+        private class GenerateConstructorWithDialogCodeAction(
+            AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
+            Document document,
+            TextSpan textSpan,
+            INamedTypeSymbol containingType,
+            Accessibility? desiredAccessibility,
+            ImmutableArray<ISymbol> viableMembers,
+            ImmutableArray<PickMembersOption> pickMembersOptions,
+            CleanCodeGenerationOptionsProvider fallbackOptions) : CodeActionWithOptions
         {
-            private readonly Document _document;
-            private readonly INamedTypeSymbol _containingType;
-            private readonly Accessibility? _desiredAccessibility;
-            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service;
-            private readonly TextSpan _textSpan;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
+            private readonly Document _document = document;
+            private readonly INamedTypeSymbol _containingType = containingType;
+            private readonly Accessibility? _desiredAccessibility = desiredAccessibility;
+            private readonly AbstractGenerateConstructorFromMembersCodeRefactoringProvider _service = service;
+            private readonly TextSpan _textSpan = textSpan;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
-            internal ImmutableArray<ISymbol> ViableMembers { get; }
-            internal ImmutableArray<PickMembersOption> PickMembersOptions { get; }
+            internal ImmutableArray<ISymbol> ViableMembers { get; } = viableMembers;
+            internal ImmutableArray<PickMembersOption> PickMembersOptions { get; } = pickMembersOptions;
 
             public override string Title => FeaturesResources.Generate_constructor;
-
-            public GenerateConstructorWithDialogCodeAction(
-                AbstractGenerateConstructorFromMembersCodeRefactoringProvider service,
-                Document document,
-                TextSpan textSpan,
-                INamedTypeSymbol containingType,
-                Accessibility? desiredAccessibility,
-                ImmutableArray<ISymbol> viableMembers,
-                ImmutableArray<PickMembersOption> pickMembersOptions,
-                CleanCodeGenerationOptionsProvider fallbackOptions)
-            {
-                _service = service;
-                _document = document;
-                _textSpan = textSpan;
-                _containingType = containingType;
-                _desiredAccessibility = desiredAccessibility;
-                ViableMembers = viableMembers;
-                PickMembersOptions = pickMembersOptions;
-                _fallbackOptions = fallbackOptions;
-            }
 
             public override object GetOptions(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeAction.cs
@@ -11,17 +11,12 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {
-        private sealed class GenerateDefaultConstructorCodeAction : AbstractCodeAction
+        private sealed class GenerateDefaultConstructorCodeAction(
+            Document document,
+            State state,
+            IMethodSymbol constructor,
+            CodeAndImportGenerationOptionsProvider fallbackOptions) : AbstractCodeAction(document, state, new[] { constructor }, GetDisplayText(state, constructor), fallbackOptions)
         {
-            public GenerateDefaultConstructorCodeAction(
-                Document document,
-                State state,
-                IMethodSymbol constructor,
-                CodeAndImportGenerationOptionsProvider fallbackOptions)
-                : base(document, state, new[] { constructor }, GetDisplayText(state, constructor), fallbackOptions)
-            {
-            }
-
             private static string GetDisplayText(State state, IMethodSymbol constructor)
             {
                 var parameters = constructor.Parameters.Select(p => p.Name);

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeActionAll.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeActionAll.cs
@@ -10,16 +10,12 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {
-        private sealed class CodeActionAll : AbstractCodeAction
+        private sealed class CodeActionAll(
+            Document document,
+            State state,
+            IList<IMethodSymbol> constructors,
+            CodeAndImportGenerationOptionsProvider fallbackOptions) : AbstractCodeAction(document, state, constructors, FeaturesResources.Generate_all, fallbackOptions)
         {
-            public CodeActionAll(
-                Document document,
-                State state,
-                IList<IMethodSymbol> constructors,
-                CodeAndImportGenerationOptionsProvider fallbackOptions)
-                : base(document, state, constructors, FeaturesResources.Generate_all, fallbackOptions)
-            {
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
@@ -14,12 +14,9 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         /// Specialized formatter for the "return a == obj.a &amp;&amp; b == obj.b &amp;&amp; c == obj.c &amp;&amp; ...
         /// code that we spit out.
         /// </summary>
-        private class FormatLargeBinaryExpressionRule : AbstractFormattingRule
+        private class FormatLargeBinaryExpressionRule(ISyntaxFactsService syntaxFacts) : AbstractFormattingRule
         {
-            private readonly ISyntaxFactsService _syntaxFacts;
-
-            public FormatLargeBinaryExpressionRule(ISyntaxFactsService syntaxFacts)
-                => _syntaxFacts = syntaxFacts;
+            private readonly ISyntaxFactsService _syntaxFacts = syntaxFacts;
 
             /// <summary>
             /// Wrap the large &amp;&amp; expression after every &amp;&amp; token.

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
@@ -20,44 +20,31 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 {
     internal partial class GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider
     {
-        private partial class GenerateEqualsAndGetHashCodeAction : CodeAction
+        private partial class GenerateEqualsAndGetHashCodeAction(
+            Document document,
+            SyntaxNode typeDeclaration,
+            INamedTypeSymbol containingType,
+            ImmutableArray<ISymbol> selectedMembers,
+            CleanCodeGenerationOptionsProvider fallbackOptions,
+            bool generateEquals,
+            bool generateGetHashCode,
+            bool implementIEquatable,
+            bool generateOperators) : CodeAction
         {
             // https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters#naming-operator-overload-parameters
             //  DO use left and right for binary operator overload parameter names if there is no meaning to the parameters.
             private const string LeftName = "left";
             private const string RightName = "right";
 
-            private readonly bool _generateEquals;
-            private readonly bool _generateGetHashCode;
-            private readonly bool _implementIEquatable;
-            private readonly bool _generateOperators;
-            private readonly Document _document;
-            private readonly SyntaxNode _typeDeclaration;
-            private readonly INamedTypeSymbol _containingType;
-            private readonly ImmutableArray<ISymbol> _selectedMembers;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
-
-            public GenerateEqualsAndGetHashCodeAction(
-                Document document,
-                SyntaxNode typeDeclaration,
-                INamedTypeSymbol containingType,
-                ImmutableArray<ISymbol> selectedMembers,
-                CleanCodeGenerationOptionsProvider fallbackOptions,
-                bool generateEquals,
-                bool generateGetHashCode,
-                bool implementIEquatable,
-                bool generateOperators)
-            {
-                _document = document;
-                _typeDeclaration = typeDeclaration;
-                _containingType = containingType;
-                _selectedMembers = selectedMembers;
-                _fallbackOptions = fallbackOptions;
-                _generateEquals = generateEquals;
-                _generateGetHashCode = generateGetHashCode;
-                _implementIEquatable = implementIEquatable;
-                _generateOperators = generateOperators;
-            }
+            private readonly bool _generateEquals = generateEquals;
+            private readonly bool _generateGetHashCode = generateGetHashCode;
+            private readonly bool _implementIEquatable = implementIEquatable;
+            private readonly bool _generateOperators = generateOperators;
+            private readonly Document _document = document;
+            private readonly SyntaxNode _typeDeclaration = typeDeclaration;
+            private readonly INamedTypeSymbol _containingType = containingType;
+            private readonly ImmutableArray<ISymbol> _selectedMembers = selectedMembers;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             public override string EquivalenceKey => Title;
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         Name = PredefinedCodeRefactoringProviderNames.GenerateEqualsAndGetHashCodeFromMembers), Shared]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.GenerateConstructorFromMembers,
                     Before = PredefinedCodeRefactoringProviderNames.AddConstructorParametersFromMembers)]
-    internal partial class GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider : AbstractGenerateFromMembersCodeRefactoringProvider
+    [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
+    internal partial class GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider(IPickMembersService? pickMembersService) : AbstractGenerateFromMembersCodeRefactoringProvider
     {
         public const string GenerateOperatorsId = nameof(GenerateOperatorsId);
         public const string ImplementIEquatableId = nameof(ImplementIEquatableId);
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         private const string EqualsName = nameof(object.Equals);
         private const string GetHashCodeName = nameof(object.GetHashCode);
 
-        private readonly IPickMembersService? _pickMembersService_forTestingPurposes;
+        private readonly IPickMembersService? _pickMembersService_forTestingPurposes = pickMembersService;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -47,10 +48,6 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             : this(pickMembersService: null)
         {
         }
-
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
-        public GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider(IPickMembersService? pickMembersService)
-            => _pickMembersService_forTestingPurposes = pickMembersService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -18,42 +18,28 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 {
     internal partial class GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider
     {
-        private class GenerateEqualsAndGetHashCodeWithDialogCodeAction : CodeActionWithOptions
+        private class GenerateEqualsAndGetHashCodeWithDialogCodeAction(
+            GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider service,
+            Document document,
+            SyntaxNode typeDeclaration,
+            INamedTypeSymbol containingType,
+            ImmutableArray<ISymbol> viableMembers,
+            ImmutableArray<PickMembersOption> pickMembersOptions,
+            CleanCodeGenerationOptionsProvider fallbackOptions,
+            ILegacyGlobalOptionsWorkspaceService globalOptions,
+            bool generateEquals = false,
+            bool generateGetHashCode = false) : CodeActionWithOptions
         {
-            private readonly bool _generateEquals;
-            private readonly bool _generateGetHashCode;
-            private readonly GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider _service;
-            private readonly Document _document;
-            private readonly SyntaxNode _typeDeclaration;
-            private readonly INamedTypeSymbol _containingType;
-            private readonly ImmutableArray<ISymbol> _viableMembers;
-            private readonly ImmutableArray<PickMembersOption> _pickMembersOptions;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
-            private readonly ILegacyGlobalOptionsWorkspaceService _globalOptions;
-
-            public GenerateEqualsAndGetHashCodeWithDialogCodeAction(
-                GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider service,
-                Document document,
-                SyntaxNode typeDeclaration,
-                INamedTypeSymbol containingType,
-                ImmutableArray<ISymbol> viableMembers,
-                ImmutableArray<PickMembersOption> pickMembersOptions,
-                CleanCodeGenerationOptionsProvider fallbackOptions,
-                ILegacyGlobalOptionsWorkspaceService globalOptions,
-                bool generateEquals = false,
-                bool generateGetHashCode = false)
-            {
-                _service = service;
-                _document = document;
-                _typeDeclaration = typeDeclaration;
-                _containingType = containingType;
-                _viableMembers = viableMembers;
-                _pickMembersOptions = pickMembersOptions;
-                _fallbackOptions = fallbackOptions;
-                _generateEquals = generateEquals;
-                _generateGetHashCode = generateGetHashCode;
-                _globalOptions = globalOptions;
-            }
+            private readonly bool _generateEquals = generateEquals;
+            private readonly bool _generateGetHashCode = generateGetHashCode;
+            private readonly GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider _service = service;
+            private readonly Document _document = document;
+            private readonly SyntaxNode _typeDeclaration = typeDeclaration;
+            private readonly INamedTypeSymbol _containingType = containingType;
+            private readonly ImmutableArray<ISymbol> _viableMembers = viableMembers;
+            private readonly ImmutableArray<PickMembersOption> _pickMembersOptions = pickMembersOptions;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
+            private readonly ILegacyGlobalOptionsWorkspaceService _globalOptions = globalOptions;
 
             public override string EquivalenceKey => Title;
 

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersCodeRefactoringProvider.SelectedMemberInfo.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersCodeRefactoringProvider.SelectedMemberInfo.cs
@@ -9,21 +9,14 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
 {
     internal abstract partial class AbstractGenerateFromMembersCodeRefactoringProvider : CodeRefactoringProvider
     {
-        protected class SelectedMemberInfo
+        protected class SelectedMemberInfo(
+            INamedTypeSymbol containingType,
+            ImmutableArray<SyntaxNode> selectedDeclarations,
+            ImmutableArray<ISymbol> selectedMembers)
         {
-            public readonly INamedTypeSymbol ContainingType;
-            public readonly ImmutableArray<SyntaxNode> SelectedDeclarations;
-            public readonly ImmutableArray<ISymbol> SelectedMembers;
-
-            public SelectedMemberInfo(
-                INamedTypeSymbol containingType,
-                ImmutableArray<SyntaxNode> selectedDeclarations,
-                ImmutableArray<ISymbol> selectedMembers)
-            {
-                ContainingType = containingType;
-                SelectedDeclarations = selectedDeclarations;
-                SelectedMembers = selectedMembers;
-            }
+            public readonly INamedTypeSymbol ContainingType = containingType;
+            public readonly ImmutableArray<SyntaxNode> SelectedDeclarations = selectedDeclarations;
+            public readonly ImmutableArray<ISymbol> SelectedMembers = selectedMembers;
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/Argument.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/Argument.cs
@@ -6,18 +6,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 {
     internal abstract partial class AbstractGenerateConstructorService<TService, TExpressionSyntax>
     {
-        protected readonly struct Argument
+        protected readonly struct Argument(RefKind refKind, string? name, TExpressionSyntax? expression)
         {
-            public readonly RefKind RefKind;
-            public readonly string Name;
-            public readonly TExpressionSyntax? Expression;
-
-            public Argument(RefKind refKind, string? name, TExpressionSyntax? expression)
-            {
-                RefKind = refKind;
-                Name = name ?? "";
-                Expression = expression;
-            }
+            public readonly RefKind RefKind = refKind;
+            public readonly string Name = name ?? "";
+            public readonly TExpressionSyntax? Expression = expression;
 
             public bool IsNamed => !string.IsNullOrEmpty(Name);
         }

--- a/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.CodeAction.cs
@@ -15,21 +15,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateEnumMember
 {
     internal abstract partial class AbstractGenerateEnumMemberService<TService, TSimpleNameSyntax, TExpressionSyntax>
     {
-        private partial class GenerateEnumMemberCodeAction : CodeAction
+        private partial class GenerateEnumMemberCodeAction(
+            Document document,
+            State state,
+            CodeAndImportGenerationOptionsProvider fallbackOptions) : CodeAction
         {
-            private readonly Document _document;
-            private readonly State _state;
-            private readonly CodeAndImportGenerationOptionsProvider _fallbackOptions;
-
-            public GenerateEnumMemberCodeAction(
-                Document document,
-                State state,
-                CodeAndImportGenerationOptionsProvider fallbackOptions)
-            {
-                _document = document;
-                _state = state;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly Document _document = document;
+            private readonly State _state = state;
+            private readonly CodeAndImportGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
@@ -12,21 +12,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
 {
     internal partial class AbstractGenerateParameterizedMemberService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>
     {
-        protected class MethodSignatureInfo : SignatureInfo
+        protected class MethodSignatureInfo(
+            SemanticDocument document,
+            State state,
+            IMethodSymbol methodSymbol,
+            ImmutableArray<string> parameterNames = default) : SignatureInfo(document, state)
         {
-            private readonly IMethodSymbol _methodSymbol;
-            private readonly ImmutableArray<string> _parameterNames;
-
-            public MethodSignatureInfo(
-                SemanticDocument document,
-                State state,
-                IMethodSymbol methodSymbol,
-                ImmutableArray<string> parameterNames = default)
-                : base(document, state)
-            {
-                _methodSymbol = methodSymbol;
-                _parameterNames = parameterNames;
-            }
+            private readonly IMethodSymbol _methodSymbol = methodSymbol;
+            private readonly ImmutableArray<string> _parameterNames = parameterNames;
 
             protected override ITypeSymbol DetermineReturnTypeWorker(CancellationToken cancellationToken)
                 => _methodSymbol.ReturnType;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
@@ -24,20 +24,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
 {
     internal abstract partial class AbstractGenerateParameterizedMemberService<TService, TSimpleNameSyntax, TExpressionSyntax, TInvocationExpressionSyntax>
     {
-        internal abstract class SignatureInfo
+        internal abstract class SignatureInfo(
+            SemanticDocument document,
+            State state)
         {
-            protected readonly SemanticDocument Document;
-            protected readonly State State;
+            protected readonly SemanticDocument Document = document;
+            protected readonly State State = state;
             private ImmutableArray<ITypeParameterSymbol> _typeParameters;
             private IDictionary<ITypeSymbol, ITypeParameterSymbol> _typeArgumentToTypeParameterMap;
-
-            public SignatureInfo(
-                SemanticDocument document,
-                State state)
-            {
-                Document = document;
-                State = state;
-            }
 
             public ImmutableArray<ITypeParameterSymbol> DetermineTypeParameters(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/TypeParameterSubstitution.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/TypeParameterSubstitution.cs
@@ -32,23 +32,15 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             return type.SubstituteTypes(visitor.Substitutions, compilation);
         }
 
-        private sealed class DetermineSubstitutionsVisitor : AsyncSymbolVisitor
+        private sealed class DetermineSubstitutionsVisitor(
+            Compilation compilation, ISet<string> availableTypeParameterNames, Project project, CancellationToken cancellationToken) : AsyncSymbolVisitor
         {
             public readonly Dictionary<ITypeSymbol, ITypeSymbol> Substitutions =
                 new();
-            private readonly CancellationToken _cancellationToken;
-            private readonly Compilation _compilation;
-            private readonly ISet<string> _availableTypeParameterNames;
-            private readonly Project _project;
-
-            public DetermineSubstitutionsVisitor(
-                Compilation compilation, ISet<string> availableTypeParameterNames, Project project, CancellationToken cancellationToken)
-            {
-                _compilation = compilation;
-                _availableTypeParameterNames = availableTypeParameterNames;
-                _project = project;
-                _cancellationToken = cancellationToken;
-            }
+            private readonly CancellationToken _cancellationToken = cancellationToken;
+            private readonly Compilation _compilation = compilation;
+            private readonly ISet<string> _availableTypeParameterNames = availableTypeParameterNames;
+            private readonly Project _project = project;
 
             public override ValueTask VisitDynamicType(IDynamicTypeSymbol symbol)
                 => default;

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
@@ -18,20 +18,12 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 {
     internal partial class AbstractGenerateVariableService<TService, TSimpleNameSyntax, TExpressionSyntax>
     {
-        private sealed class GenerateLocalCodeAction : CodeAction
+        private sealed class GenerateLocalCodeAction(TService service, Document document, State state, CodeGenerationOptionsProvider fallbackOptions) : CodeAction
         {
-            private readonly TService _service;
-            private readonly Document _document;
-            private readonly State _state;
-            private readonly CodeGenerationOptionsProvider _fallbackOptions;
-
-            public GenerateLocalCodeAction(TService service, Document document, State state, CodeGenerationOptionsProvider fallbackOptions)
-            {
-                _service = service;
-                _document = document;
-                _state = state;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly TService _service = service;
+            private readonly Document _document = document;
+            private readonly State _state = state;
+            private readonly CodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             public override string Title
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateParameterCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateParameterCodeAction.cs
@@ -12,20 +12,12 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 {
     internal partial class AbstractGenerateVariableService<TService, TSimpleNameSyntax, TExpressionSyntax>
     {
-        private class GenerateParameterCodeAction : CodeAction
+        private class GenerateParameterCodeAction(Document document, State state, bool includeOverridesAndImplementations, int parameterIndex) : CodeAction
         {
-            private readonly Document _document;
-            private readonly State _state;
-            private readonly bool _includeOverridesAndImplementations;
-            private readonly int _parameterIndex;
-
-            public GenerateParameterCodeAction(Document document, State state, bool includeOverridesAndImplementations, int parameterIndex)
-            {
-                _document = document;
-                _state = state;
-                _includeOverridesAndImplementations = includeOverridesAndImplementations;
-                _parameterIndex = parameterIndex;
-            }
+            private readonly Document _document = document;
+            private readonly State _state = state;
+            private readonly bool _includeOverridesAndImplementations = includeOverridesAndImplementations;
+            private readonly int _parameterIndex = parameterIndex;
 
             public override string Title
             {

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
@@ -18,19 +18,16 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,
         Name = PredefinedCodeRefactoringProviderNames.GenerateOverrides), Shared]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.AddConstructorParametersFromMembers)]
-    internal partial class GenerateOverridesCodeRefactoringProvider : CodeRefactoringProvider
+    [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
+    internal partial class GenerateOverridesCodeRefactoringProvider(IPickMembersService? pickMembersService) : CodeRefactoringProvider
     {
-        private readonly IPickMembersService? _pickMembersService_forTestingPurposes;
+        private readonly IPickMembersService? _pickMembersService_forTestingPurposes = pickMembersService;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public GenerateOverridesCodeRefactoringProvider() : this(null)
         {
         }
-
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
-        public GenerateOverridesCodeRefactoringProvider(IPickMembersService? pickMembersService)
-            => _pickMembersService_forTestingPurposes = pickMembersService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesWithDialogCodeAction.cs
@@ -19,30 +19,20 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
 {
     internal partial class GenerateOverridesCodeRefactoringProvider
     {
-        private sealed class GenerateOverridesWithDialogCodeAction : CodeActionWithOptions
+        private sealed class GenerateOverridesWithDialogCodeAction(
+            GenerateOverridesCodeRefactoringProvider service,
+            Document document,
+            TextSpan textSpan,
+            INamedTypeSymbol containingType,
+            ImmutableArray<ISymbol> viableMembers,
+            CodeAndImportGenerationOptionsProvider fallbackOptions) : CodeActionWithOptions
         {
-            private readonly GenerateOverridesCodeRefactoringProvider _service;
-            private readonly Document _document;
-            private readonly INamedTypeSymbol _containingType;
-            private readonly ImmutableArray<ISymbol> _viableMembers;
-            private readonly TextSpan _textSpan;
-            private readonly CodeAndImportGenerationOptionsProvider _fallbackOptions;
-
-            public GenerateOverridesWithDialogCodeAction(
-                GenerateOverridesCodeRefactoringProvider service,
-                Document document,
-                TextSpan textSpan,
-                INamedTypeSymbol containingType,
-                ImmutableArray<ISymbol> viableMembers,
-                CodeAndImportGenerationOptionsProvider fallbackOptions)
-            {
-                _service = service;
-                _document = document;
-                _containingType = containingType;
-                _viableMembers = viableMembers;
-                _textSpan = textSpan;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly GenerateOverridesCodeRefactoringProvider _service = service;
+            private readonly Document _document = document;
+            private readonly INamedTypeSymbol _containingType = containingType;
+            private readonly ImmutableArray<ISymbol> _viableMembers = viableMembers;
+            private readonly TextSpan _textSpan = textSpan;
+            private readonly CodeAndImportGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             public override string Title => FeaturesResources.Generate_overrides;
 
@@ -106,12 +96,9 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
                     cancellationToken: cancellationToken);
             }
 
-            private sealed class ChangeOptionValueOperation : CodeActionOperation
+            private sealed class ChangeOptionValueOperation(bool selectedAll) : CodeActionOperation
             {
-                private readonly bool _selectedAll;
-
-                public ChangeOptionValueOperation(bool selectedAll)
-                    => _selectedAll = selectedAll;
+                private readonly bool _selectedAll = selectedAll;
 
                 public override void Apply(Workspace workspace, CancellationToken cancellationToken)
                 {

--- a/src/Features/Core/Portable/GenerateType/GenerateTypeDialogOptions.cs
+++ b/src/Features/Core/Portable/GenerateType/GenerateTypeDialogOptions.cs
@@ -6,20 +6,13 @@
 
 namespace Microsoft.CodeAnalysis.GenerateType
 {
-    internal class GenerateTypeDialogOptions
+    internal class GenerateTypeDialogOptions(
+        bool isPublicOnlyAccessibility = false,
+        TypeKindOptions typeKindOptions = TypeKindOptions.AllOptions,
+        bool isAttribute = false)
     {
-        public bool IsPublicOnlyAccessibility { get; }
-        public TypeKindOptions TypeKindOptions { get; }
-        public bool IsAttribute { get; }
-
-        public GenerateTypeDialogOptions(
-            bool isPublicOnlyAccessibility = false,
-            TypeKindOptions typeKindOptions = TypeKindOptions.AllOptions,
-            bool isAttribute = false)
-        {
-            IsPublicOnlyAccessibility = isPublicOnlyAccessibility;
-            TypeKindOptions = typeKindOptions;
-            IsAttribute = isAttribute;
-        }
+        public bool IsPublicOnlyAccessibility { get; } = isPublicOnlyAccessibility;
+        public TypeKindOptions TypeKindOptions { get; } = typeKindOptions;
+        public bool IsAttribute { get; } = isAttribute;
     }
 }

--- a/src/Features/Core/Portable/Highlighting/ExportHighlighterAttribute.cs
+++ b/src/Features/Core/Portable/Highlighting/ExportHighlighterAttribute.cs
@@ -13,14 +13,8 @@ namespace Microsoft.CodeAnalysis.Highlighting
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
     [ExcludeFromCodeCoverage]
-    internal class ExportHighlighterAttribute : ExportAttribute
+    internal class ExportHighlighterAttribute(string language) : ExportAttribute(typeof(IHighlighter))
     {
-        public string Language { get; }
-
-        public ExportHighlighterAttribute(string language)
-            : base(typeof(IHighlighter))
-        {
-            this.Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
     }
 }

--- a/src/Features/Core/Portable/Highlighting/HighlightingService.cs
+++ b/src/Features/Core/Portable/Highlighting/HighlightingService.cs
@@ -16,18 +16,13 @@ namespace Microsoft.CodeAnalysis.Highlighting
 {
     [Export(typeof(IHighlightingService))]
     [Shared]
-    internal class HighlightingService : IHighlightingService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class HighlightingService(
+        [ImportMany] IEnumerable<Lazy<IHighlighter, LanguageMetadata>> highlighters) : IHighlightingService
     {
-        private readonly List<Lazy<IHighlighter, LanguageMetadata>> _highlighters;
+        private readonly List<Lazy<IHighlighter, LanguageMetadata>> _highlighters = highlighters.ToList();
         private static readonly PooledObjects.ObjectPool<List<TextSpan>> s_listPool = new(() => new List<TextSpan>());
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public HighlightingService(
-            [ImportMany] IEnumerable<Lazy<IHighlighter, LanguageMetadata>> highlighters)
-        {
-            _highlighters = highlighters.ToList();
-        }
 
         public void AddHighlights(
              SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -21,30 +21,19 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ImplementAbstractClass
 {
-    internal sealed class ImplementAbstractClassData
+    internal sealed class ImplementAbstractClassData(
+        Document document, ImplementTypeGenerationOptions options, SyntaxNode classNode, SyntaxToken classIdentifier,
+        INamedTypeSymbol classType, INamedTypeSymbol abstractClassType,
+        ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> unimplementedMembers)
     {
-        private readonly Document _document;
-        private readonly ImplementTypeGenerationOptions _options;
-        private readonly SyntaxNode _classNode;
-        private readonly SyntaxToken _classIdentifier;
-        private readonly ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> _unimplementedMembers;
+        private readonly Document _document = document;
+        private readonly ImplementTypeGenerationOptions _options = options;
+        private readonly SyntaxNode _classNode = classNode;
+        private readonly SyntaxToken _classIdentifier = classIdentifier;
+        private readonly ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> _unimplementedMembers = unimplementedMembers;
 
-        public readonly INamedTypeSymbol ClassType;
-        public readonly INamedTypeSymbol AbstractClassType;
-
-        public ImplementAbstractClassData(
-            Document document, ImplementTypeGenerationOptions options, SyntaxNode classNode, SyntaxToken classIdentifier,
-            INamedTypeSymbol classType, INamedTypeSymbol abstractClassType,
-            ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> unimplementedMembers)
-        {
-            _document = document;
-            _options = options;
-            _classNode = classNode;
-            _classIdentifier = classIdentifier;
-            ClassType = classType;
-            AbstractClassType = abstractClassType;
-            _unimplementedMembers = unimplementedMembers;
-        }
+        public readonly INamedTypeSymbol ClassType = classType;
+        public readonly INamedTypeSymbol AbstractClassType = abstractClassType;
 
         public static async Task<ImplementAbstractClassData?> TryGetDataAsync(
             Document document, SyntaxNode classNode, SyntaxToken classIdentifier, ImplementTypeGenerationOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
@@ -86,19 +86,15 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             return state.ClassOrStructType.FindImplementationForInterfaceMember(disposeMethod) == null;
         }
 
-        private sealed class ImplementInterfaceWithDisposePatternCodeAction : ImplementInterfaceCodeAction
+        private sealed class ImplementInterfaceWithDisposePatternCodeAction(
+            AbstractImplementInterfaceService service,
+            Document document,
+            ImplementTypeGenerationOptions options,
+            State state,
+            bool explicitly,
+            bool abstractly,
+            ISymbol? throughMember) : ImplementInterfaceCodeAction(service, document, options, state, explicitly, abstractly, onlyRemaining: !explicitly, throughMember)
         {
-            public ImplementInterfaceWithDisposePatternCodeAction(
-                AbstractImplementInterfaceService service,
-                Document document,
-                ImplementTypeGenerationOptions options,
-                State state,
-                bool explicitly,
-                bool abstractly,
-                ISymbol? throughMember) : base(service, document, options, state, explicitly, abstractly, onlyRemaining: !explicitly, throughMember)
-            {
-            }
-
             public static ImplementInterfaceWithDisposePatternCodeAction CreateImplementWithDisposePatternCodeAction(
                 AbstractImplementInterfaceService service,
                 Document document,

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
@@ -14,13 +14,13 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 {
     internal abstract partial class AbstractImplementInterfaceService
     {
-        internal class State
+        internal class State(SyntaxNode interfaceNode, SyntaxNode classOrStructDecl, INamedTypeSymbol classOrStructType, IEnumerable<INamedTypeSymbol> interfaceTypes, SemanticModel model)
         {
-            public SyntaxNode Location { get; }
-            public SyntaxNode ClassOrStructDecl { get; }
-            public INamedTypeSymbol ClassOrStructType { get; }
-            public IEnumerable<INamedTypeSymbol> InterfaceTypes { get; }
-            public SemanticModel Model { get; }
+            public SyntaxNode Location { get; } = interfaceNode;
+            public SyntaxNode ClassOrStructDecl { get; } = classOrStructDecl;
+            public INamedTypeSymbol ClassOrStructType { get; } = classOrStructType;
+            public IEnumerable<INamedTypeSymbol> InterfaceTypes { get; } = interfaceTypes;
+            public SemanticModel Model { get; } = model;
 
             // The members that are not implemented at all.
             public ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> MembersWithoutExplicitOrImplicitImplementationWhichCanBeImplicitlyImplemented { get; private set; }
@@ -31,15 +31,6 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             // The members that have no explicit implementation.
             public ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)> MembersWithoutExplicitImplementation { get; private set; }
                 = ImmutableArray<(INamedTypeSymbol type, ImmutableArray<ISymbol> members)>.Empty;
-
-            public State(SyntaxNode interfaceNode, SyntaxNode classOrStructDecl, INamedTypeSymbol classOrStructType, IEnumerable<INamedTypeSymbol> interfaceTypes, SemanticModel model)
-            {
-                Location = interfaceNode;
-                ClassOrStructDecl = classOrStructDecl;
-                ClassOrStructType = classOrStructType;
-                InterfaceTypes = interfaceTypes;
-                Model = model;
-            }
 
             public static State Generate(
                 AbstractImplementInterfaceService service,

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginItem.cs
@@ -11,52 +11,43 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.InheritanceMargin
 {
     [DataContract]
-    internal readonly struct InheritanceMarginItem : IEquatable<InheritanceMarginItem>
+    internal readonly struct InheritanceMarginItem(
+        int lineNumber,
+        string? topLevelDisplayText,
+        ImmutableArray<TaggedText> displayTexts,
+        Glyph glyph,
+        ImmutableArray<InheritanceTargetItem> targetItems) : IEquatable<InheritanceMarginItem>
     {
         /// <summary>
         /// Line number used to show the margin for the member.
         /// </summary>
         [DataMember(Order = 0)]
-        public readonly int LineNumber;
+        public readonly int LineNumber = lineNumber;
 
         /// <summary>
         /// Special display text to show when showing the 'hover' tip for a margin item.  Used to override the default
         /// text we show that says "'X' is inherited".  Used currently for showing information about top-level-imports.
         /// </summary>
         [DataMember(Order = 1)]
-        public readonly string? TopLevelDisplayText;
+        public readonly string? TopLevelDisplayText = topLevelDisplayText;
 
         /// <summary>
         /// Display texts for this member.
         /// </summary>
         [DataMember(Order = 2)]
-        public readonly ImmutableArray<TaggedText> DisplayTexts;
+        public readonly ImmutableArray<TaggedText> DisplayTexts = displayTexts;
 
         /// <summary>
         /// Member's glyph.
         /// </summary>
         [DataMember(Order = 3)]
-        public readonly Glyph Glyph;
+        public readonly Glyph Glyph = glyph;
 
         /// <summary>
         /// An array of the implementing/implemented/overriding/overridden targets for this member.
         /// </summary>
         [DataMember(Order = 4)]
-        public readonly ImmutableArray<InheritanceTargetItem> TargetItems;
-
-        public InheritanceMarginItem(
-            int lineNumber,
-            string? topLevelDisplayText,
-            ImmutableArray<TaggedText> displayTexts,
-            Glyph glyph,
-            ImmutableArray<InheritanceTargetItem> targetItems)
-        {
-            LineNumber = lineNumber;
-            TopLevelDisplayText = topLevelDisplayText;
-            DisplayTexts = displayTexts;
-            Glyph = glyph;
-            TargetItems = targetItems;
-        }
+        public readonly ImmutableArray<InheritanceTargetItem> TargetItems = targetItems;
 
         public override int GetHashCode()
             => throw ExceptionUtilities.Unreachable();

--- a/src/Features/Core/Portable/InlineHints/TypeHint.cs
+++ b/src/Features/Core/Portable/InlineHints/TypeHint.cs
@@ -8,24 +8,15 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.InlineHints
 {
-    internal readonly struct TypeHint
+    internal readonly struct TypeHint(ITypeSymbol type, TextSpan span, TextChange? textChange, bool leadingSpace = false, bool trailingSpace = false)
     {
         private static readonly ImmutableArray<SymbolDisplayPart> s_spaceArray = ImmutableArray.Create(new SymbolDisplayPart(SymbolDisplayPartKind.Space, symbol: null, " "));
 
-        public ITypeSymbol Type { get; }
-        public TextSpan Span { get; }
-        public TextChange? TextChange { get; }
-        public ImmutableArray<SymbolDisplayPart> Prefix { get; }
-        public ImmutableArray<SymbolDisplayPart> Suffix { get; }
-
-        public TypeHint(ITypeSymbol type, TextSpan span, TextChange? textChange, bool leadingSpace = false, bool trailingSpace = false)
-        {
-            Type = type;
-            Span = span;
-            TextChange = textChange;
-            Prefix = CreateSpaceSymbolPartArray(leadingSpace);
-            Suffix = CreateSpaceSymbolPartArray(trailingSpace);
-        }
+        public ITypeSymbol Type { get; } = type;
+        public TextSpan Span { get; } = span;
+        public TextChange? TextChange { get; } = textChange;
+        public ImmutableArray<SymbolDisplayPart> Prefix { get; } = CreateSpaceSymbolPartArray(leadingSpace);
+        public ImmutableArray<SymbolDisplayPart> Suffix { get; } = CreateSpaceSymbolPartArray(trailingSpace);
 
         private static ImmutableArray<SymbolDisplayPart> CreateSpaceSymbolPartArray(bool hasSpace)
             => hasSpace ? s_spaceArray : ImmutableArray<SymbolDisplayPart>.Empty;

--- a/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.InlineContext.cs
+++ b/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.InlineContext.cs
@@ -18,32 +18,25 @@ namespace Microsoft.CodeAnalysis.InlineMethod
 {
     internal abstract partial class AbstractInlineMethodRefactoringProvider<TMethodDeclarationSyntax, TStatementSyntax, TExpressionSyntax, TInvocationSyntax>
     {
-        private readonly struct InlineMethodContext
+        private readonly struct InlineMethodContext(
+            ImmutableArray<TStatementSyntax> statementsToInsertBeforeInvocationOfCallee,
+            TExpressionSyntax inlineExpression,
+            bool containsAwaitExpression)
         {
             /// <summary>
             /// Statements that should be inserted to before the invocation location of callee.
             /// </summary>
-            public ImmutableArray<TStatementSyntax> StatementsToInsertBeforeInvocationOfCallee { get; }
+            public ImmutableArray<TStatementSyntax> StatementsToInsertBeforeInvocationOfCallee { get; } = statementsToInsertBeforeInvocationOfCallee;
 
             /// <summary>
             /// Inline content for the callee method.
             /// </summary>
-            public TExpressionSyntax InlineExpression { get; }
+            public TExpressionSyntax InlineExpression { get; } = inlineExpression;
 
             /// <summary>
             /// Indicate if <see cref="InlineExpression"/> has AwaitExpression in it.
             /// </summary>
-            public bool ContainsAwaitExpression { get; }
-
-            public InlineMethodContext(
-                ImmutableArray<TStatementSyntax> statementsToInsertBeforeInvocationOfCallee,
-                TExpressionSyntax inlineExpression,
-                bool containsAwaitExpression)
-            {
-                StatementsToInsertBeforeInvocationOfCallee = statementsToInsertBeforeInvocationOfCallee;
-                InlineExpression = inlineExpression;
-                ContainsAwaitExpression = containsAwaitExpression;
-            }
+            public bool ContainsAwaitExpression { get; } = containsAwaitExpression;
         }
 
         private async Task<InlineMethodContext> GetInlineMethodContextAsync(

--- a/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.MethodParametersInfo.cs
+++ b/src/Features/Core/Portable/InlineMethod/AbstractInlineMethodRefactoringProvider.MethodParametersInfo.cs
@@ -22,7 +22,11 @@ namespace Microsoft.CodeAnalysis.InlineMethod
         /// <summary>
         /// Information about the callee method parameters to compute <see cref="InlineMethodContext"/>.
         /// </summary>
-        private readonly struct MethodParametersInfo
+        private readonly struct MethodParametersInfo(
+            ImmutableArray<(IParameterSymbol parameterSymbol, string name)> parametersWithVariableDeclarationArgument,
+            ImmutableArray<(IParameterSymbol parameterSymbol, TExpressionSyntax initExpression)> parametersToGenerateFreshVariablesFor,
+            ImmutableDictionary<IParameterSymbol, TExpressionSyntax> parametersToReplace,
+            bool mergeInlineContentAndVariableDeclarationArgument)
         {
             /// <summary>
             /// Parameters map to variable declaration argument's name.
@@ -41,7 +45,7 @@ namespace Microsoft.CodeAnalysis.InlineMethod
             /// }
             /// void Callee(out int i) => i = 100;
             /// </summary>
-            public ImmutableArray<(IParameterSymbol parameterSymbol, string name)> ParametersWithVariableDeclarationArgument { get; }
+            public ImmutableArray<(IParameterSymbol parameterSymbol, string name)> ParametersWithVariableDeclarationArgument { get; } = parametersWithVariableDeclarationArgument;
 
             /// <summary>
             /// Operations that represent Parameter has argument but the argument is not identifier or literal.
@@ -69,7 +73,7 @@ namespace Microsoft.CodeAnalysis.InlineMethod
             ///     DoSomething(a, b);
             /// }
             /// </summary>
-            public ImmutableArray<(IParameterSymbol parameterSymbol, TExpressionSyntax initExpression)> ParametersToGenerateFreshVariablesFor { get; }
+            public ImmutableArray<(IParameterSymbol parameterSymbol, TExpressionSyntax initExpression)> ParametersToGenerateFreshVariablesFor { get; } = parametersToGenerateFreshVariablesFor;
 
             /// <summary>
             /// A dictionary that contains Parameter that should be directly replaced. Key is the parameter and Value is the replacement exprssion
@@ -117,7 +121,7 @@ namespace Microsoft.CodeAnalysis.InlineMethod
             /// In this case, parameters 'a' and 'b' should just be replaced by the argument expression.
             /// Note: this might cause semantics changes. It is by design.
             /// </summary>
-            public ImmutableDictionary<IParameterSymbol, TExpressionSyntax> ParametersToReplace { get; }
+            public ImmutableDictionary<IParameterSymbol, TExpressionSyntax> ParametersToReplace { get; } = parametersToReplace;
 
             /// <summary>
             /// Indicate should inline expression and variable declaration be merged into one line.
@@ -143,19 +147,7 @@ namespace Microsoft.CodeAnalysis.InlineMethod
             /// }
             /// void Callee(out int i) => i = 100;
             /// </summary>
-            public bool MergeInlineContentAndVariableDeclarationArgument { get; }
-
-            public MethodParametersInfo(
-                ImmutableArray<(IParameterSymbol parameterSymbol, string name)> parametersWithVariableDeclarationArgument,
-                ImmutableArray<(IParameterSymbol parameterSymbol, TExpressionSyntax initExpression)> parametersToGenerateFreshVariablesFor,
-                ImmutableDictionary<IParameterSymbol, TExpressionSyntax> parametersToReplace,
-                bool mergeInlineContentAndVariableDeclarationArgument)
-            {
-                ParametersWithVariableDeclarationArgument = parametersWithVariableDeclarationArgument;
-                ParametersToGenerateFreshVariablesFor = parametersToGenerateFreshVariablesFor;
-                ParametersToReplace = parametersToReplace;
-                MergeInlineContentAndVariableDeclarationArgument = mergeInlineContentAndVariableDeclarationArgument;
-            }
+            public bool MergeInlineContentAndVariableDeclarationArgument { get; } = mergeInlineContentAndVariableDeclarationArgument;
         }
 
         private async Task<MethodParametersInfo> GetMethodParametersInfoAsync(

--- a/src/Features/Core/Portable/Intents/IntentDataProvider.cs
+++ b/src/Features/Core/Portable/Intents/IntentDataProvider.cs
@@ -11,7 +11,9 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.Features.Intents
 {
-    internal sealed class IntentDataProvider
+    internal sealed class IntentDataProvider(
+        string? serializedIntentData,
+        CleanCodeGenerationOptionsProvider fallbackOptions)
     {
         private static readonly Lazy<JsonSerializerOptions> s_serializerOptions = new Lazy<JsonSerializerOptions>(() =>
         {
@@ -23,17 +25,9 @@ namespace Microsoft.CodeAnalysis.Features.Intents
             return serializerOptions;
         });
 
-        public readonly CleanCodeGenerationOptionsProvider FallbackOptions;
+        public readonly CleanCodeGenerationOptionsProvider FallbackOptions = fallbackOptions;
 
-        private readonly string? _serializedIntentData;
-
-        public IntentDataProvider(
-            string? serializedIntentData,
-            CleanCodeGenerationOptionsProvider fallbackOptions)
-        {
-            _serializedIntentData = serializedIntentData;
-            FallbackOptions = fallbackOptions;
-        }
+        private readonly string? _serializedIntentData = serializedIntentData;
 
         public T? GetIntentData<T>() where T : class
         {

--- a/src/Features/Core/Portable/Intents/IntentProviderAttribute.cs
+++ b/src/Features/Core/Portable/Intents/IntentProviderAttribute.cs
@@ -9,15 +9,9 @@ namespace Microsoft.CodeAnalysis.Features.Intents
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    internal class IntentProviderAttribute : ExportAttribute, IIntentProviderMetadata
+    internal class IntentProviderAttribute(string intentName, string languageName) : ExportAttribute(typeof(IIntentProvider)), IIntentProviderMetadata
     {
-        public string IntentName { get; }
-        public string LanguageName { get; }
-
-        public IntentProviderAttribute(string intentName, string languageName) : base(typeof(IIntentProvider))
-        {
-            IntentName = intentName;
-            LanguageName = languageName;
-        }
+        public string IntentName { get; } = intentName;
+        public string LanguageName { get; } = languageName;
     }
 }

--- a/src/Features/Core/Portable/Intents/IntentResult.cs
+++ b/src/Features/Core/Portable/Intents/IntentResult.cs
@@ -10,35 +10,27 @@ namespace Microsoft.CodeAnalysis.Features.Intents
     /// <summary>
     /// Defines the text changes needed to apply an intent.
     /// </summary>
-    internal readonly struct IntentProcessorResult
+    internal readonly struct IntentProcessorResult(Solution solution, ImmutableArray<DocumentId> changedDocuments, string title, string actionName)
     {
         /// <summary>
         /// The changed solution for this intent result.
         /// </summary>
-        public readonly Solution Solution;
+        public readonly Solution Solution = solution;
 
         /// <summary>
         /// The set of documents that have changed for this intent result.
         /// </summary>
-        public readonly ImmutableArray<DocumentId> ChangedDocuments;
+        public readonly ImmutableArray<DocumentId> ChangedDocuments = changedDocuments;
 
         /// <summary>
         /// The title associated with this intent result.
         /// </summary>
-        public readonly string Title;
+        public readonly string Title = title ?? throw new ArgumentNullException(nameof(title));
 
         /// <summary>
         /// Contains metadata that can be used to identify the kind of sub-action these edits
         /// apply to for the requested intent.
         /// </summary>
-        public readonly string ActionName;
-
-        public IntentProcessorResult(Solution solution, ImmutableArray<DocumentId> changedDocuments, string title, string actionName)
-        {
-            Solution = solution;
-            ChangedDocuments = changedDocuments;
-            Title = title ?? throw new ArgumentNullException(nameof(title));
-            ActionName = actionName ?? throw new ArgumentNullException(nameof(actionName));
-        }
+        public readonly string ActionName = actionName ?? throw new ArgumentNullException(nameof(actionName));
     }
 }

--- a/src/Features/Core/Portable/IntroduceParameter/IntroduceParameterDocumentRewriter.cs
+++ b/src/Features/Core/Portable/IntroduceParameter/IntroduceParameterDocumentRewriter.cs
@@ -20,42 +20,27 @@ namespace Microsoft.CodeAnalysis.IntroduceParameter
 {
     internal abstract partial class AbstractIntroduceParameterCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax, TObjectCreationExpressionSyntax, TIdentifierNameSyntax, TArgumentSyntax>
     {
-        private class IntroduceParameterDocumentRewriter
+        private class IntroduceParameterDocumentRewriter(
+            AbstractIntroduceParameterCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax, TObjectCreationExpressionSyntax, TIdentifierNameSyntax, TArgumentSyntax> service,
+            Document originalDocument,
+            TExpressionSyntax expression,
+            IMethodSymbol methodSymbol,
+            SyntaxNode containingMethod,
+            IntroduceParameterCodeActionKind selectedCodeAction,
+            CodeGenerationOptionsProvider fallbackOptions,
+            bool allOccurrences)
         {
-            private readonly AbstractIntroduceParameterCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax, TObjectCreationExpressionSyntax, TIdentifierNameSyntax, TArgumentSyntax> _service;
-            private readonly Document _originalDocument;
-            private readonly SyntaxGenerator _generator;
-            private readonly ISyntaxFactsService _syntaxFacts;
-            private readonly ISemanticFactsService _semanticFacts;
-            private readonly TExpressionSyntax _expression;
-            private readonly IMethodSymbol _methodSymbol;
-            private readonly SyntaxNode _containerMethod;
-            private readonly IntroduceParameterCodeActionKind _actionKind;
-            private readonly CodeGenerationOptionsProvider _fallbackOptions;
-            private readonly bool _allOccurrences;
-
-            public IntroduceParameterDocumentRewriter(
-                AbstractIntroduceParameterCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax, TObjectCreationExpressionSyntax, TIdentifierNameSyntax, TArgumentSyntax> service,
-                Document originalDocument,
-                TExpressionSyntax expression,
-                IMethodSymbol methodSymbol,
-                SyntaxNode containingMethod,
-                IntroduceParameterCodeActionKind selectedCodeAction,
-                CodeGenerationOptionsProvider fallbackOptions,
-                bool allOccurrences)
-            {
-                _service = service;
-                _originalDocument = originalDocument;
-                _generator = SyntaxGenerator.GetGenerator(originalDocument);
-                _syntaxFacts = originalDocument.GetRequiredLanguageService<ISyntaxFactsService>();
-                _semanticFacts = originalDocument.GetRequiredLanguageService<ISemanticFactsService>();
-                _expression = expression;
-                _methodSymbol = methodSymbol;
-                _containerMethod = containingMethod;
-                _actionKind = selectedCodeAction;
-                _allOccurrences = allOccurrences;
-                _fallbackOptions = fallbackOptions;
-            }
+            private readonly AbstractIntroduceParameterCodeRefactoringProvider<TExpressionSyntax, TInvocationExpressionSyntax, TObjectCreationExpressionSyntax, TIdentifierNameSyntax, TArgumentSyntax> _service = service;
+            private readonly Document _originalDocument = originalDocument;
+            private readonly SyntaxGenerator _generator = SyntaxGenerator.GetGenerator(originalDocument);
+            private readonly ISyntaxFactsService _syntaxFacts = originalDocument.GetRequiredLanguageService<ISyntaxFactsService>();
+            private readonly ISemanticFactsService _semanticFacts = originalDocument.GetRequiredLanguageService<ISemanticFactsService>();
+            private readonly TExpressionSyntax _expression = expression;
+            private readonly IMethodSymbol _methodSymbol = methodSymbol;
+            private readonly SyntaxNode _containerMethod = containingMethod;
+            private readonly IntroduceParameterCodeActionKind _actionKind = selectedCodeAction;
+            private readonly CodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
+            private readonly bool _allOccurrences = allOccurrences;
 
             public async Task<SyntaxNode> RewriteDocumentAsync(Compilation compilation, Document document, List<SyntaxNode> invocations, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -20,10 +20,10 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
 {
     internal partial class AbstractIntroduceVariableService<TService, TExpressionSyntax, TTypeSyntax, TTypeDeclarationSyntax, TQueryExpressionSyntax, TNameSyntax>
     {
-        private sealed partial class State
+        private sealed partial class State(TService service, SemanticDocument document, CodeCleanupOptions options)
         {
-            public SemanticDocument Document { get; }
-            public CodeCleanupOptions Options { get; }
+            public SemanticDocument Document { get; } = document;
+            public CodeCleanupOptions Options { get; } = options;
             public TExpressionSyntax Expression { get; private set; }
 
             public bool InAttributeContext { get; private set; }
@@ -38,14 +38,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             public bool IsConstant { get; private set; }
 
             private SemanticMap _semanticMap;
-            private readonly TService _service;
-
-            public State(TService service, SemanticDocument document, CodeCleanupOptions options)
-            {
-                _service = service;
-                Document = document;
-                Options = options;
-            }
+            private readonly TService _service = service;
 
             public static async Task<State> GenerateAsync(
                 TService service,

--- a/src/Features/Core/Portable/LanguageServiceIndexFormat/SymbolMoniker.cs
+++ b/src/Features/Core/Portable/LanguageServiceIndexFormat/SymbolMoniker.cs
@@ -6,17 +6,11 @@ using System;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat
 {
-    internal sealed class SymbolMoniker
+    internal sealed class SymbolMoniker(string scheme, string identifier)
     {
-        public string Scheme { get; }
+        public string Scheme { get; } = scheme;
 
-        public string Identifier { get; }
-
-        public SymbolMoniker(string scheme, string identifier)
-        {
-            this.Scheme = scheme;
-            this.Identifier = identifier;
-        }
+        public string Identifier { get; } = identifier;
 
         public static bool HasMoniker(ISymbol symbol)
         {

--- a/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractStructuralTypeDisplayService.StructuralTypeCollectorVisitor.cs
+++ b/src/Features/Core/Portable/LanguageServices/AnonymousTypeDisplayService/AbstractStructuralTypeDisplayService.StructuralTypeCollectorVisitor.cs
@@ -10,13 +10,10 @@ namespace Microsoft.CodeAnalysis.LanguageService
 {
     internal partial class AbstractStructuralTypeDisplayService
     {
-        private class StructuralTypeCollectorVisitor : SymbolVisitor
+        private class StructuralTypeCollectorVisitor(Dictionary<INamedTypeSymbol, (int order, int count)> namedTypes) : SymbolVisitor
         {
             private readonly ISet<INamedTypeSymbol> _seenTypes = new HashSet<INamedTypeSymbol>();
-            private readonly Dictionary<INamedTypeSymbol, (int order, int count)> _namedTypes;
-
-            public StructuralTypeCollectorVisitor(Dictionary<INamedTypeSymbol, (int order, int count)> namedTypes)
-                => _namedTypes = namedTypes;
+            private readonly Dictionary<INamedTypeSymbol, (int order, int count)> _namedTypes = namedTypes;
 
             public override void DefaultVisit(ISymbol node)
                 => throw new NotImplementedException();

--- a/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsAggregationService.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsAggregationService.cs
@@ -31,17 +31,12 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents
     }
 
     [ExportWorkspaceService(typeof(ILegacySolutionEventsAggregationService)), Shared]
-    internal class DefaultLegacySolutionEventsAggregationService : ILegacySolutionEventsAggregationService
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class DefaultLegacySolutionEventsAggregationService(
+        [ImportMany] IEnumerable<Lazy<ILegacySolutionEventsListener>> eventsServices) : ILegacySolutionEventsAggregationService
     {
-        private readonly ImmutableArray<Lazy<ILegacySolutionEventsListener>> _eventsServices;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultLegacySolutionEventsAggregationService(
-            [ImportMany] IEnumerable<Lazy<ILegacySolutionEventsListener>> eventsServices)
-        {
-            _eventsServices = eventsServices.ToImmutableArray();
-        }
+        private readonly ImmutableArray<Lazy<ILegacySolutionEventsListener>> _eventsServices = eventsServices.ToImmutableArray();
 
         public bool ShouldReportChanges(SolutionServices services)
         {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
@@ -9,15 +9,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal partial class AbstractMetadataAsSourceService
     {
-        private class WrappedEventSymbol : AbstractWrappedSymbol, IEventSymbol
+        private class WrappedEventSymbol(IEventSymbol eventSymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService) : AbstractWrappedSymbol(eventSymbol, canImplementImplicitly, docCommentFormattingService), IEventSymbol
         {
-            private readonly IEventSymbol _symbol;
-
-            public WrappedEventSymbol(IEventSymbol eventSymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)
-                : base(eventSymbol, canImplementImplicitly, docCommentFormattingService)
-            {
-                _symbol = eventSymbol;
-            }
+            private readonly IEventSymbol _symbol = eventSymbol;
 
             public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
@@ -11,15 +11,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal partial class AbstractMetadataAsSourceService
     {
-        private class WrappedFieldSymbol : AbstractWrappedSymbol, IFieldSymbol
+        private class WrappedFieldSymbol(IFieldSymbol fieldSymbol, IDocumentationCommentFormattingService docCommentFormattingService) : AbstractWrappedSymbol(fieldSymbol, canImplementImplicitly: false, docCommentFormattingService: docCommentFormattingService), IFieldSymbol
         {
-            private readonly IFieldSymbol _symbol;
-
-            public WrappedFieldSymbol(IFieldSymbol fieldSymbol, IDocumentationCommentFormattingService docCommentFormattingService)
-                : base(fieldSymbol, canImplementImplicitly: false, docCommentFormattingService: docCommentFormattingService)
-            {
-                _symbol = fieldSymbol;
-            }
+            private readonly IFieldSymbol _symbol = fieldSymbol;
 
             public new IFieldSymbol OriginalDefinition => _symbol.OriginalDefinition;
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -12,15 +12,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal partial class AbstractMetadataAsSourceService
     {
-        private class WrappedMethodSymbol : AbstractWrappedSymbol, IMethodSymbol
+        private class WrappedMethodSymbol(IMethodSymbol methodSymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService) : AbstractWrappedSymbol(methodSymbol, canImplementImplicitly, docCommentFormattingService), IMethodSymbol
         {
-            private readonly IMethodSymbol _symbol;
-
-            public WrappedMethodSymbol(IMethodSymbol methodSymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)
-                : base(methodSymbol, canImplementImplicitly, docCommentFormattingService)
-            {
-                _symbol = methodSymbol;
-            }
+            private readonly IMethodSymbol _symbol = methodSymbol;
 
             public int Arity => _symbol.Arity;
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
@@ -11,15 +11,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal partial class AbstractMetadataAsSourceService
     {
-        private class WrappedPropertySymbol : AbstractWrappedSymbol, IPropertySymbol
+        private class WrappedPropertySymbol(IPropertySymbol propertySymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService) : AbstractWrappedSymbol(propertySymbol, canImplementImplicitly, docCommentFormattingService), IPropertySymbol
         {
-            private readonly IPropertySymbol _symbol;
-
-            public WrappedPropertySymbol(IPropertySymbol propertySymbol, bool canImplementImplicitly, IDocumentationCommentFormattingService docCommentFormattingService)
-                : base(propertySymbol, canImplementImplicitly, docCommentFormattingService)
-            {
-                _symbol = propertySymbol;
-            }
+            private readonly IPropertySymbol _symbol = propertySymbol;
 
             public ImmutableArray<IPropertySymbol> ExplicitInterfaceImplementations
             {

--- a/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
@@ -26,7 +26,9 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     [ExportMetadataAsSourceFileProvider(ProviderName), Shared]
-    internal class DecompilationMetadataAsSourceFileProvider : IMetadataAsSourceFileProvider
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal class DecompilationMetadataAsSourceFileProvider(IImplementationAssemblyLookupService implementationAssemblyLookupService) : IMetadataAsSourceFileProvider
     {
         internal const string ProviderName = "Decompilation";
 
@@ -44,19 +46,12 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         /// </summary>
         private readonly ConcurrentDictionary<string, MetadataAsSourceGeneratedFileInfo> _generatedFilenameToInformation = new(StringComparer.OrdinalIgnoreCase);
 
-        private readonly IImplementationAssemblyLookupService _implementationAssemblyLookupService;
+        private readonly IImplementationAssemblyLookupService _implementationAssemblyLookupService = implementationAssemblyLookupService;
 
         /// <summary>
         /// Only accessed and mutated from UI thread.
         /// </summary>
         private IBidirectionalMap<MetadataAsSourceGeneratedFileInfo, DocumentId> _openedDocumentIds = BidirectionalMap<MetadataAsSourceGeneratedFileInfo, DocumentId>.Empty;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DecompilationMetadataAsSourceFileProvider(IImplementationAssemblyLookupService implementationAssemblyLookupService)
-        {
-            _implementationAssemblyLookupService = implementationAssemblyLookupService;
-        }
 
         public async Task<MetadataAsSourceFile?> GetGeneratedFileAsync(
             MetadataAsSourceWorkspace metadataWorkspace,

--- a/src/Features/Core/Portable/MetadataAsSource/ExportMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/ExportMetadataAsSourceFileProvider.cs
@@ -13,14 +13,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class ExportMetadataAsSourceFileProviderAttribute : ExportAttribute
+    internal sealed class ExportMetadataAsSourceFileProviderAttribute(string name) : ExportAttribute(typeof(IMetadataAsSourceFileProvider))
     {
-        public string Name { get; }
-
-        public ExportMetadataAsSourceFileProviderAttribute(string name)
-            : base(typeof(IMetadataAsSourceFileProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-        }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileProviderMetadata.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileProviderMetadata.cs
@@ -7,11 +7,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
-    internal class MetadataAsSourceFileProviderMetadata : OrderableLanguageMetadata
+    internal class MetadataAsSourceFileProviderMetadata(IDictionary<string, object> data) : OrderableLanguageMetadata(data)
     {
-        public MetadataAsSourceFileProviderMetadata(IDictionary<string, object> data)
-            : base(data)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceWorkspace.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceWorkspace.cs
@@ -6,14 +6,8 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
-    internal class MetadataAsSourceWorkspace : Workspace
+    internal class MetadataAsSourceWorkspace(MetadataAsSourceFileService fileService, HostServices hostServices) : Workspace(hostServices, WorkspaceKind.MetadataAsSource)
     {
-        public readonly MetadataAsSourceFileService FileService;
-
-        public MetadataAsSourceWorkspace(MetadataAsSourceFileService fileService, HostServices hostServices)
-            : base(hostServices, WorkspaceKind.MetadataAsSource)
-        {
-            this.FileService = fileService;
-        }
+        public readonly MetadataAsSourceFileService FileService = fileService;
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/SymbolMappingServiceFactory.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/SymbolMappingServiceFactory.cs
@@ -25,14 +25,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
             => new SymbolMappingService(((MetadataAsSourceWorkspace)workspaceServices.Workspace).FileService);
 
-        private sealed class SymbolMappingService : ISymbolMappingService
+        private sealed class SymbolMappingService(MetadataAsSourceFileService fileService) : ISymbolMappingService
         {
-            private readonly MetadataAsSourceFileService _fileService;
-
-            public SymbolMappingService(MetadataAsSourceFileService fileService)
-            {
-                _fileService = fileService;
-            }
+            private readonly MetadataAsSourceFileService _fileService = fileService;
 
             public Task<SymbolMappingResult?> MapSymbolAsync(Document document, SymbolKey symbolId, CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
@@ -22,29 +22,20 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MoveStaticMembers
 {
-    internal class MoveStaticMembersWithDialogCodeAction : CodeActionWithOptions
+    internal class MoveStaticMembersWithDialogCodeAction(
+        Document document,
+        IMoveStaticMembersOptionsService service,
+        INamedTypeSymbol selectedType,
+        CleanCodeGenerationOptionsProvider fallbackOptions,
+        ImmutableArray<ISymbol> selectedMembers) : CodeActionWithOptions
     {
-        private readonly Document _document;
-        private readonly ImmutableArray<ISymbol> _selectedMembers;
-        private readonly INamedTypeSymbol _selectedType;
-        private readonly IMoveStaticMembersOptionsService _service;
-        private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
+        private readonly Document _document = document;
+        private readonly ImmutableArray<ISymbol> _selectedMembers = selectedMembers;
+        private readonly INamedTypeSymbol _selectedType = selectedType;
+        private readonly IMoveStaticMembersOptionsService _service = service;
+        private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
         public override string Title => FeaturesResources.Move_static_members_to_another_type;
-
-        public MoveStaticMembersWithDialogCodeAction(
-            Document document,
-            IMoveStaticMembersOptionsService service,
-            INamedTypeSymbol selectedType,
-            CleanCodeGenerationOptionsProvider fallbackOptions,
-            ImmutableArray<ISymbol> selectedMembers)
-        {
-            _document = document;
-            _service = service;
-            _selectedType = selectedType;
-            _fallbackOptions = fallbackOptions;
-            _selectedMembers = selectedMembers;
-        }
 
         public override object? GetOptions(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.MoveItemsToNamespaceCodeAction.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.MoveItemsToNamespaceCodeAction.cs
@@ -9,14 +9,9 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
 {
     internal abstract partial class AbstractMoveToNamespaceCodeAction
     {
-        private class MoveItemsToNamespaceCodeAction : AbstractMoveToNamespaceCodeAction
+        private class MoveItemsToNamespaceCodeAction(IMoveToNamespaceService changeNamespaceService, MoveToNamespaceAnalysisResult analysisResult, CodeCleanupOptionsProvider cleanupOptions) : AbstractMoveToNamespaceCodeAction(changeNamespaceService, analysisResult, cleanupOptions)
         {
             public override string Title => FeaturesResources.Move_contents_to_namespace;
-
-            public MoveItemsToNamespaceCodeAction(IMoveToNamespaceService changeNamespaceService, MoveToNamespaceAnalysisResult analysisResult, CodeCleanupOptionsProvider cleanupOptions)
-                : base(changeNamespaceService, analysisResult, cleanupOptions)
-            {
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.MoveTypeToNamespaceCodeAction.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.MoveTypeToNamespaceCodeAction.cs
@@ -9,14 +9,9 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
 {
     internal abstract partial class AbstractMoveToNamespaceCodeAction
     {
-        private class MoveTypeToNamespaceCodeAction : AbstractMoveToNamespaceCodeAction
+        private class MoveTypeToNamespaceCodeAction(IMoveToNamespaceService changeNamespaceService, MoveToNamespaceAnalysisResult analysisResult, CodeCleanupOptionsProvider cleanupOptions) : AbstractMoveToNamespaceCodeAction(changeNamespaceService, analysisResult, cleanupOptions)
         {
             public override string Title => FeaturesResources.Move_to_namespace;
-
-            public MoveTypeToNamespaceCodeAction(IMoveToNamespaceService changeNamespaceService, MoveToNamespaceAnalysisResult analysisResult, CodeCleanupOptionsProvider cleanupOptions)
-                : base(changeNamespaceService, analysisResult, cleanupOptions)
-            {
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceCodeAction.cs
@@ -15,21 +15,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MoveToNamespace
 {
-    internal abstract partial class AbstractMoveToNamespaceCodeAction : CodeActionWithOptions
+    internal abstract partial class AbstractMoveToNamespaceCodeAction(
+        IMoveToNamespaceService moveToNamespaceService,
+        MoveToNamespaceAnalysisResult analysisResult,
+        CodeCleanupOptionsProvider cleanupOptions) : CodeActionWithOptions
     {
-        private readonly IMoveToNamespaceService _moveToNamespaceService;
-        private readonly MoveToNamespaceAnalysisResult _moveToNamespaceAnalysisResult;
-        private readonly CodeCleanupOptionsProvider _cleanupOptions;
-
-        public AbstractMoveToNamespaceCodeAction(
-            IMoveToNamespaceService moveToNamespaceService,
-            MoveToNamespaceAnalysisResult analysisResult,
-            CodeCleanupOptionsProvider cleanupOptions)
-        {
-            _moveToNamespaceService = moveToNamespaceService;
-            _moveToNamespaceAnalysisResult = analysisResult;
-            _cleanupOptions = cleanupOptions;
-        }
+        private readonly IMoveToNamespaceService _moveToNamespaceService = moveToNamespaceService;
+        private readonly MoveToNamespaceAnalysisResult _moveToNamespaceAnalysisResult = analysisResult;
+        private readonly CodeCleanupOptionsProvider _cleanupOptions = cleanupOptions;
 
         /// <summary>
         /// This code action does notify clients about the rename it performs.  However, this is an optional part of

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
@@ -26,11 +26,14 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken);
     }
 
-    internal class DefaultNavigateToSearchHost : INavigateToSearcherHost
+    internal class DefaultNavigateToSearchHost(
+        Solution solution,
+        IAsynchronousOperationListener asyncListener,
+        CancellationToken disposalToken) : INavigateToSearcherHost
     {
-        private readonly Solution _solution;
-        private readonly IAsynchronousOperationListener _asyncListener;
-        private readonly CancellationToken _disposalToken;
+        private readonly Solution _solution = solution;
+        private readonly IAsynchronousOperationListener _asyncListener = asyncListener;
+        private readonly CancellationToken _disposalToken = disposalToken;
 
         /// <summary>
         /// Single task used to both hydrate the remote host with the initial workspace solution,
@@ -40,16 +43,6 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// </summary>
         private static readonly object s_gate = new();
         private static Task? s_remoteHostHydrateTask = null;
-
-        public DefaultNavigateToSearchHost(
-            Solution solution,
-            IAsynchronousOperationListener asyncListener,
-            CancellationToken disposalToken)
-        {
-            _solution = solution;
-            _asyncListener = asyncListener;
-            _disposalToken = disposalToken;
-        }
 
         public INavigateToSearchService? GetNavigateToSearchService(Project project)
             => project.GetLanguageService<INavigateToSearchService>();

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -46,14 +46,9 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             => GetCallback(callbackId).OnResultFoundAsync(result);
     }
 
-    internal sealed class NavigateToSearchServiceCallback
+    internal sealed class NavigateToSearchServiceCallback(Func<RoslynNavigateToItem, Task> onResultFound)
     {
-        private readonly Func<RoslynNavigateToItem, Task> _onResultFound;
-
-        public NavigateToSearchServiceCallback(Func<RoslynNavigateToItem, Task> onResultFound)
-        {
-            _onResultFound = onResultFound;
-        }
+        private readonly Func<RoslynNavigateToItem, Task> _onResultFound = onResultFound;
 
         public async ValueTask OnResultFoundAsync(RoslynNavigateToItem result)
         {

--- a/src/Features/Core/Portable/NavigateTo/RoslynNavigateToItem.cs
+++ b/src/Features/Core/Portable/NavigateTo/RoslynNavigateToItem.cs
@@ -23,59 +23,46 @@ namespace Microsoft.CodeAnalysis.NavigateTo
     /// rehydrate everything needed quickly on either the host or remote side.
     /// </summary>
     [DataContract]
-    internal readonly struct RoslynNavigateToItem
+    internal readonly struct RoslynNavigateToItem(
+        bool isStale,
+        DocumentId documentId,
+        ImmutableArray<ProjectId> additionalMatchingProjects,
+        DeclaredSymbolInfo declaredSymbolInfo,
+        string kind,
+        NavigateToMatchKind matchKind,
+        bool isCaseSensitive,
+        ImmutableArray<TextSpan> nameMatchSpans,
+        ImmutableArray<PatternMatch> matches)
     {
         [DataMember(Order = 0)]
-        public readonly bool IsStale;
+        public readonly bool IsStale = isStale;
 
         [DataMember(Order = 1)]
-        public readonly DocumentId DocumentId;
+        public readonly DocumentId DocumentId = documentId;
 
         [DataMember(Order = 2)]
-        public readonly ImmutableArray<ProjectId> AdditionalMatchingProjects;
+        public readonly ImmutableArray<ProjectId> AdditionalMatchingProjects = additionalMatchingProjects;
 
         [DataMember(Order = 3)]
-        public readonly DeclaredSymbolInfo DeclaredSymbolInfo;
+        public readonly DeclaredSymbolInfo DeclaredSymbolInfo = declaredSymbolInfo;
 
         /// <summary>
         /// Will be one of the values from <see cref="NavigateToItemKind"/>.
         /// </summary>
         [DataMember(Order = 4)]
-        public readonly string Kind;
+        public readonly string Kind = kind;
 
         [DataMember(Order = 5)]
-        public readonly NavigateToMatchKind MatchKind;
+        public readonly NavigateToMatchKind MatchKind = matchKind;
 
         [DataMember(Order = 6)]
-        public readonly bool IsCaseSensitive;
+        public readonly bool IsCaseSensitive = isCaseSensitive;
 
         [DataMember(Order = 7)]
-        public readonly ImmutableArray<TextSpan> NameMatchSpans;
+        public readonly ImmutableArray<TextSpan> NameMatchSpans = nameMatchSpans;
 
         [DataMember(Order = 8)]
-        public readonly ImmutableArray<PatternMatch> Matches;
-
-        public RoslynNavigateToItem(
-            bool isStale,
-            DocumentId documentId,
-            ImmutableArray<ProjectId> additionalMatchingProjects,
-            DeclaredSymbolInfo declaredSymbolInfo,
-            string kind,
-            NavigateToMatchKind matchKind,
-            bool isCaseSensitive,
-            ImmutableArray<TextSpan> nameMatchSpans,
-            ImmutableArray<PatternMatch> matches)
-        {
-            IsStale = isStale;
-            DocumentId = documentId;
-            AdditionalMatchingProjects = additionalMatchingProjects;
-            DeclaredSymbolInfo = declaredSymbolInfo;
-            Kind = kind;
-            MatchKind = matchKind;
-            IsCaseSensitive = isCaseSensitive;
-            NameMatchSpans = nameMatchSpans;
-            Matches = matches;
-        }
+        public readonly ImmutableArray<PatternMatch> Matches = matches;
 
         public async Task<INavigateToSearchResult?> TryCreateSearchResultAsync(
             Solution solution, Document? activeDocument, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Navigation/INavigableLocation.cs
+++ b/src/Features/Core/Portable/Navigation/INavigableLocation.cs
@@ -20,12 +20,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         Task<bool> NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken);
     }
 
-    internal class NavigableLocation : INavigableLocation
+    internal class NavigableLocation(Func<NavigationOptions, CancellationToken, Task<bool>> callback) : INavigableLocation
     {
-        private readonly Func<NavigationOptions, CancellationToken, Task<bool>> _callback;
-
-        public NavigableLocation(Func<NavigationOptions, CancellationToken, Task<bool>> callback)
-            => _callback = callback;
+        private readonly Func<NavigationOptions, CancellationToken, Task<bool>> _callback = callback;
 
         public Task<bool> NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/Features/Core/Portable/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -15,11 +15,15 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal partial class NavigableItemFactory
     {
-        private class SymbolLocationNavigableItem : INavigableItem
+        private class SymbolLocationNavigableItem(
+            Solution solution,
+            ISymbol symbol,
+            Location location,
+            ImmutableArray<TaggedText>? displayTaggedParts) : INavigableItem
         {
-            private readonly Solution _solution;
-            private readonly ISymbol _symbol;
-            private readonly Location _location;
+            private readonly Solution _solution = solution;
+            private readonly ISymbol _symbol = symbol;
+            private readonly Location _location = location;
 
             /// <summary>
             /// Lazily-initialized backing field for <see cref="Document"/>.
@@ -27,21 +31,9 @@ namespace Microsoft.CodeAnalysis.Navigation
             /// <seealso cref="LazyInitialization.EnsureInitialized{T, U}(ref StrongBox{T}, Func{U, T}, U)"/>
             private StrongBox<INavigableItem.NavigableDocument> _lazyDocument;
 
-            public SymbolLocationNavigableItem(
-                Solution solution,
-                ISymbol symbol,
-                Location location,
-                ImmutableArray<TaggedText>? displayTaggedParts)
-            {
-                _solution = solution;
-                _symbol = symbol;
-                _location = location;
-                DisplayTaggedParts = displayTaggedParts.GetValueOrDefault();
-            }
-
             public bool DisplayFileLocation => true;
 
-            public ImmutableArray<TaggedText> DisplayTaggedParts { get; }
+            public ImmutableArray<TaggedText> DisplayTaggedParts { get; } = displayTaggedParts.GetValueOrDefault();
 
             public Glyph Glyph => _symbol.GetGlyph();
 

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.ActionlessItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.ActionlessItem.cs
@@ -13,19 +13,14 @@ namespace Microsoft.CodeAnalysis.NavigationBar
         /// An item that is displayed and can be chosen but which has no action.
         /// </summary>
         // We suppress this as this type *does* override ComputeAdditionalHashCodeParts
-        public class ActionlessItem : RoslynNavigationBarItem, IEquatable<ActionlessItem>
+        public class ActionlessItem(
+            string text,
+            Glyph glyph,
+            ImmutableArray<RoslynNavigationBarItem> childItems = default,
+            int indent = 0,
+            bool bolded = false,
+            bool grayed = false) : RoslynNavigationBarItem(RoslynNavigationBarItemKind.Actionless, text, glyph, bolded, grayed, indent, childItems), IEquatable<ActionlessItem>
         {
-            public ActionlessItem(
-                string text,
-                Glyph glyph,
-                ImmutableArray<RoslynNavigationBarItem> childItems = default,
-                int indent = 0,
-                bool bolded = false,
-                bool grayed = false)
-                : base(RoslynNavigationBarItemKind.Actionless, text, glyph, bolded, grayed, indent, childItems)
-            {
-            }
-
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.ActionlessItem(Text, Glyph, SerializableNavigationBarItem.Dehydrate(ChildItems), Indent, Bolded, Grayed);
 

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateDefaultConstructorItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateDefaultConstructorItem.cs
@@ -8,13 +8,8 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal abstract partial class RoslynNavigationBarItem
     {
-        public class GenerateDefaultConstructor : AbstractGenerateCodeItem, IEquatable<GenerateDefaultConstructor>
+        public class GenerateDefaultConstructor(string text, SymbolKey destinationTypeSymbolKey) : AbstractGenerateCodeItem(RoslynNavigationBarItemKind.GenerateDefaultConstructor, text, Glyph.MethodPublic, destinationTypeSymbolKey), IEquatable<GenerateDefaultConstructor>
         {
-            public GenerateDefaultConstructor(string text, SymbolKey destinationTypeSymbolKey)
-                : base(RoslynNavigationBarItemKind.GenerateDefaultConstructor, text, Glyph.MethodPublic, destinationTypeSymbolKey)
-            {
-            }
-
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.GenerateDefaultConstructor(Text, DestinationTypeSymbolKey);
 

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateEventHandlerItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateEventHandlerItem.cs
@@ -8,17 +8,10 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal abstract partial class RoslynNavigationBarItem
     {
-        public class GenerateEventHandler : AbstractGenerateCodeItem, IEquatable<GenerateEventHandler>
+        public class GenerateEventHandler(string text, Glyph glyph, string containerName, SymbolKey eventSymbolKey, SymbolKey destinationTypeSymbolKey) : AbstractGenerateCodeItem(RoslynNavigationBarItemKind.GenerateEventHandler, text, glyph, destinationTypeSymbolKey), IEquatable<GenerateEventHandler>
         {
-            public readonly string ContainerName;
-            public readonly SymbolKey EventSymbolKey;
-
-            public GenerateEventHandler(string text, Glyph glyph, string containerName, SymbolKey eventSymbolKey, SymbolKey destinationTypeSymbolKey)
-                : base(RoslynNavigationBarItemKind.GenerateEventHandler, text, glyph, destinationTypeSymbolKey)
-            {
-                ContainerName = containerName;
-                EventSymbolKey = eventSymbolKey;
-            }
+            public readonly string ContainerName = containerName;
+            public readonly SymbolKey EventSymbolKey = eventSymbolKey;
 
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.GenerateEventHandler(Text, Glyph, ContainerName, EventSymbolKey, DestinationTypeSymbolKey);

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateFinalizerItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateFinalizerItem.cs
@@ -8,13 +8,8 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal abstract partial class RoslynNavigationBarItem
     {
-        public class GenerateFinalizer : AbstractGenerateCodeItem, IEquatable<GenerateFinalizer>
+        public class GenerateFinalizer(string text, SymbolKey destinationTypeSymbolKey) : AbstractGenerateCodeItem(RoslynNavigationBarItemKind.GenerateFinalizer, text, Glyph.MethodProtected, destinationTypeSymbolKey), IEquatable<GenerateFinalizer>
         {
-            public GenerateFinalizer(string text, SymbolKey destinationTypeSymbolKey)
-                : base(RoslynNavigationBarItemKind.GenerateFinalizer, text, Glyph.MethodProtected, destinationTypeSymbolKey)
-            {
-            }
-
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.GenerateFinalizer(Text, DestinationTypeSymbolKey);
 

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateMethodItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.GenerateMethodItem.cs
@@ -8,15 +8,9 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal abstract partial class RoslynNavigationBarItem
     {
-        public class GenerateMethod : AbstractGenerateCodeItem, IEquatable<GenerateMethod>
+        public class GenerateMethod(string text, Glyph glyph, SymbolKey destinationTypeSymbolId, SymbolKey methodToReplicateSymbolId) : AbstractGenerateCodeItem(RoslynNavigationBarItemKind.GenerateMethod, text, glyph, destinationTypeSymbolId), IEquatable<GenerateMethod>
         {
-            public readonly SymbolKey MethodToReplicateSymbolKey;
-
-            public GenerateMethod(string text, Glyph glyph, SymbolKey destinationTypeSymbolId, SymbolKey methodToReplicateSymbolId)
-                : base(RoslynNavigationBarItemKind.GenerateMethod, text, glyph, destinationTypeSymbolId)
-            {
-                MethodToReplicateSymbolKey = methodToReplicateSymbolId;
-            }
+            public readonly SymbolKey MethodToReplicateSymbolKey = methodToReplicateSymbolId;
 
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.GenerateMethod(Text, Glyph, DestinationTypeSymbolKey, MethodToReplicateSymbolKey);

--- a/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.SymbolItem.cs
+++ b/src/Features/Core/Portable/NavigationBar/NavigationBarItems/RoslynNavigationBarItem.SymbolItem.cs
@@ -13,36 +13,27 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal abstract partial class RoslynNavigationBarItem
     {
-        public sealed class SymbolItem : RoslynNavigationBarItem, IEquatable<SymbolItem>
+        public sealed class SymbolItem(
+            string name,
+            string text,
+            Glyph glyph,
+            bool isObsolete,
+            SymbolItemLocation location,
+            ImmutableArray<RoslynNavigationBarItem> childItems = default,
+            int indent = 0,
+            bool bolded = false) : RoslynNavigationBarItem(
+                  RoslynNavigationBarItemKind.Symbol,
+                  text,
+                  glyph,
+                  bolded,
+                  grayed: location.OtherDocumentInfo != null,
+                  indent,
+                  childItems), IEquatable<SymbolItem>
         {
-            public readonly string Name;
-            public readonly bool IsObsolete;
+            public readonly string Name = name;
+            public readonly bool IsObsolete = isObsolete;
 
-            public readonly SymbolItemLocation Location;
-
-            public SymbolItem(
-                string name,
-                string text,
-                Glyph glyph,
-                bool isObsolete,
-                SymbolItemLocation location,
-                ImmutableArray<RoslynNavigationBarItem> childItems = default,
-                int indent = 0,
-                bool bolded = false)
-                : base(
-                      RoslynNavigationBarItemKind.Symbol,
-                      text,
-                      glyph,
-                      bolded,
-                      grayed: location.OtherDocumentInfo != null,
-                      indent,
-                      childItems)
-            {
-
-                Name = name;
-                IsObsolete = isObsolete;
-                Location = location;
-            }
+            public readonly SymbolItemLocation Location = location;
 
             protected internal override SerializableNavigationBarItem Dehydrate()
                 => SerializableNavigationBarItem.SymbolItem(Text, Glyph, Name, IsObsolete, Location, SerializableNavigationBarItem.Dehydrate(ChildItems), Indent, Bolded, Grayed);

--- a/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
@@ -11,14 +11,8 @@ namespace Microsoft.CodeAnalysis.Organizing.Organizers
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal class ExportSyntaxNodeOrganizerAttribute : ExportAttribute
+    internal class ExportSyntaxNodeOrganizerAttribute(string languageName) : ExportAttribute(typeof(ISyntaxOrganizer))
     {
-        public ExportSyntaxNodeOrganizerAttribute(string languageName)
-            : base(typeof(ISyntaxOrganizer))
-        {
-            Language = languageName;
-        }
-
-        public string Language { get; }
+        public string Language { get; } = languageName;
     }
 }

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
@@ -17,22 +17,16 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.PdbSourceDocument
 {
     [Export(typeof(IPdbFileLocatorService)), Shared]
-    internal sealed class PdbFileLocatorService : IPdbFileLocatorService
+    [method: ImportingConstructor]
+    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
+    internal sealed class PdbFileLocatorService(
+        [Import(AllowDefault = true)] ISourceLinkService? sourceLinkService,
+        [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IPdbFileLocatorService
     {
         private const int SymbolLocatorTimeout = 2000;
 
-        private readonly ISourceLinkService? _sourceLinkService;
-        private readonly IPdbSourceDocumentLogger? _logger;
-
-        [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
-        public PdbFileLocatorService(
-            [Import(AllowDefault = true)] ISourceLinkService? sourceLinkService,
-            [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger)
-        {
-            _sourceLinkService = sourceLinkService;
-            _logger = logger;
-        }
+        private readonly ISourceLinkService? _sourceLinkService = sourceLinkService;
+        private readonly IPdbSourceDocumentLogger? _logger = logger;
 
         public async Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -18,7 +18,11 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.PdbSourceDocument
 {
     [Export(typeof(IPdbSourceDocumentLoaderService)), Shared]
-    internal sealed class PdbSourceDocumentLoaderService : IPdbSourceDocumentLoaderService
+    [method: ImportingConstructor]
+    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
+    internal sealed class PdbSourceDocumentLoaderService(
+        [Import(AllowDefault = true)] Lazy<ISourceLinkService>? sourceLinkService,
+        [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IPdbSourceDocumentLoaderService
     {
         private const int SourceLinkTimeout = 1000;
         private const int ExtendedSourceLinkTimeout = 4000;
@@ -27,18 +31,8 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
         /// Lazy import ISourceLinkService because it can cause debugger 
         /// binaries to be eagerly loaded even if they are never used.
         /// </summary>
-        private readonly Lazy<ISourceLinkService>? _sourceLinkService;
-        private readonly IPdbSourceDocumentLogger? _logger;
-
-        [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
-        public PdbSourceDocumentLoaderService(
-            [Import(AllowDefault = true)] Lazy<ISourceLinkService>? sourceLinkService,
-            [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger)
-        {
-            _sourceLinkService = sourceLinkService;
-            _logger = logger;
-        }
+        private readonly Lazy<ISourceLinkService>? _sourceLinkService = sourceLinkService;
+        private readonly IPdbSourceDocumentLogger? _logger = logger;
 
         public async Task<SourceFileInfo?> LoadSourceDocumentAsync(string tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -27,14 +27,20 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
 {
     [ExportMetadataAsSourceFileProvider(ProviderName), Shared]
     [ExtensionOrder(Before = DecompilationMetadataAsSourceFileProvider.ProviderName)]
-    internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider : IMetadataAsSourceFileProvider
+    [method: ImportingConstructor]
+    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    internal sealed class PdbSourceDocumentMetadataAsSourceFileProvider(
+        IPdbFileLocatorService pdbFileLocatorService,
+        IPdbSourceDocumentLoaderService pdbSourceDocumentLoaderService,
+        IImplementationAssemblyLookupService implementationAssemblyLookupService,
+        [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger) : IMetadataAsSourceFileProvider
     {
         internal const string ProviderName = "PdbSource";
 
-        private readonly IPdbFileLocatorService _pdbFileLocatorService;
-        private readonly IPdbSourceDocumentLoaderService _pdbSourceDocumentLoaderService;
-        private readonly IImplementationAssemblyLookupService _implementationAssemblyLookupService;
-        private readonly IPdbSourceDocumentLogger? _logger;
+        private readonly IPdbFileLocatorService _pdbFileLocatorService = pdbFileLocatorService;
+        private readonly IPdbSourceDocumentLoaderService _pdbSourceDocumentLoaderService = pdbSourceDocumentLoaderService;
+        private readonly IImplementationAssemblyLookupService _implementationAssemblyLookupService = implementationAssemblyLookupService;
+        private readonly IPdbSourceDocumentLogger? _logger = logger;
 
         /// <summary>
         /// Accessed only in <see cref="GetGeneratedFileAsync"/> and <see cref="CleanupGeneratedFiles"/>, both of which
@@ -56,20 +62,6 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
         /// potentially happening.
         /// </summary>
         private readonly ConcurrentDictionary<string, SourceDocumentInfo> _fileToDocumentInfoMap = new();
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public PdbSourceDocumentMetadataAsSourceFileProvider(
-            IPdbFileLocatorService pdbFileLocatorService,
-            IPdbSourceDocumentLoaderService pdbSourceDocumentLoaderService,
-            IImplementationAssemblyLookupService implementationAssemblyLookupService,
-            [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger)
-        {
-            _pdbFileLocatorService = pdbFileLocatorService;
-            _pdbSourceDocumentLoaderService = pdbSourceDocumentLoaderService;
-            _implementationAssemblyLookupService = implementationAssemblyLookupService;
-            _logger = logger;
-        }
 
         public async Task<MetadataAsSourceFile?> GetGeneratedFileAsync(
             MetadataAsSourceWorkspace metadataWorkspace,

--- a/src/Features/Core/Portable/PdbSourceDocument/SourceLinkMap.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/SourceLinkMap.cs
@@ -28,16 +28,10 @@ namespace Microsoft.SourceLink.Tools
             _entries = mappings;
         }
 
-        public readonly struct Entry
+        public readonly struct Entry(FilePathPattern filePath, UriPattern uri)
         {
-            public readonly FilePathPattern FilePath;
-            public readonly UriPattern Uri;
-
-            public Entry(FilePathPattern filePath, UriPattern uri)
-            {
-                FilePath = filePath;
-                Uri = uri;
-            }
+            public readonly FilePathPattern FilePath = filePath;
+            public readonly UriPattern Uri = uri;
 
             public void Deconstruct(out FilePathPattern filePath, out UriPattern uri)
             {
@@ -46,28 +40,16 @@ namespace Microsoft.SourceLink.Tools
             }
         }
 
-        public readonly struct FilePathPattern
+        public readonly struct FilePathPattern(string path, bool isPrefix)
         {
-            public readonly string Path;
-            public readonly bool IsPrefix;
-
-            public FilePathPattern(string path, bool isPrefix)
-            {
-                Path = path;
-                IsPrefix = isPrefix;
-            }
+            public readonly string Path = path;
+            public readonly bool IsPrefix = isPrefix;
         }
 
-        public readonly struct UriPattern
+        public readonly struct UriPattern(string prefix, string suffix)
         {
-            public readonly string Prefix;
-            public readonly string Suffix;
-
-            public UriPattern(string prefix, string suffix)
-            {
-                Prefix = prefix;
-                Suffix = suffix;
-            }
+            public readonly string Prefix = prefix;
+            public readonly string Suffix = suffix;
         }
 
         public IReadOnlyList<Entry> Entries => _entries;

--- a/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
+++ b/src/Features/Core/Portable/PickMembers/IPickMembersService.cs
@@ -17,17 +17,10 @@ namespace Microsoft.CodeAnalysis.PickMembers
             bool selectAll = true);
     }
 
-    internal class PickMembersOption
+    internal class PickMembersOption(string id, string title, bool value)
     {
-        public PickMembersOption(string id, string title, bool value)
-        {
-            Id = id;
-            Title = title;
-            Value = value;
-        }
-
-        public string Id { get; }
-        public string Title { get; }
-        public bool Value { get; set; }
+        public string Id { get; } = id;
+        public string Title { get; } = title;
+        public bool Value { get; set; } = value;
     }
 }

--- a/src/Features/Core/Portable/PullMemberUp/Dialog/PullMemberUpWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/PullMemberUp/Dialog/PullMemberUpWithDialogCodeAction.cs
@@ -16,29 +16,21 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
 {
     internal abstract partial class AbstractPullMemberUpRefactoringProvider
     {
-        private sealed class PullMemberUpWithDialogCodeAction : CodeActionWithOptions
+        private sealed class PullMemberUpWithDialogCodeAction(
+            Document document,
+            ImmutableArray<ISymbol> selectedMembers,
+            IPullMemberUpOptionsService service,
+            CleanCodeGenerationOptionsProvider fallbackOptions) : CodeActionWithOptions
         {
             /// <summary>
             /// Member which user initially selects. It will be selected initially when the dialog pops up.
             /// </summary>
-            private readonly ImmutableArray<ISymbol> _selectedMembers;
-            private readonly Document _document;
-            private readonly IPullMemberUpOptionsService _service;
-            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
+            private readonly ImmutableArray<ISymbol> _selectedMembers = selectedMembers;
+            private readonly Document _document = document;
+            private readonly IPullMemberUpOptionsService _service = service;
+            private readonly CleanCodeGenerationOptionsProvider _fallbackOptions = fallbackOptions;
 
             public override string Title => FeaturesResources.Pull_members_up_to_base_type;
-
-            public PullMemberUpWithDialogCodeAction(
-                Document document,
-                ImmutableArray<ISymbol> selectedMembers,
-                IPullMemberUpOptionsService service,
-                CleanCodeGenerationOptionsProvider fallbackOptions)
-            {
-                _document = document;
-                _selectedMembers = selectedMembers;
-                _service = service;
-                _fallbackOptions = fallbackOptions;
-            }
 
             public override object GetOptions(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/PullMemberUp/MemberAnalysisResult.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAnalysisResult.cs
@@ -6,54 +6,45 @@
 
 namespace Microsoft.CodeAnalysis.PullMemberUp
 {
-    internal readonly struct MemberAnalysisResult
+    internal readonly struct MemberAnalysisResult(
+        ISymbol member,
+        bool changeOriginalToPublic,
+        bool changeOriginalToNonStatic,
+        bool makeMemberDeclarationAbstract,
+        bool changeDestinationTypeToAbstract)
     {
         /// <summary>
         /// The member needs to be pulled up.
         /// </summary>
-        public readonly ISymbol Member;
+        public readonly ISymbol Member = member;
 
         /// <summary>
         /// Indicate whether this member needs to be changed to public so it won't cause error after it is pulled up to destination.
         /// </summary>
-        public readonly bool ChangeOriginalToPublic;
+        public readonly bool ChangeOriginalToPublic = changeOriginalToPublic;
 
         /// <summary>
         /// Indicate whether this member needs to be changed to non-static so it won't cause error after it is pulled up to destination.
         /// </summary>
-        public readonly bool ChangeOriginalToNonStatic;
+        public readonly bool ChangeOriginalToNonStatic = changeOriginalToNonStatic;
 
         /// <summary>
         /// Indicate whether this member's declaration in destination needs to be made to abstract. It is only used by the dialog UI.
         /// If this property is true, then pull a member up to a class will only generate a abstract declaration in the destination.
         /// It will always be false if the refactoring is triggered from Quick Action.
         /// </summary>
-        public readonly bool MakeMemberDeclarationAbstract;
+        public readonly bool MakeMemberDeclarationAbstract = makeMemberDeclarationAbstract;
 
         /// <summary>
         /// Indicate whether pulling this member up would change the destination to abstract. It will be true if:
         /// 1. Pull an abstract member to a non-abstract class
         /// 2. The 'Make abstract' check box of a member is checked, and the destination is a non-abstract class
         /// </summary>
-        public readonly bool ChangeDestinationTypeToAbstract;
+        public readonly bool ChangeDestinationTypeToAbstract = changeDestinationTypeToAbstract;
 
         /// <summary>
         /// Indicate whether it would cause error if we directly pull Member into destination.
         /// </summary>
         public bool PullMemberUpNeedsToDoExtraChanges => ChangeOriginalToPublic || ChangeOriginalToNonStatic || ChangeDestinationTypeToAbstract;
-
-        public MemberAnalysisResult(
-            ISymbol member,
-            bool changeOriginalToPublic,
-            bool changeOriginalToNonStatic,
-            bool makeMemberDeclarationAbstract,
-            bool changeDestinationTypeToAbstract)
-        {
-            Member = member;
-            ChangeOriginalToPublic = changeOriginalToPublic;
-            ChangeOriginalToNonStatic = changeOriginalToNonStatic;
-            MakeMemberDeclarationAbstract = makeMemberDeclarationAbstract;
-            ChangeDestinationTypeToAbstract = changeDestinationTypeToAbstract;
-        }
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/CommonQuickInfoContext.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonQuickInfoContext.cs
@@ -8,26 +8,17 @@ using Microsoft.CodeAnalysis.LanguageService;
 
 namespace Microsoft.CodeAnalysis.QuickInfo
 {
-    internal readonly struct CommonQuickInfoContext
+    internal readonly struct CommonQuickInfoContext(
+        SolutionServices services,
+        SemanticModel semanticModel,
+        int position,
+        SymbolDescriptionOptions options,
+        CancellationToken cancellationToken)
     {
-        public readonly SolutionServices Services;
-        public readonly SemanticModel SemanticModel;
-        public readonly int Position;
-        public readonly SymbolDescriptionOptions Options;
-        public readonly CancellationToken CancellationToken;
-
-        public CommonQuickInfoContext(
-            SolutionServices services,
-            SemanticModel semanticModel,
-            int position,
-            SymbolDescriptionOptions options,
-            CancellationToken cancellationToken)
-        {
-            Services = services;
-            SemanticModel = semanticModel;
-            Position = position;
-            Options = options;
-            CancellationToken = cancellationToken;
-        }
+        public readonly SolutionServices Services = services;
+        public readonly SemanticModel SemanticModel = semanticModel;
+        public readonly int Position = position;
+        public readonly SymbolDescriptionOptions Options = options;
+        public readonly CancellationToken CancellationToken = cancellationToken;
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.TokenInfo.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.TokenInfo.cs
@@ -8,27 +8,20 @@ namespace Microsoft.CodeAnalysis.QuickInfo
 {
     internal abstract partial class CommonSemanticQuickInfoProvider
     {
-        public readonly struct TokenInformation
+        public readonly struct TokenInformation(ImmutableArray<ISymbol> symbols, bool showAwaitReturn = false, NullableFlowState nullableFlowState = NullableFlowState.None)
         {
-            public readonly ImmutableArray<ISymbol> Symbols;
+            public readonly ImmutableArray<ISymbol> Symbols = symbols;
 
             /// <summary>
             /// True if this quick info came from hovering over an 'await' keyword, which we show the return
             /// type of with special text.
             /// </summary>
-            public readonly bool ShowAwaitReturn;
+            public readonly bool ShowAwaitReturn = showAwaitReturn;
 
             /// <summary>
             /// The nullable flow state to show in Quick Info; will be <see cref="NullableFlowState.None"/> to show nothing.
             /// </summary>
-            public readonly NullableFlowState NullableFlowState;
-
-            public TokenInformation(ImmutableArray<ISymbol> symbols, bool showAwaitReturn = false, NullableFlowState nullableFlowState = NullableFlowState.None)
-            {
-                Symbols = symbols;
-                ShowAwaitReturn = showAwaitReturn;
-                NullableFlowState = nullableFlowState;
-            }
+            public readonly NullableFlowState NullableFlowState = nullableFlowState;
         }
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/ExportQuickInfoProviderAttribute.cs
+++ b/src/Features/Core/Portable/QuickInfo/ExportQuickInfoProviderAttribute.cs
@@ -13,16 +13,9 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class ExportQuickInfoProviderAttribute : ExportAttribute
+    internal sealed class ExportQuickInfoProviderAttribute(string name, string language) : ExportAttribute(typeof(QuickInfoProvider))
     {
-        public string Name { get; }
-        public string Language { get; }
-
-        public ExportQuickInfoProviderAttribute(string name, string language)
-            : base(typeof(QuickInfoProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoContext.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoContext.cs
@@ -11,38 +11,30 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     /// <summary>
     /// The context presented to a <see cref="QuickInfoProvider"/> when providing quick info.
     /// </summary>
-    internal sealed class QuickInfoContext
+    /// <remarks>
+    /// Creates a <see cref="QuickInfoContext"/> instance.
+    /// </remarks>
+    internal sealed class QuickInfoContext(
+        Document document,
+        int position,
+        SymbolDescriptionOptions options,
+        CancellationToken cancellationToken)
     {
         /// <summary>
         /// The document that quick info was requested within.
         /// </summary>
-        public Document Document { get; }
+        public Document Document { get; } = document ?? throw new ArgumentNullException(nameof(document));
 
         /// <summary>
         /// The caret position where quick info was requested from.
         /// </summary>
-        public int Position { get; }
+        public int Position { get; } = position;
 
-        public SymbolDescriptionOptions Options { get; }
+        public SymbolDescriptionOptions Options { get; } = options;
 
         /// <summary>
         /// The cancellation token to use for this operation.
         /// </summary>
-        public CancellationToken CancellationToken { get; }
-
-        /// <summary>
-        /// Creates a <see cref="QuickInfoContext"/> instance.
-        /// </summary>
-        public QuickInfoContext(
-            Document document,
-            int position,
-            SymbolDescriptionOptions options,
-            CancellationToken cancellationToken)
-        {
-            Document = document ?? throw new ArgumentNullException(nameof(document));
-            Position = position;
-            Options = options;
-            CancellationToken = cancellationToken;
-        }
+        public CancellationToken CancellationToken { get; } = cancellationToken;
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoProviderMetadata.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoProviderMetadata.cs
@@ -7,11 +7,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.QuickInfo
 {
-    internal class QuickInfoProviderMetadata : OrderableLanguageMetadata
+    internal class QuickInfoProviderMetadata(IDictionary<string, object> data) : OrderableLanguageMetadata(data)
     {
-        public QuickInfoProviderMetadata(IDictionary<string, object> data)
-            : base(data)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQArrayOrPointerType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQArrayOrPointerType.cs
@@ -4,11 +4,8 @@
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQArrayOrPointerType : RQType
+    internal abstract class RQArrayOrPointerType(RQType elementType) : RQType
     {
-        public readonly RQType ElementType;
-
-        public RQArrayOrPointerType(RQType elementType)
-            => ElementType = elementType;
+        public readonly RQType ElementType = elementType;
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQArrayType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQArrayType.cs
@@ -6,15 +6,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQArrayType : RQArrayOrPointerType
+    internal class RQArrayType(int rank, RQType elementType) : RQArrayOrPointerType(elementType)
     {
-        public readonly int Rank;
-
-        public RQArrayType(int rank, RQType elementType)
-            : base(elementType)
-        {
-            Rank = rank;
-        }
+        public readonly int Rank = rank;
 
         public override SimpleTreeNode ToSimpleTree()
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQConstructedType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQConstructedType.cs
@@ -9,16 +9,10 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQConstructedType : RQType
+    internal class RQConstructedType(RQUnconstructedType definingType, IList<RQType> typeArguments) : RQType
     {
-        public readonly RQUnconstructedType DefiningType;
-        public readonly ReadOnlyCollection<RQType> TypeArguments;
-
-        public RQConstructedType(RQUnconstructedType definingType, IList<RQType> typeArguments)
-        {
-            DefiningType = definingType;
-            TypeArguments = new ReadOnlyCollection<RQType>(typeArguments);
-        }
+        public readonly RQUnconstructedType DefiningType = definingType;
+        public readonly ReadOnlyCollection<RQType> TypeArguments = new ReadOnlyCollection<RQType>(typeArguments);
 
         public override SimpleTreeNode ToSimpleTree()
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQConstructor.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQConstructor.cs
@@ -6,15 +6,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQConstructor : RQMethodBase
+    internal class RQConstructor(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQMethodBase(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQConstructor(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQErrorType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQErrorType.cs
@@ -6,12 +6,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQErrorType : RQType
+    internal class RQErrorType(string name) : RQType
     {
-        public readonly string Name;
-
-        public RQErrorType(string name)
-            => Name = name;
+        public readonly string Name = name;
 
         public override SimpleTreeNode ToSimpleTree()
             => new SimpleGroupNode(RQNameStrings.Error, Name);

--- a/src/Features/Core/Portable/RQName/Nodes/RQEvent.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQEvent.cs
@@ -4,13 +4,8 @@
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQEvent : RQMethodPropertyOrEvent
+    internal class RQEvent(RQUnconstructedType containingType, RQMethodPropertyOrEventName memberName) : RQMethodPropertyOrEvent(containingType, memberName)
     {
-        public RQEvent(RQUnconstructedType containingType, RQMethodPropertyOrEventName memberName)
-            : base(containingType, memberName)
-        {
-        }
-
         protected override string RQKeyword
         {
             get { return RQNameStrings.Event; }

--- a/src/Features/Core/Portable/RQName/Nodes/RQExplicitInterfaceMemberName.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQExplicitInterfaceMemberName.cs
@@ -6,16 +6,10 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQExplicitInterfaceMemberName : RQMethodPropertyOrEventName
+    internal class RQExplicitInterfaceMemberName(RQType interfaceType, RQOrdinaryMethodPropertyOrEventName name) : RQMethodPropertyOrEventName
     {
-        public readonly RQType InterfaceType;
-        public readonly RQOrdinaryMethodPropertyOrEventName Name;
-
-        public RQExplicitInterfaceMemberName(RQType interfaceType, RQOrdinaryMethodPropertyOrEventName name)
-        {
-            InterfaceType = interfaceType;
-            Name = name;
-        }
+        public readonly RQType InterfaceType = interfaceType;
+        public readonly RQOrdinaryMethodPropertyOrEventName Name = name;
 
         public override string OrdinaryNameValue
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQIndexer.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQIndexer.cs
@@ -6,15 +6,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQIndexer : RQPropertyBase
+    internal class RQIndexer(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQPropertyBase(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQIndexer(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQMember.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMember.cs
@@ -7,12 +7,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQMember : RQNode
+    internal abstract class RQMember(RQUnconstructedType containingType) : RQNode
     {
-        public readonly RQUnconstructedType ContainingType;
-
-        public RQMember(RQUnconstructedType containingType)
-            => ContainingType = containingType;
+        public readonly RQUnconstructedType ContainingType = containingType;
 
         public abstract string MemberName { get; }
 

--- a/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndex.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndex.cs
@@ -7,18 +7,12 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQMemberParameterIndex : RQNode
+    internal class RQMemberParameterIndex(
+        RQMember containingMember,
+        int parameterIndex) : RQNode
     {
-        public readonly RQMember ContainingMember;
-        public readonly int ParameterIndex;
-
-        public RQMemberParameterIndex(
-            RQMember containingMember,
-            int parameterIndex)
-        {
-            ContainingMember = containingMember;
-            ParameterIndex = parameterIndex;
-        }
+        public readonly RQMember ContainingMember = containingMember;
+        public readonly int ParameterIndex = parameterIndex;
 
         protected override string RQKeyword
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndexFromPartialImplementation.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndexFromPartialImplementation.cs
@@ -7,15 +7,10 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQMemberParameterIndexFromPartialImplementation : RQMemberParameterIndex
+    internal class RQMemberParameterIndexFromPartialImplementation(
+        RQMember containingMember,
+        int parameterIndex) : RQMemberParameterIndex(containingMember, parameterIndex)
     {
-        public RQMemberParameterIndexFromPartialImplementation(
-            RQMember containingMember,
-            int parameterIndex)
-            : base(containingMember, parameterIndex)
-        {
-        }
-
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {
             childList.Add(ContainingMember.ToSimpleTree());

--- a/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndexFromPartialSignature.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMemberParameterIndexFromPartialSignature.cs
@@ -7,15 +7,10 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQMemberParameterIndexFromPartialSignature : RQMemberParameterIndex
+    internal class RQMemberParameterIndexFromPartialSignature(
+        RQMember containingMember,
+        int parameterIndex) : RQMemberParameterIndex(containingMember, parameterIndex)
     {
-        public RQMemberParameterIndexFromPartialSignature(
-            RQMember containingMember,
-            int parameterIndex)
-            : base(containingMember, parameterIndex)
-        {
-        }
-
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {
             childList.Add(ContainingMember.ToSimpleTree());

--- a/src/Features/Core/Portable/RQName/Nodes/RQMemberVariable.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMemberVariable.cs
@@ -7,15 +7,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQMemberVariable : RQMember
+    internal class RQMemberVariable(RQUnconstructedType containingType, string name) : RQMember(containingType)
     {
-        public readonly string Name;
-
-        public RQMemberVariable(RQUnconstructedType containingType, string name)
-            : base(containingType)
-        {
-            Name = name;
-        }
+        public readonly string Name = name;
 
         public override string MemberName
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQMethod.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMethod.cs
@@ -6,15 +6,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQMethod : RQMethodBase
+    internal class RQMethod(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQMethodBase(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQMethod(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQMethodBase.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMethodBase.cs
@@ -6,17 +6,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQMethodBase : RQMethodOrProperty
+    internal abstract class RQMethodBase(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQMethodOrProperty(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQMethodBase(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        {
-        }
-
         protected override string RQKeyword
         {
             get { return RQNameStrings.Meth; }

--- a/src/Features/Core/Portable/RQName/Nodes/RQMethodOrProperty.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMethodOrProperty.cs
@@ -9,21 +9,14 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQMethodOrProperty : RQMethodPropertyOrEvent
+    internal abstract class RQMethodOrProperty(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQMethodPropertyOrEvent(containingType, memberName)
     {
-        public readonly int TypeParameterCount;
-        public readonly ReadOnlyCollection<RQParameter> Parameters;
-
-        public RQMethodOrProperty(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName)
-        {
-            TypeParameterCount = typeParameterCount;
-            Parameters = new ReadOnlyCollection<RQParameter>(parameters);
-        }
+        public readonly int TypeParameterCount = typeParameterCount;
+        public readonly ReadOnlyCollection<RQParameter> Parameters = new ReadOnlyCollection<RQParameter>(parameters);
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQMethodPropertyOrEvent.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQMethodPropertyOrEvent.cs
@@ -7,15 +7,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQMethodPropertyOrEvent : RQMember
+    internal abstract class RQMethodPropertyOrEvent(RQUnconstructedType containingType, RQMethodPropertyOrEventName memberName) : RQMember(containingType)
     {
-        public readonly RQMethodPropertyOrEventName RqMemberName;
-
-        public RQMethodPropertyOrEvent(RQUnconstructedType containingType, RQMethodPropertyOrEventName memberName)
-            : base(containingType)
-        {
-            RqMemberName = memberName;
-        }
+        public readonly RQMethodPropertyOrEventName RqMemberName = memberName;
 
         public override string MemberName
         {

--- a/src/Features/Core/Portable/RQName/Nodes/RQNamespace.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQNamespace.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQNamespace : RQTypeOrNamespace
+    internal class RQNamespace(IList<string> namespaceNames) : RQTypeOrNamespace(namespaceNames)
     {
-        public RQNamespace(IList<string> namespaceNames) : base(namespaceNames) { }
-
         protected override string RQKeyword
         {
             get { return RQNameStrings.Namespace; }

--- a/src/Features/Core/Portable/RQName/Nodes/RQNormalParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQNormalParameter.cs
@@ -6,10 +6,8 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQNormalParameter : RQParameter
+    internal class RQNormalParameter(RQType type) : RQParameter(type)
     {
-        public RQNormalParameter(RQType type) : base(type) { }
-
         public override SimpleTreeNode CreateSimpleTreeForType()
             => Type.ToSimpleTree();
     }

--- a/src/Features/Core/Portable/RQName/Nodes/RQOutParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQOutParameter.cs
@@ -6,10 +6,8 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQOutParameter : RQParameter
+    internal class RQOutParameter(RQType type) : RQParameter(type)
     {
-        public RQOutParameter(RQType type) : base(type) { }
-
         public override SimpleTreeNode CreateSimpleTreeForType()
             => new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Out), Type.ToSimpleTree());
     }

--- a/src/Features/Core/Portable/RQName/Nodes/RQParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQParameter.cs
@@ -6,13 +6,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQParameter
+    internal abstract class RQParameter(RQType type)
     {
-        public readonly RQType Type;
-        public RQParameter(RQType type)
-        {
-            Type = type;
-        }
+        public readonly RQType Type = type;
 
         public SimpleTreeNode ToSimpleTree()
             => new SimpleGroupNode(RQNameStrings.Param, CreateSimpleTreeForType());

--- a/src/Features/Core/Portable/RQName/Nodes/RQPointerType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQPointerType.cs
@@ -6,10 +6,8 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQPointerType : RQArrayOrPointerType
+    internal class RQPointerType(RQType elementType) : RQArrayOrPointerType(elementType)
     {
-        public RQPointerType(RQType elementType) : base(elementType) { }
-
         public override SimpleTreeNode ToSimpleTree()
             => new SimpleGroupNode(RQNameStrings.Pointer, ElementType.ToSimpleTree());
     }

--- a/src/Features/Core/Portable/RQName/Nodes/RQProperty.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQProperty.cs
@@ -6,14 +6,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQProperty : RQPropertyBase
+    internal class RQProperty(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQPropertyBase(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQProperty(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        { }
     }
 }

--- a/src/Features/Core/Portable/RQName/Nodes/RQPropertyBase.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQPropertyBase.cs
@@ -6,16 +6,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal abstract class RQPropertyBase : RQMethodOrProperty
+    internal abstract class RQPropertyBase(
+        RQUnconstructedType containingType,
+        RQMethodPropertyOrEventName memberName,
+        int typeParameterCount,
+        IList<RQParameter> parameters) : RQMethodOrProperty(containingType, memberName, typeParameterCount, parameters)
     {
-        public RQPropertyBase(
-            RQUnconstructedType containingType,
-            RQMethodPropertyOrEventName memberName,
-            int typeParameterCount,
-            IList<RQParameter> parameters)
-            : base(containingType, memberName, typeParameterCount, parameters)
-        { }
-
         protected override string RQKeyword
         {
             get { return RQNameStrings.Prop; }

--- a/src/Features/Core/Portable/RQName/Nodes/RQRefParameter.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQRefParameter.cs
@@ -6,10 +6,8 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQRefParameter : RQParameter
+    internal class RQRefParameter(RQType type) : RQParameter(type)
     {
-        public RQRefParameter(RQType type) : base(type) { }
-
         public override SimpleTreeNode CreateSimpleTreeForType()
             => new SimpleGroupNode(RQNameStrings.ParamMod, new SimpleLeafNode(RQNameStrings.Ref), Type.ToSimpleTree());
     }

--- a/src/Features/Core/Portable/RQName/Nodes/RQTypeVariableType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQTypeVariableType.cs
@@ -6,12 +6,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQTypeVariableType : RQType
+    internal class RQTypeVariableType(string name) : RQType
     {
-        public readonly string Name;
-
-        public RQTypeVariableType(string name)
-            => Name = name;
+        public readonly string Name = name;
 
         public override SimpleTreeNode ToSimpleTree()
             => new SimpleGroupNode(RQNameStrings.TyVar, Name);

--- a/src/Features/Core/Portable/RQName/Nodes/RQUnconstructedType.cs
+++ b/src/Features/Core/Portable/RQName/Nodes/RQUnconstructedType.cs
@@ -9,15 +9,9 @@ using Microsoft.CodeAnalysis.Features.RQName.SimpleTree;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
 {
-    internal class RQUnconstructedType : RQTypeOrNamespace
+    internal class RQUnconstructedType(IList<string> namespaceNames, IList<RQUnconstructedTypeInfo> typeInfos) : RQTypeOrNamespace(namespaceNames)
     {
-        public readonly ReadOnlyCollection<RQUnconstructedTypeInfo> TypeInfos;
-
-        public RQUnconstructedType(IList<string> namespaceNames, IList<RQUnconstructedTypeInfo> typeInfos)
-            : base(namespaceNames)
-        {
-            TypeInfos = new ReadOnlyCollection<RQUnconstructedTypeInfo>(typeInfos);
-        }
+        public readonly ReadOnlyCollection<RQUnconstructedTypeInfo> TypeInfos = new ReadOnlyCollection<RQUnconstructedTypeInfo>(typeInfos);
 
         protected override string RQKeyword
         {
@@ -36,15 +30,9 @@ namespace Microsoft.CodeAnalysis.Features.RQName.Nodes
         }
     }
 
-    internal readonly struct RQUnconstructedTypeInfo
+    internal readonly struct RQUnconstructedTypeInfo(string typeName, int typeVariableCount)
     {
-        public readonly string TypeName;
-        public readonly int TypeVariableCount;
-
-        public RQUnconstructedTypeInfo(string typeName, int typeVariableCount)
-        {
-            TypeName = typeName;
-            TypeVariableCount = typeVariableCount;
-        }
+        public readonly string TypeName = typeName;
+        public readonly int TypeVariableCount = typeVariableCount;
     }
 }

--- a/src/Features/Core/Portable/RQName/SimpleTree/SimpleGroupNode.cs
+++ b/src/Features/Core/Portable/RQName/SimpleTree/SimpleGroupNode.cs
@@ -7,12 +7,9 @@ using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Features.RQName.SimpleTree
 {
-    internal class SimpleGroupNode : SimpleTreeNode
+    internal class SimpleGroupNode(string text, IList<SimpleTreeNode> children) : SimpleTreeNode(text)
     {
-        private readonly IList<SimpleTreeNode> _children;
-
-        public SimpleGroupNode(string text, IList<SimpleTreeNode> children) : base(text)
-            => _children = children;
+        private readonly IList<SimpleTreeNode> _children = children;
 
         public SimpleGroupNode(string text, string singleLeafChildText) : this(text, new SimpleLeafNode(singleLeafChildText)) { }
 

--- a/src/Features/Core/Portable/RQName/SimpleTree/SimpleLeafNode.cs
+++ b/src/Features/Core/Portable/RQName/SimpleTree/SimpleLeafNode.cs
@@ -4,8 +4,7 @@
 
 namespace Microsoft.CodeAnalysis.Features.RQName.SimpleTree
 {
-    internal class SimpleLeafNode : SimpleTreeNode
+    internal class SimpleLeafNode(string text) : SimpleTreeNode(text)
     {
-        public SimpleLeafNode(string text) : base(text) { }
     }
 }

--- a/src/Features/Core/Portable/RQName/SimpleTree/SimpleTreeNode.cs
+++ b/src/Features/Core/Portable/RQName/SimpleTree/SimpleTreeNode.cs
@@ -4,11 +4,8 @@
 
 namespace Microsoft.CodeAnalysis.Features.RQName.SimpleTree
 {
-    internal abstract class SimpleTreeNode
+    internal abstract class SimpleTreeNode(string text)
     {
-        public readonly string Text;
-
-        public SimpleTreeNode(string text)
-            => Text = text;
+        public readonly string Text = text;
     }
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
@@ -28,21 +28,13 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         void RemoveSetMethod(SyntaxEditor editor, SyntaxNode setMethodDeclaration);
     }
 
-    internal readonly struct GetAndSetMethods
+    internal readonly struct GetAndSetMethods(
+        IMethodSymbol getMethod, IMethodSymbol setMethod,
+        SyntaxNode getMethodDeclaration, SyntaxNode setMethodDeclaration)
     {
-        public readonly IMethodSymbol GetMethod;
-        public readonly IMethodSymbol SetMethod;
-        public readonly SyntaxNode GetMethodDeclaration;
-        public readonly SyntaxNode SetMethodDeclaration;
-
-        public GetAndSetMethods(
-            IMethodSymbol getMethod, IMethodSymbol setMethod,
-            SyntaxNode getMethodDeclaration, SyntaxNode setMethodDeclaration)
-        {
-            GetMethod = getMethod;
-            SetMethod = setMethod;
-            GetMethodDeclaration = getMethodDeclaration;
-            SetMethodDeclaration = setMethodDeclaration;
-        }
+        public readonly IMethodSymbol GetMethod = getMethod;
+        public readonly IMethodSymbol SetMethod = setMethod;
+        public readonly SyntaxNode GetMethodDeclaration = getMethodDeclaration;
+        public readonly SyntaxNode SetMethodDeclaration = setMethodDeclaration;
     }
 }

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/AbstractReplacePropertyWithMethodsService.cs
@@ -443,20 +443,12 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
                 return token;
             }
 
-            private readonly struct ReplaceParentArgs
+            private readonly struct ReplaceParentArgs(ReferenceReplacer replacer, GetWriteValue getWriteValue, bool keepTrivia, string? conflictMessage)
             {
-                public readonly ReferenceReplacer Replacer;
-                public readonly GetWriteValue GetWriteValue;
-                public readonly bool KeepTrivia;
-                public readonly string? ConflictMessage;
-
-                public ReplaceParentArgs(ReferenceReplacer replacer, GetWriteValue getWriteValue, bool keepTrivia, string? conflictMessage)
-                {
-                    Replacer = replacer;
-                    GetWriteValue = getWriteValue;
-                    KeepTrivia = keepTrivia;
-                    ConflictMessage = conflictMessage;
-                }
+                public readonly ReferenceReplacer Replacer = replacer;
+                public readonly GetWriteValue GetWriteValue = getWriteValue;
+                public readonly bool KeepTrivia = keepTrivia;
+                public readonly string? ConflictMessage = conflictMessage;
             }
         }
     }

--- a/src/Features/Core/Portable/Shared/Naming/IdentifierNameParts.cs
+++ b/src/Features/Core/Portable/Shared/Naming/IdentifierNameParts.cs
@@ -14,16 +14,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Shared.Naming
 {
-    internal readonly struct IdentifierNameParts
+    internal readonly struct IdentifierNameParts(string baseName, ImmutableArray<string> baseNameParts)
     {
-        public readonly string BaseName;
-        public readonly ImmutableArray<string> BaseNameParts;
-
-        public IdentifierNameParts(string baseName, ImmutableArray<string> baseNameParts)
-        {
-            BaseName = baseName;
-            BaseNameParts = baseNameParts;
-        }
+        public readonly string BaseName = baseName;
+        public readonly ImmutableArray<string> BaseNameParts = baseNameParts;
 
         public static IdentifierNameParts CreateIdentifierNameParts(ISymbol symbol, ImmutableArray<NamingRule> rules)
         {

--- a/src/Features/Core/Portable/Shared/Utilities/AnnotatedSymbolMapping.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/AnnotatedSymbolMapping.cs
@@ -12,40 +12,32 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
-    internal class AnnotatedSymbolMapping
+    internal class AnnotatedSymbolMapping(
+        ImmutableDictionary<ISymbol, SyntaxAnnotation> symbolToDeclarationAnnotationMap,
+        Solution annotatedSolution,
+        ImmutableDictionary<DocumentId, ImmutableArray<ISymbol>> documentIdsToSymbolMap,
+        SyntaxAnnotation typeNodeAnnotation)
     {
         /// <summary>
         /// Used to map a symbol to the annotation that was added at the beginning of it's definition. Use the 
         /// annotation the symbol declaration again across edits.
         /// </summary>
-        public ImmutableDictionary<ISymbol, SyntaxAnnotation> SymbolToDeclarationAnnotationMap { get; }
+        public ImmutableDictionary<ISymbol, SyntaxAnnotation> SymbolToDeclarationAnnotationMap { get; } = symbolToDeclarationAnnotationMap;
 
         /// <summary>
         /// The original solution that modifications made to annotate the symbol declarations
         /// </summary>
-        public Solution AnnotatedSolution { get; }
+        public Solution AnnotatedSolution { get; } = annotatedSolution;
 
         /// <summary>
         /// A map of the document ids that were used and what symbols are in them. 
         /// </summary>
-        public ImmutableDictionary<DocumentId, ImmutableArray<ISymbol>> DocumentIdsToSymbolMap { get; }
+        public ImmutableDictionary<DocumentId, ImmutableArray<ISymbol>> DocumentIdsToSymbolMap { get; } = documentIdsToSymbolMap;
 
         /// <summary>
         /// The annotation added to the type declaration that was passed in to create the mapping
         /// </summary>
-        public SyntaxAnnotation TypeNodeAnnotation { get; }
-
-        public AnnotatedSymbolMapping(
-            ImmutableDictionary<ISymbol, SyntaxAnnotation> symbolToDeclarationAnnotationMap,
-            Solution annotatedSolution,
-            ImmutableDictionary<DocumentId, ImmutableArray<ISymbol>> documentIdsToSymbolMap,
-            SyntaxAnnotation typeNodeAnnotation)
-        {
-            SymbolToDeclarationAnnotationMap = symbolToDeclarationAnnotationMap;
-            AnnotatedSolution = annotatedSolution;
-            DocumentIdsToSymbolMap = documentIdsToSymbolMap;
-            TypeNodeAnnotation = typeNodeAnnotation;
-        }
+        public SyntaxAnnotation TypeNodeAnnotation { get; } = typeNodeAnnotation;
 
         /// <summary>
         /// Creates a <see cref="AnnotatedSymbolMapping"/> where the first token of each symbol is annotated

--- a/src/Features/Core/Portable/Shared/Utilities/CompilationAvailableEventSource.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/CompilationAvailableEventSource.cs
@@ -19,20 +19,15 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     /// is asked for for a particular project, any existing outstanding work to produce a <see cref="Compilation"/> for
     /// a prior <see cref="Project"/> will be cancelled.
     /// </summary>
-    internal class CompilationAvailableEventSource : IDisposable
+    internal class CompilationAvailableEventSource(
+        IAsynchronousOperationListener asyncListener) : IDisposable
     {
-        private readonly IAsynchronousOperationListener _asyncListener;
+        private readonly IAsynchronousOperationListener _asyncListener = asyncListener;
 
         /// <summary>
         /// Cancellation tokens controlling background computation of the compilation.
         /// </summary>
         private readonly ReferenceCountedDisposable<CancellationSeries> _cancellationSeries = new(new CancellationSeries());
-
-        public CompilationAvailableEventSource(
-            IAsynchronousOperationListener asyncListener)
-        {
-            _asyncListener = asyncListener;
-        }
 
         public void Dispose()
             => _cancellationSeries.Dispose();

--- a/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/SupportedPlatformData.cs
@@ -11,21 +11,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
-    internal sealed class SupportedPlatformData
+    internal sealed class SupportedPlatformData(Solution solution, List<ProjectId> invalidProjects, IEnumerable<ProjectId> candidateProjects)
     {
         // Because completion finds lots of symbols that exist in 
         // all projects, we'll instead maintain a list of projects 
         // missing the symbol.
-        public readonly List<ProjectId> InvalidProjects;
-        public readonly IEnumerable<ProjectId> CandidateProjects;
-        public readonly Solution Solution;
-
-        public SupportedPlatformData(Solution solution, List<ProjectId> invalidProjects, IEnumerable<ProjectId> candidateProjects)
-        {
-            InvalidProjects = invalidProjects;
-            CandidateProjects = candidateProjects;
-            Solution = solution;
-        }
+        public readonly List<ProjectId> InvalidProjects = invalidProjects;
+        public readonly IEnumerable<ProjectId> CandidateProjects = candidateProjects;
+        public readonly Solution Solution = solution;
 
         public IList<SymbolDisplayPart> ToDisplayParts()
         {

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -10,23 +10,17 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
 {
     internal abstract partial class AbstractSignatureHelpProvider
     {
-        internal class SymbolKeySignatureHelpItem : SignatureHelpItem, IEquatable<SymbolKeySignatureHelpItem>
+        internal class SymbolKeySignatureHelpItem(
+            ISymbol symbol,
+            bool isVariadic,
+            Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
+            IEnumerable<TaggedText> prefixParts,
+            IEnumerable<TaggedText> separatorParts,
+            IEnumerable<TaggedText> suffixParts,
+            IEnumerable<SignatureHelpParameter> parameters,
+            IEnumerable<TaggedText>? descriptionParts) : SignatureHelpItem(isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts), IEquatable<SymbolKeySignatureHelpItem>
         {
-            public SymbolKey? SymbolKey { get; }
-
-            public SymbolKeySignatureHelpItem(
-                ISymbol symbol,
-                bool isVariadic,
-                Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
-                IEnumerable<TaggedText> prefixParts,
-                IEnumerable<TaggedText> separatorParts,
-                IEnumerable<TaggedText> suffixParts,
-                IEnumerable<SignatureHelpParameter> parameters,
-                IEnumerable<TaggedText>? descriptionParts)
-                : base(isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
-            {
-                SymbolKey = symbol?.GetSymbolKey();
-            }
+            public SymbolKey? SymbolKey { get; } = symbol?.GetSymbolKey();
 
             public override bool Equals(object? obj)
                 => Equals(obj as SymbolKeySignatureHelpItem);

--- a/src/Features/Core/Portable/SignatureHelp/ExportSignatureHelpProviderAttribute.cs
+++ b/src/Features/Core/Portable/SignatureHelp/ExportSignatureHelpProviderAttribute.cs
@@ -9,16 +9,9 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal class ExportSignatureHelpProviderAttribute : ExportAttribute
+    internal class ExportSignatureHelpProviderAttribute(string name, string language) : ExportAttribute(typeof(ISignatureHelpProvider))
     {
-        public string Name { get; }
-        public string Language { get; }
-
-        public ExportSignatureHelpProviderAttribute(string name, string language)
-            : base(typeof(ISignatureHelpProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
     }
 }

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpParameter.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpParameter.cs
@@ -17,67 +17,56 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
     /// Once that it done, this will be converted to normal SignatureHelpParameters which only 
     /// point to TaggedText parts.
     /// </summary>
-    internal class SignatureHelpSymbolParameter
+    internal class SignatureHelpSymbolParameter(
+        string name,
+        bool isOptional,
+        Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
+        IEnumerable<SymbolDisplayPart> displayParts,
+        IEnumerable<SymbolDisplayPart>? prefixDisplayParts = null,
+        IEnumerable<SymbolDisplayPart>? suffixDisplayParts = null,
+        IEnumerable<SymbolDisplayPart>? selectedDisplayParts = null)
     {
         /// <summary>
         /// The name of this parameter.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; } = name ?? string.Empty;
 
         /// <summary>
         /// Documentation for this parameter.  This should normally be presented to the user when
         /// this parameter is selected.
         /// </summary>
-        public Func<CancellationToken, IEnumerable<TaggedText>> DocumentationFactory { get; }
+        public Func<CancellationToken, IEnumerable<TaggedText>> DocumentationFactory { get; } = documentationFactory ?? s_emptyDocumentationFactory;
 
         /// <summary>
         /// Display parts to show before the normal display parts for the parameter.
         /// </summary>
-        public IList<SymbolDisplayPart> PrefixDisplayParts { get; }
+        public IList<SymbolDisplayPart> PrefixDisplayParts { get; } = prefixDisplayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// Display parts to show after the normal display parts for the parameter.
         /// </summary>
-        public IList<SymbolDisplayPart> SuffixDisplayParts { get; }
+        public IList<SymbolDisplayPart> SuffixDisplayParts { get; } = suffixDisplayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// Display parts for this parameter.  This should normally be presented to the user as part
         /// of the entire signature display.
         /// </summary>
-        public IList<SymbolDisplayPart> DisplayParts { get; }
+        public IList<SymbolDisplayPart> DisplayParts { get; } = displayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// True if this parameter is optional or not.  Optional parameters may be presented in a
         /// different manner to users.
         /// </summary>
-        public bool IsOptional { get; }
+        public bool IsOptional { get; } = isOptional;
 
         /// <summary>
         /// Display parts for this parameter that should be presented to the user when this
         /// parameter is selected.
         /// </summary>
-        public IList<SymbolDisplayPart> SelectedDisplayParts { get; }
+        public IList<SymbolDisplayPart> SelectedDisplayParts { get; } = selectedDisplayParts.ToImmutableArrayOrEmpty();
 
         private static readonly Func<CancellationToken, IEnumerable<TaggedText>> s_emptyDocumentationFactory =
             _ => SpecializedCollections.EmptyEnumerable<TaggedText>();
-
-        public SignatureHelpSymbolParameter(
-            string name,
-            bool isOptional,
-            Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
-            IEnumerable<SymbolDisplayPart> displayParts,
-            IEnumerable<SymbolDisplayPart>? prefixDisplayParts = null,
-            IEnumerable<SymbolDisplayPart>? suffixDisplayParts = null,
-            IEnumerable<SymbolDisplayPart>? selectedDisplayParts = null)
-        {
-            Name = name ?? string.Empty;
-            IsOptional = isOptional;
-            DocumentationFactory = documentationFactory ?? s_emptyDocumentationFactory;
-            DisplayParts = displayParts.ToImmutableArrayOrEmpty();
-            PrefixDisplayParts = prefixDisplayParts.ToImmutableArrayOrEmpty();
-            SuffixDisplayParts = suffixDisplayParts.ToImmutableArrayOrEmpty();
-            SelectedDisplayParts = selectedDisplayParts.ToImmutableArrayOrEmpty();
-        }
 
         internal IEnumerable<SymbolDisplayPart> GetAllParts()
         {
@@ -97,46 +86,53 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
         }
     }
 
-    internal class SignatureHelpParameter
+    internal class SignatureHelpParameter(
+        string name,
+        bool isOptional,
+        Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
+        IEnumerable<TaggedText> displayParts,
+        IEnumerable<TaggedText>? prefixDisplayParts = null,
+        IEnumerable<TaggedText>? suffixDisplayParts = null,
+        IEnumerable<TaggedText>? selectedDisplayParts = null)
     {
         /// <summary>
         /// The name of this parameter.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; } = name ?? string.Empty;
 
         /// <summary>
         /// Documentation for this parameter.  This should normally be presented to the user when
         /// this parameter is selected.
         /// </summary>
-        public Func<CancellationToken, IEnumerable<TaggedText>> DocumentationFactory { get; }
+        public Func<CancellationToken, IEnumerable<TaggedText>> DocumentationFactory { get; } = documentationFactory ?? s_emptyDocumentationFactory;
 
         /// <summary>
         /// Display parts to show before the normal display parts for the parameter.
         /// </summary>
-        public IList<TaggedText> PrefixDisplayParts { get; }
+        public IList<TaggedText> PrefixDisplayParts { get; } = prefixDisplayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// Display parts to show after the normal display parts for the parameter.
         /// </summary>
-        public IList<TaggedText> SuffixDisplayParts { get; }
+        public IList<TaggedText> SuffixDisplayParts { get; } = suffixDisplayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// Display parts for this parameter.  This should normally be presented to the user as part
         /// of the entire signature display.
         /// </summary>
-        public IList<TaggedText> DisplayParts { get; }
+        public IList<TaggedText> DisplayParts { get; } = displayParts.ToImmutableArrayOrEmpty();
 
         /// <summary>
         /// True if this parameter is optional or not.  Optional parameters may be presented in a
         /// different manner to users.
         /// </summary>
-        public bool IsOptional { get; }
+        public bool IsOptional { get; } = isOptional;
 
         /// <summary>
         /// Display parts for this parameter that should be presented to the user when this
         /// parameter is selected.
         /// </summary>
-        public IList<TaggedText> SelectedDisplayParts { get; }
+        public IList<TaggedText> SelectedDisplayParts { get; } = selectedDisplayParts.ToImmutableArrayOrEmpty();
 
         private static readonly Func<CancellationToken, IEnumerable<TaggedText>> s_emptyDocumentationFactory =
             _ => SpecializedCollections.EmptyEnumerable<TaggedText>();
@@ -157,24 +153,6 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
                   suffixDisplayParts.ToTaggedText(),
                   selectedDisplayParts.ToTaggedText())
         {
-        }
-
-        public SignatureHelpParameter(
-            string name,
-            bool isOptional,
-            Func<CancellationToken, IEnumerable<TaggedText>>? documentationFactory,
-            IEnumerable<TaggedText> displayParts,
-            IEnumerable<TaggedText>? prefixDisplayParts = null,
-            IEnumerable<TaggedText>? suffixDisplayParts = null,
-            IEnumerable<TaggedText>? selectedDisplayParts = null)
-        {
-            Name = name ?? string.Empty;
-            IsOptional = isOptional;
-            DocumentationFactory = documentationFactory ?? s_emptyDocumentationFactory;
-            DisplayParts = displayParts.ToImmutableArrayOrEmpty();
-            PrefixDisplayParts = prefixDisplayParts.ToImmutableArrayOrEmpty();
-            SuffixDisplayParts = suffixDisplayParts.ToImmutableArrayOrEmpty();
-            SelectedDisplayParts = selectedDisplayParts.ToImmutableArrayOrEmpty();
         }
 
         internal IEnumerable<TaggedText> GetAllParts()

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpState.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpState.cs
@@ -6,19 +6,11 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.SignatureHelp
 {
-    internal readonly struct SignatureHelpState
+    internal readonly struct SignatureHelpState(int argumentIndex, int argumentCount, string? argumentName, ImmutableArray<string> argumentNames)
     {
-        public readonly int ArgumentIndex;
-        public readonly int ArgumentCount;
-        public readonly string? ArgumentName;
-        public readonly ImmutableArray<string> ArgumentNames;
-
-        public SignatureHelpState(int argumentIndex, int argumentCount, string? argumentName, ImmutableArray<string> argumentNames)
-        {
-            ArgumentIndex = argumentIndex;
-            ArgumentCount = argumentCount;
-            ArgumentName = argumentName;
-            ArgumentNames = argumentNames;
-        }
+        public readonly int ArgumentIndex = argumentIndex;
+        public readonly int ArgumentCount = argumentCount;
+        public readonly string? ArgumentName = argumentName;
+        public readonly ImmutableArray<string> ArgumentNames = argumentNames;
     }
 }

--- a/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
+++ b/src/Features/Core/Portable/Snippets/AbstractSnippetService.cs
@@ -18,17 +18,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Snippets
 {
-    internal abstract class AbstractSnippetService : ISnippetService
+    internal abstract class AbstractSnippetService(IEnumerable<Lazy<ISnippetProvider, LanguageMetadata>> lazySnippetProviders) : ISnippetService
     {
-        private readonly ImmutableArray<Lazy<ISnippetProvider, LanguageMetadata>> _lazySnippetProviders;
+        private readonly ImmutableArray<Lazy<ISnippetProvider, LanguageMetadata>> _lazySnippetProviders = lazySnippetProviders.ToImmutableArray();
         private readonly Dictionary<string, ISnippetProvider> _identifierToProviderMap = new();
         private readonly object _snippetProvidersLock = new();
         private ImmutableArray<ISnippetProvider> _snippetProviders;
-
-        public AbstractSnippetService(IEnumerable<Lazy<ISnippetProvider, LanguageMetadata>> lazySnippetProviders)
-        {
-            _lazySnippetProviders = lazySnippetProviders.ToImmutableArray();
-        }
 
         /// <summary>
         /// This should never be called prior to GetSnippetsAsync because it gets populated

--- a/src/Features/Core/Portable/Snippets/ExportSnippetProviderAttribute.cs
+++ b/src/Features/Core/Portable/Snippets/ExportSnippetProviderAttribute.cs
@@ -10,16 +10,9 @@ namespace Microsoft.CodeAnalysis.Snippets
 {
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class ExportSnippetProviderAttribute : ExportAttribute
+    internal sealed class ExportSnippetProviderAttribute(string name, string language) : ExportAttribute(typeof(ISnippetProvider))
     {
-        public string Name { get; }
-        public string Language { get; }
-
-        public ExportSnippetProviderAttribute(string name, string language)
-            : base(typeof(ISnippetProvider))
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Language = language ?? throw new ArgumentNullException(nameof(language));
-        }
+        public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+        public string Language { get; } = language ?? throw new ArgumentNullException(nameof(language));
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetData.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetData.cs
@@ -14,17 +14,10 @@ namespace Microsoft.CodeAnalysis.Snippets
     /// Avoids using the Snippet and creating a TextChange/finding cursor
     /// position before we know it was the selected CompletionItem.
     /// </summary>
-    internal readonly struct SnippetData
+    internal readonly struct SnippetData(string description, string identifier, ImmutableArray<string> additionalFilterTexts)
     {
-        public readonly string Description;
-        public readonly string Identifier;
-        public readonly ImmutableArray<string> AdditionalFilterTexts;
-
-        public SnippetData(string description, string identifier, ImmutableArray<string> additionalFilterTexts)
-        {
-            Description = description;
-            Identifier = identifier;
-            AdditionalFilterTexts = additionalFilterTexts;
-        }
+        public readonly string Description = description;
+        public readonly string Identifier = identifier;
+        public readonly ImmutableArray<string> AdditionalFilterTexts = additionalFilterTexts;
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetInfo.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetInfo.cs
@@ -6,19 +6,11 @@
 
 namespace Microsoft.CodeAnalysis.Snippets
 {
-    internal sealed class SnippetInfo
+    internal sealed class SnippetInfo(string shortcut, string title, string description, string path)
     {
-        public string Shortcut { get; }
-        public string Title { get; }
-        public string Description { get; }
-        public string Path { get; }
-
-        public SnippetInfo(string shortcut, string title, string description, string path)
-        {
-            Shortcut = shortcut;
-            Title = title;
-            Description = description;
-            Path = path;
-        }
+        public string Shortcut { get; } = shortcut;
+        public string Title { get; } = title;
+        public string Description { get; } = description;
+        public string Path { get; } = path;
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/IDocumentDifferenceService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IDocumentDifferenceService.cs
@@ -8,16 +8,10 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
-    internal class DocumentDifferenceResult
+    internal class DocumentDifferenceResult(InvocationReasons changeType, SyntaxNode? changedMember = null)
     {
-        public InvocationReasons ChangeType { get; }
-        public SyntaxNode? ChangedMember { get; }
-
-        public DocumentDifferenceResult(InvocationReasons changeType, SyntaxNode? changedMember = null)
-        {
-            ChangeType = changeType;
-            ChangedMember = changedMember;
-        }
+        public InvocationReasons ChangeType { get; } = changeType;
+        public SyntaxNode? ChangedMember { get; } = changedMember;
     }
 
     internal interface IDocumentDifferenceService : ILanguageService

--- a/src/Features/Core/Portable/SolutionCrawler/ISolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/ISolutionCrawlerProgressReporter.cs
@@ -25,21 +25,15 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         event EventHandler<ProgressData> ProgressChanged;
     }
 
-    internal readonly struct ProgressData
+    internal readonly struct ProgressData(ProgressStatus type, int? pendingItemCount)
     {
-        public ProgressStatus Status { get; }
+        public ProgressStatus Status { get; } = type;
 
         /// <summary>
         /// number of pending work item in the queue. 
         /// null means N/A for the associated <see cref="Status"/>
         /// </summary>
-        public int? PendingItemCount { get; }
-
-        public ProgressData(ProgressStatus type, int? pendingItemCount)
-        {
-            Status = type;
-            PendingItemCount = pendingItemCount;
-        }
+        public int? PendingItemCount { get; } = pendingItemCount;
     }
 
     internal enum ProgressStatus

--- a/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
@@ -12,39 +12,30 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
-    internal abstract class IdleProcessor
+    internal abstract class IdleProcessor(
+        IAsynchronousOperationListener listener,
+        TimeSpan backOffTimeSpan,
+        CancellationToken cancellationToken)
     {
         private static readonly TimeSpan s_minimumDelay = TimeSpan.FromMilliseconds(50);
 
         private readonly object _gate = new();
 
-        protected readonly IAsynchronousOperationListener Listener;
-        protected readonly CancellationToken CancellationToken;
-        protected readonly TimeSpan BackOffTimeSpan;
+        protected readonly IAsynchronousOperationListener Listener = listener;
+        protected readonly CancellationToken CancellationToken = cancellationToken;
+        protected readonly TimeSpan BackOffTimeSpan = backOffTimeSpan;
 
         // points to processor task
         private Task? _processorTask;
 
         // there is one thread that writes to it and one thread reads from it
-        private SharedStopwatch _timeSinceLastAccess;
+        private SharedStopwatch _timeSinceLastAccess = SharedStopwatch.StartNew();
 
         /// <summary>
         /// Whether or not this processor is paused.  As long as it is paused, it will not start executing new work,
         /// even if <see cref="BackOffTimeSpan"/> has been met.
         /// </summary>
         private bool _isPaused_doNotAccessDirectly;
-
-        public IdleProcessor(
-            IAsynchronousOperationListener listener,
-            TimeSpan backOffTimeSpan,
-            CancellationToken cancellationToken)
-        {
-            Listener = listener;
-            CancellationToken = cancellationToken;
-
-            BackOffTimeSpan = backOffTimeSpan;
-            _timeSinceLastAccess = SharedStopwatch.StartNew();
-        }
 
         protected abstract Task WaitAsync(CancellationToken cancellationToken);
         protected abstract Task ExecuteAsync();

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -304,18 +304,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        internal sealed class Registration
+        internal sealed class Registration(int correlationId, Workspace workspace, SolutionCrawlerProgressReporter progressReporter)
         {
-            public readonly int CorrelationId;
-            public readonly Workspace Workspace;
-            public readonly SolutionCrawlerProgressReporter ProgressReporter;
-
-            public Registration(int correlationId, Workspace workspace, SolutionCrawlerProgressReporter progressReporter)
-            {
-                CorrelationId = correlationId;
-                Workspace = workspace;
-                ProgressReporter = progressReporter;
-            }
+            public readonly int CorrelationId = correlationId;
+            public readonly Workspace Workspace = workspace;
+            public readonly SolutionCrawlerProgressReporter ProgressReporter = progressReporter;
 
             public Solution GetSolutionToAnalyze()
                 => Workspace.CurrentSolution;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -14,14 +14,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     {
         internal partial class WorkCoordinator
         {
-            private class AsyncDocumentWorkItemQueue : AsyncWorkItemQueue<DocumentId>
+            private class AsyncDocumentWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace) : AsyncWorkItemQueue<DocumentId>(progressReporter, workspace)
             {
                 private readonly Dictionary<ProjectId, Dictionary<DocumentId, WorkItem>> _documentWorkQueue = new();
-
-                public AsyncDocumentWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace)
-                    : base(progressReporter, workspace)
-                {
-                }
 
                 protected override int WorkItemCount_NoLock => _documentWorkQueue.Count;
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -15,14 +15,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     {
         internal partial class WorkCoordinator
         {
-            private sealed class AsyncProjectWorkItemQueue : AsyncWorkItemQueue<ProjectId>
+            private sealed class AsyncProjectWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace) : AsyncWorkItemQueue<ProjectId>(progressReporter, workspace)
             {
                 private readonly Dictionary<ProjectId, WorkItem> _projectWorkQueue = new();
-
-                public AsyncProjectWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace)
-                    : base(progressReporter, workspace)
-                {
-                }
 
                 protected override int WorkItemCount_NoLock => _projectWorkQueue.Count;
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -17,26 +17,18 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     {
         internal partial class WorkCoordinator
         {
-            private abstract class AsyncWorkItemQueue<TKey> : IDisposable
+            private abstract class AsyncWorkItemQueue<TKey>(SolutionCrawlerProgressReporter progressReporter, Workspace workspace) : IDisposable
                 where TKey : class
             {
                 private readonly object _gate = new();
-                private readonly SemaphoreSlim _semaphore;
+                private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(initialCount: 0);
                 private bool _disposed;
 
-                private readonly Workspace _workspace;
-                private readonly SolutionCrawlerProgressReporter _progressReporter;
+                private readonly Workspace _workspace = workspace;
+                private readonly SolutionCrawlerProgressReporter _progressReporter = progressReporter;
 
                 // map containing cancellation source for the item given out.
                 private readonly Dictionary<object, CancellationTokenSource> _cancellationMap = new();
-
-                public AsyncWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace)
-                {
-                    _semaphore = new SemaphoreSlim(initialCount: 0);
-
-                    _workspace = workspace;
-                    _progressReporter = progressReporter;
-                }
 
                 protected abstract int WorkItemCount_NoLock { get; }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -371,15 +371,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
                 }
 
-                private class AnalyzersGetter
+                private class AnalyzersGetter(IEnumerable<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> analyzerProviders)
                 {
-                    private readonly List<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> _analyzerProviders;
+                    private readonly List<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> _analyzerProviders = analyzerProviders.ToList();
                     private readonly Dictionary<Workspace, ImmutableArray<(IIncrementalAnalyzer analyzer, bool highPriorityForActiveFile)>> _analyzerMap = new();
-
-                    public AnalyzersGetter(IEnumerable<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> analyzerProviders)
-                    {
-                        _analyzerProviders = analyzerProviders.ToList();
-                    }
 
                     public ImmutableArray<IIncrementalAnalyzer> GetOrderedAnalyzers(Workspace workspace, bool onlyHighPriorityAnalyzer)
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -304,23 +304,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     return graph.GetProjectsThatDirectlyDependOnThisProject(projectId).Concat(projectId);
                 }
 
-                private readonly struct Data
+                private readonly struct Data(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
                 {
-                    private readonly DocumentId _documentId;
-                    private readonly Document? _document;
+                    private readonly DocumentId _documentId = documentId;
+                    private readonly Document? _document = document;
 
-                    public readonly Project Project;
-                    public readonly SyntaxPath? ChangedMember;
-                    public readonly IAsyncToken AsyncToken;
-
-                    public Data(Project project, DocumentId documentId, Document? document, SyntaxPath? changedMember, IAsyncToken asyncToken)
-                    {
-                        _documentId = documentId;
-                        _document = document;
-                        Project = project;
-                        ChangedMember = changedMember;
-                        AsyncToken = asyncToken;
-                    }
+                    public readonly Project Project = project;
+                    public readonly SyntaxPath? ChangedMember = changedMember;
+                    public readonly IAsyncToken AsyncToken = asyncToken;
 
                     public Document GetRequiredDocument()
                         => WorkCoordinator.GetRequiredDocument(Project, _documentId, _document);
@@ -444,18 +435,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             await EnqueueWorkItemAsync(project, documentId, document: null).ConfigureAwait(false);
                     }
 
-                    private readonly struct Data
+                    private readonly struct Data(ProjectId projectId, bool needDependencyTracking, IAsyncToken asyncToken)
                     {
-                        public readonly IAsyncToken AsyncToken;
-                        public readonly ProjectId ProjectId;
-                        public readonly bool NeedDependencyTracking;
-
-                        public Data(ProjectId projectId, bool needDependencyTracking, IAsyncToken asyncToken)
-                        {
-                            AsyncToken = asyncToken;
-                            ProjectId = projectId;
-                            NeedDependencyTracking = needDependencyTracking;
-                        }
+                        public readonly IAsyncToken AsyncToken = asyncToken;
+                        public readonly ProjectId ProjectId = projectId;
+                        public readonly bool NeedDependencyTracking = needDependencyTracking;
                     }
                 }
             }

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
@@ -35,20 +35,12 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             return spans.ToImmutable();
         }
 
-        private readonly ref struct Worker
+        private readonly ref struct Worker(ISyntaxFactsService syntaxFacts, ISyntaxClassificationService classifier, ArrayBuilder<SpellCheckSpan> spans)
         {
-            private readonly ISyntaxFactsService _syntaxFacts;
-            private readonly ISyntaxKinds _syntaxKinds;
-            private readonly ISyntaxClassificationService _classifier;
-            private readonly ArrayBuilder<SpellCheckSpan> _spans;
-
-            public Worker(ISyntaxFactsService syntaxFacts, ISyntaxClassificationService classifier, ArrayBuilder<SpellCheckSpan> spans)
-            {
-                _syntaxFacts = syntaxFacts;
-                _syntaxKinds = syntaxFacts.SyntaxKinds;
-                _classifier = classifier;
-                _spans = spans;
-            }
+            private readonly ISyntaxFactsService _syntaxFacts = syntaxFacts;
+            private readonly ISyntaxKinds _syntaxKinds = syntaxFacts.SyntaxKinds;
+            private readonly ISyntaxClassificationService _classifier = classifier;
+            private readonly ArrayBuilder<SpellCheckSpan> _spans = spans;
 
             private void AddSpan(SpellCheckSpan span)
             {

--- a/src/Features/Core/Portable/StackTraceExplorer/IgnoredFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/IgnoredFrame.cs
@@ -7,14 +7,9 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
 namespace Microsoft.CodeAnalysis.StackTraceExplorer
 {
-    internal sealed class IgnoredFrame : ParsedFrame
+    internal sealed class IgnoredFrame(VirtualCharSequence originalText) : ParsedFrame
     {
-        private readonly VirtualCharSequence _originalText;
-
-        public IgnoredFrame(VirtualCharSequence originalText)
-        {
-            _originalText = originalText;
-        }
+        private readonly VirtualCharSequence _originalText = originalText;
 
         public override string ToString()
         {

--- a/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
@@ -20,15 +20,10 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
     /// A line from <see cref="StackTraceAnalyzer.Parse(string, CancellationToken)"/> that
     /// was parsed by <see cref="StackFrameParser"/>
     /// </summary>
-    internal sealed class ParsedStackFrame : ParsedFrame
+    internal sealed class ParsedStackFrame(
+        StackFrameTree tree) : ParsedFrame
     {
-        public readonly StackFrameTree Tree;
-
-        public ParsedStackFrame(
-            StackFrameTree tree)
-        {
-            Tree = tree;
-        }
+        public readonly StackFrameTree Tree = tree;
 
         public StackFrameCompilationUnit Root => Tree.Root;
 

--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceAnalysisResult.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceAnalysisResult.cs
@@ -8,17 +8,11 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.StackTraceExplorer
 {
-    internal readonly struct StackTraceAnalysisResult
+    internal readonly struct StackTraceAnalysisResult(
+        string originalString,
+        ImmutableArray<ParsedFrame> parsedLines)
     {
-        public StackTraceAnalysisResult(
-            string originalString,
-            ImmutableArray<ParsedFrame> parsedLines)
-        {
-            OriginalString = originalString;
-            ParsedFrames = parsedLines;
-        }
-
-        public string OriginalString { get; }
-        public ImmutableArray<ParsedFrame> ParsedFrames { get; }
+        public string OriginalString { get; } = originalString;
+        public ImmutableArray<ParsedFrame> ParsedFrames { get; } = parsedLines;
     }
 }

--- a/src/Features/Core/Portable/StringIndentation/IStringIndentationService.cs
+++ b/src/Features/Core/Portable/StringIndentation/IStringIndentationService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.StringIndentation
         Task<ImmutableArray<StringIndentationRegion>> GetStringIndentationRegionsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
     }
 
-    internal readonly struct StringIndentationRegion
+    internal readonly struct StringIndentationRegion(TextSpan indentSpan, ImmutableArray<TextSpan> holeSpans = default)
     {
         /// <summary>
         /// The entire span of the indent region.  Given code like:
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.StringIndentation
         ///         """;
         /// </code>
         /// </summary>
-        public readonly TextSpan IndentSpan;
+        public readonly TextSpan IndentSpan = indentSpan;
 
         /// <summary>
         /// Regions of the literal that count as 'code holes' and which the lines of the tagger should not draw through.
@@ -107,12 +107,6 @@ namespace Microsoft.CodeAnalysis.StringIndentation
         /// </code>
         /// 
         /// </summary>
-        public readonly ImmutableArray<TextSpan> OrderedHoleSpans;
-
-        public StringIndentationRegion(TextSpan indentSpan, ImmutableArray<TextSpan> holeSpans = default)
-        {
-            IndentSpan = indentSpan;
-            OrderedHoleSpans = holeSpans.NullToEmpty().Sort();
-        }
+        public readonly ImmutableArray<TextSpan> OrderedHoleSpans = holeSpans.NullToEmpty().Sort();
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockSpan.cs
+++ b/src/Features/Core/Portable/Structure/BlockSpan.cs
@@ -6,24 +6,32 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal readonly struct BlockSpan
+    internal readonly struct BlockSpan(
+        string type,
+        bool isCollapsible,
+        TextSpan textSpan,
+        TextSpan hintSpan,
+        (TextSpan textSpan, TextSpan hintSpan)? primarySpans = null,
+        string bannerText = BlockSpan.Ellipses,
+        bool autoCollapse = false,
+        bool isDefaultCollapsed = false)
     {
         private const string Ellipses = "...";
 
         /// <summary>
         /// Whether or not this span can be collapsed.
         /// </summary>
-        public bool IsCollapsible { get; }
+        public bool IsCollapsible { get; } = isCollapsible;
 
         /// <summary>
         /// The span of text to collapse.
         /// </summary>
-        public TextSpan TextSpan { get; }
+        public TextSpan TextSpan { get; } = textSpan;
 
         /// <summary>
         /// The span of text to display in the hint on mouse hover.
         /// </summary>
-        public TextSpan HintSpan { get; }
+        public TextSpan HintSpan { get; } = hintSpan;
 
         /// <summary>
         /// Gets the optional span of the primary header of the code block represented by this tag. For example, in the
@@ -42,52 +50,32 @@ namespace Microsoft.CodeAnalysis.Structure
         /// block span for the  "if" block. This allows structure visualizing features to provide more useful context
         /// when visualizing "else" structure blocks.
         /// </summary>
-        public (TextSpan textSpan, TextSpan hintSpan)? PrimarySpans { get; }
+        public (TextSpan textSpan, TextSpan hintSpan)? PrimarySpans { get; } = primarySpans;
 
         /// <summary>
         /// The text to display inside the collapsed region.
         /// </summary>
-        public string BannerText { get; }
+        public string BannerText { get; } = bannerText;
 
         /// <summary>
         /// Whether or not this region should be automatically collapsed when the 'Collapse to Definitions' command is invoked.
         /// </summary>
-        public bool AutoCollapse { get; }
+        public bool AutoCollapse { get; } = autoCollapse;
 
         /// <summary>
         /// Whether this region should be collapsed by default when a file is opened the first time.
         /// </summary>
-        public bool IsDefaultCollapsed { get; }
+        public bool IsDefaultCollapsed { get; } = isDefaultCollapsed;
 
         /// <summary>
         /// A string defined from <see cref="BlockTypes"/>.
         /// </summary>
-        public string Type { get; }
+        public string Type { get; } = type;
 
         public BlockSpan(
             string type, bool isCollapsible, TextSpan textSpan, string bannerText = Ellipses, bool autoCollapse = false, bool isDefaultCollapsed = false)
             : this(type, isCollapsible, textSpan, textSpan, primarySpans: null, bannerText, autoCollapse, isDefaultCollapsed)
         {
-        }
-
-        public BlockSpan(
-            string type,
-            bool isCollapsible,
-            TextSpan textSpan,
-            TextSpan hintSpan,
-            (TextSpan textSpan, TextSpan hintSpan)? primarySpans = null,
-            string bannerText = Ellipses,
-            bool autoCollapse = false,
-            bool isDefaultCollapsed = false)
-        {
-            TextSpan = textSpan;
-            HintSpan = hintSpan;
-            PrimarySpans = primarySpans;
-            BannerText = bannerText;
-            AutoCollapse = autoCollapse;
-            IsDefaultCollapsed = isDefaultCollapsed;
-            IsCollapsible = isCollapsible;
-            Type = type;
         }
 
         public override string ToString()

--- a/src/Features/Core/Portable/Structure/BlockStructure.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructure.cs
@@ -8,11 +8,8 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
-    internal class BlockStructure
+    internal class BlockStructure(ImmutableArray<BlockSpan> spans)
     {
-        public ImmutableArray<BlockSpan> Spans { get; }
-
-        public BlockStructure(ImmutableArray<BlockSpan> spans)
-            => Spans = spans;
+        public ImmutableArray<BlockSpan> Spans { get; } = spans;
     }
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureContext.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureContext.cs
@@ -11,20 +11,13 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.Structure
 {
     [NonCopyable]
-    internal readonly struct BlockStructureContext : IDisposable
+    internal readonly struct BlockStructureContext(SyntaxTree syntaxTree, BlockStructureOptions options, CancellationToken cancellationToken) : IDisposable
     {
         public readonly ArrayBuilder<BlockSpan> Spans = ArrayBuilder<BlockSpan>.GetInstance();
 
-        public readonly SyntaxTree SyntaxTree;
-        public readonly BlockStructureOptions Options;
-        public readonly CancellationToken CancellationToken;
-
-        public BlockStructureContext(SyntaxTree syntaxTree, BlockStructureOptions options, CancellationToken cancellationToken)
-        {
-            SyntaxTree = syntaxTree;
-            Options = options;
-            CancellationToken = cancellationToken;
-        }
+        public readonly SyntaxTree SyntaxTree = syntaxTree;
+        public readonly BlockStructureOptions Options = options;
+        public readonly CancellationToken CancellationToken = cancellationToken;
 
         public void Dispose()
             => Spans.Free();

--- a/src/Features/Core/Portable/SymbolSearch/Windows/IAddReferenceDatabaseWrapper.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/IAddReferenceDatabaseWrapper.cs
@@ -19,11 +19,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         AddReferenceDatabase Database { get; }
     }
 
-    internal class AddReferenceDatabaseWrapper : IAddReferenceDatabaseWrapper
+    internal class AddReferenceDatabaseWrapper(AddReferenceDatabase database) : IAddReferenceDatabaseWrapper
     {
-        public AddReferenceDatabase Database { get; }
-
-        public AddReferenceDatabaseWrapper(AddReferenceDatabase database)
-            => Database = database;
+        public AddReferenceDatabase Database { get; } = database;
     }
 }

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -96,20 +96,12 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 s_logs.RemoveFirst();
         }
 
-        private sealed class Updater
+        private sealed class Updater(SymbolSearchUpdateEngine service, string source, string localSettingsDirectory)
         {
-            private readonly SymbolSearchUpdateEngine _service;
-            private readonly string _source;
-            private readonly DirectoryInfo _cacheDirectoryInfo;
-
-            public Updater(SymbolSearchUpdateEngine service, string source, string localSettingsDirectory)
-            {
-                _service = service;
-                _source = source;
-
-                _cacheDirectoryInfo = new DirectoryInfo(Path.Combine(
+            private readonly SymbolSearchUpdateEngine _service = service;
+            private readonly string _source = source;
+            private readonly DirectoryInfo _cacheDirectoryInfo = new DirectoryInfo(Path.Combine(
                     localSettingsDirectory, "PackageCache", string.Format(Invariant($"Format{AddReferenceDatabaseTextFileFormatVersion}"))));
-            }
 
             /// <summary>
             /// Internal for testing purposes.

--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngineProxy.cs
@@ -9,12 +9,9 @@ using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
-    internal sealed class SymbolSearchUpdateEngineProxy : ISymbolSearchUpdateEngine
+    internal sealed class SymbolSearchUpdateEngineProxy(RemoteHostClient client) : ISymbolSearchUpdateEngine
     {
-        private readonly RemoteServiceConnection<IRemoteSymbolSearchUpdateService> _connection;
-
-        public SymbolSearchUpdateEngineProxy(RemoteHostClient client)
-            => _connection = client.CreateConnection<IRemoteSymbolSearchUpdateService>(callbackTarget: null);
+        private readonly RemoteServiceConnection<IRemoteSymbolSearchUpdateService> _connection = client.CreateConnection<IRemoteSymbolSearchUpdateService>(callbackTarget: null);
 
         public void Dispose()
             => _connection.Dispose();

--- a/src/Features/Core/Portable/UnusedReferences/ReferenceInfo.cs
+++ b/src/Features/Core/Portable/UnusedReferences/ReferenceInfo.cs
@@ -9,13 +9,13 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.UnusedReferences
 {
     [DataContract]
-    internal class ReferenceInfo
+    internal class ReferenceInfo(ReferenceType referenceType, string itemSpecification, bool treatAsUsed, ImmutableArray<string> compilationAssemblies, ImmutableArray<ReferenceInfo> dependencies)
     {
         /// <summary>
         /// Indicates the type of reference.
         /// </summary>
         [DataMember(Order = 0)]
-        public ReferenceType ReferenceType { get; }
+        public ReferenceType ReferenceType { get; } = referenceType;
 
         /// <summary>
         /// Uniquely identifies the reference.
@@ -24,34 +24,25 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
         /// Should match the Include or Name attribute used in the project file.
         /// </remarks>
         [DataMember(Order = 1)]
-        public string ItemSpecification { get; }
+        public string ItemSpecification { get; } = itemSpecification;
 
         /// <summary>
         /// Indicates that this reference should be treated as if it were used.
         /// </summary>
         [DataMember(Order = 2)]
-        public bool TreatAsUsed { get; }
+        public bool TreatAsUsed { get; } = treatAsUsed;
 
         /// <summary>
         /// The full assembly paths that this reference directly adds to the compilation.
         /// </summary>
         [DataMember(Order = 3)]
-        public ImmutableArray<string> CompilationAssemblies { get; }
+        public ImmutableArray<string> CompilationAssemblies { get; } = compilationAssemblies;
 
         /// <summary>
         /// The dependencies that this reference transitively brings in to the compilation.
         /// </summary>
         [DataMember(Order = 4)]
-        public ImmutableArray<ReferenceInfo> Dependencies { get; }
-
-        public ReferenceInfo(ReferenceType referenceType, string itemSpecification, bool treatAsUsed, ImmutableArray<string> compilationAssemblies, ImmutableArray<ReferenceInfo> dependencies)
-        {
-            ReferenceType = referenceType;
-            ItemSpecification = itemSpecification;
-            TreatAsUsed = treatAsUsed;
-            CompilationAssemblies = compilationAssemblies;
-            Dependencies = dependencies;
-        }
+        public ImmutableArray<ReferenceInfo> Dependencies { get; } = dependencies;
 
         public ReferenceInfo WithItemSpecification(string itemSpecification)
             => new(ReferenceType, itemSpecification, TreatAsUsed, CompilationAssemblies, Dependencies);

--- a/src/Features/Core/Portable/UnusedReferences/ReferenceUpdate.cs
+++ b/src/Features/Core/Portable/UnusedReferences/ReferenceUpdate.cs
@@ -4,22 +4,16 @@
 
 namespace Microsoft.CodeAnalysis.UnusedReferences
 {
-    internal sealed class ReferenceUpdate
+    internal sealed class ReferenceUpdate(UpdateAction action, ReferenceInfo referenceInfo)
     {
         /// <summary>
         /// Indicates action to perform on the reference.
         /// </summary>
-        public UpdateAction Action { get; set; }
+        public UpdateAction Action { get; set; } = action;
 
         /// <summary>
         /// Gets the reference to be updated.
         /// </summary>
-        public ReferenceInfo ReferenceInfo { get; }
-
-        public ReferenceUpdate(UpdateAction action, ReferenceInfo referenceInfo)
-        {
-            Action = action;
-            ReferenceInfo = referenceInfo;
-        }
+        public ReferenceInfo ReferenceInfo { get; } = referenceInfo;
     }
 }

--- a/src/Features/Core/Portable/ValueTracking/SerializableValueTrackedItem.cs
+++ b/src/Features/Core/Portable/ValueTracking/SerializableValueTrackedItem.cs
@@ -12,31 +12,23 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.ValueTracking
 {
     [DataContract]
-    internal sealed class SerializableValueTrackedItem
+    internal sealed class SerializableValueTrackedItem(
+        SymbolKey symbolKey,
+        TextSpan textSpan,
+        DocumentId documentId,
+        SerializableValueTrackedItem? parent = null)
     {
         [DataMember(Order = 0)]
-        public SymbolKey SymbolKey { get; }
+        public SymbolKey SymbolKey { get; } = symbolKey;
 
         [DataMember(Order = 1)]
-        public TextSpan TextSpan { get; }
+        public TextSpan TextSpan { get; } = textSpan;
 
         [DataMember(Order = 2)]
-        public DocumentId DocumentId { get; }
+        public DocumentId DocumentId { get; } = documentId;
 
         [DataMember(Order = 3)]
-        public SerializableValueTrackedItem? Parent { get; }
-
-        public SerializableValueTrackedItem(
-            SymbolKey symbolKey,
-            TextSpan textSpan,
-            DocumentId documentId,
-            SerializableValueTrackedItem? parent = null)
-        {
-            SymbolKey = symbolKey;
-            Parent = parent;
-            TextSpan = textSpan;
-            DocumentId = documentId;
-        }
+        public SerializableValueTrackedItem? Parent { get; } = parent;
 
         public static SerializableValueTrackedItem Dehydrate(Solution solution, ValueTrackedItem valueTrackedItem, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
@@ -14,13 +14,9 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 {
     internal static partial class ValueTracker
     {
-        private class FindReferencesProgress : IStreamingFindReferencesProgress, IStreamingProgressTracker
+        private class FindReferencesProgress(OperationCollector valueTrackingProgressCollector) : IStreamingFindReferencesProgress, IStreamingProgressTracker
         {
-            private readonly OperationCollector _operationCollector;
-            public FindReferencesProgress(OperationCollector valueTrackingProgressCollector)
-            {
-                _operationCollector = valueTrackingProgressCollector;
-            }
+            private readonly OperationCollector _operationCollector = valueTrackingProgressCollector;
 
             public IStreamingProgressTracker ProgressTracker => this;
 

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.OperationCollector.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.OperationCollector.cs
@@ -15,16 +15,10 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 {
     internal static partial class ValueTracker
     {
-        private class OperationCollector
+        private class OperationCollector(ValueTrackingProgressCollector progressCollector, Solution solution)
         {
-            public ValueTrackingProgressCollector ProgressCollector { get; }
-            public Solution Solution { get; }
-
-            public OperationCollector(ValueTrackingProgressCollector progressCollector, Solution solution)
-            {
-                ProgressCollector = progressCollector;
-                Solution = solution;
-            }
+            public ValueTrackingProgressCollector ProgressCollector { get; } = progressCollector;
+            public Solution Solution { get; } = solution;
 
             public Task VisitAsync(IOperation operation, CancellationToken cancellationToken)
                 => operation switch

--- a/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
+++ b/src/Features/Core/Portable/Workspace/MiscellaneousFileUtilities.cs
@@ -101,16 +101,10 @@ namespace Microsoft.CodeAnalysis.Features.Workspaces
         }
     }
 
-    internal class LanguageInformation
+    internal class LanguageInformation(string languageName, string scriptExtension)
     {
-        public LanguageInformation(string languageName, string scriptExtension)
-        {
-            this.LanguageName = languageName;
-            this.ScriptExtension = scriptExtension;
-        }
-
-        public string LanguageName { get; }
-        public string ScriptExtension { get; }
+        public string LanguageName { get; } = languageName;
+        public string ScriptExtension { get; } = scriptExtension;
     }
 }
 

--- a/src/Features/Core/Portable/Wrapping/Edit.cs
+++ b/src/Features/Core/Portable/Wrapping/Edit.cs
@@ -70,22 +70,13 @@ namespace Microsoft.CodeAnalysis.Wrapping
             return new Edit(leftLastToken, leftTrailingTrivia, rightFirstToken, rightLeadingTrivia);
         }
 
-        private sealed class InvalidEditException : Exception
+        private sealed class InvalidEditException(SyntaxToken left, SyntaxToken right) : Exception($"Left token had an end '{left.Span.End}' past the start of right token '{right.Span.Start}'")
         {
             // Used for analyzing dumps
 #pragma warning disable IDE0052 // Remove unread private members
-            private readonly SyntaxTree? _tree;
-            private readonly SyntaxToken _left;
-            private readonly SyntaxToken _right;
-#pragma warning restore IDE0052 // Remove unread private members
-
-            public InvalidEditException(SyntaxToken left, SyntaxToken right)
-                : base($"Left token had an end '{left.Span.End}' past the start of right token '{right.Span.Start}'")
-            {
-                _tree = left.SyntaxTree;
-                _left = left;
-                _right = right;
-            }
+            private readonly SyntaxTree? _tree = left.SyntaxTree;
+            private readonly SyntaxToken _left = left;
+            private readonly SyntaxToken _right = right;
         }
     }
 }

--- a/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
+++ b/src/Features/Core/Portable/Wrapping/WrapItemsAction.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
     /// also update the wrapping most-recently-used list when the code action is actually
     /// invoked.
     /// </summary>
-    internal class WrapItemsAction : DocumentChangeAction
+    internal class WrapItemsAction(string title, string parentTitle, Func<CancellationToken, Task<Document>> createChangedDocument) : DocumentChangeAction(title, createChangedDocument, title, CodeActionPriority.Low)
     {
         // Keeps track of the invoked code actions.  That way we can prioritize those code actions 
         // in the future since they're more likely the ones the user wants.  This is important as 
@@ -29,22 +29,9 @@ namespace Microsoft.CodeAnalysis.Wrapping
         // choose to be prioritized accordingly.
         private static ImmutableArray<string> s_mruTitles = ImmutableArray<string>.Empty;
 
-        public string ParentTitle { get; }
+        public string ParentTitle { get; } = parentTitle;
 
-        public string SortTitle { get; }
-
-        // Make our code action low priority.  This option will be offered *a lot*, and 
-        // much of  the time will not be something the user particularly wants to do.  
-        // It should be offered after all other normal refactorings.
-        //
-        // This value is only relevant if this code action is the only one in its group,
-        // and it ends up getting inlined as a top-level-action that is offered.
-        public WrapItemsAction(string title, string parentTitle, Func<CancellationToken, Task<Document>> createChangedDocument)
-            : base(title, createChangedDocument, title, CodeActionPriority.Low)
-        {
-            ParentTitle = parentTitle;
-            SortTitle = parentTitle + "_" + title;
-        }
+        public string SortTitle { get; } = parentTitle + "_" + title;
 
         protected override Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
         {
@@ -96,16 +83,10 @@ namespace Microsoft.CodeAnalysis.Wrapping
         private static string GetSortTitle(CodeAction codeAction)
             => (codeAction as WrapItemsAction)?.SortTitle ?? codeAction.Title;
 
-        private class RecordCodeActionOperation : CodeActionOperation
+        private class RecordCodeActionOperation(string sortTitle, string parentTitle) : CodeActionOperation
         {
-            private readonly string _sortTitle;
-            private readonly string _parentTitle;
-
-            public RecordCodeActionOperation(string sortTitle, string parentTitle)
-            {
-                _sortTitle = sortTitle;
-                _parentTitle = parentTitle;
-            }
+            private readonly string _sortTitle = sortTitle;
+            private readonly string _parentTitle = parentTitle;
 
             internal override bool ApplyDuringTests => false;
 

--- a/src/Features/Core/Portable/Wrapping/WrappingGroup.cs
+++ b/src/Features/Core/Portable/Wrapping/WrappingGroup.cs
@@ -16,22 +16,16 @@ namespace Microsoft.CodeAnalysis.Wrapping
     ///         wrap all optoin 2
     ///         ...
     /// </summary>
-    internal readonly struct WrappingGroup
+    internal readonly struct WrappingGroup(bool isInlinable, ImmutableArray<WrapItemsAction> wrappingActions)
     {
         /// <summary>
         /// Whether or not the items in this group can be inlined in the topmost lightbulb.
         /// </summary>
-        public readonly bool IsInlinable;
+        public readonly bool IsInlinable = isInlinable;
 
         /// <summary>
         /// The actual wrapping code actions for this group to present to the user.
         /// </summary>
-        public readonly ImmutableArray<WrapItemsAction> WrappingActions;
-
-        public WrappingGroup(bool isInlinable, ImmutableArray<WrapItemsAction> wrappingActions)
-        {
-            IsInlinable = isInlinable;
-            WrappingActions = wrappingActions;
-        }
+        public readonly ImmutableArray<WrapItemsAction> WrappingActions = wrappingActions;
     }
 }


### PR DESCRIPTION
This approach differs from the last in that we preserve redundant fields.  We can consider followup PRs that then remove these.   It does make the code somewhat more confusing to keep these in, as these state values are themselves never read from other instances.  But this may smooth out the transition to using these.