### PR TITLE
Reduce memory consumption around SpellChecker object creation/usage.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -70,15 +70,24 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public bool ContainsExtensionMethod => _receiverTypeNameToExtensionMethodMap?.Count > 0;
 
-        private readonly SpellChecker _spellChecker;
+        private SpellChecker? _spellChecker;
+        private SpellChecker SpellChecker
+        {
+            get
+            {
+                _spellChecker ??= CreateSpellChecker(Checksum, _nodes);
+
+                return _spellChecker.Value;
+            }
+        }
 
         private SymbolTreeInfo(
             Checksum checksum,
             ImmutableArray<Node> sortedNodes,
-            SpellChecker spellChecker,
             OrderPreservingMultiDictionary<string, string> inheritanceMap,
             MultiDictionary<string, ExtensionMethodInfo>? receiverTypeNameToExtensionMethodMap)
-            : this(checksum, sortedNodes, spellChecker,
+            : this(checksum, sortedNodes,
+                   spellChecker: null,
                    CreateIndexBasedInheritanceMap(sortedNodes, inheritanceMap),
                    receiverTypeNameToExtensionMethodMap)
         {
@@ -87,7 +96,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private SymbolTreeInfo(
             Checksum checksum,
             ImmutableArray<Node> sortedNodes,
-            SpellChecker spellChecker,
+            SpellChecker? spellChecker,
             OrderPreservingMultiDictionary<int, int> inheritanceMap,
             MultiDictionary<string, ExtensionMethodInfo>? receiverTypeNameToExtensionMethodMap)
         {
@@ -104,7 +113,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var sortedNodes = SortNodes(unsortedNodes);
 
             return new SymbolTreeInfo(checksum, sortedNodes,
-                CreateSpellChecker(checksum, sortedNodes),
                 new OrderPreservingMultiDictionary<string, string>(),
                 new MultiDictionary<string, ExtensionMethodInfo>());
         }
@@ -173,7 +181,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             using var similarNames = TemporaryArray<string>.Empty;
             using var result = TemporaryArray<ISymbol>.Empty;
 
-            _spellChecker.FindSimilarWords(ref similarNames.AsRef(), name, substringsAreSimilar: false);
+            SpellChecker.FindSimilarWords(ref similarNames.AsRef(), name, substringsAreSimilar: false);
 
             foreach (var similarName in similarNames)
             {
@@ -459,10 +467,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             MultiDictionary<string, ExtensionMethodInfo>? receiverTypeNameToExtensionMethodMap)
         {
             var sortedNodes = SortNodes(unsortedNodes);
-            var spellChecker = CreateSpellChecker(checksum, sortedNodes);
 
             return new SymbolTreeInfo(
-                checksum, sortedNodes, spellChecker, inheritanceMap, receiverTypeNameToExtensionMethodMap);
+                checksum, sortedNodes, inheritanceMap, receiverTypeNameToExtensionMethodMap);
         }
 
         private static OrderPreservingMultiDictionary<int, int> CreateIndexBasedInheritanceMap(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Builder.cs
@@ -95,7 +95,7 @@ namespace Roslyn.Utilities
             {
                 // TODO(cyrusn): Properly handle unicode normalization here.
                 var distinctValues = values.Where(v => v.Length > 0).Distinct(CaseInsensitiveComparison.Comparer).ToArray();
-                var charCount = values.Sum(v => v.Length);
+                var charCount = distinctValues.Sum(v => v.Length);
 
                 _concatenatedLowerCaseWords = new char[charCount];
                 _wordSpans = new TextSpan[distinctValues.Length];


### PR DESCRIPTION
It is surprisingly difficult to find a codepath that actually requires the SymbolTreeInfo's spellchecker object to be populated. FuzzyFindAsync is the only codepath that requires it, so it makes sense to lazily defer creation of the spellchecker until that method is invoked.

As SymbolTreeInfo is serialized, that process needed to be modified to allow a null spellchecker.

Finally, I noticed a small bug in BKTree.Builder's ctor where it was creating a char array that could be too large (depending on whether it's input values contains duplicates)