### PR TITLE
Break individual string literals into multiple spell checking spans for all the individual words within them.

### DIFF
--- a/src/EditorFeatures/CSharpTest/SpellCheck/SpellCheckSpanTests.cs
+++ b/src/EditorFeatures/CSharpTest/SpellCheck/SpellCheckSpanTests.cs
@@ -101,125 +101,173 @@ class {|Identifier:C|}
         [Fact]
         public async Task TestString1()
         {
-            await TestAsync(@"{|String:"" goo ""|}");
+            await TestAsync(@""" {|String:goo|} """);
         }
 
         [Fact]
         public async Task TestString2()
         {
-            await TestAsync(@"{|String:"" goo |}");
+            await TestAsync(@""" goo ");
         }
 
         [Fact]
         public async Task TestString3()
         {
             await TestAsync(@"
-{|String:"" goo ""|}");
+"" {|String:goo|} """);
         }
 
         [Fact]
         public async Task TestString4()
         {
             await TestAsync(@"
-{|String:"" goo |}");
+"" goo ");
         }
 
         [Fact]
         public async Task TestString5()
         {
             await TestAsync(@"
-{|String:@"" goo ""|}");
+@"" {|String:goo|} """);
         }
 
         [Fact]
         public async Task TestString6()
         {
             await TestAsync(@"
-{|String:@"" goo |}");
+@"" goo ");
         }
 
         [Fact]
         public async Task TestString7()
         {
-            await TestAsync(@"{|String:"""""" goo """"""|}");
+            await TestAsync(@""""""" {|String:goo|} """"""");
         }
 
         [Fact]
         public async Task TestString8()
         {
-            await TestAsync(@"{|String:"""""" goo """"|}");
+            await TestAsync(@""""""" goo """"");
         }
 
         [Fact]
         public async Task TestString9()
         {
-            await TestAsync(@"{|String:"""""" goo ""|}");
+            await TestAsync(@""""""" goo """);
         }
 
         [Fact]
         public async Task TestString10()
         {
-            await TestAsync(@"{|String:"""""" goo |}");
+            await TestAsync(@""""""" goo ");
         }
 
         [Fact]
         public async Task TestString11()
         {
-            await TestAsync(@"{|String:""""""
-    goo 
-    """"""|}");
+            await TestAsync(@"""""""
+    {|String:goo|} 
+    """"""");
         }
 
         [Fact]
         public async Task TestString12()
         {
-            await TestAsync(@"{|String:""""""
+            await TestAsync(@"""""""
     goo
-    """"|}");
+    """"");
         }
 
         [Fact]
         public async Task TestString13()
         {
-            await TestAsync(@"{|String:""""""
+            await TestAsync(@"""""""
     goo
-    ""|}");
+    """);
         }
 
         [Fact]
         public async Task TestString14()
         {
-            await TestAsync(@"{|String:""""""
+            await TestAsync(@"""""""
     goo
-    |}");
+    ");
         }
 
         [Fact]
         public async Task TestString15()
         {
             await TestAsync(@"
-$""{|String: goo |}""");
+$"" {|String:goo|} """);
         }
 
         [Fact]
         public async Task TestString16()
         {
             await TestAsync(@"
-$""{|String: goo |}{0}{|String: bar |}""");
+$"" {|String:goo|} {0} {|String:bar|} """);
         }
 
         [Fact]
         public async Task TestString17()
         {
             await TestAsync(@"
-$""""""{|String: goo |}{0}{|String: bar |}""""""");
+$"""""" {|String:goo|} {0} {|String:bar|} """"""");
         }
 
         [Fact]
         public async Task TestString18()
         {
             await TestAsync(@"
-$""""""{|String: goo |}{0:abcd}{|String: bar |}""""""");
+$"""""" {|String:goo|} {0:abcd} {|String:bar|} """"""");
+        }
+
+        [Fact]
+        public async Task TestEscapedString1()
+        {
+            await TestAsync(""" " {|String:goo|}\r\n{|String:bar|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString2()
+        {
+            await TestAsync(""" " {|String:goo|}\r\t{|String:bar|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString3()
+        {
+            await TestAsync(""" " {|String:goo|}\r\u0065bar " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString4()
+        {
+            await TestAsync(""" " {|String:C|}:\t{|String:ests|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString5()
+        {
+            await TestAsync(""" @" {|String:C|}:\{|String:tests|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString6()
+        {
+            await TestAsync(""" " {|String:C|}:\\{|String:tests|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString7()
+        {
+            await TestAsync(""" " {|String:C|}:\\{|String:tests|}\\{|String:goo|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString8()
+        {
+            await TestAsync(""" @" {|String:C|}:\{|String:tests|}\{|String:goo|} " """);
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/SpellCheck/CSharpSpellCheckSpanService.cs
+++ b/src/Features/CSharp/Portable/SpellCheck/CSharpSpellCheckSpanService.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Composition;
-using Microsoft.CodeAnalysis.CSharp.Classification;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.SpellCheck;
 

--- a/src/Features/VisualBasicTest/SpellCheck/SpellCheckSpanTests.vb
+++ b/src/Features/VisualBasicTest/SpellCheck/SpellCheckSpanTests.vb
@@ -53,49 +53,49 @@ end class")
         <Fact>
         Public Async Function TestString1() As Task
             Await TestAsync("
-dim {|Identifier:x|} = {|String:"" goo ""|}")
+dim {|Identifier:x|} = "" {|String:goo|} """)
         End Function
 
         <Fact>
         Public Async Function TestString2() As Task
             Await TestAsync("
-dim {|Identifier:x|} = {|String:"" goo |}")
+dim {|Identifier:x|} = "" goo ")
         End Function
 
         <Fact>
         Public Async Function TestString3() As Task
             Await TestAsync("
-dim {|Identifier:x|} = {|String:""
-    goo
-""|}")
+dim {|Identifier:x|} = ""
+    {|String:goo|}
+""")
         End Function
 
         <Fact>
         Public Async Function TestString4() As Task
             Await TestAsync("
-dim {|Identifier:x|} = {|String:""
+dim {|Identifier:x|} = ""
     goo
-|}")
+")
         End Function
 
         <Fact>
         Public Async Function TestString5() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $""{|String: goo |}""")
+dim {|Identifier:x|} = $"" {|String:goo|} """)
         End Function
 
         <Fact>
         Public Async Function TestString6() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $""{|String:
-    goo
-|}""")
+dim {|Identifier:x|} = $""
+    {|String:goo|}
+""")
         End Function
 
         <Fact>
         Public Async Function TestString7() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $""{|String: goo |}{0}{|String: bar |}""")
+dim {|Identifier:x|} = $"" {|String:goo|} {0} {|String:bar|} """)
         End Function
 
         <Fact>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
@@ -90,6 +90,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
         public bool IsDigit
             => SurrogateChar != 0 ? char.IsDigit(SurrogateChar) : Rune.IsDigit(Rune);
 
+        public bool IsLetter
+            => SurrogateChar != 0 ? char.IsLetter(SurrogateChar) : Rune.IsLetter(Rune);
+
         public bool IsLetterOrDigit
             => SurrogateChar != 0 ? char.IsLetterOrDigit(SurrogateChar) : Rune.IsLetterOrDigit(Rune);
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1846094

The editor isn't able to determine waht to do with an escaped C# character (like `\u0065`).  To address this, we have the language server itself only return only the portions of a string literal corresponding to sequences of unescaped letters.  