### PR TITLE
EnC analyzer refactoring: Abstract member bodies

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -4,6 +4,9 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -257,13 +257,7 @@ namespace Roslyn.Utilities
         public static OneOrMany<T> Create<T>(T one)
             => new OneOrMany<T>(one);
 
-        public static OneOrMany<T> Create<T>(T one, T two)
-            => new OneOrMany<T>(ImmutableArray.Create(one, two));
-
         public static OneOrMany<T> Create<T>(ImmutableArray<T> many)
             => new OneOrMany<T>(many);
-
-        public static OneOrMany<T> OneOrNone<T>(T? item)
-            => item is null ? OneOrMany<T>.Empty : new OneOrMany<T>(item);
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -258,7 +257,13 @@ namespace Roslyn.Utilities
         public static OneOrMany<T> Create<T>(T one)
             => new OneOrMany<T>(one);
 
+        public static OneOrMany<T> Create<T>(T one, T two)
+            => new OneOrMany<T>(ImmutableArray.Create(one, two));
+
         public static OneOrMany<T> Create<T>(ImmutableArray<T> many)
             => new OneOrMany<T>(many);
+
+        public static OneOrMany<T> OneOrNone<T>(T? item)
+            => item is null ? OneOrMany<T>.Empty : new OneOrMany<T>(item);
     }
 }

--- a/src/Compilers/Test/Core/Mocks/TestEqualityComparer.cs
+++ b/src/Compilers/Test/Core/Mocks/TestEqualityComparer.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Roslyn.Test.Utilities
+{
+    public class TestEqualityComparer<T>(Func<T?, T?, bool>? equals = null, Func<T, int>? getHashCode = null) : IEqualityComparer<T>
+    {
+        public bool Equals(T? x, T? y)
+            => (equals ?? EqualityComparer<T>.Default.Equals)(x, y);
+
+        public int GetHashCode([DisallowNull] T obj)
+            => (getHashCode ?? EqualityComparer<T>.Default.GetHashCode!)(obj);
+    }
+}

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
@@ -53,7 +53,7 @@ class C
                 {
                     DocumentResults(
                         active,
-                        diagnostics: new[] { Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.method, "Goo(int a)")) })
+                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", DeletedSymbolDisplay(FeaturesResources.method, "Goo(int a)")) })
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -726,14 +726,14 @@ class C
         }
 
         [Fact]
-        public void Delete_EntireNamespace()
+        public void Delete_Entire_Namespace()
         {
             var src1 = @"
 namespace N
 {
     class C
     {
-        static void Main(String[] args)
+        static void Main()
         {
             <AS:0>Console.WriteLine(1);</AS:0>
         }
@@ -745,7 +745,62 @@ namespace N
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, null, DeletedSymbolDisplay(FeaturesResources.class_, "N.C")));
+                Diagnostic(RudeEditKind.Delete, "", GetResource("class", "N.C")),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "Main()")));
+        }
+
+        [Fact]
+        public void Delete_Entire_Type()
+        {
+            var src1 = @"
+namespace N
+{
+    class C
+    {
+        static void Main()
+        {
+            <AS:0>Console.WriteLine(1);</AS:0>
+        }
+    }
+}";
+            var src2 = @"<AS:0>namespace N</AS:0>;";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active,
+                Diagnostic(RudeEditKind.Delete, "namespace N", GetResource("class", "C")),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method", "Main()")));
+        }
+
+        [Fact]
+        public void Delete_Entire_Method()
+        {
+            var src1 = @"
+namespace N
+{
+    class C
+    {
+        static void Main()
+        {
+            <AS:0>Console.WriteLine(1);</AS:0>
+        }
+    }
+}";
+            var src2 = @"
+namespace N
+{
+    <AS:0>class C</AS:0>
+    {
+    }
+}
+";
+
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active,
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("method", "Main()")));
         }
 
         #endregion
@@ -1046,8 +1101,8 @@ class A
             edits.VerifySemanticDiagnostics(active);
         }
 
-        [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/742334")]
-        public void InstanceConstructorWithoutInitializer()
+        [Fact]
+        public void Constructor_Instance_ImplicitInitializer()
         {
             var src1 = @"
 class C
@@ -1080,7 +1135,26 @@ class C
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializer_Internal_Update1()
+        public void Constructor_Instance_ExplicitInitializer_Update_Subexpression()
+        {
+            var src1 = @"
+class C
+{
+    public C(int a) : base(a switch { 1 => <AS:0>1</AS:0>, _ => 2 }) {}
+}";
+            var src2 = @"
+class C
+{
+    public C(int a) : base(1) <AS:0>{</AS:0>}
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_Instance_ExplicitInitializer_Update_Internal()
         {
             var src1 = @"
 class D
@@ -1138,7 +1212,117 @@ class C : D
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializer_Internal_Update2()
+        public void Constructor_Instance_ExplicitInitializer_Update_Leaf()
+        {
+            var src1 = @"
+class D
+{
+    public D(int d) { }
+}
+
+class C : D
+{
+    public C() : <AS:0>base(1)</AS:0> {}
+
+    static void Main(string[] args)
+    {
+        <AS:1>C c = new C();</AS:1>
+    }
+}";
+            var src2 = @"
+class D
+{
+    public D(int d) { }
+}
+
+class C : D
+{
+    public C() : <AS:0>base(2)</AS:0> {}
+
+    static void Main(string[] args)
+    {
+        <AS:1>C c = new C();</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_Instance_ImplicitInitializer_Update_ToExplicit_Leaf()
+        {
+            var src1 = @"
+class D
+{
+    public D() { }
+    public D(int d) { }
+}
+
+class C : D
+{
+    <AS:0>public C()</AS:0> {}
+
+    static void Main(string[] args)
+    {
+        <AS:1>C c = new C();</AS:1>
+    }
+}";
+            var src2 = @"
+class D
+{
+    public D() { }
+    public D(int d) { }
+}
+
+class C : D
+{
+    public C() : <AS:0>base(2)</AS:0> {}
+
+    static void Main(string[] args)
+    {
+        <AS:1>C c = new C();</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active);
+        }
+
+        [Fact]
+        public void Constructor_Instance_ImplicitInitializer_Update_ToExplicit_Internal()
+        {
+            var src1 = @"
+class D
+{
+    public D(int d) <AS:0>{</AS:0> }
+}
+
+class C : D
+{
+    <AS:1>public C()</AS:1> {}
+}";
+            var src2 = @"
+class D
+{
+    public D(int d) <AS:0>{</AS:0> }
+}
+
+class C : D
+{
+    public C() : <AS:1>base(1)</AS:1> {}
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "base(1)"));
+        }
+
+        [Fact]
+        public void Constructor_Instance_ExplicitInitializer_Update_ToImplicit_Internal()
         {
             var src1 = @"
 class D
@@ -1188,76 +1372,7 @@ class C : D
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializer_Internal_Update3()
-        {
-            var src1 = @"
-class D
-{
-    public D(int d) <AS:0>{</AS:0> }
-}
-
-class C : D
-{
-    <AS:1>public C()</AS:1> {}
-}";
-            var src2 = @"
-class D
-{
-    public D(int d) <AS:0>{</AS:0> }
-}
-
-class C : D
-{
-    public C() : <AS:1>base(1)</AS:1> {}
-}";
-            var edits = GetTopEdits(src1, src2);
-            var active = GetActiveStatements(src1, src2);
-
-            edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementUpdate, "base(1)"));
-        }
-
-        [Fact]
-        public void InstanceConstructorWithInitializer_Leaf_Update1()
-        {
-            var src1 = @"
-class D
-{
-    public D(int d) { }
-}
-
-class C : D
-{
-    public C() : <AS:0>base(1)</AS:0> {}
-
-    static void Main(string[] args)
-    {
-        <AS:1>C c = new C();</AS:1>
-    }
-}";
-            var src2 = @"
-class D
-{
-    public D(int d) { }
-}
-
-class C : D
-{
-    public C() : <AS:0>base(2)</AS:0> {}
-
-    static void Main(string[] args)
-    {
-        <AS:1>C c = new C();</AS:1>
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-            var active = GetActiveStatements(src1, src2);
-
-            edits.VerifySemanticDiagnostics(active);
-        }
-
-        [Fact]
-        public void InstanceConstructorWithInitializer_Leaf_Update2()
+        public void Constructor_Instance_ExplicitInitializer_Update_ToImplicit_Leaf()
         {
             var src1 = @"
 class D
@@ -1298,48 +1413,7 @@ class C : D
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializer_Leaf_Update3()
-        {
-            var src1 = @"
-class D
-{
-    public D() { }
-    public D(int d) { }
-}
-
-class C : D
-{
-    <AS:0>public C()</AS:0> {}
-
-    static void Main(string[] args)
-    {
-        <AS:1>C c = new C();</AS:1>
-    }
-}";
-            var src2 = @"
-class D
-{
-    public D() { }
-    public D(int d) { }
-}
-
-class C : D
-{
-    public C() : <AS:0>base(2)</AS:0> {}
-
-    static void Main(string[] args)
-    {
-        <AS:1>C c = new C();</AS:1>
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-            var active = GetActiveStatements(src1, src2);
-
-            edits.VerifySemanticDiagnostics(active);
-        }
-
-        [Fact]
-        public void InstanceConstructorWithInitializerWithLambda_Update1()
+        public void Constructor_Instance_ExplicitInitializer_WithLambda_Update1()
         {
             var src1 = @"
 class C
@@ -1358,7 +1432,7 @@ class C
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializerWithLambda_Update2()
+        public void Constructor_Instance_ExplicitInitializer_WithLambda_Update2()
         {
             var src1 = @"
 class C
@@ -1377,7 +1451,7 @@ class C
         }
 
         [Fact]
-        public void InstanceConstructorWithInitializerWithLambda_Update3()
+        public void Constructor_Instance_ExplicitInitializer_WithLambda_Update3()
         {
             var src1 = @"
 class C
@@ -1395,10 +1469,29 @@ class C
             edits.VerifySemanticDiagnostics(active);
         }
 
+        [Fact]
+        public void Constructor_Instance_ExplicitInitializer_Delete()
+        {
+            var src1 = @"
+class C
+{
+    public C(int a) : base(a switch { 1 => <AS:0>1</AS:0>, _ => 2 }) {}
+}";
+            var src2 = @"
+class C
+{
+    public C(int a) <AS:0>{</AS:0>}
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(active);
+        }
+
         [Theory]
         [InlineData("class ")]
         [InlineData("struct")]
-        public void InstanceConstructor_DeleteParameterless(string typeKind)
+        public void Constructor_Instance_Delete_Parameterless(string typeKind)
         {
             var src1 = "partial " + typeKind + " C { public C() { <AS:0>System.Console.WriteLine(1);</AS:0> } }";
             var src2 = "<AS:0>partial " + typeKind + " C</AS:0> { }";
@@ -2225,7 +2318,8 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.field, "a")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("field", "a")),
+                Diagnostic(RudeEditKind.Delete, "class C", GetResource("field", "a")));
         }
 
         [Fact]
@@ -2359,8 +2453,9 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.Move, "int c", FeaturesResources.field),
-                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.field, "a")));
+                Diagnostic(RudeEditKind.Move, "int c", GetResource("field")),
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("field", "a")),
+                Diagnostic(RudeEditKind.Delete, "class C", GetResource("field", "a")));
         }
 
         [Fact]
@@ -2410,7 +2505,8 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.Delete, "class C", DeletedSymbolDisplay(FeaturesResources.field, "a")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "class C", GetResource("field", "a")),
+                Diagnostic(RudeEditKind.Delete, "class C", GetResource("field", "a")));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.Debugging
             var expectedEnvelope = expectedSpans.IsEmpty ? default : TextSpan.FromBounds(expectedSpans[0].Start, expectedSpans[^1].End);
             Assert.NotNull(declarationNode);
 
-            var actualEnvelope = BreakpointSpans.GetEnvelope(declarationNode);
+            var actualEnvelope = SyntaxUtilities.TryGetDeclarationBody(declarationNode)?.Envelope ?? default;
             Assert.Equal(expectedEnvelope, actualEnvelope);
         }
 
@@ -252,16 +252,6 @@ class C
             [|}|]    
         [|}|]
     [|}|]
-}");
-        }
-
-        [Fact]
-        public void GetBreakpointSequence_InstanceContructor_NoBody()
-        {
-            VerifyAllSpansInDeclaration<ConstructorDeclarationSyntax>(@"
-class Class
-{
-    [|Clas$$s()|]
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -175,7 +175,6 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
         public static MatchingPairs ToMatchingPairs(IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>> matches)
             => EditAndContinueTestHelpers.ToMatchingPairs(matches);
 
-
         internal static MemberBody MakeMethodBody(
             string bodySource,
             MethodKind kind = MethodKind.Regular)

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -84,6 +84,8 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
                 "where clause" => CSharpFeaturesResources.where_clause,
                 "select clause" => CSharpFeaturesResources.select_clause,
                 "groupby clause" => CSharpFeaturesResources.groupby_clause,
+                "top-level statement" => CSharpFeaturesResources.top_level_statement,
+                "top-level code" => CSharpFeaturesResources.top_level_code,
                 _ => null
             };
 
@@ -112,7 +114,7 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
 
         private static SyntaxTree ParseSource(string markedSource, int documentIndex = 0)
             => SyntaxFactory.ParseSyntaxTree(
-                ActiveStatementsDescription.ClearTags(markedSource),
+                SourceMarkers.Clear(markedSource),
                 CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview),
                 path: GetDocumentFilePath(documentIndex));
 
@@ -150,11 +152,10 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
             var m1 = MakeMethodBody(src1, kind);
             var m2 = MakeMethodBody(src2, kind);
 
-            var analyzer = CreateAnalyzer();
-            var match = analyzer.ComputeBodyMatch(m1, m2, Array.Empty<AbstractEditAndContinueAnalyzer.ActiveNode>());
+            var match = m1.ComputeMatch(m2, knownMatches: null);
 
-            var stateMachineInfo1 = analyzer.GetStateMachineInfo(m1);
-            var stateMachineInfo2 = analyzer.GetStateMachineInfo(m2);
+            var stateMachineInfo1 = m1.GetStateMachineInfo();
+            var stateMachineInfo2 = m2.GetStateMachineInfo();
             var needsSyntaxMap = stateMachineInfo1.HasSuspensionPoints && stateMachineInfo2.HasSuspensionPoints;
 
             Assert.Equal(kind is not MethodKind.Regular and not MethodKind.ConstructorWithParameters, needsSyntaxMap);
@@ -174,9 +175,8 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
         public static MatchingPairs ToMatchingPairs(IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>> matches)
             => EditAndContinueTestHelpers.ToMatchingPairs(matches);
 
-#nullable disable
 
-        internal static BlockSyntax MakeMethodBody(
+        internal static MemberBody MakeMethodBody(
             string bodySource,
             MethodKind kind = MethodKind.Regular)
         {
@@ -189,14 +189,20 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
 
             var declaration = (BaseMethodDeclarationSyntax)((ClassDeclarationSyntax)((CompilationUnitSyntax)root).Members[0]).Members[0];
 
-            // We need to preserve the parent node to allow detection of state machine methods in the analyzer.
-            // If we are not testing a state machine method we only use the body to avoid updating positions in all existing tests.
-            if (kind != MethodKind.Regular)
+            if (kind == MethodKind.ConstructorWithParameters)
             {
-                return ((BaseMethodDeclarationSyntax)SyntaxFactory.SyntaxTree(declaration).GetRoot()).Body;
+                var body = SyntaxUtilities.TryGetDeclarationBody(declaration);
+                Contract.ThrowIfNull(body);
+                return body;
             }
 
-            return (BlockSyntax)SyntaxFactory.SyntaxTree(declaration.Body).GetRoot();
+            // We need to preserve the parent node to allow detection of state machine methods in the analyzer.
+            // If we are not testing a state machine method we only use the body to avoid updating positions in all existing tests.
+            var bodyNode = (kind != MethodKind.Regular)
+                ? ((BaseMethodDeclarationSyntax)SyntaxFactory.SyntaxTree(declaration).GetRoot()).Body
+                : (BlockSyntax)SyntaxFactory.SyntaxTree(declaration.Body!).GetRoot();
+
+            return SyntaxUtilities.CreateSimpleBody(bodyNode)!;
         }
 
         internal static string WrapMethodBodyWithClass(string bodySource, MethodKind kind = MethodKind.Regular)
@@ -208,7 +214,7 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
                  _ => "class C { void F() { " + bodySource + " } }",
              };
 
-        internal static ActiveStatementsDescription GetActiveStatements(string oldSource, string newSource, ActiveStatementFlags[] flags = null, int documentIndex = 0)
+        internal static ActiveStatementsDescription GetActiveStatements(string oldSource, string newSource, ActiveStatementFlags[]? flags = null, int documentIndex = 0)
             => new(oldSource, newSource, source => SyntaxFactory.ParseSyntaxTree(source, path: GetDocumentFilePath(documentIndex)), flags);
 
         internal static SyntaxMapDescription GetSyntaxMap(string oldSource, string newSource)
@@ -217,16 +223,17 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
         internal static void VerifyPreserveLocalVariables(EditScript<SyntaxNode> edits, bool preserveLocalVariables)
         {
             var oldDeclaration = (MethodDeclarationSyntax)((ClassDeclarationSyntax)((CompilationUnitSyntax)edits.Match.OldRoot).Members[0]).Members[0];
-            var oldBody = ((MethodDeclarationSyntax)SyntaxFactory.SyntaxTree(oldDeclaration).GetRoot()).Body;
+            var oldBody = SyntaxUtilities.TryGetDeclarationBody(oldDeclaration);
+            Contract.ThrowIfNull(oldBody);
 
             var newDeclaration = (MethodDeclarationSyntax)((ClassDeclarationSyntax)((CompilationUnitSyntax)edits.Match.NewRoot).Members[0]).Members[0];
-            var newBody = ((MethodDeclarationSyntax)SyntaxFactory.SyntaxTree(newDeclaration).GetRoot()).Body;
+            var newBody = SyntaxUtilities.TryGetDeclarationBody(newDeclaration);
+            Contract.ThrowIfNull(newBody);
 
-            var analyzer = CreateAnalyzer();
-            _ = analyzer.ComputeBodyMatch(oldBody, newBody, Array.Empty<AbstractEditAndContinueAnalyzer.ActiveNode>());
+            _ = oldBody.ComputeMatch(newBody, knownMatches: null);
 
-            var oldStateMachineInfo = analyzer.GetStateMachineInfo(oldBody);
-            var newStateMachineInfo = analyzer.GetStateMachineInfo(newBody);
+            var oldStateMachineInfo = oldBody.GetStateMachineInfo();
+            var newStateMachineInfo = newBody.GetStateMachineInfo();
             var needsSyntaxMap = oldStateMachineInfo.HasSuspensionPoints && newStateMachineInfo.HasSuspensionPoints;
 
             // Active methods are detected to preserve local variables for variable mapping and

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
@@ -574,6 +574,39 @@ class C
                 semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar"), preserveLocalVariables: true) });
         }
 
+        [Fact]
+        public void Lambda_Recompile()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        var x = new System.Func<int>(
+            () => 1
+
+        );
+    }
+}";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+        var x = new System.Func<int>(
+            () =>
+                  1
+        );
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), preserveLocalVariables: true) });
+        }
+
         #endregion
 
         #region Constructors
@@ -608,9 +641,9 @@ class C
             edits.VerifyLineEdits(
                 new[]
                 {
-                    new SourceLineUpdate(4, 8),
+                    new SourceLineUpdate(3, 7),
                     new SourceLineUpdate(6, 6),
-                    new SourceLineUpdate(8, 4)
+                    new SourceLineUpdate(7, 3)
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -33,12 +34,12 @@ Console.WriteLine(1)/*4*/;
 
             var knownMatches = new KeyValuePair<SyntaxNode, SyntaxNode>[]
             {
-                new KeyValuePair<SyntaxNode, SyntaxNode>(m1.Statements[1], m2.Statements[0])
+                new KeyValuePair<SyntaxNode, SyntaxNode>(((BlockSyntax)m1.RootNodes.First()).Statements[1], ((BlockSyntax)m2.RootNodes.First()).Statements[0])
             };
 
             // pre-matched:
 
-            var match = SyntaxComparer.Statement.ComputeMatch(m1, m2, knownMatches);
+            var match = m1.ComputeMatch(m2, knownMatches);
 
             var actual = ToMatchingPairs(match);
 
@@ -52,7 +53,7 @@ Console.WriteLine(1)/*4*/;
 
             // not pre-matched:
 
-            match = SyntaxComparer.Statement.ComputeMatch(m1, m2);
+            match = m1.ComputeMatch(m2, knownMatches: null);
 
             actual = ToMatchingPairs(match);
 
@@ -79,8 +80,8 @@ Console.WriteLine(2);
             var m1 = MakeMethodBody(src1);
             var m2 = MakeMethodBody(src2);
 
-            var knownMatches = new[] { new KeyValuePair<SyntaxNode, SyntaxNode>(m1, m2) };
-            var match = SyntaxComparer.Statement.ComputeMatch(m1, m2, knownMatches);
+            var knownMatches = new[] { new KeyValuePair<SyntaxNode, SyntaxNode>(m1.RootNodes.First(), m2.RootNodes.First()) };
+            var match = m1.ComputeMatch(m2, knownMatches);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
@@ -7,6 +7,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.EditAndContinue;
 using Roslyn.Test.Utilities;
 using Xunit;
 using SyntaxUtilities = Microsoft.CodeAnalysis.CSharp.EditAndContinue.SyntaxUtilities;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue
 
             foreach (var oldNode in oldRoot.DescendantNodes().Where(n => n.FullSpan.Length > 0))
             {
-                var newNode = SyntaxUtilities.FindPartner(oldRoot, newRoot, oldNode);
+                var newNode = AbstractEditAndContinueAnalyzer.FindPartner(newRoot, oldRoot, oldNode);
                 Assert.True(SyntaxFactory.AreEquivalent(oldNode, newNode), $"Node '{oldNode}' not equivalent to '{newNode}'.");
             }
         }
@@ -102,7 +103,7 @@ class C
 }
 ").GetRoot();
 
-            SyntaxUtilities.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, out var leftNode, out var rightNodeOpt);
+            AbstractEditAndContinueAnalyzer.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, out var leftNode, out var rightNodeOpt);
             Assert.Equal("0", leftNode.ToString());
             Assert.Null(rightNodeOpt);
         }
@@ -152,7 +153,7 @@ class C
 }
 ").GetRoot();
 
-            SyntaxUtilities.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, out var leftNode, out var rightNodeOpt);
+            AbstractEditAndContinueAnalyzer.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, out var leftNode, out var rightNodeOpt);
             Assert.Equal("3", leftNode.ToString());
             Assert.Null(rightNodeOpt);
         }

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -3756,7 +3756,7 @@ class C { int Y => 1; }
             // Project4: Test2.cs (link from P1)
 
             using var _ = CreateWorkspace(out var solution, out var service);
-            solution = AddDefaultTestProject(solution, ActiveStatementsDescription.ClearTags(markedSources));
+            solution = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSources));
 
             var documents = solution.Projects.Single().Documents;
             var doc1 = documents.First();
@@ -3873,7 +3873,7 @@ class C { int Y => 1; }
                 });
 
             using var _ = CreateWorkspace(out var solution, out var service);
-            solution = AddDefaultTestProject(solution, ActiveStatementsDescription.ClearTags(markedSources));
+            solution = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSources));
             var project = solution.Projects.Single();
             var document = project.Documents.Single();
 
@@ -3943,8 +3943,8 @@ class C
 }
 */
 ";
-            var source1 = ActiveStatementsDescription.ClearTags(markedSource1);
-            var source2 = ActiveStatementsDescription.ClearTags(markedSource2);
+            var source1 = SourceMarkers.Clear(markedSource1);
+            var source2 = SourceMarkers.Clear(markedSource2);
 
             var additionalFileSourceV1 = @"
        xxxxxxxxxxxxxxxxx
@@ -4034,8 +4034,8 @@ class C
     }
 }
 ";
-            var source1 = ActiveStatementsDescription.ClearTags(markedSource1);
-            var source2 = ActiveStatementsDescription.ClearTags(markedSource2);
+            var source1 = SourceMarkers.Clear(markedSource1);
+            var source2 = SourceMarkers.Clear(markedSource2);
 
             using var _ = CreateWorkspace(out var solution, out var service);
             (solution, var document) = AddDefaultTestProject(solution, source1);
@@ -4121,10 +4121,10 @@ class C
             var markedSourceV3 = Update(markedSourceV2, marker: "2");
             var markedSourceV4 = Update(markedSourceV3, marker: "3");
 
-            var moduleId = EmitAndLoadLibraryToDebuggee(ActiveStatementsDescription.ClearTags(markedSourceV1));
+            var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSourceV1));
 
             using var _ = CreateWorkspace(out var solution, out var service);
-            (solution, var document) = AddDefaultTestProject(solution, ActiveStatementsDescription.ClearTags(markedSourceV1));
+            (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSourceV1));
             var documentId = document.Id;
 
             var debuggingSession = await StartDebuggingSessionAsync(service, solution);
@@ -4142,7 +4142,7 @@ class C
                     ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, // F
                 }));
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSourceV2)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSourceV2)));
 
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
@@ -4162,7 +4162,7 @@ class C
 
             // Hot Reload update F v2 -> v3
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSourceV3)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSourceV3)));
 
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
@@ -4198,7 +4198,7 @@ class C
                 new ActiveStatementSpan(0, new LinePositionSpan(new(4,41), new(4,42)), ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.LeafFrame, unmappedDocumentId: null),
             }, spans);
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSourceV4)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSourceV4)));
 
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
@@ -4265,17 +4265,17 @@ class C
     }
 }";
 
-            var moduleId = EmitAndLoadLibraryToDebuggee(ActiveStatementsDescription.ClearTags(markedSource1));
+            var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSource1));
 
             using var _ = CreateWorkspace(out var solution, out var service);
-            (solution, var document) = AddDefaultTestProject(solution, ActiveStatementsDescription.ClearTags(markedSource1));
+            (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSource1));
             var documentId = document.Id;
 
             var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
             // Update to snapshot 2, but don't apply
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSource2)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSource2)));
 
             // EnC update F v2 -> v3
 
@@ -4301,7 +4301,7 @@ class C
                 new ActiveStatementSpan(1, expectedSpanF1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.NonLeafFrame, documentId)
             }, spans);
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSource3)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSource3)));
 
             // check that the active statement is mapped correctly to snapshot v3:
             var expectedSpanG2 = new LinePositionSpan(new LinePosition(3, 41), new LinePosition(3, 42));
@@ -4367,17 +4367,17 @@ class C
     {
     }
 }";
-            var moduleId = EmitAndLoadLibraryToDebuggee(ActiveStatementsDescription.ClearTags(markedSource1));
+            var moduleId = EmitAndLoadLibraryToDebuggee(SourceMarkers.Clear(markedSource1));
 
             using var _ = CreateWorkspace(out var solution, out var service);
-            (solution, var document) = AddDefaultTestProject(solution, ActiveStatementsDescription.ClearTags(markedSource1));
+            (solution, var document) = AddDefaultTestProject(solution, SourceMarkers.Clear(markedSource1));
             var documentId = document.Id;
 
             var debuggingSession = await StartDebuggingSessionAsync(service, solution);
 
             // Apply update: F v1 -> v2.
 
-            solution = solution.WithDocumentText(documentId, CreateText(ActiveStatementsDescription.ClearTags(markedSource2)));
+            solution = solution.WithDocumentText(documentId, CreateText(SourceMarkers.Clear(markedSource2)));
 
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);

--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             for (var i = 0; i < markedSources.Length; i++)
             {
                 var name = $"test{i + 1}.cs";
-                var text = SourceText.From(ActiveStatementsDescription.ClearTags(markedSources[i]), Encoding.UTF8);
+                var text = SourceText.From(SourceMarkers.Clear(markedSources[i]), Encoding.UTF8);
                 var id = DocumentId.CreateNewId(project.Id, name);
                 solution = solution.AddDocument(id, name, text, filePath: Path.Combine(TempRoot.Root, name));
             }
@@ -489,7 +489,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     ActiveStatementFlags.None | ActiveStatementFlags.NonLeafFrame,           // F4
                 });
 
-            var exceptionSpans = ActiveStatementsDescription.GetExceptionRegions(markedSourceV1);
+            var exceptionSpans = SourceMarkers.GetExceptionRegions(markedSourceV1);
 
             var filePath = activeStatementsPreRemap[0].DocumentName;
             var spanPreRemap2 = new SourceFileSpan(filePath, activeStatementsPreRemap[2].SourceSpan.ToLinePositionSpan());

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/ActiveStatementsDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/ActiveStatementsDescription.cs
@@ -7,13 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Contracts.EditAndContinue;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
@@ -39,8 +37,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public ActiveStatementsDescription(string oldMarkedSource, string newMarkedSource, Func<string, SyntaxTree> syntaxTreeFactory, ActiveStatementFlags[]? flags)
         {
-            var oldSource = ClearTags(oldMarkedSource);
-            var newSource = ClearTags(newMarkedSource);
+            var oldSource = SourceMarkers.Clear(oldMarkedSource);
+            var newSource = SourceMarkers.Clear(newMarkedSource);
 
             var oldTree = syntaxTreeFactory(oldSource);
             var newTree = syntaxTreeFactory(newSource);
@@ -52,13 +50,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 documentPathMap: oldDocumentMap.ToImmutableDictionary(e => e.Key, e => e.Value.OrderBy(ActiveStatementsMap.Comparer).ToImmutableArray()),
                 instructionMap: OldStatements.ToDictionary(s => new ManagedInstructionId(new ManagedMethodId(Guid.NewGuid(), 0x060000001, version: 1), ilOffset: 0), s => s.Statement));
 
-            var newActiveStatementMarkers = GetActiveSpans(newMarkedSource).ToArray();
+            var newActiveStatementMarkers = SourceMarkers.GetActiveSpans(newMarkedSource).ToArray();
 
             var activeStatementCount = Math.Max(OldStatements.Length, (newActiveStatementMarkers.Length == 0) ? -1 : newActiveStatementMarkers.Max(m => m.Id));
 
             var newMappedSpans = new ArrayBuilder<SourceFileSpan>();
             var newMappedRegions = new ArrayBuilder<ImmutableArray<SourceFileSpan>>();
-            var newExceptionRegionMarkers = GetExceptionRegions(newMarkedSource);
+            var newExceptionRegionMarkers = SourceMarkers.GetExceptionRegions(newMarkedSource);
 
             newMappedSpans.ZeroInit(activeStatementCount);
             newMappedRegions.ZeroInit(activeStatementCount);
@@ -86,7 +84,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             // edits the source and we get their positions when analyzing the new source.
             // The EnC analyzer uses old tracking spans as hints to find matching nodes.
             var newText = newTree.GetText();
-            OldUnmappedTrackingSpans = GetTrackingSpans(newMarkedSource, activeStatementCount).
+            OldUnmappedTrackingSpans = SourceMarkers.GetTrackingSpans(newMarkedSource, activeStatementCount).
                 SelectAsArray(s => newText.Lines.GetLinePositionSpan(s));
         }
 
@@ -96,8 +94,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             ActiveStatementFlags[]? flags,
             Dictionary<string, List<ActiveStatement>> documentMap)
         {
-            var activeStatementMarkers = GetActiveSpans(markedSource).ToArray();
-            var exceptionRegionMarkers = GetExceptionRegions(markedSource);
+            var activeStatementMarkers = SourceMarkers.GetActiveSpans(markedSource).ToArray();
+            var exceptionRegionMarkers = SourceMarkers.GetExceptionRegions(markedSource);
 
             return activeStatementMarkers.Aggregate(
                 new List<UnmappedActiveStatement>(),
@@ -124,7 +122,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                         new ActiveStatementExceptionRegions(exceptionRegions, isActiveStatementCovered: true));
 
                     documentActiveStatements.Add(unmappedActiveStatement.Statement);
-                    return SetListItem(list, ordinal, unmappedActiveStatement);
+                    return SourceMarkers.SetListItem(list, ordinal, unmappedActiveStatement);
                 }).ToImmutableArray();
         }
 
@@ -143,7 +141,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             foreach (var markedSource in markedSources)
             {
                 var documentName = filePaths?[sourceIndex] ?? Path.Combine(TempRoot.Root, TestWorkspace.GetDefaultTestSourceDocumentName(sourceIndex, extension));
-                var tree = syntaxTreeFactory(ClearTags(markedSource), documentName);
+                var tree = syntaxTreeFactory(SourceMarkers.Clear(markedSource), documentName);
                 var statements = CreateActiveStatementMapFromMarkers(markedSource, tree, flags, map);
 
                 activeStatements.AddRange(statements.Where(s => s.Statement != null));
@@ -175,167 +173,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     documentName: statement.FilePath,
                     sourceSpan: statement.Span.ToSourceSpan(),
                     flags: statement.Flags));
-        }
-
-        internal static string ClearTags(string source)
-            => s_tags.Replace(source, m => new string(' ', m.Length));
-
-        internal static string[] ClearTags(string[] sources)
-            => sources.Select(ClearTags).ToArray();
-
-        private static readonly Regex s_tags = new Regex(
-            @"[<][/]?(AS|ER|N|TS)[:][.0-9,]+[>]",
-            RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
-
-        private static readonly Regex s_activeStatementPattern = new Regex(
-            @"[<]AS[:]    (?<Id>[0-9,]+) [>]
-              (?<ActiveStatement>.*)
-              [<][/]AS[:] (\k<Id>)      [>]",
-            RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
-
-        public static readonly Regex ExceptionRegionPattern = new Regex(
-            @"[<]ER[:]      (?<Id>(?:[0-9]+[.][0-9]+[,]?)+)   [>]
-              (?<ExceptionRegion>.*)
-              [<][/]ER[:]   (\k<Id>)                 [>]",
-            RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
-
-        private static readonly Regex s_trackingStatementPattern = new Regex(
-            @"[<]TS[:]    (?<Id>[0-9,]+) [>]
-              (?<TrackingStatement>.*)
-              [<][/]TS[:] (\k<Id>)      [>]",
-            RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
-
-        internal static IEnumerable<int> GetIds(Match match)
-            => match.Groups["Id"].Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse);
-
-        internal static int[] GetIds(string ids)
-            => ids.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
-
-        internal static IEnumerable<(int, int)> GetDottedIds(Match match)
-            => from ids in match.Groups["Id"].Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-               let parts = ids.Split('.')
-               select (int.Parse(parts[0]), int.Parse(parts[1]));
-
-        private static IEnumerable<(TextSpan Span, int[] Ids)> GetSpansRecursive(Regex regex, string contentGroupName, string markedSource, int offset)
-        {
-            foreach (var match in regex.Matches(markedSource).ToEnumerable())
-            {
-                var markedSyntax = match.Groups[contentGroupName];
-                var ids = GetIds(match.Groups["Id"].Value);
-                var absoluteOffset = offset + markedSyntax.Index;
-
-                var span = markedSyntax.Length != 0 ? new TextSpan(absoluteOffset, markedSyntax.Length) : new TextSpan();
-                yield return (span, ids);
-
-                foreach (var nestedSpan in GetSpansRecursive(regex, contentGroupName, markedSyntax.Value, absoluteOffset))
-                {
-                    yield return nestedSpan;
-                }
-            }
-        }
-
-        internal static IEnumerable<(TextSpan Span, int Id)> GetActiveSpans(string markedSource)
-        {
-            foreach (var (span, ids) in GetSpansRecursive(s_activeStatementPattern, "ActiveStatement", markedSource, offset: 0))
-            {
-                foreach (var id in ids)
-                {
-                    yield return (span, id);
-                }
-            }
-        }
-
-        internal static TextSpan[] GetTrackingSpans(string src, int count)
-        {
-            var matches = s_trackingStatementPattern.Matches(src);
-            if (matches.Count == 0)
-            {
-                return Array.Empty<TextSpan>();
-            }
-
-            var result = new TextSpan[count];
-
-            for (var i = 0; i < matches.Count; i++)
-            {
-                var span = matches[i].Groups["TrackingStatement"];
-                foreach (var id in GetIds(matches[i]))
-                {
-                    result[id] = new TextSpan(span.Index, span.Length);
-                }
-            }
-
-            Contract.ThrowIfTrue(result.Any(span => span == default));
-
-            return result;
-        }
-
-        internal static ImmutableArray<ImmutableArray<TextSpan>> GetExceptionRegions(string markedSource)
-        {
-            var matches = ExceptionRegionPattern.Matches(markedSource);
-            var plainSource = ClearTags(markedSource);
-
-            var result = new List<List<TextSpan>>();
-
-            for (var i = 0; i < matches.Count; i++)
-            {
-                var exceptionRegion = matches[i].Groups["ExceptionRegion"];
-
-                foreach (var (activeStatementId, exceptionRegionId) in GetDottedIds(matches[i]))
-                {
-                    EnsureSlot(result, activeStatementId);
-                    result[activeStatementId] ??= new List<TextSpan>();
-                    EnsureSlot(result[activeStatementId], exceptionRegionId);
-
-                    var regionText = plainSource.AsSpan().Slice(exceptionRegion.Index, exceptionRegion.Length);
-                    var start = IndexOfDifferent(regionText, ' ');
-                    var length = LastIndexOfDifferent(regionText, ' ') - start + 1;
-
-                    result[activeStatementId][exceptionRegionId] = new TextSpan(exceptionRegion.Index + start, length);
-                }
-            }
-
-            return result.Select(r => r.AsImmutableOrEmpty()).ToImmutableArray();
-        }
-
-        public static int IndexOfDifferent(ReadOnlySpan<char> span, char c)
-        {
-            for (var i = 0; i < span.Length; i++)
-            {
-                if (span[i] != c)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        public static int LastIndexOfDifferent(ReadOnlySpan<char> span, char c)
-        {
-            for (var i = span.Length - 1; i >= 0; i--)
-            {
-                if (span[i] != c)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        public static List<T> SetListItem<T>(List<T> list, int i, T item)
-        {
-            EnsureSlot(list, i);
-            list[i] = item;
-            return list;
-        }
-
-        public static void EnsureSlot<T>(List<T> list, int i)
-        {
-            while (i >= list.Count)
-            {
-                list.Add(default!);
-            }
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -455,7 +455,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         internal static IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>> GetMethodMatches(AbstractEditAndContinueAnalyzer analyzer, Match<SyntaxNode> bodyMatch)
         {
-            Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
+            Dictionary<LambdaBody, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
             var map = analyzer.GetTestAccessor().ComputeMap(bodyMatch, new ArrayBuilder<ActiveNode>(), ref lazyActiveOrMatchedLambdas);
 
             var result = new Dictionary<SyntaxNode, SyntaxNode>();

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/SourceMarkers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/SourceMarkers.cs
@@ -1,0 +1,203 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
+
+internal static class SourceMarkers
+{
+    private static readonly Regex s_tags = new(
+        @"[<][/]?(AS|ER|N|TS)[:][.0-9,]+[>]",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    private static readonly Regex s_activeStatementPattern = new(
+        @"[<]AS[:]    (?<Id>[0-9,]+) [>]
+            (?<ActiveStatement>.*)
+          [<][/]AS[:] (\k<Id>)       [>]",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    public static readonly Regex ExceptionRegionPattern = new(
+        @"[<]ER[:]      (?<Id>(?:[0-9]+[.][0-9]+[,]?)+)   [>]
+            (?<ExceptionRegion>.*)
+          [<][/]ER[:]   (\k<Id>)                          [>]",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    private static readonly Regex s_trackingStatementPattern = new(
+        @"[<]TS[:]    (?<Id>[0-9,]+) [>]
+            (?<TrackingStatement>.*)
+          [<][/]TS[:] (\k<Id>)       [>]",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    private static readonly Regex s_nodePattern = new(
+        @"[<]N[:]      (?<Id>[0-9]+[.][0-9]+)   [>]
+            (?<Node>.*)
+          [<][/]N[:]   (\k<Id>)                 [>]",
+        RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+
+    internal static string Clear(string source)
+        => s_tags.Replace(source, m => new string(' ', m.Length));
+
+    internal static string[] Clear(string[] sources)
+        => sources.Select(Clear).ToArray();
+
+    private static IEnumerable<(int, int)> ParseIds(Match match)
+        => from ids in match.Groups["Id"].Value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+           let parts = ids.Split('.')
+           select (int.Parse(parts[0]), (parts.Length > 1) ? int.Parse(parts[1]) : 0);
+
+    private static IEnumerable<(TextSpan Span, ImmutableArray<(int major, int minor)> Ids)> GetSpans(string markedSource, Regex regex, string contentGroupName)
+    {
+        return Recurse(markedSource, offset: 0);
+
+        IEnumerable<(TextSpan Span, ImmutableArray<(int major, int minor)> Ids)> Recurse(string markedSource, int offset)
+        {
+            foreach (var match in regex.Matches(markedSource).ToEnumerable())
+            {
+                var markedSyntax = match.Groups[contentGroupName];
+                var ids = ParseIds(match).ToImmutableArray();
+                var absoluteOffset = offset + markedSyntax.Index;
+
+                var span = markedSyntax.Length != 0 ? new TextSpan(absoluteOffset, markedSyntax.Length) : new TextSpan();
+                yield return (span, ids);
+
+                foreach (var nestedSpan in Recurse(markedSyntax.Value, absoluteOffset))
+                {
+                    yield return nestedSpan;
+                }
+            }
+        }
+    }
+
+    public static IEnumerable<(TextSpan Span, int Id)> GetActiveSpans(string markedSource)
+    {
+        foreach (var (span, ids) in GetSpans(markedSource, s_activeStatementPattern, "ActiveStatement"))
+        {
+            foreach (var (major, _) in ids)
+            {
+                yield return (span, major);
+            }
+        }
+    }
+
+    public static TextSpan[] GetTrackingSpans(string src, int count)
+    {
+        var matches = s_trackingStatementPattern.Matches(src);
+        if (matches.Count == 0)
+        {
+            return Array.Empty<TextSpan>();
+        }
+
+        var result = new TextSpan[count];
+
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var span = matches[i].Groups["TrackingStatement"];
+            foreach (var (id, _) in ParseIds(matches[i]))
+            {
+                result[id] = new TextSpan(span.Index, span.Length);
+            }
+        }
+
+        Contract.ThrowIfTrue(result.Any(span => span == default));
+
+        return result;
+    }
+
+    public static ImmutableArray<ImmutableArray<TextSpan>> GetExceptionRegions(string markedSource)
+    {
+        var matches = ExceptionRegionPattern.Matches(markedSource);
+        var plainSource = Clear(markedSource);
+
+        var result = new List<List<TextSpan>>();
+
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var exceptionRegion = matches[i].Groups["ExceptionRegion"];
+
+            foreach (var (activeStatementId, exceptionRegionId) in ParseIds(matches[i]))
+            {
+                EnsureSlot(result, activeStatementId);
+                result[activeStatementId] ??= new List<TextSpan>();
+                EnsureSlot(result[activeStatementId], exceptionRegionId);
+
+                var regionText = plainSource.AsSpan().Slice(exceptionRegion.Index, exceptionRegion.Length);
+                var start = IndexOfDifferent(regionText, ' ');
+                var length = LastIndexOfDifferent(regionText, ' ') - start + 1;
+
+                result[activeStatementId][exceptionRegionId] = new TextSpan(exceptionRegion.Index + start, length);
+            }
+        }
+
+        return result.Select(r => r.AsImmutableOrEmpty()).ToImmutableArray();
+    }
+
+    public static ImmutableArray<ImmutableArray<TextSpan>> GetNodeSpans(string markedSource)
+    {
+        var result = new List<List<TextSpan>>();
+      
+        foreach (var (span, ids) in GetSpans(markedSource, s_nodePattern, "Node"))
+        {
+            Debug.Assert(ids.Length == 1);
+
+            var (major, minor) = ids[0];
+
+            EnsureSlot(result, major);
+            result[major] ??= new List<TextSpan>();
+            EnsureSlot(result[major], minor);
+            result[major][minor] = span;
+        }
+
+        return result.Select(r => r.AsImmutableOrEmpty()).AsImmutableOrEmpty();
+    }
+
+    public static int IndexOfDifferent(ReadOnlySpan<char> span, char c)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (span[i] != c)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    public static int LastIndexOfDifferent(ReadOnlySpan<char> span, char c)
+    {
+        for (var i = span.Length - 1; i >= 0; i--)
+        {
+            if (span[i] != c)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    public static List<T> SetListItem<T>(List<T> list, int i, T item)
+    {
+        EnsureSlot(list, i);
+        list[i] = item;
+        return list;
+    }
+
+    public static void EnsureSlot<T>(List<T> list, int i)
+    {
+        while (i >= list.Count)
+        {
+            list.Add(default!);
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/SourceMarkers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/SourceMarkers.cs
@@ -144,7 +144,7 @@ internal static class SourceMarkers
     public static ImmutableArray<ImmutableArray<TextSpan>> GetNodeSpans(string markedSource)
     {
         var result = new List<List<TextSpan>>();
-      
+
         foreach (var (span, ids) in GetSpans(markedSource, s_nodePattern, "Node"))
         {
             Debug.Assert(ids.Length == 1);

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
@@ -164,7 +164,7 @@ End Namespace
 
         Private Shared Function ParseSource(markedSource As String, Optional documentIndex As Integer = 0) As SyntaxTree
             Return SyntaxFactory.ParseSyntaxTree(
-                ActiveStatementsDescription.ClearTags(markedSource),
+                SourceMarkers.Clear(markedSource),
                 VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
                 path:=GetDocumentFilePath(documentIndex))
         End Function
@@ -196,11 +196,10 @@ End Namespace
             Dim m1 = MakeMethodBody(src1, methodKind)
             Dim m2 = MakeMethodBody(src2, methodKind)
 
-            Dim analyzer = CreateAnalyzer()
-            Dim match = analyzer.ComputeBodyMatch(m1, m2, Array.Empty(Of AbstractEditAndContinueAnalyzer.ActiveNode)())
+            Dim match = m1.ComputeMatch(m2, knownMatches:=Nothing)
 
-            Dim stateMachineInfo1 = analyzer.GetStateMachineInfo(m1)
-            Dim stateMachineInfo2 = analyzer.GetStateMachineInfo(m2)
+            Dim stateMachineInfo1 = m1.GetStateMachineInfo()
+            Dim stateMachineInfo2 = m2.GetStateMachineInfo()
             Dim needsSyntaxMap = stateMachineInfo1.HasSuspensionPoints AndAlso stateMachineInfo2.HasSuspensionPoints
 
             Assert.Equal(methodKind <> MethodKind.Regular, needsSyntaxMap)
@@ -223,7 +222,7 @@ End Namespace
             Return EditAndContinueTestHelpers.ToMatchingPairs(matches)
         End Function
 
-        Friend Shared Function MakeMethodBody(bodySource As String, Optional stateMachine As MethodKind = MethodKind.Regular) As SyntaxNode
+        Friend Shared Function MakeMethodBody(bodySource As String, Optional stateMachine As MethodKind = MethodKind.Regular) As MemberBody
             Dim source = WrapMethodBodyWithClass(bodySource, stateMachine)
 
             Dim tree = ParseSource(source)
@@ -231,7 +230,7 @@ End Namespace
             tree.GetDiagnostics().Verify()
 
             Dim declaration = DirectCast(DirectCast(root, CompilationUnitSyntax).Members(0), ClassBlockSyntax).Members(0)
-            Return SyntaxFactory.SyntaxTree(declaration).GetRoot()
+            Return SyntaxUtilities.TryGetDeclarationBody(SyntaxFactory.SyntaxTree(declaration).GetRoot())
         End Function
 
         Private Shared Function WrapMethodBodyWithClass(bodySource As String, Optional kind As MethodKind = MethodKind.Regular) As String

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementMatchingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/StatementMatchingTests.vb
@@ -71,8 +71,8 @@ End If
             Dim m1 = MakeMethodBody(src1)
             Dim m2 = MakeMethodBody(src2)
 
-            Dim knownMatches = {New KeyValuePair(Of SyntaxNode, SyntaxNode)(m1, m2)}
-            Dim match = SyntaxComparer.Statement.ComputeMatch(m1, m2, knownMatches)
+            Dim knownMatches = {New KeyValuePair(Of SyntaxNode, SyntaxNode)(m1.RootNodes.First(), m2.RootNodes().First())}
+            Dim match = m1.ComputeMatch(m2, knownMatches)
             Dim actual = ToMatchingPairs(match)
 
             Dim expected = New MatchingPairs From
@@ -1391,12 +1391,14 @@ End Try
             Dim src1 = "Console.WriteLine(1   ) : Console.WriteLine( 1  )"
             Dim src2 = "Console.WriteLine(  1 ) : Console.WriteLine(   1)"
 
-            Dim m1 = DirectCast(MakeMethodBody(src1), MethodBlockSyntax)
-            Dim m2 = DirectCast(MakeMethodBody(src2), MethodBlockSyntax)
-            Dim knownMatches = {New KeyValuePair(Of SyntaxNode, SyntaxNode)(m1.Statements(1), m2.Statements(0))}
+            Dim m1 = MakeMethodBody(src1)
+            Dim m2 = MakeMethodBody(src2)
+            Dim b1 = DirectCast(m1.RootNodes.First(), MethodBlockSyntax)
+            Dim b2 = DirectCast(m2.RootNodes.First(), MethodBlockSyntax)
+            Dim knownMatches = {New KeyValuePair(Of SyntaxNode, SyntaxNode)(b1.Statements(1), b2.Statements(0))}
 
             ' pre-matched:
-            Dim match = SyntaxComparer.Statement.ComputeMatch(m1, m2, knownMatches)
+            Dim match = m1.ComputeMatch(m2, knownMatches)
             Dim actual = ToMatchingPairs(match)
 
             Dim expected = New MatchingPairs From
@@ -1410,7 +1412,7 @@ End Try
             expected.AssertEqual(actual)
 
             ' not pre-matched:
-            match = SyntaxComparer.Statement.ComputeMatch(m1, m2)
+            match = m1.ComputeMatch(m2, knownMatches:=Nothing)
             actual = ToMatchingPairs(match)
 
             expected = New MatchingPairs From

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/SyntaxUtilitiesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/SyntaxUtilitiesTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports SyntaxUtilities = Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.SyntaxUtilities
 
@@ -15,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
             Dim newRoot = SyntaxFactory.ParseSyntaxTree(newSource).GetRoot()
 
             For Each oldNode In oldRoot.DescendantNodes().Where(Function(n) n.FullSpan.Length > 0)
-                Dim newNode = SyntaxUtilities.FindPartner(oldRoot, newRoot, oldNode)
+                Dim newNode = AbstractEditAndContinueAnalyzer.FindPartner(newRoot, oldRoot, oldNode)
                 Assert.True(SyntaxFactory.AreEquivalent(oldNode, newNode), $"Node 'oldNodeEnd' not equivalent to 'newNodeEnd'.")
             Next
         End Sub
@@ -81,7 +82,7 @@ End Class
 
             Dim leftNode As SyntaxNode = Nothing
             Dim rightNodeOpt As SyntaxNode = Nothing
-            SyntaxUtilities.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, leftNode, rightNodeOpt)
+            AbstractEditAndContinueAnalyzer.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, leftNode, rightNodeOpt)
             Assert.Equal("0", leftNode.ToString())
             Assert.Null(rightNodeOpt)
         End Sub
@@ -125,7 +126,7 @@ End Class
 
             Dim leftNode As SyntaxNode = Nothing
             Dim rightNodeOpt As SyntaxNode = Nothing
-            SyntaxUtilities.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, leftNode, rightNodeOpt)
+            AbstractEditAndContinueAnalyzer.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, leftNode, rightNodeOpt)
             Assert.Equal("3", leftNode.ToString())
             Assert.Null(rightNodeOpt)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -10860,7 +10860,6 @@ End Class
                 capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
         End Sub
 
-
         <Fact>
         Public Sub ParameterUpdate_TypeChange_Identifier()
             Dim src1 = "Class C : " & vbLf & "Public ReadOnly Property P(a$) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -1362,12 +1362,12 @@ End Class"
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Event E2", FeaturesResources.event_),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F1", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F2", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F3 As Integer", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F4 As New Object", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F3", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F4", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F5(1, 2)", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F6?", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "WE As Object", VBFeaturesResources.WithEvents_field),
-                Diagnostic(RudeEditKind.InsertVirtual, "WE As Object", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "WE", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertVirtual, "WE", VBFeaturesResources.WithEvents_field),
                 Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
             }, capabilities:=nonGenericCapabilities)
 
@@ -1375,11 +1375,11 @@ End Class"
             {
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F1", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F2", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F3 As Integer", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F4 As New Object", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F3", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F4", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F5(1, 2)", FeaturesResources.field),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "F6?", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertVirtual, "WE As Object", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertVirtual, "WE", VBFeaturesResources.WithEvents_field),
                 Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
             }, capabilities:=nonGenericCapabilities Or EditAndContinueCapabilities.GenericAddMethodToExistingType)
 
@@ -1389,14 +1389,14 @@ End Class"
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Property P3", FeaturesResources.auto_property),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Event E1(sender As Object, e As EventArgs)", FeaturesResources.event_),
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Event E2", FeaturesResources.event_),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "WE As Object", VBFeaturesResources.WithEvents_field),
-                Diagnostic(RudeEditKind.InsertVirtual, "WE As Object", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "WE", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertVirtual, "WE", VBFeaturesResources.WithEvents_field),
                 Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
             }, capabilities:=nonGenericCapabilities Or EditAndContinueCapabilities.GenericAddFieldToExistingType)
 
             edits.VerifySemanticDiagnostics(
             {
-                Diagnostic(RudeEditKind.InsertVirtual, "WE As Object", VBFeaturesResources.WithEvents_field),
+                Diagnostic(RudeEditKind.InsertVirtual, "WE", VBFeaturesResources.WithEvents_field),
                 Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
             }, capabilities:=nonGenericCapabilities Or EditAndContinueCapabilities.GenericAddMethodToExistingType Or EditAndContinueCapabilities.GenericAddFieldToExistingType)
         End Sub
@@ -1430,8 +1430,8 @@ End Class
             edits.VerifySemanticDiagnostics(
             {
                 Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Sub F()", FeaturesResources.method),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "X As Integer", FeaturesResources.field),
-                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Y As Integer", FeaturesResources.field)
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "X", FeaturesResources.field),
+                Diagnostic(RudeEditKind.InsertNotSupportedByRuntime, "Y", FeaturesResources.field)
             }, capabilities:=nonGenericCapabilities)
 
             edits.VerifySemanticDiagnostics(capabilities:=
@@ -7559,7 +7559,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertVirtual, "F As C", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.InsertVirtual, "F", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
@@ -7579,7 +7579,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertVirtual, "G As C", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.InsertVirtual, "G", VBFeaturesResources.WithEvents_field))
         End Sub
 
         <Fact>
@@ -7596,8 +7596,8 @@ End Structure
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertIntoStruct, "Private Event d As System.Action", FeaturesResources.event_, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "b As Integer", FeaturesResources.field, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "c As Integer", FeaturesResources.field, VBFeaturesResources.structure_))
+                Diagnostic(RudeEditKind.InsertIntoStruct, "b", FeaturesResources.field, VBFeaturesResources.structure_),
+                Diagnostic(RudeEditKind.InsertIntoStruct, "c", FeaturesResources.field, VBFeaturesResources.structure_))
         End Sub
 
         <Fact>
@@ -7662,9 +7662,9 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7692,9 +7692,9 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7726,7 +7726,7 @@ End Class
 
             ' TODO: We don't compare the ordering currently. We could allow this edit if the ordering is preserved.
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7756,7 +7756,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "a As Integer", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "a", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -10823,7 +10823,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub ParameterUpdate_AsClause1()
+        Public Sub ParameterUpdate_TypeChange_AsClause1()
             Dim src1 = "Class C : " & vbLf & "Public ReadOnly Property P(a As Integer) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
             Dim src2 = "Class C : " & vbLf & "Public ReadOnly Property P(a As Object) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
             Dim edits = GetTopEdits(src1, src2)
@@ -10842,7 +10842,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub ParameterUpdate_AsClause2()
+        Public Sub ParameterUpdate_TypeChange_AsClause2()
             Dim src1 = "Class C : " & vbLf & "Public ReadOnly Property P(a As Integer) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
             Dim src2 = "Class C : " & vbLf & "Public ReadOnly Property P(a) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
             Dim edits = GetTopEdits(src1, src2)
@@ -10855,6 +10855,26 @@ End Class
                 semanticEdits:=
                 {
                     SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Int32)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
+                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.P"))
+                },
+                capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
+        End Sub
+
+
+        <Fact>
+        Public Sub ParameterUpdate_TypeChange_Identifier()
+            Dim src1 = "Class C : " & vbLf & "Public ReadOnly Property P(a$) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
+            Dim src2 = "Class C : " & vbLf & "Public ReadOnly Property P(a%) As Integer" & vbLf & "Get" & vbLf & "Return 0 : End Get : End Property : End Class"
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [a$]@38 -> [a%]@38")
+
+            edits.VerifySemantics(
+                ActiveStatementsDescription.Empty,
+                semanticEdits:=
+                {
+                    SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_String)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
                     SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember("C.P"))
                 },
                 capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -345,9 +345,11 @@
     <value>switch statement</value>
     <comment>{Locked="switch"} "switch" is a C# keyword and should not be localized.</comment>
   </data>
-  <data name="global_statement" xml:space="preserve">
-    <value>global statement</value>
-    <comment>{Locked="global"} "global" is a C# keyword and should not be localized.</comment>
+  <data name="top_level_statement" xml:space="preserve">
+    <value>top-level statement</value>
+  </data>
+  <data name="top_level_code" xml:space="preserve">
+    <value>top-level code</value>
   </data>
   <data name="extern_alias" xml:space="preserve">
     <value>extern alias</value>

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -271,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.BaseConstructorInitializer:
                 case SyntaxKind.ThisConstructorInitializer:
-                    return CreateSpanForConstructorInitializer((ConstructorInitializerSyntax)node);
+                    return CreateSpanForExplicitConstructorInitializer((ConstructorInitializerSyntax)node);
 
                 // Query clauses:
                 // 
@@ -330,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
-        private static TextSpan? CreateSpanForConstructorDeclaration(ConstructorDeclarationSyntax constructorSyntax, int position)
+        internal static TextSpan? CreateSpanForConstructorDeclaration(ConstructorDeclarationSyntax constructorSyntax, int position)
         {
             if (constructorSyntax.ExpressionBody != null &&
                 position > constructorSyntax.ExpressionBody.ArrowToken.Span.Start)
@@ -340,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             if (constructorSyntax.Initializer != null)
             {
-                return CreateSpanForConstructorInitializer(constructorSyntax.Initializer);
+                return CreateSpanForExplicitConstructorInitializer(constructorSyntax.Initializer);
             }
 
             // static ctor doesn't have a default initializer:
@@ -359,12 +360,20 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 return null;
             }
 
-            // the declaration is the span of the implicit initializer
-            return CreateSpan(constructorSyntax.Modifiers, constructorSyntax.Identifier, constructorSyntax.ParameterList.CloseParenToken);
+            return CreateSpanForImplicitConstructorInitializer(constructorSyntax);
         }
 
-        private static TextSpan CreateSpanForConstructorInitializer(ConstructorInitializerSyntax constructorInitializer)
+        internal static TextSpan CreateSpanForImplicitConstructorInitializer(ConstructorDeclarationSyntax constructor)
+            => CreateSpan(constructor.Modifiers, constructor.Identifier, constructor.ParameterList.CloseParenToken);
+
+        internal static IEnumerable<SyntaxToken> GetActiveTokensForImplicitConstructorInitializer(ConstructorDeclarationSyntax constructor)
+            => constructor.Modifiers.Concat(SpecializedCollections.SingletonEnumerable(constructor.Identifier)).Concat(constructor.ParameterList.DescendantTokens());
+
+        internal static TextSpan CreateSpanForExplicitConstructorInitializer(ConstructorInitializerSyntax constructorInitializer)
             => CreateSpan(constructorInitializer.ThisOrBaseKeyword, constructorInitializer.ArgumentList.CloseParenToken);
+
+        internal static IEnumerable<SyntaxToken> GetActiveTokensForExplicitConstructorInitializer(ConstructorInitializerSyntax constructorInitializer)
+            => SpecializedCollections.SingletonEnumerable(constructorInitializer.ThisOrBaseKeyword).Concat(constructorInitializer.ArgumentList.DescendantTokens());
 
         private static TextSpan? TryCreateSpanForFieldDeclaration(BaseFieldDeclarationSyntax fieldDeclaration, int position)
             => TryCreateSpanForVariableDeclaration(fieldDeclaration.Declaration, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken, position);
@@ -643,17 +652,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return CreateSpan(variableDeclarator);
         }
 
-        private static TextSpan CreateSpanForVariableDeclarator(
+        internal static TextSpan CreateSpanForVariableDeclarator(
             VariableDeclaratorSyntax variableDeclarator,
-            SyntaxTokenList modifiersOpt,
-            SyntaxToken semicolonOpt)
+            SyntaxTokenList modifiers,
+            SyntaxToken semicolon)
         {
-            if (variableDeclarator.Initializer == null)
-            {
-                return default;
-            }
-
-            if (modifiersOpt.Any(SyntaxKind.ConstKeyword))
+            if (variableDeclarator.Initializer == null || modifiers.Any(SyntaxKind.ConstKeyword))
             {
                 return default;
             }
@@ -661,15 +665,39 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             var variableDeclaration = (VariableDeclarationSyntax)variableDeclarator.Parent!;
             if (variableDeclaration.Variables.Count == 1)
             {
-                return CreateSpan(modifiersOpt, variableDeclaration, semicolonOpt);
+                return CreateSpan(modifiers, variableDeclaration, semicolon);
             }
 
             if (variableDeclarator == variableDeclaration.Variables[0])
             {
-                return CreateSpan(modifiersOpt, variableDeclaration, variableDeclarator);
+                return CreateSpan(modifiers, variableDeclaration, variableDeclarator);
             }
 
             return CreateSpan(variableDeclarator);
+        }
+
+        internal static IEnumerable<SyntaxToken> GetActiveTokensForVariableDeclarator(VariableDeclaratorSyntax variableDeclarator, SyntaxTokenList modifiers, SyntaxToken semicolon)
+        {
+            if (variableDeclarator.Initializer == null || modifiers.Any(SyntaxKind.ConstKeyword))
+            {
+                return SpecializedCollections.EmptyEnumerable<SyntaxToken>();
+            }
+
+            // [|int F = 1;|]
+            var variableDeclaration = (VariableDeclarationSyntax)variableDeclarator.Parent!;
+            if (variableDeclaration.Variables.Count == 1)
+            {
+                return modifiers.Concat(variableDeclaration.DescendantTokens()).Concat(semicolon);
+            }
+
+            // [|int F = 1|], G = 2;
+            if (variableDeclarator == variableDeclaration.Variables[0])
+            {
+                return modifiers.Concat(variableDeclaration.Type.DescendantTokens()).Concat(variableDeclarator.DescendantTokens());
+            }
+
+            // int F = 1, [|G = 2|];
+            return variableDeclarator.DescendantTokens();
         }
 
         private static VariableDeclaratorSyntax? FindClosestDeclaratorWithInitializer(SeparatedSyntaxList<VariableDeclaratorSyntax> declarators, int position)
@@ -784,50 +812,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Returns a span that contains all possible breakpoint spans of top-level <paramref name="declaration"/>
-        /// and no breakpoint spans that do not belong to the <paramref name="declaration"/>.
-        /// 
-        /// Returns default if the declaration does not have any breakpoint spans.
-        /// </summary>
-        internal static TextSpan GetEnvelope(SyntaxNode declaration)
-        {
-            if (declaration is VariableDeclaratorSyntax { Parent.Parent: BaseFieldDeclarationSyntax fieldDeclaration } variableDeclarator)
-            {
-                return CreateSpanForVariableDeclarator(variableDeclarator, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken);
-            }
-
-            if (declaration is ConstructorDeclarationSyntax constructorDeclaration)
-            {
-                var firstSpan = CreateSpanForConstructorDeclaration(constructorDeclaration, constructorDeclaration.Identifier.SpanStart);
-                if (firstSpan == null)
-                {
-                    return default;
-                }
-
-                var constructorBody = (SyntaxNode?)constructorDeclaration.ExpressionBody ?? constructorDeclaration.Body;
-                if (constructorBody == null)
-                {
-                    return firstSpan.Value;
-                }
-
-                return TextSpan.FromBounds(firstSpan.Value.Start, constructorBody.Span.End);
-            }
-
-            if (declaration is CompilationUnitSyntax unit && unit.ContainsGlobalStatements())
-            {
-                return TextSpan.FromBounds(unit.Members[0].SpanStart, unit.Members.OfType<GlobalStatementSyntax>().Last().Span.End);
-            }
-
-            var body = SyntaxUtilities.TryGetMethodDeclarationBody(declaration);
-            if (body == null)
-            {
-                return default;
-            }
-
-            return body.Span;
         }
     }
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1401,7 +1401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 case SyntaxKind.CompilationUnit:
                     var unit = (CompilationUnitSyntax)node;
-                    
+
                     // When deleting something from a compilation unit we just report diagnostics for the last global statement
                     var globalStatements = unit.Members.OfType<GlobalStatementSyntax>();
                     var globalNode =

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -146,45 +146,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return false;
         }
 
-        /// <returns>
-        /// Given a node representing a declaration or a top-level match node returns:
-        /// - <see cref="BlockSyntax"/> for method-like member declarations with block bodies (methods, operators, constructors, destructors, accessors).
-        /// - <see cref="ExpressionSyntax"/> for variable declarators of fields, properties with an initializer expression, or 
-        ///   for method-like member declarations with expression bodies (methods, properties, indexers, operators)
-        /// - <see cref="CompilationUnitSyntax"/> for top level statements
-        /// 
-        /// A null reference otherwise.
-        /// </returns>
-        internal override SyntaxNode? TryGetDeclarationBody(SyntaxNode node)
-        {
-            if (node is VariableDeclaratorSyntax variableDeclarator)
-            {
-                return variableDeclarator.Initializer?.Value;
-            }
-
-            if (IsCompilationUnitWithGlobalStatements(node))
-            {
-                // For top level statements, where there is no syntax node to represent the entire body of the synthesized
-                // main method we just use the compilation unit itself
-                return node;
-            }
-
-            return SyntaxUtilities.TryGetMethodDeclarationBody(node);
-        }
+        internal override MemberBody? TryGetDeclarationBody(SyntaxNode node)
+            => SyntaxUtilities.TryGetDeclarationBody(node);
 
         internal override bool IsDeclarationWithSharedBody(SyntaxNode declaration)
             => false;
-
-        protected override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model, SyntaxNode memberBody)
-        {
-            if (memberBody is CompilationUnitSyntax unit && unit.ContainsGlobalStatements())
-            {
-                return model.AnalyzeDataFlow(((GlobalStatementSyntax)unit.Members[0]).Statement, unit.Members.OfType<GlobalStatementSyntax>().Last().Statement)!.Captured;
-            }
-
-            Debug.Assert(memberBody.IsKind(SyntaxKind.Block) || memberBody is ExpressionSyntax);
-            return model.AnalyzeDataFlow(memberBody).Captured;
-        }
 
         protected override bool AreHandledEventsEqual(IMethodSymbol oldMethod, IMethodSymbol newMethod)
             => true;
@@ -210,87 +176,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                          (model.GetSymbolInfo(nameSyntax, cancellationToken).Symbol?.Equals(localOrParameter) ?? false)
                    select node;
         }
-
-        /// <returns>
-        /// If <paramref name="node"/> is a method, accessor, operator, destructor, or constructor without an initializer,
-        /// tokens of its block body, or tokens of the expression body.
-        /// 
-        /// If <paramref name="node"/> is an indexer declaration the tokens of its expression body.
-        /// 
-        /// If <paramref name="node"/> is a property declaration the tokens of its expression body or initializer.
-        ///   
-        /// If <paramref name="node"/> is a constructor with an initializer, 
-        /// tokens of the initializer concatenated with tokens of the constructor body.
-        /// 
-        /// If <paramref name="node"/> is a variable declarator of a field with an initializer,
-        /// subset of the tokens of the field declaration depending on which variable declarator it is.
-        /// 
-        /// If <paramref name="node"/> is a <see cref="CompilationUnitSyntax"/> the tokens of all its global statements.
-        /// Null reference otherwise.
-        /// </returns>
-        internal override IEnumerable<SyntaxToken>? TryGetActiveTokens(SyntaxNode node)
-        {
-            if (node.IsKind(SyntaxKind.VariableDeclarator))
-            {
-                // TODO: The logic is similar to BreakpointSpans.TryCreateSpanForVariableDeclaration. Can we abstract it?
-
-                var declarator = node;
-                var fieldDeclaration = (BaseFieldDeclarationSyntax)declarator.Parent!.Parent!;
-                var variableDeclaration = fieldDeclaration.Declaration;
-
-                if (fieldDeclaration.Modifiers.Any(SyntaxKind.ConstKeyword))
-                {
-                    return null;
-                }
-
-                if (variableDeclaration.Variables.Count == 1)
-                {
-                    if (variableDeclaration.Variables[0].Initializer == null)
-                    {
-                        return null;
-                    }
-
-                    return fieldDeclaration.Modifiers.Concat(variableDeclaration.DescendantTokens()).Concat(fieldDeclaration.SemicolonToken);
-                }
-
-                if (declarator == variableDeclaration.Variables[0])
-                {
-                    return fieldDeclaration.Modifiers.Concat(variableDeclaration.Type.DescendantTokens()).Concat(node.DescendantTokens());
-                }
-
-                return declarator.DescendantTokens();
-            }
-
-            if (node is PropertyDeclarationSyntax { ExpressionBody: var propertyExpressionBody and not null })
-            {
-                return propertyExpressionBody.Expression.DescendantTokens();
-            }
-
-            if (node is IndexerDeclarationSyntax { ExpressionBody: var indexerExpressionBody and not null })
-            {
-                return indexerExpressionBody.Expression.DescendantTokens();
-            }
-
-            if (node is CompilationUnitSyntax unit && unit.ContainsGlobalStatements())
-            {
-                return unit.Members.OfType<GlobalStatementSyntax>().SelectMany(globalStatement => globalStatement.DescendantTokens());
-            }
-
-            var bodyTokens = SyntaxUtilities.TryGetMethodDeclarationBody(node)?.DescendantTokens();
-
-            if (node is ConstructorDeclarationSyntax ctor)
-            {
-                if (ctor.Initializer != null)
-                {
-                    bodyTokens = ctor.Initializer.DescendantTokens().Concat(bodyTokens ?? Enumerable.Empty<SyntaxToken>());
-                }
-            }
-
-            return bodyTokens;
-        }
-
-        internal override (TextSpan envelope, TextSpan hole) GetActiveSpanEnvelope(SyntaxNode declaration)
-            => (BreakpointSpans.GetEnvelope(declaration), default);
 
         protected override SyntaxNode GetEncompassingAncestorImpl(SyntaxNode bodyOrMatchRoot)
         {
@@ -323,59 +208,35 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return bodyOrMatchRoot;
         }
 
-        protected override SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, TextSpan span, SyntaxNode? partnerDeclarationBody, out SyntaxNode? partner, out int statementPart)
+        internal static SyntaxNode FindStatementAndPartner(
+            TextSpan span,
+            SyntaxNode body,
+            SyntaxNode? partnerBody,
+            out SyntaxNode? partnerStatement,
+            out int statementPart)
         {
             var position = span.Start;
 
-            SyntaxUtilities.AssertIsBody(declarationBody, allowLambda: false);
-
-            if (position < declarationBody.SpanStart)
-            {
-                // Only constructors and the field initializers may have an [|active statement|] starting outside of the <<body>>.
-                // Constructor:                          [|public C()|] <<{ }>>
-                // Constructor initializer:              public C() : [|base(expr)|] <<{ }>>
-                // Constructor initializer with lambda:  public C() : base(() => { [|...|] }) <<{ }>>
-                // Field initializers:                   [|public int a = <<expr>>|], [|b = <<expr>>|];
-
-                // No need to special case property initializers here, the active statement always spans the initializer expression.
-
-                if (declarationBody.Parent.IsKind(SyntaxKind.ConstructorDeclaration))
-                {
-                    var constructor = (ConstructorDeclarationSyntax)declarationBody.Parent;
-                    var partnerConstructor = (ConstructorDeclarationSyntax?)partnerDeclarationBody?.Parent;
-
-                    if (constructor.Initializer == null || position < constructor.Initializer.ColonToken.SpanStart)
-                    {
-                        statementPart = DefaultStatementPart;
-                        partner = partnerConstructor;
-                        return constructor;
-                    }
-
-                    declarationBody = constructor.Initializer;
-                    partnerDeclarationBody = partnerConstructor?.Initializer;
-                }
-            }
-
-            if (!declarationBody.FullSpan.Contains(position))
+            if (!body.FullSpan.Contains(position))
             {
                 // invalid position, let's find a labeled node that encompasses the body:
-                position = declarationBody.SpanStart;
+                position = body.SpanStart;
             }
 
             SyntaxNode node;
-            if (partnerDeclarationBody != null)
+            if (partnerBody != null)
             {
-                SyntaxUtilities.FindLeafNodeAndPartner(declarationBody, position, partnerDeclarationBody, out node, out partner);
+                FindLeafNodeAndPartner(body, position, partnerBody, out node, out partnerStatement);
             }
             else
             {
-                node = declarationBody.FindToken(position).Parent!;
-                partner = null;
+                node = body.FindToken(position).Parent!;
+                partnerStatement = null;
             }
 
             while (true)
             {
-                var isBody = node == declarationBody || LambdaUtilities.IsLambdaBodyStatementOrExpression(node);
+                var isBody = node == body || LambdaUtilities.IsLambdaBodyStatementOrExpression(node);
 
                 if (isBody || SyntaxComparer.Statement.HasLabel(node))
                 {
@@ -415,9 +276,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                             node = ((VariableDeclarationSyntax)node).Variables.First();
 
-                            if (partner != null)
+                            if (partnerStatement != null)
                             {
-                                partner = ((VariableDeclarationSyntax)partner).Variables.First();
+                                partnerStatement = ((VariableDeclarationSyntax)partnerStatement).Variables.First();
                             }
 
                             statementPart = DefaultStatementPart;
@@ -465,9 +326,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 }
 
                 node = node.Parent!;
-                if (partner != null)
+                if (partnerStatement != null)
                 {
-                    partner = partner.Parent;
+                    partnerStatement = partnerStatement.Parent;
                 }
             }
         }
@@ -517,9 +378,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 _ => throw ExceptionUtilities.UnexpectedValue(part),
             };
 
-        protected override bool AreEquivalentLambdaBodies(SyntaxNode oldLambda, SyntaxNode oldLambdaBody, SyntaxNode newLambda, SyntaxNode newLambdaBody)
-            => SyntaxFactory.AreEquivalent(oldLambdaBody, newLambdaBody);
-
         private static bool AreEquivalentIgnoringLambdaBodies(SyntaxNode left, SyntaxNode right)
         {
             // usual case:
@@ -531,22 +389,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return LambdaUtilities.AreEquivalentIgnoringLambdaBodies(left, right);
         }
 
-        internal override SyntaxNode FindDeclarationBodyPartner(SyntaxNode leftRoot, SyntaxNode rightRoot, SyntaxNode leftNode)
-            => SyntaxUtilities.FindPartner(leftRoot, rightRoot, leftNode);
-
         internal override bool IsClosureScope(SyntaxNode node)
             => LambdaUtilities.IsClosureScope(node);
 
-        protected override SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode node)
+        protected override LambdaBody? FindEnclosingLambdaBody(SyntaxNode root, SyntaxNode node)
         {
-            var root = GetEncompassingAncestor(container);
-
             var current = node;
             while (current != root && current != null)
             {
                 if (LambdaUtilities.IsLambdaBodyStatementOrExpression(current, out var body))
                 {
-                    return body;
+                    return SyntaxUtilities.CreateLambdaBody(body);
                 }
 
                 current = current.Parent;
@@ -554,12 +407,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             return null;
         }
-
-        protected override IEnumerable<SyntaxNode> GetLambdaBodyExpressionsAndStatements(SyntaxNode lambdaBody)
-            => SpecializedCollections.SingletonEnumerable(lambdaBody);
-
-        protected override SyntaxNode? TryGetPartnerLambdaBody(SyntaxNode oldBody, SyntaxNode newLambda)
-            => LambdaUtilities.TryGetCorrespondingLambdaBody(oldBody, newLambda);
 
         protected override Match<SyntaxNode> ComputeTopLevelMatch(SyntaxNode oldCompilationUnit, SyntaxNode newCompilationUnit)
             => SyntaxComparer.TopLevel.ComputeMatch(oldCompilationUnit, newCompilationUnit);
@@ -577,20 +424,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 _ => declaration.GetParameterList()
             };
 
-        protected override Match<SyntaxNode> ComputeTopLevelDeclarationMatch(SyntaxNode oldDeclaration, SyntaxNode newDeclaration)
-        {
-            Contract.ThrowIfNull(oldDeclaration.Parent);
-            Contract.ThrowIfNull(newDeclaration.Parent);
-            var comparer = new SyntaxComparer(oldDeclaration.Parent, newDeclaration.Parent, new[] { oldDeclaration }, new[] { newDeclaration }, compareStatementSyntax: false);
-            return comparer.ComputeMatch(oldDeclaration.Parent, newDeclaration.Parent);
-        }
-
-        protected override Match<SyntaxNode> ComputeBodyMatchImpl(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        internal static Match<SyntaxNode> ComputeBodyMatch(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
         {
             SyntaxUtilities.AssertIsBody(oldBody, allowLambda: true);
             SyntaxUtilities.AssertIsBody(newBody, allowLambda: true);
 
-            if (oldBody is ExpressionSyntax || newBody is ExpressionSyntax || (oldBody.Parent.IsKind(SyntaxKind.LocalFunctionStatement) && newBody.Parent.IsKind(SyntaxKind.LocalFunctionStatement)))
+            if (oldBody is ExpressionSyntax ||
+                newBody is ExpressionSyntax ||
+                (oldBody.Parent.IsKind(SyntaxKind.LocalFunctionStatement) && newBody.Parent.IsKind(SyntaxKind.LocalFunctionStatement)))
             {
                 Debug.Assert(oldBody is ExpressionSyntax or BlockSyntax);
                 Debug.Assert(newBody is ExpressionSyntax or BlockSyntax);
@@ -620,18 +461,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 var oldRoot = GetMatchingRoot(oldBody);
                 var newRoot = GetMatchingRoot(newBody);
                 return new SyntaxComparer(oldRoot, newRoot, GetChildNodes(oldRoot, oldBody), GetChildNodes(newRoot, newBody), compareStatementSyntax: true).ComputeMatch(oldRoot, newRoot, knownMatches);
-            }
-
-            if (oldBody.Parent.IsKind(SyntaxKind.ConstructorDeclaration))
-            {
-                // We need to include constructor initializer in the match, since it may contain lambdas.
-                // Use the constructor declaration as a root.
-                RoslynDebug.Assert(oldBody.IsKind(SyntaxKind.Block));
-                RoslynDebug.Assert(newBody.IsKind(SyntaxKind.Block));
-                RoslynDebug.Assert(newBody.Parent.IsKind(SyntaxKind.ConstructorDeclaration));
-                RoslynDebug.Assert(newBody.Parent is object);
-
-                return SyntaxComparer.Statement.ComputeMatch(oldBody.Parent, newBody.Parent, knownMatches);
             }
 
             return SyntaxComparer.Statement.ComputeMatch(oldBody, newBody, knownMatches);
@@ -674,40 +503,25 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
-        protected override bool TryMatchActiveStatement(
-            SyntaxNode oldStatement,
-            int statementPart,
+        internal static bool TryMatchActiveStatement(
             SyntaxNode oldBody,
             SyntaxNode newBody,
+            SyntaxNode oldStatement,
             [NotNullWhen(true)] out SyntaxNode? newStatement)
         {
-            SyntaxUtilities.AssertIsBody(oldBody, allowLambda: true);
-            SyntaxUtilities.AssertIsBody(newBody, allowLambda: true);
+            // TODO: Consider mapping an expression body to an equivalent statement expression or return statement and vice versa.
+            // It would benefit transformations of expression bodies to block bodies of lambdas, methods, operators and properties.
+            // See https://github.com/dotnet/roslyn/issues/22696
 
-            switch (oldStatement.Kind())
+            // field initializer, lambda and query expressions:
+            if (oldStatement == oldBody && !newBody.IsKind(SyntaxKind.Block))
             {
-                case SyntaxKind.ThisConstructorInitializer:
-                case SyntaxKind.BaseConstructorInitializer:
-                case SyntaxKind.ConstructorDeclaration:
-                    var newConstructor = (ConstructorDeclarationSyntax)(newBody.Parent.IsKind(SyntaxKind.ArrowExpressionClause) ? newBody.Parent.Parent : newBody.Parent)!;
-                    newStatement = (SyntaxNode?)newConstructor.Initializer ?? newConstructor;
-                    return true;
-
-                default:
-                    // TODO: Consider mapping an expression body to an equivalent statement expression or return statement and vice versa.
-                    // It would benefit transformations of expression bodies to block bodies of lambdas, methods, operators and properties.
-                    // See https://github.com/dotnet/roslyn/issues/22696
-
-                    // field initializer, lambda and query expressions:
-                    if (oldStatement == oldBody && !newBody.IsKind(SyntaxKind.Block))
-                    {
-                        newStatement = newBody;
-                        return true;
-                    }
-
-                    newStatement = null;
-                    return false;
+                newStatement = newBody;
+                return true;
             }
+
+            newStatement = null;
+            return false;
         }
 
         #endregion
@@ -725,22 +539,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         protected override bool IsGlobalStatement(SyntaxNode node)
             => node.IsKind(SyntaxKind.GlobalStatement);
-
-        protected override TextSpan GetGlobalStatementDiagnosticSpan(SyntaxNode node, EditKind editKind)
-        {
-            if (node is CompilationUnitSyntax unit)
-            {
-                // When deleting something from a compilation unit we just report diagnostics for the last global statement
-                if (editKind == EditKind.Delete)
-                {
-                    return unit.Members.OfType<GlobalStatementSyntax>().LastOrDefault()?.Span ?? default;
-                }
-
-                return unit.Members.OfType<GlobalStatementSyntax>().FirstOrDefault()?.Span ?? default;
-            }
-
-            return GetDiagnosticSpan(node, editKind);
-        }
 
         protected override IEnumerable<SyntaxNode> GetTopLevelTypeDeclarations(SyntaxNode compilationUnit)
         {
@@ -1464,11 +1262,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                IsTypeDeclaration(node) ||
                node is BaseNamespaceDeclarationSyntax;
 
-        internal override bool ContainsLambda(SyntaxNode declaration)
-            => declaration.DescendantNodes().Any(LambdaUtilities.IsLambda);
-
-        internal override bool IsLambda(SyntaxNode node)
-            => LambdaUtilities.IsLambda(node);
+        internal override Func<SyntaxNode, bool> IsLambda
+            => LambdaUtilities.IsLambda;
 
         internal override bool IsLocalFunction(SyntaxNode node)
             => node.IsKind(SyntaxKind.LocalFunctionStatement);
@@ -1479,11 +1274,19 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         internal override bool IsNestedFunction(SyntaxNode node)
             => node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax;
 
-        internal override bool TryGetLambdaBodies(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? body1, out SyntaxNode? body2)
-            => LambdaUtilities.TryGetLambdaBodies(node, out body1, out body2);
+        internal override bool TryGetLambdaBodies(SyntaxNode node, [NotNullWhen(true)] out LambdaBody? body1, out LambdaBody? body2)
+        {
+            if (LambdaUtilities.TryGetLambdaBodies(node, out var bodyNode1, out var bodyNode2))
+            {
+                body1 = SyntaxUtilities.CreateLambdaBody(bodyNode1);
+                body2 = (bodyNode2 != null) ? SyntaxUtilities.CreateLambdaBody(bodyNode2) : null;
+                return true;
+            }
 
-        internal override SyntaxNode GetLambda(SyntaxNode lambdaBody)
-            => LambdaUtilities.GetLambda(lambdaBody);
+            body1 = null;
+            body2 = null;
+            return false;
+        }
 
         internal override IMethodSymbol GetLambdaExpressionSymbol(SemanticModel model, SyntaxNode lambdaExpression, CancellationToken cancellationToken)
         {
@@ -1597,7 +1400,20 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             switch (kind)
             {
                 case SyntaxKind.CompilationUnit:
-                    return default(TextSpan);
+                    var unit = (CompilationUnitSyntax)node;
+                    
+                    // When deleting something from a compilation unit we just report diagnostics for the last global statement
+                    var globalStatements = unit.Members.OfType<GlobalStatementSyntax>();
+                    var globalNode =
+                        (editKind == EditKind.Delete ? globalStatements.LastOrDefault() : globalStatements.FirstOrDefault()) ??
+                        unit.ChildNodes().FirstOrDefault();
+
+                    if (globalNode == null)
+                    {
+                        return null;
+                    }
+
+                    return GetDiagnosticSpan(globalNode, editKind);
 
                 case SyntaxKind.GlobalStatement:
                     return node.Span;
@@ -1967,8 +1783,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 // top-level
 
                 case SyntaxKind.CompilationUnit:
+                    return CSharpFeaturesResources.top_level_code;
+
                 case SyntaxKind.GlobalStatement:
-                    return CSharpFeaturesResources.global_statement;
+                    return CSharpFeaturesResources.top_level_statement;
 
                 case SyntaxKind.ExternAliasDirective:
                     return CSharpFeaturesResources.extern_alias;
@@ -2441,14 +2259,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 }
             }
 
-            public void ClassifyDeclarationBodyRudeUpdates(SyntaxNode newBody)
+            public void ClassifyDeclarationBodyRudeUpdates(DeclarationBody newBody)
             {
-                foreach (var node in newBody.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda))
+                foreach (var root in newBody.RootNodes)
                 {
-                    if (node.Kind() is SyntaxKind.StackAllocArrayCreationExpression or SyntaxKind.ImplicitStackAllocArrayCreationExpression)
+                    foreach (var node in root.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda))
                     {
-                        ReportError(RudeEditKind.StackAllocUpdate, node, _newNode);
-                        return;
+                        if (node.Kind() is SyntaxKind.StackAllocArrayCreationExpression or SyntaxKind.ImplicitStackAllocArrayCreationExpression)
+                        {
+                            ReportError(RudeEditKind.StackAllocUpdate, node, _newNode);
+                            return;
+                        }
                     }
                 }
             }
@@ -2469,7 +2290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             classifier.ClassifyEdit();
         }
 
-        internal override void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, SyntaxNode newBody, TextSpan? span)
+        internal override void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, DeclarationBody newBody, TextSpan? span)
         {
             var classifier = new EditClassifier(this, diagnostics, oldNode: null, newDeclaration, EditKind.Update, span: span);
             classifier.ClassifyDeclarationBodyRudeUpdates(newBody);
@@ -2681,12 +2502,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         internal override bool IsStateMachineMethod(SyntaxNode declaration)
             => SyntaxUtilities.IsAsyncDeclaration(declaration) || SyntaxUtilities.IsIterator(declaration);
-
-        internal override StateMachineInfo GetStateMachineInfo(SyntaxNode body)
-            => new(
-                IsAsync: SyntaxUtilities.IsAsyncDeclaration(body.Parent),
-                IsIterator: SyntaxUtilities.IsIterator(body),
-                HasSuspensionPoints: SyntaxUtilities.GetSuspensionPoints(body).Any());
 
         internal override void ReportStateMachineSuspensionPointRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode)
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/CSharpLambdaBody.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal sealed class CSharpLambdaBody(SyntaxNode node) : LambdaBody
+{
+    public SyntaxNode Node
+        => node;
+
+    public sealed override SyntaxTree SyntaxTree
+        => node.SyntaxTree;
+
+    public override OneOrMany<SyntaxNode> RootNodes
+        => OneOrMany.Create(node);
+
+    public override StateMachineInfo GetStateMachineInfo()
+        => new(
+            IsAsync: SyntaxUtilities.IsAsyncDeclaration(node.Parent!),
+            IsIterator: SyntaxUtilities.IsIterator(node),
+            HasSuspensionPoints: SyntaxUtilities.GetSuspensionPoints(node).Any());
+
+    public override Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        => CSharpEditAndContinueAnalyzer.ComputeBodyMatch(node, ((CSharpLambdaBody)newBody).Node, knownMatches);
+
+    public override bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement)
+        => CSharpEditAndContinueAnalyzer.TryMatchActiveStatement(Node, ((CSharpLambdaBody)newBody).Node, oldStatement, out newStatement);
+
+    public override LambdaBody? TryGetPartnerLambdaBody(SyntaxNode newLambda)
+        => LambdaUtilities.TryGetCorrespondingLambdaBody(node, newLambda) is { } newNode ? new CSharpLambdaBody(newNode) : null;
+
+    public override IEnumerable<SyntaxNode> GetExpressionsAndStatements()
+        => SpecializedCollections.SingletonEnumerable(node);
+
+    public override SyntaxNode GetLambda()
+        => LambdaUtilities.GetLambda(node);
+
+    public override bool IsSyntaxEquivalentTo(LambdaBody other)
+        => SyntaxFactory.AreEquivalent(node, ((CSharpLambdaBody)other).Node);
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+/// <summary>
+/// Breakpoint spans:
+/// 
+/// [|public int a = expr;|]
+/// [|public int a = expr|], [|b = expr|];
+/// </summary>
+internal sealed class FieldWithInitializerDeclarationBody(VariableDeclaratorSyntax variableDeclarator) : MemberBody
+{
+    public ExpressionSyntax InitializerExpression
+        => variableDeclarator.Initializer!.Value;
+
+    private BaseFieldDeclarationSyntax GetFieldDeclaration()
+        => (BaseFieldDeclarationSyntax)variableDeclarator.Parent!.Parent!;
+
+    public override SyntaxTree SyntaxTree
+        => variableDeclarator.SyntaxTree;
+
+    public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
+        => model.AnalyzeDataFlow(InitializerExpression)!.Captured;
+
+    public override ActiveStatementEnvelope Envelope
+    {
+        get
+        {
+            var fieldDeclaration = GetFieldDeclaration();
+            return BreakpointSpans.CreateSpanForVariableDeclarator(variableDeclarator, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken);
+        }
+    }
+
+    public override SyntaxNode EncompassingAncestor
+        => GetFieldDeclaration();
+
+    public override IEnumerable<SyntaxToken> GetActiveTokens()
+    {
+        var fieldDeclaration = GetFieldDeclaration();
+        return BreakpointSpans.GetActiveTokensForVariableDeclarator(variableDeclarator, fieldDeclaration.Modifiers, fieldDeclaration.SemicolonToken);
+    }
+
+    public override StateMachineInfo GetStateMachineInfo()
+        => new(IsAsync: false, IsIterator: false, HasSuspensionPoints: false);
+
+    public override OneOrMany<SyntaxNode> RootNodes
+        => OneOrMany.Create<SyntaxNode>(InitializerExpression);
+
+    public override Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        => CSharpEditAndContinueAnalyzer.ComputeBodyMatch(InitializerExpression, ((FieldWithInitializerDeclarationBody)newBody).InitializerExpression, knownMatches);
+
+    public override bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement)
+    {
+        if (oldStatement == InitializerExpression)
+        {
+            newStatement = ((FieldWithInitializerDeclarationBody)newBody).InitializerExpression;
+            return true;
+        }
+
+        newStatement = null;
+        return false;
+    }
+
+    public override SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart)
+        => CSharpEditAndContinueAnalyzer.FindStatementAndPartner(
+            span,
+            body: InitializerExpression,
+            partnerBody: ((FieldWithInitializerDeclarationBody?)partnerDeclarationBody)?.InitializerExpression,
+            out partnerStatement,
+            out statementPart);
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorDeclarationBody.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal abstract class InstanceConstructorDeclarationBody(ConstructorDeclarationSyntax constructor) : MemberBody
+{
+    public ConstructorDeclarationSyntax Constructor
+        => constructor;
+
+    public SyntaxNode Body
+        => (SyntaxNode?)constructor.Body ?? constructor.ExpressionBody?.Expression!;
+
+    /// <summary>
+    /// Active statement node for the implicit or explicit constructor initializer.
+    /// Implicit initializer: [|public C()|] { }
+    /// Explicit initializer: public C() : [|base(expr)|] { }
+    /// </summary>
+    public abstract SyntaxNode InitializerActiveStatement { get; }
+
+    public sealed override SyntaxNode EncompassingAncestor
+        => Constructor;
+
+    public sealed override SyntaxTree SyntaxTree
+        => constructor.SyntaxTree;
+
+    public override OneOrMany<SyntaxNode> RootNodes
+        => OneOrMany.Create<SyntaxNode>(Constructor);
+
+    public sealed override SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart)
+    {
+        var partnerCtorBody = (InstanceConstructorDeclarationBody?)partnerDeclarationBody;
+
+        if (span.Start == InitializerActiveStatement.SpanStart)
+        {
+            statementPart = AbstractEditAndContinueAnalyzer.DefaultStatementPart;
+            partnerStatement = partnerCtorBody?.InitializerActiveStatement;
+            return InitializerActiveStatement;
+        }
+
+        if (Constructor.Initializer?.Span.Contains(span.Start) == true)
+        {
+            // Partner body does not have any non-trivial changes and thus the initializer is also present.
+            Debug.Assert(partnerCtorBody == null || partnerCtorBody?.Constructor.Initializer != null);
+
+            return CSharpEditAndContinueAnalyzer.FindStatementAndPartner(
+                span,
+                body: Constructor.Initializer,
+                partnerBody: partnerCtorBody?.Constructor.Initializer,
+                out partnerStatement,
+                out statementPart);
+        }
+
+        return CSharpEditAndContinueAnalyzer.FindStatementAndPartner(
+                span,
+                body: Body,
+                partnerBody: partnerCtorBody?.Body,
+                out partnerStatement,
+                out statementPart);
+    }
+
+    public sealed override StateMachineInfo GetStateMachineInfo()
+        => new(IsAsync: false, IsIterator: false, HasSuspensionPoints: false);
+
+    public sealed override Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        => SyntaxComparer.Statement.ComputeMatch(Constructor, ((InstanceConstructorDeclarationBody)newBody).Constructor, knownMatches);
+
+    public sealed override bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement)
+    {
+        var newCtorBody = (InstanceConstructorDeclarationBody)newBody;
+
+        if (oldStatement is (kind: SyntaxKind.ThisConstructorInitializer or SyntaxKind.BaseConstructorInitializer or SyntaxKind.ConstructorDeclaration))
+        {
+            newStatement = newCtorBody.Constructor.Initializer ?? (SyntaxNode)newCtorBody.Constructor;
+            return true;
+        }
+
+        return CSharpEditAndContinueAnalyzer.TryMatchActiveStatement(Body, newCtorBody.Body, oldStatement, out newStatement);
+    }
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorWithExplicitInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorWithExplicitInitializerDeclarationBody.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal sealed class InstanceConstructorWithExplicitInitializerDeclarationBody(ConstructorDeclarationSyntax constructor)
+    : InstanceConstructorDeclarationBody(constructor)
+{
+    private ConstructorInitializerSyntax Initializer
+        => Constructor.Initializer!;
+
+    public override SyntaxNode InitializerActiveStatement
+        => Initializer;
+
+    public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
+        => model.AnalyzeDataFlow(Initializer)!.Captured.AddRange(model.AnalyzeDataFlow(Body).Captured).Distinct();
+
+    public override ActiveStatementEnvelope Envelope
+        => TextSpan.FromBounds(BreakpointSpans.CreateSpanForExplicitConstructorInitializer(Initializer).Start, Body.Span.End);
+
+    public override IEnumerable<SyntaxToken> GetActiveTokens()
+        => BreakpointSpans.GetActiveTokensForExplicitConstructorInitializer(Initializer).Concat(Body.DescendantTokens());
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorWithImplicitInitializerDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/InstanceConstructorWithImplicitInitializerDeclarationBody.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal sealed class InstanceConstructorWithImplicitInitializerDeclarationBody(ConstructorDeclarationSyntax constructor)
+    : InstanceConstructorDeclarationBody(constructor)
+{
+    public override SyntaxNode InitializerActiveStatement
+        => Constructor;
+
+    public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
+        => model.AnalyzeDataFlow(Body).Captured;
+
+    public override ActiveStatementEnvelope Envelope
+        => TextSpan.FromBounds(BreakpointSpans.CreateSpanForImplicitConstructorInitializer(Constructor).Start, Body.Span.End);
+
+    public override IEnumerable<SyntaxToken> GetActiveTokens()
+        => BreakpointSpans.GetActiveTokensForImplicitConstructorInitializer(Constructor).Concat(Body.DescendantTokens());
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/SimpleMemberBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/SimpleMemberBody.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal sealed class SimpleMemberBody(SyntaxNode node) : AbstractSimpleMemberBody(node)
+{
+    public override SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart)
+        => CSharpEditAndContinueAnalyzer.FindStatementAndPartner(
+            span,
+            body: Node,
+            partnerBody: ((SimpleMemberBody?)partnerDeclarationBody)?.Node,
+            out partnerStatement,
+            out statementPart);
+
+    public override StateMachineInfo GetStateMachineInfo()
+        => new(
+            IsAsync: SyntaxUtilities.IsAsyncDeclaration(Node.Parent!),
+            IsIterator: SyntaxUtilities.IsIterator(Node),
+            HasSuspensionPoints: SyntaxUtilities.GetSuspensionPoints(Node).Any());
+
+    public override Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        => CSharpEditAndContinueAnalyzer.ComputeBodyMatch(Node, ((SimpleMemberBody)newBody).Node, knownMatches);
+
+    public override bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement)
+        => CSharpEditAndContinueAnalyzer.TryMatchActiveStatement(Node, ((SimpleMemberBody)newBody).Node, oldStatement, out newStatement);
+}

--- a/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/TopLevelCodeDeclarationBody.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/DeclarationBody/TopLevelCodeDeclarationBody.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Differencing;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue;
+
+internal sealed class TopLevelCodeDeclarationBody(CompilationUnitSyntax unit) : MemberBody
+{
+    public CompilationUnitSyntax Unit
+        => unit;
+
+    private IEnumerable<GlobalStatementSyntax> GlobalStatements
+        => unit.Members.OfType<GlobalStatementSyntax>();
+
+    public override SyntaxTree SyntaxTree
+        => unit.SyntaxTree;
+
+    public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
+        => model.AnalyzeDataFlow(((GlobalStatementSyntax)unit.Members[0]).Statement, GlobalStatements.Last().Statement)!.Captured;
+
+    public override ActiveStatementEnvelope Envelope
+        => TextSpan.FromBounds(unit.Members[0].SpanStart, GlobalStatements.Last().Span.End);
+
+    public override SyntaxNode EncompassingAncestor
+        => unit;
+
+    public override IEnumerable<SyntaxToken>? GetActiveTokens()
+        => GlobalStatements.SelectMany(globalStatement => globalStatement.DescendantTokens());
+
+    public override StateMachineInfo GetStateMachineInfo()
+    {
+        var isAsync = GlobalStatements.Any(static s => SyntaxUtilities.GetSuspensionPoints(s).Any());
+        return new StateMachineInfo(IsAsync: isAsync, IsIterator: false, HasSuspensionPoints: isAsync);
+    }
+
+    public override OneOrMany<SyntaxNode> RootNodes
+        => OneOrMany.Create(GlobalStatements.ToImmutableArray<SyntaxNode>());
+
+    public override Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches)
+        => CSharpEditAndContinueAnalyzer.ComputeBodyMatch(Unit, ((TopLevelCodeDeclarationBody)newBody).Unit, knownMatches);
+
+    public override SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart)
+        => CSharpEditAndContinueAnalyzer.FindStatementAndPartner(
+            span,
+            body: Unit,
+            partnerBody: ((TopLevelCodeDeclarationBody?)partnerDeclarationBody)?.Unit,
+            out partnerStatement,
+            out statementPart);
+
+    public override bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement)
+    {
+        newStatement = null;
+        return false;
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -432,6 +432,16 @@
         <target state="translated">klauzule case příkazu switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blok try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">místní ref nebo výraz</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">příkaz global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -432,6 +432,16 @@
         <target state="translated">case-Klausel für switch-Anweisung</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try-Block</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref – "local" oder Ausdruck</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global – Anweisung</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -432,6 +432,16 @@
         <target state="translated">cláusula case de la instrucción switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloque try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref local o expresión</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">declaración global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -432,6 +432,16 @@
         <target state="translated">clause case d'une instruction switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloc try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">variable locale ou expression ref</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">instruction global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -432,6 +432,16 @@
         <target state="translated">clausola case dell'istruzione switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blocco try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">espressione o variabile locale ref</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">istruzione global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -432,6 +432,16 @@
         <target state="translated">switch ステートメントの case 句</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try ブロック</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref ローカルまたは式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global ステートメント</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -432,6 +432,16 @@
         <target state="translated">switch 문 case 절</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 블록</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref 지역 또는 식</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global 문</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -432,6 +432,16 @@
         <target state="translated">klauzula case instrukcji switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blok try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref — lokalna zmienna lub wyrażenie</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">instrukcja global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -432,6 +432,16 @@
         <target state="translated">cláusula case da instrução switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloco try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">expressão ou variável local ref</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">instrução global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -432,6 +432,16 @@
         <target state="translated">предложение case оператора switch</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">блок try</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">локальная переменная ref или выражение</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">инструкция global</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -432,6 +432,16 @@
         <target state="translated">switch deyimi case yan tümcesi</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try bloğu</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">yerel ref veya ifade</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global deyimi</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -432,6 +432,16 @@
         <target state="translated">switch 语句 case 子句</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 块</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref 本地函数或表达式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global 语句</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -432,6 +432,16 @@
         <target state="translated">switch 陳述式 case 子句</target>
         <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="top_level_code">
+        <source>top-level code</source>
+        <target state="new">top-level code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="top_level_statement">
+        <source>top-level statement</source>
+        <target state="new">top-level statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 區塊</target>
@@ -576,11 +586,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref 區域或運算式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="global_statement">
-        <source>global statement</source>
-        <target state="translated">global 陳述式</target>
-        <note>{Locked="global"} "global" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_directive">
         <source>using directive</source>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -6476,9 +6476,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         #region Helpers
 
-        protected static OneOrMany<T> OneOrNone<T>(T? item)
-            => item is null ? OneOrMany<T>.Empty : OneOrMany.Create(item);
-
         private static bool AreEqualIgnoringTrivia(SyntaxToken oldToken, SyntaxToken newToken)
         {
             if (oldToken.Span.Length != newToken.Span.Length)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -3166,7 +3166,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
                         }
-                        
+
                         semanticEdits.Add(new SemanticEditInfo(editKind, symbolKey, syntaxMap, syntaxMapTree: null,
                             IsPartialEdit(oldSymbol, newSymbol, editScript.Match.OldRoot.SyntaxTree, editScript.Match.NewRoot.SyntaxTree) ? symbolKey : null));
                     }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -97,26 +97,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal abstract bool TryFindMemberDeclaration(SyntaxNode? root, SyntaxNode node, out OneOrMany<SyntaxNode> declarations);
 
         /// <summary>
-        /// If the specified node represents a member declaration returns a node that represents its body,
-        /// i.e. a node used as the root of statement-level match.
+        /// If the specified node represents a member declaration returns an object that represents its body.
         /// </summary>
         /// <param name="node">A node representing a declaration or a top-level edit node.</param>
         /// 
         /// <returns>
-        /// Returns null for nodes that don't represent declarations.
+        /// Null for nodes that don't represent declarations.
         /// </returns>
-        /// <remarks>
-        /// The implementation has to decide what kinds of nodes in top-level match relationship represent a declaration.
-        /// Every member declaration must be represented by exactly one node, but not all nodes have to represent a declaration.
-        /// 
-        /// If a member doesn't have a body (null is returned) it can't have associated active statements.
-        /// 
-        /// Body does not need to cover all active statements that may be associated with the member. 
-        /// E.g. Body of a C# constructor is the method body block. Active statements may be placed on the base constructor call.
-        ///      Body of a VB field declaration with shared AsNew initializer is the New expression. Active statements might be placed on the field variables.
-        /// <see cref="FindStatementAndPartner"/> has to account for such cases.
-        /// </remarks>
-        internal abstract SyntaxNode? TryGetDeclarationBody(SyntaxNode node);
+        internal abstract MemberBody? TryGetDeclarationBody(SyntaxNode node);
 
         /// <summary>
         /// True if the specified <paramref name="declaration"/> node shares body with another declaration.
@@ -124,29 +112,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal abstract bool IsDeclarationWithSharedBody(SyntaxNode declaration);
 
         /// <summary>
-        /// If the specified node represents a member declaration returns all tokens of the member declaration
-        /// that might be covered by an active statement.
-        /// </summary>
-        /// <returns>
-        /// Tokens covering all possible breakpoint spans associated with the member, 
-        /// or null if the specified node doesn't represent a member declaration or 
-        /// doesn't have a body that can contain active statements.
-        /// </returns>
-        /// <remarks>
-        /// The implementation has to decide what kinds of nodes in top-level match relationship represent a declaration.
-        /// Every member declaration must be represented by exactly one node, but not all nodes have to represent a declaration.
-        /// 
-        /// TODO: consider implementing this via <see cref="GetActiveSpanEnvelope"/>.
-        /// </remarks>
-        internal abstract IEnumerable<SyntaxToken>? TryGetActiveTokens(SyntaxNode node);
-
-        /// <summary>
-        /// Returns a span that contains all possible breakpoint spans of the <paramref name="declaration"/>
-        /// and no breakpoint spans that do not belong to the <paramref name="declaration"/>.
+        /// Returns an envelope that contains all possible breakpoint spans of the body of the <paramref name="declaration"/>
+        /// and no breakpoint spans that do not belong to the body.
         /// 
         /// Returns default if the declaration does not have any breakpoint spans.
         /// </summary>
-        internal abstract (TextSpan envelope, TextSpan hole) GetActiveSpanEnvelope(SyntaxNode declaration);
+        internal ActiveStatementEnvelope GetActiveSpanEnvelope(SyntaxNode declaration)
+            => TryGetDeclarationBody(declaration)?.Envelope ?? default;
 
         /// <summary>
         /// Returns an ancestor that encompasses all active and statement level 
@@ -167,65 +139,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract SyntaxNode GetEncompassingAncestorImpl(SyntaxNode bodyOrMatchRoot);
 
         /// <summary>
-        /// Finds a statement at given span and a declaration body.
-        /// Also returns the corresponding partner statement in <paramref name="partnerDeclarationBody"/>, if specified.
-        /// </summary>
-        /// <remarks>
-        /// The declaration body node may not contain the <paramref name="span"/>. 
-        /// This happens when an active statement associated with the member is outside of its body
-        /// (e.g. C# constructor, or VB <c>Dim a,b As New T</c>).
-        /// If the position doesn't correspond to any statement uses the start of the <paramref name="declarationBody"/>.
-        /// </remarks>
-        protected abstract SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, TextSpan span, SyntaxNode? partnerDeclarationBody, out SyntaxNode? partner, out int statementPart);
-
-        private SyntaxNode FindStatement(SyntaxNode declarationBody, TextSpan span, out int statementPart)
-            => FindStatementAndPartner(declarationBody, span, null, out _, out statementPart);
-
-        /// <summary>
-        /// Maps <paramref name="leftNode"/> of a body of <paramref name="leftDeclaration"/> to corresponding body node
-        /// of <paramref name="rightDeclaration"/>, assuming that the declaration bodies only differ in trivia.
-        /// </summary>
-        internal abstract SyntaxNode FindDeclarationBodyPartner(SyntaxNode leftDeclaration, SyntaxNode rightDeclaration, SyntaxNode leftNode);
-
-        /// <summary>
         /// Returns a node that represents a body of a lambda containing specified <paramref name="node"/>,
         /// or null if the node isn't contained in a lambda. If a node is returned it must uniquely represent the lambda,
         /// i.e. be no two distinct nodes may represent the same lambda.
         /// </summary>
-        protected abstract SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode node);
-
-        /// <summary>
-        /// Given a node that represents a lambda body returns all nodes of the body in a syntax list.
-        /// </summary>
-        /// <remarks>
-        /// Note that VB lambda bodies are represented by a lambda header and that some lambda bodies share 
-        /// their parent nodes with other bodies (e.g. join clause expressions).
-        /// </remarks>
-        protected abstract IEnumerable<SyntaxNode> GetLambdaBodyExpressionsAndStatements(SyntaxNode lambdaBody);
-
-        protected abstract SyntaxNode? TryGetPartnerLambdaBody(SyntaxNode oldBody, SyntaxNode newLambda);
-
-        /// <summary>
-        /// Determines if two syntax nodes are the same, disregarding trivia differences.
-        /// </summary>
-        protected abstract bool AreEquivalentLambdaBodies(SyntaxNode oldLambda, SyntaxNode oldLambdaBody, SyntaxNode newLambda, SyntaxNode newLambdaBody);
+        protected abstract LambdaBody? FindEnclosingLambdaBody(SyntaxNode root, SyntaxNode node);
 
         protected abstract Match<SyntaxNode> ComputeTopLevelMatch(SyntaxNode oldCompilationUnit, SyntaxNode newCompilationUnit);
         protected abstract BidirectionalMap<SyntaxNode>? ComputeParameterMap(SyntaxNode oldDeclaration, SyntaxNode newDeclaration);
-        protected abstract Match<SyntaxNode> ComputeBodyMatchImpl(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches);
-        protected abstract Match<SyntaxNode> ComputeTopLevelDeclarationMatch(SyntaxNode oldDeclaration, SyntaxNode newDeclaration);
         protected abstract IEnumerable<SequenceEdit> GetSyntaxSequenceEdits(ImmutableArray<SyntaxNode> oldNodes, ImmutableArray<SyntaxNode> newNodes);
-
-        /// <summary>
-        /// Matches old active statement to new active statement without constructing full method body match.
-        /// This is needed for active statements that are outside of method body, like constructor initializer.
-        /// </summary>
-        protected abstract bool TryMatchActiveStatement(
-            SyntaxNode oldStatement,
-            int statementPart,
-            SyntaxNode oldBody,
-            SyntaxNode newBody,
-            [NotNullWhen(true)] out SyntaxNode? newStatement);
 
         protected abstract bool TryGetEnclosingBreakpointSpan(SyntaxNode root, int position, out TextSpan span);
 
@@ -261,7 +183,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract bool IsNamespaceDeclaration(SyntaxNode node);
         protected abstract bool IsCompilationUnitWithGlobalStatements(SyntaxNode node);
         protected abstract bool IsGlobalStatement(SyntaxNode node);
-        protected abstract TextSpan GetGlobalStatementDiagnosticSpan(SyntaxNode node, EditKind editKind);
 
         /// <summary>
         /// Returns all top-level type declarations (non-nested) for a given compilation unit node.
@@ -280,12 +201,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             SemanticModel newModel,
             IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
             CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Analyzes data flow in the member body represented by the specified node and returns all captured variables and parameters (including "this").
-        /// If the body is a field/property initializer analyzes the initializer expression only.
-        /// </summary>
-        protected abstract ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model, SyntaxNode memberBody);
 
         /// <summary>
         /// Enumerates all use sites of a specified variable within the specified syntax subtrees.
@@ -428,17 +343,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract ushort LineDirectiveSyntaxKind { get; }
         protected abstract SymbolDisplayFormat ErrorDisplayFormat { get; }
         protected abstract List<SyntaxNode> GetExceptionHandlingAncestors(SyntaxNode node, bool isNonLeaf);
-        internal abstract StateMachineInfo GetStateMachineInfo(SyntaxNode body);
         protected abstract TextSpan GetExceptionHandlingRegion(SyntaxNode node, out bool coversAllChildren);
 
         internal abstract void ReportTopLevelSyntacticRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, Edit<SyntaxNode> edit, Dictionary<SyntaxNode, EditKind> editMap);
         internal abstract void ReportEnclosingExceptionHandlingRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, IEnumerable<Edit<SyntaxNode>> exceptionHandlingEdits, SyntaxNode oldStatement, TextSpan newStatementSpan);
         internal abstract void ReportOtherRudeEditsAroundActiveStatement(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode oldStatement, SyntaxNode newStatement, bool isNonLeaf);
-        internal abstract void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, SyntaxNode newBody, TextSpan? span);
+        internal abstract void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, DeclarationBody newBody, TextSpan? span);
         internal abstract void ReportInsertedMemberSymbolRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newSymbol, SyntaxNode newNode, bool insertingIntoExistingContainingType);
         internal abstract void ReportStateMachineSuspensionPointRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode);
 
-        internal abstract bool IsLambda(SyntaxNode node);
+        internal abstract Func<SyntaxNode, bool> IsLambda { get; }
         internal abstract bool IsInterfaceDeclaration(SyntaxNode node);
         internal abstract bool IsRecordDeclaration(SyntaxNode node);
 
@@ -450,11 +364,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal abstract bool IsLocalFunction(SyntaxNode node);
         internal abstract bool IsGenericLocalFunction(SyntaxNode node);
         internal abstract bool IsClosureScope(SyntaxNode node);
-        internal abstract bool ContainsLambda(SyntaxNode declaration);
-        internal abstract SyntaxNode GetLambda(SyntaxNode lambdaBody);
         internal abstract IMethodSymbol GetLambdaExpressionSymbol(SemanticModel model, SyntaxNode lambdaExpression, CancellationToken cancellationToken);
         internal abstract SyntaxNode? GetContainingQueryExpression(SyntaxNode node);
         internal abstract bool QueryClauseLambdasTypeEquivalent(SemanticModel oldModel, SyntaxNode oldNode, SemanticModel newModel, SyntaxNode newNode, CancellationToken cancellationToken);
+
+        internal bool ContainsLambda(MemberBody body)
+        {
+            var isLambda = IsLambda;
+            return body.RootNodes.Any(static (root, isLambda) => root.DescendantNodesAndSelf().Any(isLambda), isLambda);
+        }
 
         /// <summary>
         /// Returns true if the parameters of the symbol are lifted into a scope that is different from the symbol's body.
@@ -471,7 +389,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// 
         /// Some lambda queries (group by, join by) have two bodies.
         /// </remarks>
-        internal abstract bool TryGetLambdaBodies(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? body1, out SyntaxNode? body2);
+        internal abstract bool TryGetLambdaBodies(SyntaxNode node, [NotNullWhen(true)] out LambdaBody? body1, out LambdaBody? body2);
 
         internal abstract bool IsStateMachineMethod(SyntaxNode declaration);
 
@@ -846,8 +764,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                 // The tracking span might have been moved outside of lambda.
                                 // It is not an error to move the statement - we just ignore it.
-                                var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldMember.FindToken(adjustedOldStatementStart).Parent!);
-                                var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, trackedStatement);
+                                var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody.EncompassingAncestor, oldMember.FindToken(adjustedOldStatementStart).Parent!);
+                                var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody.EncompassingAncestor, trackedStatement);
                                 if (oldEnclosingLambdaBody == newEnclosingLambdaBody)
                                 {
                                     newStatement = trackedStatement;
@@ -858,7 +776,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             if (newStatement == null)
                             {
                                 Contract.ThrowIfFalse(statementPart == -1);
-                                FindStatementAndPartner(oldBody, oldStatementSpan, newBody, out newStatement, out statementPart);
+                                oldBody.FindStatementAndPartner(oldStatementSpan, newBody, out newStatement, out statementPart);
                                 Contract.ThrowIfNull(newStatement);
                             }
 
@@ -891,12 +809,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        internal readonly struct ActiveNode(int activeStatementIndex, SyntaxNode oldNode, SyntaxNode? enclosingLambdaBody, int statementPart, SyntaxNode? newTrackedNode)
+        internal readonly struct ActiveNode(int activeStatementIndex, SyntaxNode oldNode, LambdaBody? enclosingLambdaBody, int statementPart, SyntaxNode? newTrackedNode)
         {
             public readonly int ActiveStatementIndex = activeStatementIndex;
             public readonly SyntaxNode OldNode = oldNode;
             public readonly SyntaxNode? NewTrackedNode = newTrackedNode;
-            public readonly SyntaxNode? EnclosingLambdaBody = enclosingLambdaBody;
+            public readonly LambdaBody? EnclosingLambdaBody = enclosingLambdaBody;
             public readonly int StatementPart = statementPart;
         }
 
@@ -910,14 +828,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // both fields are non-null for a matching lambda (lambda that exists in both old and new document):
             public readonly Match<SyntaxNode>? Match;
-            public readonly SyntaxNode? NewBody;
+            public readonly LambdaBody? NewBody;
 
             public LambdaInfo(List<int> activeNodeIndices)
                 : this(activeNodeIndices, null, null)
             {
             }
 
-            private LambdaInfo(List<int>? activeNodeIndices, Match<SyntaxNode>? match, SyntaxNode? newLambdaBody)
+            private LambdaInfo(List<int>? activeNodeIndices, Match<SyntaxNode>? match, LambdaBody? newLambdaBody)
             {
                 ActiveNodeIndices = activeNodeIndices;
                 Match = match;
@@ -927,15 +845,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             public bool HasActiveStatement
                 => ActiveNodeIndices != null;
 
-            public LambdaInfo WithMatch(Match<SyntaxNode> match, SyntaxNode newLambdaBody)
+            public LambdaInfo WithMatch(Match<SyntaxNode> match, LambdaBody newLambdaBody)
                 => new(ActiveNodeIndices, match, newLambdaBody);
         }
 
         private void AnalyzeChangedMemberBody(
             SyntaxNode oldDeclaration,
             SyntaxNode newDeclaration,
-            SyntaxNode oldBody,
-            SyntaxNode? newBody,
+            MemberBody oldBody,
+            MemberBody? newBody,
             SemanticModel oldModel,
             SemanticModel newModel,
             ISymbol oldMember,
@@ -957,7 +875,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             syntaxMap = null;
 
-            var activeStatementIndices = GetOverlappingActiveStatements(oldDeclaration, oldActiveStatements);
+            var activeStatementIndices = GetOverlappingActiveStatements(oldBody, oldActiveStatements);
 
             if (newBody == null)
             {
@@ -984,12 +902,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             try
             {
-                _testFaultInjector?.Invoke(newBody);
+                _testFaultInjector?.Invoke(newBody.RootNodes.First());
 
                 // Populated with active lambdas and matched lambdas. 
                 // Unmatched non-active lambdas are not included.
                 // { old-lambda-body -> info }
-                Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
+                Dictionary<LambdaBody, LambdaInfo>? lazyActiveOrMatchedLambdas = null;
 
                 // finds leaf nodes that correspond to the old active statements:
                 using var _ = ArrayBuilder<ActiveNode>.GetInstance(out var activeNodes);
@@ -997,13 +915,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     var oldStatementSpan = oldActiveStatements[activeStatementIndex].UnmappedSpan;
 
-                    var oldStatementSyntax = FindStatement(oldBody, oldStatementSpan, out var statementPart);
+                    var oldStatementSyntax = oldBody.FindStatement(oldStatementSpan, out var statementPart);
                     Contract.ThrowIfNull(oldStatementSyntax);
 
-                    var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldStatementSyntax);
+                    var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody.EncompassingAncestor, oldStatementSyntax);
                     if (oldEnclosingLambdaBody != null)
                     {
-                        lazyActiveOrMatchedLambdas ??= new Dictionary<SyntaxNode, LambdaInfo>();
+                        lazyActiveOrMatchedLambdas ??= new Dictionary<LambdaBody, LambdaInfo>();
 
                         if (!lazyActiveOrMatchedLambdas.TryGetValue(oldEnclosingLambdaBody, out var lambda))
                         {
@@ -1018,7 +936,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (TryGetTrackedStatement(newActiveStatementSpans, activeStatementIndex, newText, newDeclaration, newBody, out var newStatementSyntax, out var _))
                     {
-                        var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, newStatementSyntax);
+                        var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody.EncompassingAncestor, newStatementSyntax);
 
                         // The tracking span might have been moved outside of the lambda span.
                         // It is not an error to move the statement - we just ignore it.
@@ -1034,17 +952,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 var activeNodesInBody = activeNodes.Where(n => n.EnclosingLambdaBody == null).ToArray();
 
-                var bodyMatch = ComputeBodyMatch(oldBody, newBody, activeNodesInBody);
+                var bodyMatch = ComputeMatch(oldBody, newBody, activeNodesInBody);
                 var map = ComputeMap(bodyMatch, activeNodes, ref lazyActiveOrMatchedLambdas);
 
-                var oldStateMachineInfo = GetStateMachineInfo(oldBody);
-                var newStateMachineInfo = GetStateMachineInfo(newBody);
-                ReportStateMachineBodyUpdateRudeEdits(bodyMatch, oldStateMachineInfo, newBody, newStateMachineInfo, hasActiveStatement: activeNodesInBody.Length != 0, diagnostics);
+                var oldStateMachineInfo = oldBody.GetStateMachineInfo();
+                var newStateMachineInfo = newBody.GetStateMachineInfo();
+                ReportStateMachineBodyUpdateRudeEdits(bodyMatch, oldStateMachineInfo, newDeclaration, newStateMachineInfo, hasActiveStatement: activeNodesInBody.Length != 0, diagnostics);
 
                 ReportMemberOrLambdaBodyUpdateRudeEdits(
                     diagnostics,
                     oldModel,
-                    oldBody,
+                    oldDeclaration,
                     oldMember,
                     newDeclaration,
                     newBody,
@@ -1112,7 +1030,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     {
                         match = bodyMatch;
 
-                        hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldBody, newBody, out newStatementSyntax) ||
+                        hasMatching = oldBody.TryMatchActiveStatement(newBody, oldStatementSyntax, statementPart, out newStatementSyntax) ||
                                       match.TryGetNewNode(oldStatementSyntax, out newStatementSyntax);
                     }
                     else
@@ -1127,7 +1045,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         {
                             RoslynDebug.Assert(newEnclosingLambdaBody != null); // matching lambda has body
 
-                            hasMatching = TryMatchActiveStatement(oldStatementSyntax, statementPart, oldEnclosingLambdaBody, newEnclosingLambdaBody, out newStatementSyntax) ||
+                            hasMatching = oldEnclosingLambdaBody.TryMatchActiveStatement(newEnclosingLambdaBody, oldStatementSyntax, statementPart, out newStatementSyntax) ||
                                           match.TryGetNewNode(oldStatementSyntax, out newStatementSyntax);
                         }
                         else
@@ -1165,7 +1083,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         newSpan = GetDeletedNodeDiagnosticSpan(oldEnclosingLambdaBody, bodyMatch, lazyActiveOrMatchedLambdas);
 
                         // Lambda containing the active statement can't be found in the new source.
-                        var oldLambda = GetLambda(oldEnclosingLambdaBody);
+                        var oldLambda = oldEnclosingLambdaBody.GetLambda();
                         diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ActiveStatementLambdaRemoved, newSpan, oldLambda,
                             new[] { GetDisplayName(oldLambda) }));
                     }
@@ -1220,17 +1138,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     newExceptionRegions[i] = ImmutableArray<SourceFileSpan>.Empty;
                 }
 
-                string bodyName;
+                string declarationName;
                 try
                 {
-                    bodyName = GetBodyDisplayName(newBody);
+                    declarationName = GetDisplayName(newDeclaration);
                 }
                 catch
                 {
-                    bodyName = $"<node {newBody.RawKind} has no display name>";
+                    declarationName = $"<node {newDeclaration.RawKind} has no display name>";
                 }
 
-                var bodySpan = GetBodyDiagnosticSpan(newBody, EditKind.Update);
+                var bodySpan = GetDiagnosticSpan(newDeclaration, EditKind.Update);
 
                 // We expect OOM to be thrown during the analysis if the number of statements is too large.
                 // In such case we report a rude edit for the document. If the host is actually running out of memory,
@@ -1240,21 +1158,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     diagnostics.Add(new RudeEditDiagnostic(
                         RudeEditKind.MemberBodyTooBig,
                         bodySpan,
-                        newBody,
-                        arguments: new[] { bodyName }));
+                        newDeclaration,
+                        arguments: new[] { declarationName }));
                 }
                 else
                 {
                     diagnostics.Add(new RudeEditDiagnostic(
                         RudeEditKind.MemberBodyInternalError,
                         bodySpan,
-                        newBody,
-                        arguments: new[] { bodyName, e.ToString() }));
+                        newDeclaration,
+                        arguments: new[] { declarationName, e.ToString() }));
                 }
             }
         }
 
-        private bool TryGetTrackedStatement(ImmutableArray<LinePositionSpan> activeStatementSpans, int index, SourceText text, SyntaxNode declaration, SyntaxNode body, [NotNullWhen(true)] out SyntaxNode? trackedStatement, out int trackedStatementPart)
+        private bool TryGetTrackedStatement(ImmutableArray<LinePositionSpan> activeStatementSpans, int index, SourceText text, SyntaxNode declaration, MemberBody body, [NotNullWhen(true)] out SyntaxNode? trackedStatement, out int trackedStatementPart)
         {
             trackedStatement = null;
             trackedStatementPart = -1;
@@ -1283,7 +1201,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return false;
             }
 
-            trackedStatement = FindStatement(body, trackedSpan, out trackedStatementPart);
+            trackedStatement = body.FindStatement(trackedSpan, out trackedStatementPart);
             return true;
         }
 
@@ -1349,7 +1267,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private BidirectionalMap<SyntaxNode> ComputeMap(
             Match<SyntaxNode> memberBodyMatch,
             ArrayBuilder<ActiveNode> memberBodyActiveNodes,
-            ref Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas)
+            ref Dictionary<LambdaBody, LambdaInfo>? lazyActiveOrMatchedLambdas)
         {
             ArrayBuilder<Match<SyntaxNode>>? lambdaBodyMatches = null;
             var currentLambdaBodyMatch = -1;
@@ -1369,20 +1287,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     if (TryGetLambdaBodies(oldNode, out var oldLambdaBody1, out var oldLambdaBody2))
                     {
                         lambdaBodyMatches ??= ArrayBuilder<Match<SyntaxNode>>.GetInstance();
-                        lazyActiveOrMatchedLambdas ??= new Dictionary<SyntaxNode, LambdaInfo>();
+                        lazyActiveOrMatchedLambdas ??= new Dictionary<LambdaBody, LambdaInfo>();
 
-                        var newLambdaBody1 = TryGetPartnerLambdaBody(oldLambdaBody1, newNode);
+                        var newLambdaBody1 = oldLambdaBody1.TryGetPartnerLambdaBody(newNode);
                         if (newLambdaBody1 != null)
                         {
-                            lambdaBodyMatches.Add(ComputeLambdaBodyMatch(oldLambdaBody1, newLambdaBody1, memberBodyActiveNodes, lazyActiveOrMatchedLambdas));
+                            lambdaBodyMatches.Add(ComputeMatch(oldLambdaBody1, newLambdaBody1, memberBodyActiveNodes, lazyActiveOrMatchedLambdas));
                         }
 
                         if (oldLambdaBody2 != null)
                         {
-                            var newLambdaBody2 = TryGetPartnerLambdaBody(oldLambdaBody2, newNode);
+                            var newLambdaBody2 = oldLambdaBody2.TryGetPartnerLambdaBody(newNode);
                             if (newLambdaBody2 != null)
                             {
-                                lambdaBodyMatches.Add(ComputeLambdaBodyMatch(oldLambdaBody2, newLambdaBody2, memberBodyActiveNodes, lazyActiveOrMatchedLambdas));
+                                lambdaBodyMatches.Add(ComputeMatch(oldLambdaBody2, newLambdaBody2, memberBodyActiveNodes, lazyActiveOrMatchedLambdas));
                             }
                         }
                     }
@@ -1426,11 +1344,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return new BidirectionalMap<SyntaxNode>(map, reverseMap);
         }
 
-        private Match<SyntaxNode> ComputeLambdaBodyMatch(
-            SyntaxNode oldLambdaBody,
-            SyntaxNode newLambdaBody,
+        private static Match<SyntaxNode> ComputeMatch(
+            LambdaBody oldLambdaBody,
+            LambdaBody newLambdaBody,
             IReadOnlyList<ActiveNode> memberBodyActiveNodes,
-            [Out] Dictionary<SyntaxNode, LambdaInfo> activeOrMatchedLambdas)
+            [Out] Dictionary<LambdaBody, LambdaInfo> activeOrMatchedLambdas)
         {
             IEnumerable<ActiveNode> activeNodesInLambdaBody;
             if (activeOrMatchedLambdas.TryGetValue(oldLambdaBody, out var info))
@@ -1445,7 +1363,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 info = new LambdaInfo();
             }
 
-            var lambdaBodyMatch = ComputeBodyMatch(oldLambdaBody, newLambdaBody, activeNodesInLambdaBody);
+            var lambdaBodyMatch = ComputeMatch(oldLambdaBody, newLambdaBody, activeNodesInLambdaBody);
 
             activeOrMatchedLambdas[oldLambdaBody] = info.WithMatch(lambdaBodyMatch, newLambdaBody);
 
@@ -1455,13 +1373,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Called for a member body and for bodies of all lambdas and local functions (recursively) found in the member body.
         /// </summary>
-        internal Match<SyntaxNode> ComputeBodyMatch(SyntaxNode oldBody, SyntaxNode newBody, IEnumerable<ActiveNode> activeNodes)
-            => ComputeBodyMatchImpl(oldBody, newBody, knownMatches: GetMatchingActiveNodes(activeNodes));
+        private static Match<SyntaxNode> ComputeMatch(DeclarationBody oldBody, DeclarationBody newBody, IEnumerable<ActiveNode> activeNodes)
+            => oldBody.ComputeMatch(newBody, knownMatches: GetMatchingActiveNodes(activeNodes));
 
         private void ReportStateMachineBodyUpdateRudeEdits(
             Match<SyntaxNode> match,
             StateMachineInfo oldStateMachineInfo,
-            SyntaxNode newBody,
+            SyntaxNode newDeclaration,
             StateMachineInfo newStateMachineInfo,
             bool hasActiveStatement,
             ArrayBuilder<RudeEditDiagnostic> diagnostics)
@@ -1488,7 +1406,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 diagnostics.Add(new RudeEditDiagnostic(
                     RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement,
-                    GetBodyDiagnosticSpan(newBody, EditKind.Update)));
+                    GetDiagnosticSpan(newDeclaration, EditKind.Update)));
             }
 
             // report removing async as rude:
@@ -1496,9 +1414,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 diagnostics.Add(new RudeEditDiagnostic(
                     RudeEditKind.ChangingFromAsynchronousToSynchronous,
-                    GetBodyDiagnosticSpan(newBody, EditKind.Update),
-                    newBody,
-                    new[] { GetBodyDisplayName(newBody) }));
+                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                    newDeclaration,
+                    new[] { GetDisplayName(newDeclaration) }));
             }
 
             // VB supports iterator lambdas/methods without yields
@@ -1506,9 +1424,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 diagnostics.Add(new RudeEditDiagnostic(
                     RudeEditKind.ModifiersUpdate,
-                    GetBodyDiagnosticSpan(newBody, EditKind.Update),
-                    newBody,
-                    new[] { GetBodyDisplayName(newBody) }));
+                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                    newDeclaration,
+                    new[] { GetDisplayName(newDeclaration) }));
             }
         }
 
@@ -1585,20 +1503,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return new ActiveStatementExceptionRegions(result.ToImmutable(), isCovered);
         }
 
-        private TextSpan GetDeletedNodeDiagnosticSpan(SyntaxNode deletedLambdaBody, Match<SyntaxNode> match, Dictionary<SyntaxNode, LambdaInfo> lambdaInfos)
+        private TextSpan GetDeletedNodeDiagnosticSpan(LambdaBody deletedLambdaBody, Match<SyntaxNode> match, Dictionary<LambdaBody, LambdaInfo> lambdaInfos)
         {
             var oldLambdaBody = deletedLambdaBody;
             while (true)
             {
-                var oldParentLambdaBody = FindEnclosingLambdaBody(match.OldRoot, GetLambda(oldLambdaBody));
+                var oldLambda = oldLambdaBody.GetLambda();
+                var oldParentLambdaBody = FindEnclosingLambdaBody(match.OldRoot, oldLambda);
                 if (oldParentLambdaBody == null)
                 {
-                    return GetDeletedNodeDiagnosticSpan(match.Matches, oldLambdaBody);
+                    return GetDeletedNodeDiagnosticSpan(match.Matches, oldLambda);
                 }
 
                 if (lambdaInfos.TryGetValue(oldParentLambdaBody, out var lambdaInfo) && lambdaInfo.Match != null)
                 {
-                    return GetDeletedNodeDiagnosticSpan(lambdaInfo.Match.Matches, oldLambdaBody);
+                    return GetDeletedNodeDiagnosticSpan(lambdaInfo.Match.Matches, oldLambda);
                 }
 
                 oldLambdaBody = oldParentLambdaBody;
@@ -1650,10 +1569,32 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return GetDeletedNodeDiagnosticSpan(forwardMap, deletedNode);
         }
 
+        internal TextSpan GetDeletedDeclarationActiveSpan(IReadOnlyDictionary<SyntaxNode, SyntaxNode> forwardMap, SyntaxNode deletedDeclaration)
+        {
+            if (IsDeclarationWithInitializer(deletedDeclaration))
+            {
+                return GetDeletedNodeActiveSpan(forwardMap, deletedDeclaration);
+            }
+
+            // TODO: if the member isn't a field/property we should return empty span.
+            // We need to adjust the tracking span design and UpdateUneditedSpans to account for such empty spans.
+
+            var hasAncestor = TryGetMatchingAncestor(forwardMap, deletedDeclaration, out var newAncestor);
+            Debug.Assert(hasAncestor && newAncestor != null);
+
+            // the only matching ancestor is teh compilation unit:
+            if (newAncestor.Parent == null)
+            {
+                return default;
+            }
+
+            return GetDiagnosticSpan(newAncestor, EditKind.Delete);
+        }
+
         internal TextSpan GetDeletedNodeDiagnosticSpan(IReadOnlyDictionary<SyntaxNode, SyntaxNode> forwardMap, SyntaxNode deletedNode)
         {
             var hasAncestor = TryGetMatchingAncestor(forwardMap, deletedNode, out var newAncestor);
-            RoslynDebug.Assert(hasAncestor && newAncestor != null);
+            Debug.Assert(hasAncestor && newAncestor != null);
             return GetDiagnosticSpan(newAncestor, EditKind.Delete);
         }
 
@@ -1678,17 +1619,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return false;
         }
 
-        private IEnumerable<int> GetOverlappingActiveStatements(SyntaxNode declaration, ImmutableArray<UnmappedActiveStatement> statements)
+        private static IEnumerable<int> GetOverlappingActiveStatements(MemberBody body, ImmutableArray<UnmappedActiveStatement> statements)
         {
-            var (envelope, hole) = GetActiveSpanEnvelope(declaration);
-            if (envelope == default)
-            {
-                yield break;
-            }
+            var (span, hole) = body.Envelope;
 
             var range = ActiveStatementsMap.GetSpansStartingInSpan(
-                envelope.Start,
-                envelope.End,
+                span.Start,
+                span.End,
                 statements,
                 startPositionComparer: (x, y) => x.UnmappedSpan.Start.CompareTo(y));
 
@@ -1979,7 +1916,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     continue;
                 }
 
-                var newTokens = TryGetActiveTokens(newNode);
+                var newTokens = TryGetDeclarationBody(newNode)?.GetActiveTokens();
                 if (newTokens == null)
                 {
                     continue;
@@ -1988,7 +1925,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // A (rude) edit could have been made that changes whether the node may contain active statements,
                 // so although the nodes match they might not have the same active tokens.
                 // E.g. field declaration changed to const field declaration.
-                var oldTokens = TryGetActiveTokens(oldNode);
+                var oldTokens = TryGetDeclarationBody(oldNode)?.GetActiveTokens();
                 if (oldTokens == null)
                 {
                     continue;
@@ -2059,8 +1996,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     oldHasToken = oldTokensEnum.MoveNext();
                     newHasToken = newTokensEnum.MoveNext();
 
-                    // no update edit => tokens must match:
-                    Debug.Assert(oldHasToken == newHasToken);
+                    // If tokens differ in other parts then in trivia, skip the current matching node pair since we are only looking for trivia changes.
+                    // This may happen when active tokens of member bodies overlap with nodes that do not represent a body.
+                    // For example, in VB an initializer of a variable declarator node is included in the bodies of each modified identifier listed in the declarator,
+                    // the declarator itself doesn't represent a body.
+                    if (oldHasToken != newHasToken || oldHasToken && !AreEqualIgnoringTrivia(oldTokensEnum.Current, newTokensEnum.Current))
+                    {
+                        requiresUpdate = false;
+                        break;
+                    }
 
                     if (!oldHasToken)
                     {
@@ -2575,47 +2519,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     Contract.ThrowIfNull(oldSymbol);
                                     Contract.ThrowIfNull(oldDeclaration);
 
-                                    var activeStatementIndices = GetOverlappingActiveStatements(oldDeclaration, oldActiveStatements);
-                                    var hasActiveStatement = activeStatementIndices.Any();
-
-                                    // TODO: if the member isn't a field/property we should return empty span.
-                                    // We need to adjust the tracking span design and UpdateUneditedSpans to account for such empty spans.
-                                    if (hasActiveStatement)
-                                    {
-                                        var newSpan = IsDeclarationWithInitializer(oldDeclaration)
-                                            ? GetDeletedNodeActiveSpan(editScript.Match.Matches, oldDeclaration)
-                                            : GetDeletedNodeDiagnosticSpan(editScript.Match.Matches, oldDeclaration);
-
-                                        foreach (var index in activeStatementIndices)
-                                        {
-                                            Debug.Assert(newActiveStatements[index] is null);
-
-                                            newActiveStatements[index] = GetActiveStatementWithSpan(oldActiveStatements[index], editScript.Match.NewRoot.SyntaxTree, newSpan, diagnostics, cancellationToken);
-                                            newExceptionRegions[index] = ImmutableArray<SourceFileSpan>.Empty;
-                                        }
-                                    }
-
                                     syntaxMap = null;
                                     editKind = SemanticEditKind.Delete;
+
+                                    ReportDeletedMemberActiveStatementsRudeEdits();
 
                                     // Check if the declaration has been moved from one document to another.
                                     if (newSymbol is { } and not IMethodSymbol { IsPartialDefinition: true })
                                     {
                                         // Symbol has actually not been deleted but rather moved to another document, another partial type declaration
                                         // or replaced with an implicitly generated one (e.g. parameterless constructor, auto-generated record methods, etc.)
-
-                                        // Report rude edit if the deleted code contains active statements.
-                                        // TODO (https://github.com/dotnet/roslyn/issues/51177):
-                                        // Only report rude edit when replacing member with an implicit one if it has an active statement.
-                                        // We might be able to support moving active members but we would need to 
-                                        // 1) Move AnalyzeChangedMemberBody from Insert to Delete
-                                        // 2) Handle active statements that moved to a different document in ActiveStatementTrackingService
-                                        // 3) The debugger's ManagedActiveStatementUpdate might need another field indicating the source file path.
-                                        if (hasActiveStatement)
-                                        {
-                                            ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newCompilation, RudeEditKind.DeleteActiveStatement, cancellationToken);
-                                            continue;
-                                        }
 
                                         // Ignore the delete if there is going to be an insert corresponding to the new symbol that will create an update edit.
                                         if (HasInsertMatchingDelete(newSymbol, oldCompilation, cancellationToken))
@@ -2652,102 +2565,48 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                         editKind = SemanticEditKind.Update;
                                         break;
                                     }
-                                    else
-                                    {
-                                        var diagnosticSpan = GetDeletedNodeDiagnosticSpan(editScript.Match.Matches, oldDeclaration);
 
-                                        // If we got here for a global statement then the actual edit is a delete of the synthesized Main method
-                                        if (IsGlobalMain(oldSymbol))
+                                    var diagnosticSpan = GetDeletedNodeDiagnosticSpan(editScript.Match.Matches, oldDeclaration);
+
+                                    // If we got here for a global statement then the actual edit is a delete of the synthesized Main method
+                                    if (IsGlobalMain(oldSymbol))
+                                    {
+                                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.Delete, diagnosticSpan, edit.OldNode, new[] { GetDisplayName(edit.OldNode!, EditKind.Delete) }));
+                                        continue;
+                                    }
+
+                                    var rudeEditKind = RudeEditKind.Delete;
+
+                                    // If the associated member declaration (parameter/type parameter -> method) has also been deleted skip
+                                    // the delete of the symbol as it will be deleted by the delete of the associated member. We pass the edit kind
+                                    // in here to avoid property/event accessors from being caught up in this, because those deletes we want to process
+                                    // separately, below.
+                                    //
+                                    // Associated member declarations must be in the same document as the symbol, so we don't need to resolve their symbol.
+                                    // In some cases the symbol even can't be resolved unambiguously. Consider e.g. resolving a method with its parameter deleted -
+                                    // we wouldn't know which overload to resolve to.
+                                    if (TryGetAssociatedMemberDeclaration(oldDeclaration, EditKind.Delete, out var oldAssociatedMemberDeclaration))
+                                    {
+                                        if (HasEdit(editMap, oldAssociatedMemberDeclaration, EditKind.Delete))
                                         {
-                                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.Delete, diagnosticSpan, edit.OldNode, new[] { GetDisplayName(edit.OldNode!, EditKind.Delete) }));
                                             continue;
                                         }
 
-                                        var rudeEditKind = RudeEditKind.Delete;
-
-                                        // If the associated member declaration (parameter/type parameter -> method) has also been deleted skip
-                                        // the delete of the symbol as it will be deleted by the delete of the associated member. We pass the edit kind
-                                        // in here to avoid property/event accessors from being caught up in this, because those deletes we want to process
-                                        // separately, below.
-                                        //
-                                        // Associated member declarations must be in the same document as the symbol, so we don't need to resolve their symbol.
-                                        // In some cases the symbol even can't be resolved unambiguously. Consider e.g. resolving a method with its parameter deleted -
-                                        // we wouldn't know which overload to resolve to.
-                                        if (TryGetAssociatedMemberDeclaration(oldDeclaration, EditKind.Delete, out var oldAssociatedMemberDeclaration))
+                                        // We allow deleting parameters, by issuing delete and insert edits for the old and new method
+                                        if (oldSymbol is IParameterSymbol oldParameter)
                                         {
-                                            if (HasEdit(editMap, oldAssociatedMemberDeclaration, EditKind.Delete))
+                                            if (TryAddParameterInsertOrDeleteEdits(semanticEdits, oldParameter, oldModel, newModel, capabilities, syntaxMap, editScript, processedSymbols, cancellationToken, out var notSupportedByRuntime))
                                             {
                                                 continue;
                                             }
 
-                                            // We allow deleting parameters, by issuing delete and insert edits for the old and new method
-                                            if (oldSymbol is IParameterSymbol oldParameter)
+                                            if (notSupportedByRuntime)
                                             {
-                                                if (TryAddParameterInsertOrDeleteEdits(semanticEdits, oldParameter, oldModel, newModel, capabilities, syntaxMap, editScript, processedSymbols, cancellationToken, out var notSupportedByRuntime))
-                                                {
-                                                    continue;
-                                                }
-
-                                                if (notSupportedByRuntime)
-                                                {
-                                                    rudeEditKind = RudeEditKind.DeleteNotSupportedByRuntime;
-                                                }
-                                            }
-                                        }
-                                        else if (oldSymbol.ContainingType != null)
-                                        {
-                                            // Check if the symbol being deleted is a member of a type that's also being deleted.
-                                            // If so, skip the member deletion and only report the containing symbol deletion.
-                                            var containingTypeKey = SymbolKey.Create(oldSymbol.ContainingType, cancellationToken);
-                                            var newContainingSymbol = containingTypeKey.Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
-                                            if (newContainingSymbol == null)
-                                            {
-                                                continue;
-                                            }
-
-                                            if (!hasActiveStatement && AllowsDeletion(oldSymbol))
-                                            {
-                                                var newContainingType = (INamedTypeSymbol)newContainingSymbol;
-
-                                                // If a property or field is deleted from a record the synthesized members may change
-                                                // (PrintMembers print all properties and fields, Equals and GHC compare all data members, etc.)
-                                                if (SymbolPresenceAffectsSynthesizedRecordMembers(oldSymbol))
-                                                {
-                                                    // If the deleted member has been replaced by another member (of a different kind, otherwise newSymbol would be non-null) of the same name
-                                                    // we should not update record members as they will be updated by an insertion edit of the other member.
-                                                    // An insert edit must exist for the other member, otherwise we would have two members in the old type of the same name but different kind (field/property).
-                                                    var newMatchingSymbol = newContainingType.GetMembers(oldSymbol.Name).FirstOrDefault(m => m is IPropertySymbol or IFieldSymbol);
-                                                    if (newMatchingSymbol is null)
-                                                    {
-                                                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newContainingType, cancellationToken);
-                                                    }
-                                                }
-
-                                                if (IsDeclarationWithInitializer(oldDeclaration))
-                                                {
-                                                    DeferConstructorEdit(oldSymbol.ContainingType, newContainingType, oldDeclaration, syntaxMap, oldSymbol.IsStatic, isMemberWithDeletedInitializer: true);
-                                                }
-
-                                                AddDeleteEditsForMemberAndAccessors(semanticEdits, oldSymbol, containingTypeKey, syntaxMap, partialType: null, cancellationToken);
-
-                                                // Note: Delete of a constructor does not need to be deferred since it does not affect other constructors.
-                                                // We do need to handle deletion of a primary record constructor though.
-                                                if (oldSymbol.ContainingType.IsRecord && IsPrimaryConstructor(oldSymbol, cancellationToken))
-                                                {
-                                                    var oldPrimaryConstructor = (IMethodSymbol)oldSymbol;
-
-                                                    // Deconstructor delete:
-                                                    AddDeconstructorEdits(semanticEdits, oldPrimaryConstructor, otherConstructor: null, containingTypeKey, oldCompilation, newCompilation, syntaxMap: null, processedSymbols, isParameterDelete: true, cancellationToken);
-
-                                                    // Synthesized method updates:
-                                                    AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newContainingType, cancellationToken);
-                                                }
-
-                                                continue;
+                                                rudeEditKind = RudeEditKind.DeleteNotSupportedByRuntime;
                                             }
                                         }
 
-                                        // deleting symbol is not allowed
+                                        // deleting is not allowed
 
                                         diagnostics.Add(new RudeEditDiagnostic(
                                             rudeEditKind,
@@ -2757,6 +2616,76 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                         continue;
                                     }
+
+                                    if (oldSymbol.ContainingType == null)
+                                    {
+                                        // deleting type is not allowed
+                                        Debug.Assert(oldSymbol is INamedTypeSymbol);
+
+                                        diagnostics.Add(new RudeEditDiagnostic(
+                                            rudeEditKind,
+                                            diagnosticSpan,
+                                            oldDeclaration,
+                                            new[] { GetDisplayKindAndName(oldSymbol, GetDisplayName(oldDeclaration, EditKind.Delete), fullyQualify: diagnosticSpan.IsEmpty) }));
+
+                                        continue;
+                                    }
+
+                                    // Check if the symbol being deleted is a member of a type that's also being deleted.
+                                    // If so, skip the member deletion and only report the containing symbol deletion.
+                                    var containingTypeKey = SymbolKey.Create(oldSymbol.ContainingType, cancellationToken);
+                                    var newContainingType = (INamedTypeSymbol?)containingTypeKey.Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                                    if (newContainingType == null)
+                                    {
+                                        continue;
+                                    }
+
+                                    if (!AllowsDeletion(oldSymbol))
+                                    {
+                                        diagnostics.Add(new RudeEditDiagnostic(
+                                            rudeEditKind,
+                                            diagnosticSpan,
+                                            oldDeclaration,
+                                            new[] { GetDisplayKindAndName(oldSymbol, GetDisplayName(oldDeclaration, EditKind.Delete), fullyQualify: diagnosticSpan.IsEmpty) }));
+
+                                        continue;
+                                    }
+
+                                    if (IsDeclarationWithInitializer(oldDeclaration))
+                                    {
+                                        DeferConstructorEdit(oldSymbol.ContainingType, newContainingType, oldDeclaration, syntaxMap, oldSymbol.IsStatic, isMemberWithDeletedInitializer: true);
+                                    }
+
+                                    // If a property or field is deleted from a record the synthesized members may change
+                                    // (PrintMembers print all properties and fields, Equals and GHC compare all data members, etc.)
+                                    if (SymbolPresenceAffectsSynthesizedRecordMembers(oldSymbol))
+                                    {
+                                        // If the deleted member has been replaced by another member (of a different kind, otherwise newSymbol would be non-null) of the same name
+                                        // we should not update record members as they will be updated by an insertion edit of the other member.
+                                        // An insert edit must exist for the other member, otherwise we would have two members in the old type of the same name but different kind (field/property).
+                                        var newMatchingSymbol = newContainingType.GetMembers(oldSymbol.Name).FirstOrDefault(m => m is IPropertySymbol or IFieldSymbol);
+                                        if (newMatchingSymbol is null)
+                                        {
+                                            AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newContainingType, cancellationToken);
+                                        }
+                                    }
+
+                                    AddDeleteEditsForMemberAndAccessors(semanticEdits, oldSymbol, containingTypeKey, syntaxMap, partialType: null, cancellationToken);
+
+                                    // Note: Delete of a constructor does not need to be deferred since it does not affect other constructors.
+                                    // We do need to handle deletion of a primary record constructor though.
+                                    if (oldSymbol.ContainingType.IsRecord && IsPrimaryConstructor(oldSymbol, cancellationToken))
+                                    {
+                                        var oldPrimaryConstructor = (IMethodSymbol)oldSymbol;
+
+                                        // Deconstructor delete:
+                                        AddDeconstructorEdits(semanticEdits, oldPrimaryConstructor, otherConstructor: null, containingTypeKey, oldCompilation, newCompilation, syntaxMap: null, processedSymbols, isParameterDelete: true, cancellationToken);
+
+                                        // Synthesized method updates:
+                                        AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newContainingType, cancellationToken);
+                                    }
+
+                                    continue;
                                 }
 
                             case EditKind.Insert:
@@ -2859,7 +2788,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                                 if (isDeclarationWithInitializer)
                                                 {
-                                                    AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newCompilation, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                                                    AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
                                                 }
 
                                                 DeferConstructorEdit(oldSymbol.ContainingType, newContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic,
@@ -3055,7 +2984,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                         if (isDeclarationWithInitializer)
                                         {
-                                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newCompilation, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
                                         }
 
                                         DeferConstructorEdit(oldSymbol.ContainingType, newSymbol.ContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic,
@@ -3107,13 +3036,60 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newProperty.ContainingType, cancellationToken);
                         }
 
+                        void ReportDeletedMemberActiveStatementsRudeEdits()
+                        {
+                            Contract.ThrowIfNull(oldDeclaration);
+                            Contract.ThrowIfNull(oldSymbol);
+
+                            var oldBody = TryGetDeclarationBody(oldDeclaration);
+                            if (oldBody == null)
+                            {
+                                return;
+                            }
+
+                            var activeStatementIndices = GetOverlappingActiveStatements(oldBody, oldActiveStatements);
+                            if (!activeStatementIndices.Any())
+                            {
+                                return;
+                            }
+
+                            // A delete edit might be created for a symbol whose declaration just moved within the same syntax tree.
+                            // An active statement in a body of such symbol will be updated when the body change is analyzed and
+                            // should not be deleted here.
+                            //
+                            // An example is a VB field declaration with multiple names:
+                            //   Dim [|a|], b As New C() -> Dim [|a As New C()|]
+                            // In the old compilation fields 'a' and 'b' are each represented by a modified identifier.
+                            // In the new compilation field 'a' is represented by the variable declarator.
+                            // Two deletes are created for this change: Delete(ModIdf('a')) and Delete(ModIdf('b')), only the second one actually deletes the field.
+                            //
+                            // TODO: consider supporting moving AS to a different file -- https://github.com/dotnet/roslyn/issues/51177.
+                            //
+                            if (newSymbol?.DeclaringSyntaxReferences.Length == 1 && newDeclaration?.SyntaxTree == newModel.SyntaxTree)
+                            {
+                                return;
+                            }
+
+                            var newSpan = GetDeletedDeclarationActiveSpan(editScript.Match.Matches, oldDeclaration);
+
+                            foreach (var index in activeStatementIndices)
+                            {
+                                Debug.Assert(newActiveStatements[index] == null);
+
+                                newActiveStatements[index] = GetActiveStatementWithSpan(oldActiveStatements[index], editScript.Match.NewRoot.SyntaxTree, newSpan, diagnostics, cancellationToken);
+                                newExceptionRegions[index] = ImmutableArray<SourceFileSpan>.Empty;
+                            }
+
+                            ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newModel, RudeEditKind.DeleteActiveStatement, cancellationToken);
+                        }
+
                         Contract.ThrowIfFalse(editKind is SemanticEditKind.Update or SemanticEditKind.Insert);
 
                         if (editKind == SemanticEditKind.Update)
                         {
                             Contract.ThrowIfNull(oldSymbol);
 
-                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newCompilation, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
 
                             if (newSymbol is INamedTypeSymbol or IFieldSymbol or IParameterSymbol or ITypeParameterSymbol)
                             {
@@ -3165,8 +3141,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 SymbolKey.Create(oldSymbol, cancellationToken).Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol is null)
                             {
                                 Contract.ThrowIfNull(oldDeclaration);
-                                var activeStatementIndices = GetOverlappingActiveStatements(oldDeclaration, oldActiveStatements);
-                                if (activeStatementIndices.Any())
+
+                                var oldBody = TryGetDeclarationBody(oldDeclaration);
+                                if (oldBody != null && GetOverlappingActiveStatements(oldBody, oldActiveStatements).Any())
                                 {
                                     Contract.ThrowIfNull(newDeclaration);
                                     AddRudeUpdateAroundActiveStatement(diagnostics, newDeclaration);
@@ -3189,7 +3166,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
                         }
-
+                        
                         semanticEdits.Add(new SemanticEditInfo(editKind, symbolKey, syntaxMap, syntaxMapTree: null,
                             IsPartialEdit(oldSymbol, newSymbol, editScript.Match.OldRoot.SyntaxTree, editScript.Match.NewRoot.SyntaxTree) ? symbolKey : null));
                     }
@@ -3241,35 +3218,46 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         }
 
                         // We need to provide syntax map to the compiler if the member is active (see member update above):
-                        var isActiveMember =
-                            GetOverlappingActiveStatements(oldDeclaration, oldActiveStatements).Any() ||
-                            IsStateMachineMethod(oldDeclaration) ||
-                            ContainsLambda(oldDeclaration);
-
-                        var syntaxMap = isActiveMember ? CreateSyntaxMapForEquivalentNodes(oldDeclaration, newDeclaration) : null;
+                        var oldBody = TryGetDeclarationBody(oldDeclaration);
+                        var newBody = TryGetDeclarationBody(newDeclaration);
 
                         // only trivia changed:
+                        Debug.Assert(oldBody is null == newBody is null);
                         Debug.Assert(IsConstructorWithMemberInitializers(oldSymbol, cancellationToken) == IsConstructorWithMemberInitializers(newSymbol, cancellationToken));
                         Debug.Assert(IsDeclarationWithInitializer(oldDeclaration) == IsDeclarationWithInitializer(newDeclaration));
 
-                        var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newSymbol, cancellationToken);
-                        var isDeclarationWithInitializer = IsDeclarationWithInitializer(newDeclaration);
+                        Func<SyntaxNode, SyntaxNode?>? syntaxMap = null;
 
-                        if (isConstructorWithMemberInitializers || isDeclarationWithInitializer)
+                        if (oldBody != null)
                         {
-                            // TODO: only create syntax map if any field initializers are active/contain lambdas or this is a partial type
-                            syntaxMap ??= CreateSyntaxMapForEquivalentNodes(oldDeclaration, newDeclaration);
+                            Debug.Assert(newBody != null);
 
-                            if (isConstructorWithMemberInitializers)
+                            var isActiveMember =
+                                GetOverlappingActiveStatements(oldBody, oldActiveStatements).Any() ||
+                                IsStateMachineMethod(oldDeclaration) ||
+                                ContainsLambda(oldBody);
+
+                            syntaxMap = isActiveMember ? CreateSyntaxMapForEquivalentNodes(oldBody, newBody) : null;
+
+                            var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newSymbol, cancellationToken);
+                            var isDeclarationWithInitializer = IsDeclarationWithInitializer(newDeclaration);
+
+                            if (isConstructorWithMemberInitializers || isDeclarationWithInitializer)
                             {
-                                processedSymbols.Remove(newSymbol);
+                                // TODO: only create syntax map if any field initializers are active/contain lambdas or this is a partial type
+                                syntaxMap ??= CreateSyntaxMapForEquivalentNodes(oldBody, newBody);
+
+                                if (isConstructorWithMemberInitializers)
+                                {
+                                    processedSymbols.Remove(newSymbol);
+                                }
+
+                                DeferConstructorEdit(oldContainingType, newContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic, isMemberWithDeletedInitializer: false);
+
+                                // Don't add a separate semantic edit.
+                                // Updates of data members with initializers and constructors that emit initializers will be aggregated and added later.
+                                continue;
                             }
-
-                            DeferConstructorEdit(oldContainingType, newContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic, isMemberWithDeletedInitializer: false);
-
-                            // Don't add a separate semantic edit.
-                            // Updates of data members with initializers and constructors that emit initializers will be aggregated and added later.
-                            continue;
                         }
 
                         // updating generic methods and types
@@ -3292,7 +3280,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         editScript.Match,
                         oldModel,
                         oldCompilation,
-                        newCompilation,
+                        newModel,
                         processedSymbols,
                         capabilities,
                         isStatic: false,
@@ -3308,7 +3296,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         editScript.Match,
                         oldModel,
                         oldCompilation,
-                        newCompilation,
+                        newModel,
                         processedSymbols,
                         capabilities,
                         isStatic: true,
@@ -3911,10 +3899,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportMemberOrLambdaBodyUpdateRudeEdits(
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
             SemanticModel? oldModel,
-            SyntaxNode oldBody,
+            SyntaxNode oldDeclaration,
             ISymbol oldMember,
             SyntaxNode newDeclaration,
-            SyntaxNode newBody,
+            DeclarationBody newBody,
             ISymbol newMember,
             Match<SyntaxNode> memberBodyMatch,
             EditAndContinueCapabilitiesGrantor capabilities,
@@ -3926,7 +3914,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             if (oldStateMachineInfo.IsStateMachine)
             {
                 Contract.ThrowIfNull(oldModel);
-                ReportMissingStateMachineAttribute(oldModel.Compilation, oldStateMachineInfo, newBody, diagnostics);
+                ReportMissingStateMachineAttribute(oldModel.Compilation, oldStateMachineInfo, newDeclaration, diagnostics);
             }
 
             if (!oldStateMachineInfo.IsStateMachine &&
@@ -3948,8 +3936,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if ((InGenericContext(oldMember) ||
                      InGenericContext(newMember) ||
-                     InGenericLocalContext(oldBody, memberBodyMatch.OldRoot) ||
-                     InGenericLocalContext(newBody, memberBodyMatch.NewRoot)) &&
+                     IsLambda(oldDeclaration) && InGenericLocalContext(oldDeclaration, OneOrMany.Create(memberBodyMatch.OldRoot)) ||
+                     IsLambda(newDeclaration) && InGenericLocalContext(newDeclaration, OneOrMany.Create(memberBodyMatch.NewRoot))) &&
                     !capabilities.Grant(EditAndContinueCapabilities.GenericAddFieldToExistingType))
                 {
                     diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, GetDiagnosticSpan(newDeclaration, EditKind.Update), newDeclaration, new[] { GetDisplayName(newDeclaration) }));
@@ -3962,7 +3950,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ISymbol oldSymbol,
             ISymbol newSymbol,
             SyntaxNode? newNode,
-            Compilation newCompilation,
+            SemanticModel newModel,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasGeneratedAttributeChange,
             out bool hasGeneratedReturnTypeAttributeChange,
@@ -4262,7 +4250,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             if (rudeEdit != RudeEditKind.None)
             {
-                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newCompilation, cancellationToken);
+                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
             }
         }
 
@@ -4464,7 +4452,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ISymbol oldSymbol,
             ISymbol newSymbol,
             SyntaxNode? newNode,
-            Compilation newCompilation,
+            SemanticModel newModel,
             Match<SyntaxNode> topMatch,
             EditAndContinueCapabilitiesGrantor capabilities,
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
@@ -4476,9 +4464,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // TODO: fails in VB on delegate parameter https://github.com/dotnet/roslyn/issues/53337
             // Contract.ThrowIfFalse(newSymbol.IsImplicitlyDeclared == newDeclaration is null);
 
-            ReportCustomAttributeRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newCompilation, capabilities, out var hasAttributeChange, out var hasReturnTypeAttributeChange, cancellationToken);
+            ReportCustomAttributeRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newModel, capabilities, out var hasAttributeChange, out var hasReturnTypeAttributeChange, cancellationToken);
 
-            ReportUpdatedSymbolDeclarationRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newCompilation, capabilities, out var hasGeneratedAttributeChange, out var hasGeneratedReturnTypeAttributeChange, out var hasParameterRename, out var hasParameterTypeChange, out var hasReturnTypeChange, cancellationToken);
+            ReportUpdatedSymbolDeclarationRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newModel, capabilities, out var hasGeneratedAttributeChange, out var hasGeneratedReturnTypeAttributeChange, out var hasParameterRename, out var hasParameterTypeChange, out var hasReturnTypeChange, cancellationToken);
             hasAttributeChange |= hasGeneratedAttributeChange;
             hasReturnTypeAttributeChange |= hasGeneratedReturnTypeAttributeChange;
 
@@ -4494,7 +4482,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return;
                 }
 
-                AddParameterUpdateSemanticEdit(semanticEdits, (IParameterSymbol)oldSymbol, (IParameterSymbol)newSymbol, newCompilation, syntaxMap, reportDeleteAndInsertEdits: hasParameterTypeChange, processedSymbols, cancellationToken);
+                AddParameterUpdateSemanticEdit(semanticEdits, (IParameterSymbol)oldSymbol, (IParameterSymbol)newSymbol, newModel.Compilation, syntaxMap, reportDeleteAndInsertEdits: hasParameterTypeChange, processedSymbols, cancellationToken);
             }
             else if (hasReturnTypeChange)
             {
@@ -4503,7 +4491,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
             else if (hasAttributeChange || hasReturnTypeAttributeChange)
             {
-                AddCustomAttributeSemanticEdits(semanticEdits, oldSymbol, newSymbol, newCompilation, topMatch, syntaxMap, processedSymbols, hasAttributeChange, hasReturnTypeAttributeChange, cancellationToken);
+                AddCustomAttributeSemanticEdits(semanticEdits, oldSymbol, newSymbol, newModel.Compilation, topMatch, syntaxMap, processedSymbols, hasAttributeChange, hasReturnTypeAttributeChange, cancellationToken);
             }
         }
 
@@ -4627,7 +4615,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ISymbol oldSymbol,
             ISymbol newSymbol,
             SyntaxNode? newNode,
-            Compilation newCompilation,
+            SemanticModel newModel,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasAttributeChange,
             out bool hasReturnTypeAttributeChange,
@@ -4635,19 +4623,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             // This is the only case we care about whether to issue an edit or not, because this is the only case where types have their attributes checked
             // and types are the only things that would otherwise not have edits reported.
-            hasAttributeChange = ReportCustomAttributeRudeEdits(diagnostics, oldSymbol.GetAttributes(), newSymbol.GetAttributes(), oldSymbol, newSymbol, newNode, newCompilation, capabilities, cancellationToken);
+            hasAttributeChange = ReportCustomAttributeRudeEdits(diagnostics, oldSymbol.GetAttributes(), newSymbol.GetAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
 
             hasReturnTypeAttributeChange = false;
 
             if (oldSymbol is IMethodSymbol oldMethod &&
                 newSymbol is IMethodSymbol newMethod)
             {
-                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldMethod.GetReturnTypeAttributes(), newMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newCompilation, capabilities, cancellationToken);
+                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldMethod.GetReturnTypeAttributes(), newMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
             }
             else if (oldSymbol is INamedTypeSymbol { DelegateInvokeMethod: not null and var oldInvokeMethod } &&
                      newSymbol is INamedTypeSymbol { DelegateInvokeMethod: not null and var newInvokeMethod })
             {
-                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldInvokeMethod.GetReturnTypeAttributes(), newInvokeMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newCompilation, capabilities, cancellationToken);
+                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldInvokeMethod.GetReturnTypeAttributes(), newInvokeMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
             }
         }
 
@@ -4658,7 +4646,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ISymbol oldSymbol,
             ISymbol newSymbol,
             SyntaxNode? newNode,
-            Compilation newCompilation,
+            SemanticModel newModel,
             EditAndContinueCapabilitiesGrantor capabilities,
             CancellationToken cancellationToken)
         {
@@ -4678,7 +4666,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // If the runtime doesn't support changing attributes we don't need to check anything else
             if (!capabilities.Grant(EditAndContinueCapabilities.ChangeCustomAttributes))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingAttributesNotSupportedByRuntime, oldSymbol, newSymbol, newNode, newCompilation, cancellationToken);
+                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingAttributesNotSupportedByRuntime, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
                 return false;
             }
 
@@ -4686,7 +4674,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             if (oldSymbol is ITypeParameterSymbol)
             {
                 var rudeEdit = oldSymbol.ContainingSymbol.Kind == SymbolKind.Method ? RudeEditKind.GenericMethodUpdate : RudeEditKind.GenericTypeUpdate;
-                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newCompilation, cancellationToken);
+                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
                 return false;
             }
 
@@ -4925,11 +4913,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportDeletedMemberRudeEdit(
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
             ISymbol oldSymbol,
-            Compilation newCompilation,
+            SemanticModel newModel,
             RudeEditKind rudeEditKind,
             CancellationToken cancellationToken)
         {
-            var newNode = GetDeleteRudeEditDiagnosticNode(oldSymbol, newCompilation, cancellationToken);
+            var newNode = GetDeleteRudeEditDiagnosticNode(oldSymbol, newModel, cancellationToken);
 
             diagnostics.Add(new RudeEditDiagnostic(
                 rudeEditKind,
@@ -4949,7 +4937,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, ISymbol newSymbol, SyntaxNode? newNode, CancellationToken cancellationToken)
         {
             var node = newNode ?? GetRudeEditDiagnosticNode(newSymbol, cancellationToken);
-            var span = (rudeEdit == RudeEditKind.ChangeImplicitMainReturnType) ? GetGlobalStatementDiagnosticSpan(node, EditKind.Delete) : GetDiagnosticSpan(node, EditKind.Update);
+            var span = GetDiagnosticSpan(node, (rudeEdit == RudeEditKind.ChangeImplicitMainReturnType) ? EditKind.Delete : EditKind.Update);
 
             var arguments = rudeEdit switch
             {
@@ -4975,11 +4963,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             diagnostics.Add(new RudeEditDiagnostic(rudeEdit, span, node, arguments));
         }
 
-        private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, ISymbol oldSymbol, ISymbol newSymbol, SyntaxNode? newNode, Compilation newCompilation, CancellationToken cancellationToken)
+        private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, ISymbol oldSymbol, ISymbol newSymbol, SyntaxNode? newNode, SemanticModel newModel, CancellationToken cancellationToken)
         {
             if (newSymbol.IsImplicitlyDeclared && rudeEdit != RudeEditKind.GenericTypeUpdate)
             {
-                ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newCompilation, rudeEdit, cancellationToken);
+                ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newModel, rudeEdit, cancellationToken);
             }
             else
             {
@@ -5004,13 +4992,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             throw ExceptionUtilities.Unreachable();
         }
 
-        private SyntaxNode GetDeleteRudeEditDiagnosticNode(ISymbol oldSymbol, Compilation newCompilation, CancellationToken cancellationToken)
+        private SyntaxNode GetDeleteRudeEditDiagnosticNode(ISymbol oldSymbol, SemanticModel newModel, CancellationToken cancellationToken)
         {
             var oldContainer = oldSymbol.ContainingSymbol;
             while (oldContainer != null)
             {
                 var containerKey = SymbolKey.Create(oldContainer, cancellationToken);
-                var newContainer = containerKey.Resolve(newCompilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                var newContainer = containerKey.Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
                 if (newContainer != null)
                 {
                     return GetRudeEditDiagnosticNode(newContainer, cancellationToken);
@@ -5019,7 +5007,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 oldContainer = oldContainer.ContainingSymbol;
             }
 
-            throw ExceptionUtilities.Unreachable();
+            return newModel.SyntaxTree.GetRoot(cancellationToken);
         }
 
         #region Type Layout Update Validation 
@@ -5129,10 +5117,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         #endregion
 
-        private Func<SyntaxNode, SyntaxNode?> CreateSyntaxMapForEquivalentNodes(SyntaxNode oldDeclaration, SyntaxNode newDeclaration)
+        private static Func<SyntaxNode, SyntaxNode?> CreateSyntaxMapForEquivalentNodes(MemberBody oldBody, MemberBody newBody)
         {
-            return newNode => newDeclaration.FullSpan.Contains(newNode.SpanStart) ?
-                FindDeclarationBodyPartner(newDeclaration, oldDeclaration, newNode) : null;
+            var oldRootNodes = oldBody.RootNodes;
+            var newRootNodes = newBody.RootNodes;
+
+            return newNode => FindPartner(oldRootNodes, newRootNodes, newNode);
         }
 
         private static Func<SyntaxNode, SyntaxNode?> CreateSyntaxMap(IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap)
@@ -5164,7 +5154,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // The node is in a declaration that hasn't been changed:
                     if (reverseTopMatches.TryGetValue(newDeclaration, out var oldDeclaration))
                     {
-                        return FindDeclarationBodyPartner(newDeclaration, oldDeclaration, newNode);
+                        var oldBody = TryGetDeclarationBody(oldDeclaration);
+                        var newBody = TryGetDeclarationBody(newDeclaration);
+
+                        // The declarations must have bodies since we found newNode in the newDeclaration's body
+                        // and the new body can only differ from the old one in trivia.
+                        Debug.Assert(oldBody != null);
+                        Debug.Assert(newBody != null);
+
+                        return FindPartner(oldBody.RootNodes, newBody.RootNodes, newNode);
                     }
                 }
 
@@ -5179,7 +5177,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Match<SyntaxNode> topMatch,
             SemanticModel? oldModel,
             Compilation oldCompilation,
-            Compilation newCompilation,
+            SemanticModel newModel,
             HashSet<ISymbol> processedSymbols,
             EditAndContinueCapabilitiesGrantor capabilities,
             bool isStatic,
@@ -5329,7 +5327,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (oldCtor != null)
                     {
-                        AnalyzeSymbolUpdate(oldCtor, newCtor, newDeclaration, newCompilation, topMatch, capabilities, diagnostics, semanticEdits, syntaxMapToUse, processedSymbols, cancellationToken);
+                        AnalyzeSymbolUpdate(oldCtor, newCtor, newDeclaration, newModel, topMatch, capabilities, diagnostics, semanticEdits, syntaxMapToUse, processedSymbols, cancellationToken);
 
                         semanticEdits.Add(new SemanticEditInfo(
                             SemanticEditKind.Update,
@@ -5357,10 +5355,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         if (oldCtorIsPrimary != newCtorIsPrimary)
                         {
                             // Deconstructor:
-                            AddDeconstructorEdits(semanticEdits, oldCtor, newCtor, typeKey, oldCompilation, newCompilation, syntaxMap: null, processedSymbols, isParameterDelete: newCtorIsPrimary, cancellationToken);
+                            AddDeconstructorEdits(semanticEdits, oldCtor, newCtor, typeKey, oldCompilation, newModel.Compilation, syntaxMap: null, processedSymbols, isParameterDelete: newCtorIsPrimary, cancellationToken);
 
                             // Synthesized method updates:
-                            AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newCompilation, newCtor.ContainingType, cancellationToken);
+                            AddSynthesizedRecordMethodUpdatesForPropertyChange(semanticEdits, newModel.Compilation, newCtor.ContainingType, cancellationToken);
                         }
                     }
                 }
@@ -5405,7 +5403,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     member.DeclaringSyntaxReferences.Length > 0) // skip generated fields (e.g. VB auto-property backing fields)
                 {
                     var syntax = GetSymbolDeclarationSyntax(member, cancellationToken);
-                    if (IsDeclarationWithInitializer(syntax) && ContainsLambda(syntax))
+                    if (IsDeclarationWithInitializer(syntax) && TryGetDeclarationBody(syntax) is { } body && ContainsLambda(body))
                     {
                         return true;
                     }
@@ -5446,14 +5444,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportLambdaAndClosureRudeEdits(
             SemanticModel oldModel,
             ISymbol oldMember,
-            SyntaxNode oldMemberBody,
+            MemberBody oldMemberBody,
             SyntaxNode oldDeclaration,
             SemanticModel newModel,
             ISymbol newMember,
-            SyntaxNode newMemberBody,
+            MemberBody newMemberBody,
             SyntaxNode newDeclaration,
             Match<SyntaxNode> memberBodyMatch,
-            IReadOnlyDictionary<SyntaxNode, LambdaInfo>? matchedLambdas,
+            IReadOnlyDictionary<LambdaBody, LambdaInfo>? matchedLambdas,
             BidirectionalMap<SyntaxNode> map,
             EditAndContinueCapabilitiesGrantor capabilities,
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
@@ -5475,9 +5473,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     var lambdaBodyMatch = newLambdaInfo.Match;
                     Debug.Assert(lambdaBodyMatch != null);
 
-                    var oldStateMachineInfo = GetStateMachineInfo(oldLambdaBody);
-                    var newStateMachineInfo = GetStateMachineInfo(newLambdaBody);
-                    ReportStateMachineBodyUpdateRudeEdits(lambdaBodyMatch, oldStateMachineInfo, newLambdaBody, newStateMachineInfo, newLambdaInfo.HasActiveStatement, diagnostics);
+                    var oldLambda = oldLambdaBody.GetLambda();
+                    var newLambda = newLambdaBody.GetLambda();
+
+                    var oldStateMachineInfo = oldLambdaBody.GetStateMachineInfo();
+                    var newStateMachineInfo = newLambdaBody.GetStateMachineInfo();
+                    ReportStateMachineBodyUpdateRudeEdits(lambdaBodyMatch, oldStateMachineInfo, newLambda, newStateMachineInfo, newLambdaInfo.HasActiveStatement, diagnostics);
 
                     // When the delta IL of the containing method is emitted lambdas declared in it are also emitted.
                     // If the runtime does not support changing IL of the method (e.g. method containing stackalloc)
@@ -5485,15 +5486,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // If only trivia change the IL is going to be unchanged and only sequence points in the PDB change,
                     // so we do not report rude edits.
 
-                    var oldLambda = GetLambda(oldLambdaBody);
-                    var newLambda = GetLambda(newLambdaBody);
-
-                    if (!AreEquivalentLambdaBodies(oldLambda, oldLambdaBody, newLambda, newLambdaBody))
+                    if (!oldLambdaBody.IsSyntaxEquivalentTo(newLambdaBody))
                     {
                         ReportMemberOrLambdaBodyUpdateRudeEdits(
                             diagnostics,
                             oldModel,
-                            oldLambdaBody,
+                            oldLambda,
                             oldMember,
                             newLambda,
                             newLambdaBody,
@@ -5571,8 +5569,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            var oldCaptures = GetCapturedVariables(oldModel, oldMemberBody);
-            var newCaptures = GetCapturedVariables(newModel, newMemberBody);
+            var oldCaptures = oldMemberBody.GetCapturedVariables(oldModel);
+            var newCaptures = newMemberBody.GetCapturedVariables(newModel);
 
             // { new capture index -> old capture index }
             using var _1 = ArrayBuilder<int>.GetInstance(newCaptures.Length, fillWithValue: 0, out var reverseCapturesMap);
@@ -5588,11 +5586,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 oldCaptures,
                 oldMember,
                 oldDeclaration,
-                oldMemberBody,
                 newCaptures,
                 newMember,
                 newDeclaration,
-                newMemberBody,
                 map,
                 reverseCapturesMap,
                 newCapturesToClosureScopes,
@@ -5647,18 +5643,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             var newCapture = newCaptures[newCaptureIndex];
 
                             var rudeEdit = newAccessed ? RudeEditKind.AccessingCapturedVariableInLambda : RudeEditKind.NotAccessingCapturedVariableInLambda;
-                            var arguments = new[] { newCapture.Name, GetDisplayName(GetLambda(newLambdaBody)) };
+                            var arguments = new[] { newCapture.Name, GetDisplayName(newLambdaBody.GetLambda()) };
 
                             if (newCapture.IsThisParameter() || oldAccessed)
                             {
                                 // changed accessed to "this", or captured variable accessed in old lambda is not accessed in the new lambda
-                                diagnostics.Add(new RudeEditDiagnostic(rudeEdit, GetDiagnosticSpan(GetLambda(newLambdaBody), EditKind.Update), null, arguments));
+                                diagnostics.Add(new RudeEditDiagnostic(rudeEdit, GetDiagnosticSpan(newLambdaBody.GetLambda(), EditKind.Update), null, arguments));
                             }
                             else if (newAccessed)
                             {
                                 // captured variable accessed in new lambda is not accessed in the old lambda
                                 var hasUseSites = false;
-                                foreach (var useSite in GetVariableUseSites(GetLambdaBodyExpressionsAndStatements(newLambdaBody), newCapture, newModel, cancellationToken))
+                                foreach (var useSite in GetVariableUseSites(newLambdaBody.GetExpressionsAndStatements(), newCapture, newModel, cancellationToken))
                                 {
                                     hasUseSites = true;
                                     diagnostics.Add(new RudeEditDiagnostic(rudeEdit, useSite.Span, null, arguments));
@@ -5724,7 +5720,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // We currently allow #1, #2, and #3 and report a rude edit for the other cases.
             // In future we might be able to enable more.
 
-            var containingTypeDeclaration = TryGetContainingTypeDeclaration(newMemberBody);
+            var containingTypeDeclaration = TryGetContainingTypeDeclaration(newDeclaration);
             var isInInterfaceDeclaration = containingTypeDeclaration != null && IsInterfaceDeclaration(containingTypeDeclaration);
             var isNewMemberInGenericContext = InGenericContext(newMember);
 
@@ -5761,7 +5757,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             syntaxMapRequired = newHasLambdasOrLocalFunctions;
 
-            bool CanAddNewLambda(SyntaxNode newLambda, SyntaxNode newLambdaBody1, SyntaxNode? newLambdaBody2)
+            bool CanAddNewLambda(SyntaxNode newLambda, LambdaBody newLambdaBody1, LambdaBody? newLambdaBody2)
             {
                 // Adding a lambda/local function might result in 
                 // 1) emitting a new closure type 
@@ -5782,7 +5778,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // We assume that [2] is always required since the closure type might already exist.
                 var requiredCapabilities = EditAndContinueCapabilities.AddMethodToExistingType;
 
-                var inGenericLocalContext = InGenericLocalContext(newLambda, newMemberBody);
+                var inGenericLocalContext = InGenericLocalContext(newLambda, newMemberBody.RootNodes);
 
                 if (isNewMemberInGenericContext || inGenericLocalContext)
                 {
@@ -5821,19 +5817,22 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private IEnumerable<(SyntaxNode lambda, SyntaxNode lambdaBody1, SyntaxNode? lambdaBody2)> GetLambdaBodies(SyntaxNode body)
+        private IEnumerable<(SyntaxNode lambda, LambdaBody lambdaBody1, LambdaBody? lambdaBody2)> GetLambdaBodies(MemberBody body)
         {
-            foreach (var node in body.DescendantNodesAndSelf())
+            foreach (var root in body.RootNodes)
             {
-                if (TryGetLambdaBodies(node, out var body1, out var body2))
+                foreach (var node in root.DescendantNodesAndSelf())
                 {
-                    yield return (node, body1, body2);
+                    if (TryGetLambdaBodies(node, out var body1, out var body2))
+                    {
+                        yield return (node, body1, body2);
+                    }
                 }
             }
         }
 
         private void ReportMultiScopeCaptures(
-            SyntaxNode lambdaBody,
+            LambdaBody lambdaBody,
             SemanticModel model,
             ImmutableArray<ISymbol> captures,
             ImmutableArray<ISymbol> newCaptures,
@@ -5870,11 +5869,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         {
                             if (captures[i].IsThisParameter())
                             {
-                                errorSpan = GetDiagnosticSpan(GetLambda(lambdaBody), EditKind.Insert);
+                                errorSpan = GetDiagnosticSpan(lambdaBody.GetLambda(), EditKind.Insert);
                             }
                             else
                             {
-                                errorSpan = GetVariableUseSites(GetLambdaBodyExpressionsAndStatements(lambdaBody), captures[i], model, cancellationToken).First().Span;
+                                errorSpan = GetVariableUseSites(lambdaBody.GetExpressionsAndStatements(), captures[i], model, cancellationToken).First().Span;
                             }
 
                             rudeEdit = RudeEditKind.InsertLambdaWithMultiScopeCapture;
@@ -5889,7 +5888,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             rudeEdit,
                             errorSpan,
                             null,
-                            new[] { GetDisplayName(GetLambda(lambdaBody)), captures[firstAccessedCaptureIndex].Name, captures[i].Name }));
+                            new[] { GetDisplayName(lambdaBody.GetLambda()), captures[firstAccessedCaptureIndex].Name, captures[i].Name }));
 
                         break;
                     }
@@ -5897,11 +5896,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private BitVector GetAccessedCaptures(SyntaxNode lambdaBody, SemanticModel model, ImmutableArray<ISymbol> captures, PooledDictionary<ISymbol, int> capturesIndex)
+        private static BitVector GetAccessedCaptures(LambdaBody lambdaBody, SemanticModel model, ImmutableArray<ISymbol> captures, PooledDictionary<ISymbol, int> capturesIndex)
         {
             var result = BitVector.Create(captures.Length);
 
-            foreach (var expressionOrStatement in GetLambdaBodyExpressionsAndStatements(lambdaBody))
+            foreach (var expressionOrStatement in lambdaBody.GetExpressionsAndStatements())
             {
                 var dataFlow = model.AnalyzeDataFlow(expressionOrStatement);
                 MarkVariables(ref result, dataFlow.ReadInside, capturesIndex);
@@ -5953,8 +5952,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // Note that in VB implicit value parameter in property setter doesn't have a location.
             // In C# its location is the location of the setter.
             // See https://github.com/dotnet/roslyn/issues/14273
-            return IsGlobalMain(symbol) ? GetGlobalStatementDiagnosticSpan(GetSymbolDeclarationSyntax(symbol, cancellationToken), EditKind.Update) :
-                   symbol is IParameterSymbol && IsGlobalMain(symbol.ContainingSymbol) ? GetGlobalStatementDiagnosticSpan(GetSymbolDeclarationSyntax(symbol.ContainingSymbol, cancellationToken), EditKind.Update) :
+            return IsGlobalMain(symbol) ? GetDiagnosticSpan(GetSymbolDeclarationSyntax(symbol, cancellationToken), EditKind.Update) :
+                   symbol is IParameterSymbol && IsGlobalMain(symbol.ContainingSymbol) ? GetDiagnosticSpan(GetSymbolDeclarationSyntax(symbol.ContainingSymbol, cancellationToken), EditKind.Update) :
                    symbol.Locations.FirstOrDefault()?.SourceSpan ?? symbol.ContainingSymbol.Locations.First().SourceSpan;
         }
 
@@ -6031,11 +6030,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ImmutableArray<ISymbol> oldCaptures,
             ISymbol oldMember,
             SyntaxNode oldDeclaration,
-            SyntaxNode oldMemberBody,
             ImmutableArray<ISymbol> newCaptures,
             ISymbol newMember,
             SyntaxNode newDeclaration,
-            SyntaxNode newMemberBody,
             BidirectionalMap<SyntaxNode> bodyMap,
             [Out] ArrayBuilder<int> reverseCapturesMap,                  // {new capture index -> old capture index}
             [Out] ArrayBuilder<SyntaxNode?> newCapturesToClosureScopes,  // {new capture index -> new closure scope}
@@ -6228,8 +6225,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // scope check for local variables (parameters can't change scope):
                 if (oldCapture.Kind != SymbolKind.Parameter)
                 {
-                    var oldScope = GetCapturedVariableScope(oldCapture, oldMemberBody, cancellationToken);
-                    var newScope = GetCapturedVariableScope(newCapture, newMemberBody, cancellationToken);
+                    var oldScope = GetCapturedLocalScope(oldCapture, cancellationToken);
+                    var newScope = GetCapturedLocalScope(newCapture, cancellationToken);
                     if (!AreEquivalentClosureScopes(oldScope, newScope, bodyMap.Reverse))
                     {
                         diagnostics.Add(new RudeEditDiagnostic(
@@ -6333,17 +6330,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportLambdaSignatureRudeEdits(
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
             SemanticModel oldModel,
-            SyntaxNode oldLambdaBody,
+            LambdaBody oldLambdaBody,
             SemanticModel newModel,
-            SyntaxNode newLambdaBody,
+            LambdaBody newLambdaBody,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasSignatureErrors,
             CancellationToken cancellationToken)
         {
             hasSignatureErrors = false;
 
-            var newLambda = GetLambda(newLambdaBody);
-            var oldLambda = GetLambda(oldLambdaBody);
+            var newLambda = newLambdaBody.GetLambda();
+            var oldLambda = oldLambdaBody.GetLambda();
 
             Debug.Assert(IsNestedFunction(newLambda) == IsNestedFunction(oldLambda));
 
@@ -6387,16 +6384,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // custom attributes
 
-            ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol, newLambdaSymbol, newLambda, newModel.Compilation, capabilities, out _, out _, cancellationToken);
+            ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol, newLambdaSymbol, newLambda, newModel, capabilities, out _, out _, cancellationToken);
 
             for (var i = 0; i < oldLambdaSymbol.Parameters.Length; i++)
             {
-                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.Parameters[i], newLambdaSymbol.Parameters[i], newLambda, newModel.Compilation, capabilities, out _, out _, cancellationToken);
+                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.Parameters[i], newLambdaSymbol.Parameters[i], newLambda, newModel, capabilities, out _, out _, cancellationToken);
             }
 
             for (var i = 0; i < oldLambdaSymbol.TypeParameters.Length; i++)
             {
-                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.TypeParameters[i], newLambdaSymbol.TypeParameters[i], newLambda, newModel.Compilation, capabilities, out _, out _, cancellationToken);
+                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.TypeParameters[i], newLambdaSymbol.TypeParameters[i], newLambda, newModel, capabilities, out _, out _, cancellationToken);
             }
         }
 
@@ -6408,29 +6405,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 _ => throw ExceptionUtilities.UnexpectedValue(localOrParameter.Kind),
             };
 
-        private SyntaxNode GetCapturedVariableScope(ISymbol localOrParameter, SyntaxNode memberBody, CancellationToken cancellationToken)
+        private SyntaxNode GetCapturedLocalScope(ISymbol local, CancellationToken cancellationToken)
         {
-            Debug.Assert(localOrParameter.Kind != SymbolKind.RangeVariable);
+            Debug.Assert(local.Kind is not (SymbolKind.RangeVariable or SymbolKind.Parameter));
 
-            if (localOrParameter.Kind == SymbolKind.Parameter)
-            {
-                var member = localOrParameter.ContainingSymbol;
-
-                // lambda parameters and C# constructor parameters are lifted to their own scope:
-                if (member is IMethodSymbol { MethodKind: MethodKind.AnonymousFunction } || HasParameterClosureScope(member))
-                {
-                    var result = GetSymbolDeclarationSyntax(localOrParameter, cancellationToken);
-                    Debug.Assert(IsLambda(result));
-                    return result;
-                }
-
-                return memberBody;
-            }
-
-            var node = GetSymbolDeclarationSyntax(localOrParameter, cancellationToken);
+            var node = GetSymbolDeclarationSyntax(local, cancellationToken);
             while (true)
             {
-                RoslynDebug.Assert(node is object);
+                Debug.Assert(node != null);
                 if (IsClosureScope(node))
                 {
                     return node;
@@ -6440,14 +6422,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private static bool AreEquivalentClosureScopes(SyntaxNode oldScopeOpt, SyntaxNode newScopeOpt, IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap)
+        private static bool AreEquivalentClosureScopes(SyntaxNode? oldScope, SyntaxNode? newScope, IReadOnlyDictionary<SyntaxNode, SyntaxNode> reverseMap)
         {
-            if (oldScopeOpt == null || newScopeOpt == null)
+            if (oldScope == null || newScope == null)
             {
-                return oldScopeOpt == newScopeOpt;
+                return oldScope == newScope;
             }
 
-            return reverseMap.TryGetValue(newScopeOpt, out var mappedScope) && mappedScope == oldScopeOpt;
+            return reverseMap.TryGetValue(newScope, out var mappedScope) && mappedScope == oldScope;
         }
 
         #endregion
@@ -6457,7 +6439,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void ReportMissingStateMachineAttribute(
             Compilation oldCompilation,
             StateMachineInfo kinds,
-            SyntaxNode newBody,
+            SyntaxNode newDeclaration,
             ArrayBuilder<RudeEditDiagnostic> diagnostics)
         {
             var stateMachineAttributeQualifiedName = kinds switch
@@ -6482,8 +6464,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 diagnostics.Add(new RudeEditDiagnostic(
                     RudeEditKind.UpdatingStateMachineMethodMissingAttribute,
-                    GetBodyDiagnosticSpan(newBody, EditKind.Update),
-                    newBody,
+                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                    newDeclaration,
                     new[] { stateMachineAttributeQualifiedName }));
             }
         }
@@ -6493,6 +6475,139 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         #endregion
 
         #region Helpers
+
+        protected static OneOrMany<T> OneOrNone<T>(T? item)
+            => item is null ? OneOrMany<T>.Empty : OneOrMany.Create(item);
+
+        private static bool AreEqualIgnoringTrivia(SyntaxToken oldToken, SyntaxToken newToken)
+        {
+            if (oldToken.Span.Length != newToken.Span.Length)
+            {
+                return false;
+            }
+
+            // TODO: avoid allocations
+            return oldToken.WithLeadingTrivia(trivia: null).WithTrailingTrivia(trivia: null).IsEquivalentTo(
+                newToken.WithLeadingTrivia(trivia: null).WithTrailingTrivia(trivia: null));
+        }
+
+        private static SyntaxNode? FindPartner(OneOrMany<SyntaxNode> rootNodes, OneOrMany<SyntaxNode> otherRootNodes, SyntaxNode otherNode)
+        {
+            Debug.Assert(rootNodes.Count == otherRootNodes.Count);
+
+            for (var i = 0; i < rootNodes.Count; i++)
+            {
+                var otherRootNode = otherRootNodes[i];
+                if (otherRootNode.FullSpan.Contains(otherNode.SpanStart))
+                {
+                    return FindPartner(rootNodes[i], otherRootNode, otherNode);
+                }
+            }
+
+            return null;
+        }
+
+        internal static SyntaxNode FindPartner(SyntaxNode root, SyntaxNode otherRoot, SyntaxNode otherNode)
+        {
+            Debug.Assert(otherNode.SyntaxTree == otherRoot.SyntaxTree);
+            Debug.Assert(otherRoot.FullSpan.Contains(otherNode.SpanStart));
+
+            // Finding a partner of a zero-width node is complicated and not supported atm:
+            Debug.Assert(otherNode.FullSpan.Length > 0);
+
+            var originalLeftNode = otherNode;
+            var leftPosition = otherNode.SpanStart;
+            otherNode = otherRoot;
+            var rightNode = root;
+
+            while (otherNode != originalLeftNode)
+            {
+                Debug.Assert(otherNode.RawKind == rightNode.RawKind);
+                var leftChild = ChildThatContainsPosition(otherNode, leftPosition, out var childIndex);
+
+                // Can only happen when searching for zero-width node.
+                Debug.Assert(!leftChild.IsToken);
+
+                rightNode = rightNode.ChildNodesAndTokens()[childIndex].AsNode()!;
+                otherNode = leftChild.AsNode()!;
+            }
+
+            return rightNode;
+        }
+
+        /// <summary>
+        /// Returns child node or token that contains given position.
+        /// </summary>
+        /// <remarks>
+        /// This is a copy of <see cref="SyntaxNode.ChildThatContainsPosition"/> that also returns the index of the child node.
+        /// </remarks>
+        internal static SyntaxNodeOrToken ChildThatContainsPosition(SyntaxNode self, int position, out int childIndex)
+        {
+            var childList = self.ChildNodesAndTokens();
+
+            var left = 0;
+            var right = childList.Count - 1;
+
+            while (left <= right)
+            {
+                var middle = left + ((right - left) / 2);
+                var node = childList[middle];
+
+                var span = node.FullSpan;
+                if (position < span.Start)
+                {
+                    right = middle - 1;
+                }
+                else if (position >= span.End)
+                {
+                    left = middle + 1;
+                }
+                else
+                {
+                    childIndex = middle;
+                    return node;
+                }
+            }
+
+            // we could check up front that index is within FullSpan,
+            // but we wan to optimize for the common case where position is valid.
+            Debug.Assert(!self.FullSpan.Contains(position), "Position is valid. How could we not find a child?");
+            throw new ArgumentOutOfRangeException(nameof(position));
+        }
+
+        internal static void FindLeafNodeAndPartner(SyntaxNode leftRoot, int leftPosition, SyntaxNode rightRoot, out SyntaxNode leftNode, out SyntaxNode? rightNode)
+        {
+            leftNode = leftRoot;
+            rightNode = rightRoot;
+            while (true)
+            {
+                if (rightNode != null && leftNode.RawKind != rightNode.RawKind)
+                {
+                    rightNode = null;
+                }
+
+                var leftChild = ChildThatContainsPosition(leftNode, leftPosition, out var childIndex);
+                if (leftChild.IsToken)
+                {
+                    return;
+                }
+
+                if (rightNode != null)
+                {
+                    var rightNodeChildNodesAndTokens = rightNode.ChildNodesAndTokens();
+                    if (childIndex >= 0 && childIndex < rightNodeChildNodesAndTokens.Count)
+                    {
+                        rightNode = rightNodeChildNodesAndTokens[childIndex].AsNode();
+                    }
+                    else
+                    {
+                        rightNode = null;
+                    }
+                }
+
+                leftNode = leftChild.AsNode()!;
+            }
+        }
 
         private static SyntaxNode? TryGetNode(SyntaxNode root, int position)
             => root.FullSpan.Contains(position) ? root.FindToken(position).Parent : null;
@@ -6576,15 +6691,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private bool InGenericLocalContext(SyntaxNode node, SyntaxNode containingMemberBody)
+        private bool InGenericLocalContext(SyntaxNode node, OneOrMany<SyntaxNode> roots)
         {
             var current = node;
 
-            while (current != containingMemberBody)
+            while (true)
             {
                 if (IsGenericLocalFunction(current))
                 {
                     return true;
+                }
+
+                if (roots.Contains(current))
+                {
+                    break;
                 }
 
                 current = current.Parent;
@@ -6703,7 +6823,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             internal BidirectionalMap<SyntaxNode> ComputeMap(
                 Match<SyntaxNode> bodyMatch,
                 ArrayBuilder<ActiveNode> memberBodyActiveNodes,
-                ref Dictionary<SyntaxNode, LambdaInfo>? lazyActiveOrMatchedLambdas)
+                ref Dictionary<LambdaBody, LambdaInfo>? lazyActiveOrMatchedLambdas)
             {
                 return _abstractEditAndContinueAnalyzer.ComputeMap(bodyMatch, memberBodyActiveNodes, ref lazyActiveOrMatchedLambdas);
             }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractSimpleMemberBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractSimpleMemberBody.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal abstract class AbstractSimpleMemberBody(SyntaxNode node) : MemberBody
+{
+    public SyntaxNode Node
+        => node;
+
+    public sealed override SyntaxTree SyntaxTree
+        => node.SyntaxTree;
+
+    public sealed override OneOrMany<SyntaxNode> RootNodes
+        => OneOrMany.Create(node);
+
+    public sealed override ActiveStatementEnvelope Envelope
+        => node.Span;
+
+    public sealed override SyntaxNode EncompassingAncestor
+        => node;
+
+    public sealed override IEnumerable<SyntaxToken>? GetActiveTokens()
+        => node.DescendantTokens();
+
+    public override ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model)
+        => model.AnalyzeDataFlow(Node).Captured;
+}

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementEnvelope.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementEnvelope.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+/// <summary>
+/// Represents a <see cref="Span"/> that covers all active statements of <see cref="MemberBody"/> with a possible <see cref="Hole"/> excluded.
+/// </summary>
+internal readonly record struct ActiveStatementEnvelope(TextSpan Span, TextSpan Hole = default)
+{
+    public static implicit operator ActiveStatementEnvelope(TextSpan span)
+        => new(span, default);
+}

--- a/src/Features/Core/Portable/EditAndContinue/DeclarationBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DeclarationBody.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Differencing;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal abstract class DeclarationBody : IEquatable<DeclarationBody>
+{
+    public abstract SyntaxTree SyntaxTree { get; }
+
+    /// <summary>
+    /// Root nodes of the body. Descendant nodes of these roots include all nodes of the body and no nodes that do not belong to the body.
+    /// Note: descendant nodes may include some tokens that are not part of the body.
+    /// </summary>
+    public abstract OneOrMany<SyntaxNode> RootNodes { get; }
+
+    public abstract StateMachineInfo GetStateMachineInfo();
+
+    /// <summary>
+    /// Computes a statement-level syntax tree match of this body with <paramref name="newBody"/>.
+    /// TODO: Consider returning <see cref="BidirectionalMap{T}"/> that includes matches of all roots of the body.
+    /// <see cref="TryMatchActiveStatement"/> might not be needed if we do so.
+    /// </summary>
+    public abstract Match<SyntaxNode> ComputeMatch(DeclarationBody newBody, IEnumerable<KeyValuePair<SyntaxNode, SyntaxNode>>? knownMatches);
+
+    /// <summary>
+    /// Matches old active statement node to new active statement node for nodes that are not accounted for in the body match or do not match but should be mapped
+    /// (e.g. constructor initializers, opening brace of block body to expression body, etc.).
+    /// </summary>
+    public abstract bool TryMatchActiveStatement(DeclarationBody newBody, SyntaxNode oldStatement, int statementPart, [NotNullWhen(true)] out SyntaxNode? newStatement);
+
+    public bool Equals(DeclarationBody? other)
+        => ReferenceEquals(this, other) ||
+           GetType() == other?.GetType() && RootNodes.First() == other.RootNodes.First();
+
+    public override bool Equals(object? obj)
+        => Equals(obj as DeclarationBody);
+
+    public override int GetHashCode()
+        => RootNodes.First().GetHashCode();
+}

--- a/src/Features/Core/Portable/EditAndContinue/DeclarationBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DeclarationBody.cs
@@ -37,11 +37,29 @@ internal abstract class DeclarationBody : IEquatable<DeclarationBody>
 
     public bool Equals(DeclarationBody? other)
         => ReferenceEquals(this, other) ||
-           GetType() == other?.GetType() && RootNodes.First() == other.RootNodes.First();
+           GetType() == other?.GetType() && SequenceEqual(RootNodes, other.RootNodes);
 
     public override bool Equals(object? obj)
         => Equals(obj as DeclarationBody);
 
     public override int GetHashCode()
         => RootNodes.First().GetHashCode();
+
+    private static bool SequenceEqual(OneOrMany<SyntaxNode> left, OneOrMany<SyntaxNode> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (left[i] != right[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Features/Core/Portable/EditAndContinue/LambdaBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/LambdaBody.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal abstract class LambdaBody : DeclarationBody
+{
+    public abstract SyntaxNode GetLambda();
+
+    /// <summary>
+    /// Determines if the bodies are syntactically same disregarding trivia differences.
+    /// </summary>
+    public abstract bool IsSyntaxEquivalentTo(LambdaBody other);
+
+    public abstract LambdaBody? TryGetPartnerLambdaBody(SyntaxNode newLambda);
+
+    /// <summary>
+    /// Returns all nodes of the body.
+    /// </summary>
+    /// <remarks>
+    /// Note that VB lambda bodies are represented by a lambda header and that some lambda bodies share 
+    /// their parent nodes with other bodies (e.g. join clause expressions).
+    /// </remarks>
+    public abstract IEnumerable<SyntaxNode> GetExpressionsAndStatements();
+}

--- a/src/Features/Core/Portable/EditAndContinue/MemberBody.cs
+++ b/src/Features/Core/Portable/EditAndContinue/MemberBody.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue;
+
+internal abstract class MemberBody : DeclarationBody
+{
+    /// <summary>
+    /// A span that contains all possible breakpoint spans of <see cref="MemberBody"/>
+    /// and no breakpoint spans that do not belong to the <see cref="MemberBody"/>.
+    /// </summary>
+    public abstract ActiveStatementEnvelope Envelope { get; }
+
+    /// <summary>
+    /// <see cref="SyntaxNode"/> that includes all active tokens (<see cref="GetActiveTokens"/>) and its span covers the entire <see cref="Envelope"/>.
+    /// </summary>
+    public abstract SyntaxNode EncompassingAncestor { get; }
+
+    /// <summary>
+    /// All tokens of the body that may be part of an active statement.
+    /// </summary>
+    public abstract IEnumerable<SyntaxToken>? GetActiveTokens();
+
+    /// <summary>
+    /// Finds am active statement at given span within this body and the corresponding partner statement in 
+    /// <paramref name="partnerDeclarationBody"/>, if specified. Only called with <paramref name="partnerDeclarationBody"/> when
+    /// the body does not have any non-trivial changes and thus the correpsonding active statement is always found in the partner body.
+    /// </summary>
+    public abstract SyntaxNode FindStatementAndPartner(TextSpan span, MemberBody? partnerDeclarationBody, out SyntaxNode? partnerStatement, out int statementPart);
+
+    public SyntaxNode FindStatement(TextSpan span, out int statementPart)
+        => FindStatementAndPartner(span, partnerDeclarationBody: null, out _, out statementPart);
+
+    /// <summary>
+    /// Analyzes data flow in the member body represented by the specified node and returns all captured variables and parameters (including "this").
+    /// If the body is a field/property initializer analyzes the initializer expression only.
+    /// </summary>
+    public abstract ImmutableArray<ISymbol> GetCapturedVariables(SemanticModel model);
+}

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldOrPropertyDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldOrPropertyDeclarationBody.vb
@@ -1,0 +1,137 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Diagnostics.CodeAnalysis
+Imports System.Linq.Expressions
+Imports Microsoft.CodeAnalysis.Differencing
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' Property initializers:
+    '''   Property [|p As Integer = expr|]
+    '''   Property [|p As New C(expr)|]
+    ''' 
+    ''' Simple field initializers:
+    '''   Dim [|a = expr|]
+    '''   Dim [|a As Integer = expr|]
+    '''   Dim [|a = expr|], [|b = expr|], [|c As Integer = expr|]
+    '''   Dim [|a As New C(expr)|] 
+    ''' 
+    ''' Array initialized fields
+    '''   Dim [|a(expr, ...)|] As Integer
+    '''   
+    ''' Shared initializers
+    '''   Dim [|a|], [|b|] As New C(expr)
+    ''' </summary>
+    Friend MustInherit Class FieldOrPropertyDeclarationBody
+        Inherits MemberBody
+
+        ''' <summary>
+        ''' Node that represents the active statement for the initializer of the member.
+        ''' </summary>
+        Public MustOverride ReadOnly Property InitializerActiveStatement As SyntaxNode
+
+        ''' <summary>
+        ''' Node that may include other active statements than <see cref="InitializerActiveStatement"/> (e.g. in a lambda).
+        ''' <see cref="Expression"/> or <see cref="ArgumentListSyntax"/>.
+        ''' </summary>
+        Public MustOverride ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+
+        Public NotOverridable Overrides ReadOnly Property SyntaxTree As SyntaxTree
+            Get
+                Return InitializerActiveStatement.SyntaxTree
+            End Get
+        End Property
+
+        Public NotOverridable Overrides ReadOnly Property RootNodes As OneOrMany(Of SyntaxNode)
+            Get
+                Return OneOrMany.Create(OtherActiveStatementContainer.Parent)
+            End Get
+        End Property
+
+        Public NotOverridable Overrides Function ComputeMatch(newBody As DeclarationBody, knownMatches As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))) As Match(Of SyntaxNode)
+            Dim newFieldBody = DirectCast(newBody, FieldOrPropertyDeclarationBody)
+
+            If TypeOf OtherActiveStatementContainer Is ExpressionSyntax Then
+                ' Dim a = <Expression>
+                ' Dim a As <NewExpression>
+                ' Dim a, b, c As <NewExpression>
+                Return New SyntaxComparer(
+                        OtherActiveStatementContainer.Parent,
+                        newFieldBody.OtherActiveStatementContainer.Parent,
+                        {OtherActiveStatementContainer},
+                        {newFieldBody.OtherActiveStatementContainer},
+                        matchingLambdas:=False,
+                        compareStatementSyntax:=True).
+                       ComputeMatch(OtherActiveStatementContainer.Parent, newFieldBody.OtherActiveStatementContainer.Parent, knownMatches)
+            End If
+
+            ' Method, accessor, operator, etc. bodies are represented by the declaring block, which is also the root.
+            ' The body of an array initialized fields is an ArgumentListSyntax, which is the match root.
+            Return SyntaxComparer.Statement.ComputeMatch(OtherActiveStatementContainer, newFieldBody.OtherActiveStatementContainer, knownMatches)
+        End Function
+
+        Public NotOverridable Overrides Function FindStatementAndPartner(
+                span As TextSpan, partnerDeclarationBody As MemberBody, ByRef partnerStatement As SyntaxNode, ByRef statementPart As Integer) As SyntaxNode
+
+            ' If active statement span starts at InitializerActiveStatement it must be an active statement covering the whole modified identifier
+            ' (not e.g. active statement of a lambda within the array bounds.
+
+            Dim partnerFieldOrProperty = DirectCast(partnerDeclarationBody, FieldOrPropertyDeclarationBody)
+
+            If span.Start = InitializerActiveStatement.SpanStart Then
+                If partnerDeclarationBody IsNot Nothing Then
+                    partnerStatement = partnerFieldOrProperty.InitializerActiveStatement
+                End If
+
+                Return InitializerActiveStatement
+            End If
+
+            Return VisualBasicEditAndContinueAnalyzer.FindStatementAndPartner(
+                    span,
+                    body:=OtherActiveStatementContainer,
+                    partnerBody:=partnerFieldOrProperty?.OtherActiveStatementContainer,
+                    partnerStatement,
+                    statementPart)
+        End Function
+
+        Public Overrides Function TryMatchActiveStatement(newBody As DeclarationBody, oldStatement As SyntaxNode, statementPart As Integer, <NotNullWhen(True)> ByRef newStatement As SyntaxNode) As Boolean
+            If oldStatement Is InitializerActiveStatement Then
+                newStatement = DirectCast(newBody, FieldOrPropertyDeclarationBody).InitializerActiveStatement
+                Return True
+            End If
+
+            newStatement = Nothing
+            Return False
+        End Function
+
+        Public Overrides ReadOnly Property EncompassingAncestor As SyntaxNode
+            Get
+                Return InitializerActiveStatement
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property Envelope As ActiveStatementEnvelope
+            Get
+                Return InitializerActiveStatement.Span
+            End Get
+        End Property
+
+        Public Overrides Function GetActiveTokens() As IEnumerable(Of SyntaxToken)
+            Return InitializerActiveStatement.DescendantTokens()
+        End Function
+
+        Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
+            Return model.AnalyzeDataFlow(OtherActiveStatementContainer).Captured
+        End Function
+
+        Public NotOverridable Overrides Function GetStateMachineInfo() As StateMachineInfo
+            Return StateMachineInfo.None
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.vb
@@ -2,8 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
@@ -18,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
 
-        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+        Public Sub New(variableDeclarator As VariableDeclaratorSyntax)
             Debug.Assert(variableDeclarator.Names.Count = 1)
             _variableDeclarator = variableDeclarator
         End Sub

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithInitializerDeclarationBody.vb
@@ -1,0 +1,44 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' Field declarations:
+    '''   Dim [|a = expr|]
+    '''   Dim [|a As Integer = expr|]
+    '''   Dim [|a = expr|], [|b = expr|], [|c As Integer = expr|]
+    ''' </summary>
+    Friend NotInheritable Class FieldWithInitializerDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
+
+        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+            Debug.Assert(variableDeclarator.Names.Count = 1)
+            _variableDeclarator = variableDeclarator
+        End Sub
+
+        Public ReadOnly Property Name As ModifiedIdentifierSyntax
+            Get
+                Return _variableDeclarator.Names(0)
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return _variableDeclarator
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return _variableDeclarator.Initializer.Value
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleArrayBoundsDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleArrayBoundsDeclarationBody.vb
@@ -1,0 +1,42 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' A field that's part of declaration with multiple identifiers with array bounds.
+    ''' 
+    ''' Dim [|a(n)|], [|b(n)|] As Integer
+    ''' </summary>
+    Friend NotInheritable Class FieldWithMultipleArrayBoundsDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Private ReadOnly _identifier As ModifiedIdentifierSyntax
+
+        Sub New(identifier As ModifiedIdentifierSyntax)
+            _identifier = identifier
+        End Sub
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return _identifier
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return _identifier.ArrayBounds
+            End Get
+        End Property
+
+        Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
+            ' Edge case, no need to be efficient, currently there can either be no captured variables or just "Me".
+            ' Dim a((Function(n) n + 1).Invoke(1), (Function(n) n + 2).Invoke(2)) As Integer
+            Return SyntaxUtilities.GetArrayBoundsCapturedVariables(model, _identifier.ArrayBounds)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleArrayBoundsDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleArrayBoundsDeclarationBody.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
@@ -17,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _identifier As ModifiedIdentifierSyntax
 
-        Sub New(identifier As ModifiedIdentifierSyntax)
+        Public Sub New(identifier As ModifiedIdentifierSyntax)
             _identifier = identifier
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleAsNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleAsNewClauseDeclarationBody.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -17,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _modifedIdentifier As ModifiedIdentifierSyntax
 
-        Sub New(modifiedIdentifier As ModifiedIdentifierSyntax)
+        Public Sub New(modifiedIdentifier As ModifiedIdentifierSyntax)
             _modifedIdentifier = modifiedIdentifier
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleAsNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithMultipleAsNewClauseDeclarationBody.vb
@@ -1,0 +1,54 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' A field that's part of declaration with multiple identifiers and As New clause:
+    '''   Dim [|a|], [|b|] As New C(expr)
+    ''' </summary>
+    Friend NotInheritable Class FieldWithMultipleAsNewClauseDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Private ReadOnly _modifedIdentifier As ModifiedIdentifierSyntax
+
+        Sub New(modifiedIdentifier As ModifiedIdentifierSyntax)
+            _modifedIdentifier = modifiedIdentifier
+        End Sub
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return _modifedIdentifier
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return DirectCast(DirectCast(_modifedIdentifier.Parent, VariableDeclaratorSyntax).AsClause, AsNewClauseSyntax).NewExpression
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property Envelope As ActiveStatementEnvelope
+            Get
+                Return New ActiveStatementEnvelope(
+                        Span:=TextSpan.FromBounds(_modifedIdentifier.Span.Start, OtherActiveStatementContainer.Span.End),
+                        Hole:=TextSpan.FromBounds(_modifedIdentifier.Span.End, OtherActiveStatementContainer.Span.Start))
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property EncompassingAncestor As SyntaxNode
+            Get
+                Return _modifedIdentifier.Parent
+            End Get
+        End Property
+
+        Public Overrides Function GetActiveTokens() As IEnumerable(Of SyntaxToken)
+            Return InitializerActiveStatement.DescendantTokens().Concat(OtherActiveStatementContainer.DescendantTokens())
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleArrayBoundsDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleArrayBoundsDeclarationBody.vb
@@ -1,0 +1,47 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' A field that's part of declaration with single identifier with array bounds.
+    '''   Dim [|a(n)|] As Integer
+    ''' </summary>
+    Friend NotInheritable Class FieldWithSingleArrayBoundsDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
+
+        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+            _variableDeclarator = variableDeclarator
+        End Sub
+
+        Public ReadOnly Property Name As ModifiedIdentifierSyntax
+            Get
+                Return _variableDeclarator.Names(0)
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return Name
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return Name.ArrayBounds
+            End Get
+        End Property
+
+        Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
+            ' Edge case, no need to be efficient, currently there can either be no captured variables or just "Me".
+            ' Dim a((Function(n) n + 1).Invoke(1), (Function(n) n + 2).Invoke(2)) As Integer
+            Return SyntaxUtilities.GetArrayBoundsCapturedVariables(model, Name.ArrayBounds)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleArrayBoundsDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleArrayBoundsDeclarationBody.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
@@ -16,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
 
-        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+        Public Sub New(variableDeclarator As VariableDeclaratorSyntax)
             _variableDeclarator = variableDeclarator
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleAsNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleAsNewClauseDeclarationBody.vb
@@ -2,8 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
@@ -16,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
 
-        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+        Public Sub New(variableDeclarator As VariableDeclaratorSyntax)
             _variableDeclarator = variableDeclarator
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleAsNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/FieldWithSingleAsNewClauseDeclarationBody.vb
@@ -1,0 +1,35 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' A field that's part of declaration with a single identifier and As New clause:
+    '''   Dim [|a As New C()|]
+    ''' </summary>
+    Friend NotInheritable Class FieldWithSingleAsNewClauseDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Private ReadOnly _variableDeclarator As VariableDeclaratorSyntax
+
+        Sub New(variableDeclarator As VariableDeclaratorSyntax)
+            _variableDeclarator = variableDeclarator
+        End Sub
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return _variableDeclarator
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return DirectCast(_variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
     Friend NotInheritable Class MethodBody
         Inherits AbstractSimpleMemberBody
 
-        Sub New(node As MethodBlockBaseSyntax)
+        Public Sub New(node As MethodBlockBaseSyntax)
             MyBase.New(node)
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/MethodBody.vb
@@ -1,0 +1,52 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Diagnostics.CodeAnalysis
+Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.Differencing
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    Friend NotInheritable Class MethodBody
+        Inherits AbstractSimpleMemberBody
+
+        Sub New(node As MethodBlockBaseSyntax)
+            MyBase.New(node)
+        End Sub
+
+        Public Overrides Function GetCapturedVariables(model As SemanticModel) As ImmutableArray(Of ISymbol)
+            Dim methodBlock = DirectCast(Node, MethodBlockBaseSyntax)
+            If methodBlock.Statements.IsEmpty Then
+                Return ImmutableArray(Of ISymbol).Empty
+            End If
+
+            Return model.AnalyzeDataFlow(methodBlock.Statements.First, methodBlock.Statements.Last).Captured
+        End Function
+
+        Public Overrides Function GetStateMachineInfo() As StateMachineInfo
+            Return VisualBasicEditAndContinueAnalyzer.GetStateMachineInfo(Node)
+        End Function
+
+        Public Overrides Function ComputeMatch(newBody As DeclarationBody, knownMatches As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))) As Match(Of SyntaxNode)
+            Return SyntaxComparer.Statement.ComputeMatch(Node, DirectCast(newBody, MethodBody).Node, knownMatches)
+        End Function
+
+        Public Overrides Function FindStatementAndPartner(span As TextSpan, partnerDeclarationBody As MemberBody, <Out> ByRef partnerStatement As SyntaxNode, <Out> ByRef statementPart As Integer) As SyntaxNode
+            Return VisualBasicEditAndContinueAnalyzer.FindStatementAndPartner(
+                span,
+                body:=Node,
+                partnerBody:=DirectCast(partnerDeclarationBody, MethodBody)?.Node,
+                partnerStatement,
+                statementPart)
+        End Function
+
+        Public Overrides Function TryMatchActiveStatement(newBody As DeclarationBody, oldStatement As SyntaxNode, statementPart As Integer, <NotNullWhen(True)> ByRef newStatement As SyntaxNode) As Boolean
+            newStatement = Nothing
+            Return False
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithInitializerDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithInitializerDeclarationBody.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Public ReadOnly Property PropertyStatement As PropertyStatementSyntax
 
-        Sub New(propertyStatement As PropertyStatementSyntax)
+        Public Sub New(propertyStatement As PropertyStatementSyntax)
             Me.PropertyStatement = propertyStatement
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithInitializerDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithInitializerDeclarationBody.vb
@@ -1,0 +1,47 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' Property [|P As Integer = initializer|]
+    ''' </summary>
+    Friend NotInheritable Class PropertyWithInitializerDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Public ReadOnly Property PropertyStatement As PropertyStatementSyntax
+
+        Sub New(propertyStatement As PropertyStatementSyntax)
+            Me.PropertyStatement = propertyStatement
+        End Sub
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return PropertyStatement
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return PropertyStatement.Initializer.Value
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property Envelope As ActiveStatementEnvelope
+            Get
+                Return TextSpan.FromBounds(PropertyStatement.Identifier.Span.Start, PropertyStatement.Initializer.Span.End)
+            End Get
+        End Property
+
+        Public Overrides Function GetActiveTokens() As IEnumerable(Of SyntaxToken)
+            ' Property: Attributes Modifiers [|Identifier$ Initializer|] ImplementsClause
+            Return SpecializedCollections.SingletonEnumerable(PropertyStatement.Identifier).Concat(
+                    If(PropertyStatement.AsClause?.DescendantTokens(), Array.Empty(Of SyntaxToken))).Concat(PropertyStatement.Initializer.DescendantTokens())
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithNewClauseDeclarationBody.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Public ReadOnly Property PropertyStatement As PropertyStatementSyntax
 
-        Sub New(propertyStatement As PropertyStatementSyntax)
+        Public Sub New(propertyStatement As PropertyStatementSyntax)
             Me.PropertyStatement = propertyStatement
         End Sub
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithNewClauseDeclarationBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/PropertyWithNewClauseDeclarationBody.vb
@@ -1,0 +1,46 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    ''' <summary>
+    ''' Property [|P As New C()|]
+    ''' </summary>
+    Friend NotInheritable Class PropertyWithNewClauseDeclarationBody
+        Inherits FieldOrPropertyDeclarationBody
+
+        Public ReadOnly Property PropertyStatement As PropertyStatementSyntax
+
+        Sub New(propertyStatement As PropertyStatementSyntax)
+            Me.PropertyStatement = propertyStatement
+        End Sub
+
+        Public Overrides ReadOnly Property InitializerActiveStatement As SyntaxNode
+            Get
+                Return PropertyStatement
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property OtherActiveStatementContainer As SyntaxNode
+            Get
+                Return DirectCast(PropertyStatement.AsClause, AsNewClauseSyntax).NewExpression
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property Envelope As ActiveStatementEnvelope
+            Get
+                Return TextSpan.FromBounds(PropertyStatement.Identifier.Span.Start, PropertyStatement.AsClause.Span.End)
+            End Get
+        End Property
+
+        Public Overrides Function GetActiveTokens() As IEnumerable(Of SyntaxToken)
+            ' Property: Attributes Modifiers [|Identifier AsClause Initializer|] ImplementsClause
+            Return SpecializedCollections.SingletonEnumerable(PropertyStatement.Identifier).Concat(PropertyStatement.AsClause.DescendantTokens())
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Private ReadOnly _node As SyntaxNode
 
-        Sub New(node As SyntaxNode)
+        Public Sub New(node As SyntaxNode)
             Debug.Assert(TypeOf node.Parent Is LambdaExpressionSyntax OrElse TypeOf node Is ExpressionSyntax)
             _node = node
         End Sub

--- a/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/DeclarationBody/VisualBasicLambdaBody.vb
@@ -1,0 +1,94 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Diagnostics.CodeAnalysis
+Imports Microsoft.CodeAnalysis.EditAndContinue
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
+    Friend NotInheritable Class VisualBasicLambdaBody
+        Inherits LambdaBody
+
+        Private ReadOnly _node As SyntaxNode
+
+        Sub New(node As SyntaxNode)
+            Debug.Assert(TypeOf node.Parent Is LambdaExpressionSyntax OrElse TypeOf node Is ExpressionSyntax)
+            _node = node
+        End Sub
+
+        Public Overrides ReadOnly Property SyntaxTree As SyntaxTree
+            Get
+                Return _node.SyntaxTree
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property RootNodes As OneOrMany(Of SyntaxNode)
+            Get
+                If TypeOf _node.Parent Is LambdaExpressionSyntax Then
+                    Return OneOrMany.Create(_node.Parent)
+                Else
+                    Return OneOrMany.Create(_node)
+                End If
+            End Get
+        End Property
+
+        Public Overrides Function GetStateMachineInfo() As StateMachineInfo
+            Return VisualBasicEditAndContinueAnalyzer.GetStateMachineInfo(_node)
+        End Function
+
+        Public Overrides Function TryGetPartnerLambdaBody(newLambda As SyntaxNode) As LambdaBody
+            Return SyntaxUtilities.CreateLambdaBody(LambdaUtilities.GetCorrespondingLambdaBody(_node, newLambda))
+        End Function
+
+        Public Overrides Function GetExpressionsAndStatements() As IEnumerable(Of SyntaxNode)
+            Return LambdaUtilities.GetLambdaBodyExpressionsAndStatements(_node)
+        End Function
+
+        Public Overrides Function GetLambda() As SyntaxNode
+            Return LambdaUtilities.GetLambda(_node)
+        End Function
+
+        Public Overrides Function IsSyntaxEquivalentTo(other As LambdaBody) As Boolean
+            Return GetExpressionsAndStatements().SequenceEqual(other.GetExpressionsAndStatements(), AddressOf SyntaxFactory.AreEquivalent)
+        End Function
+
+        Public Overrides Function ComputeMatch(newBody As DeclarationBody, knownMatches As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))) As Differencing.Match(Of SyntaxNode)
+            Dim newLambdaBody = DirectCast(newBody, VisualBasicLambdaBody)
+
+            If TypeOf _node.Parent Is LambdaExpressionSyntax Then
+                ' The root is a single/multi line sub/function lambda.
+                Return New SyntaxComparer(_node.Parent, newLambdaBody._node.Parent, _node.Parent.ChildNodes(), newLambdaBody._node.Parent.ChildNodes(), matchingLambdas:=True, compareStatementSyntax:=True).
+                   ComputeMatch(_node.Parent, newLambdaBody._node.Parent, knownMatches)
+            Else
+                ' Queries: The root is a query clause, the body is the expression.
+                Return New SyntaxComparer(_node.Parent, newLambdaBody._node.Parent, {_node}, {newLambdaBody._node}, matchingLambdas:=False, compareStatementSyntax:=True).
+                           ComputeMatch(_node.Parent, newLambdaBody._node.Parent, knownMatches)
+            End If
+        End Function
+
+        Public Overrides Function TryMatchActiveStatement(newBody As DeclarationBody, oldStatement As SyntaxNode, statementPart As Integer, <NotNullWhen(True)> ByRef newStatement As SyntaxNode) As Boolean
+            Dim newLambdaBody = DirectCast(newBody, VisualBasicLambdaBody)
+
+            If TypeOf _node.Parent Is LambdaExpressionSyntax Then
+                Dim oldSingleLineLambda = TryCast(_node.Parent, SingleLineLambdaExpressionSyntax)
+                Dim newSingleLineLambda = TryCast(newLambdaBody._node.Parent, SingleLineLambdaExpressionSyntax)
+
+                If oldSingleLineLambda IsNot Nothing AndAlso
+                   newSingleLineLambda IsNot Nothing AndAlso
+                   oldStatement Is oldSingleLineLambda.Body Then
+
+                    newStatement = newSingleLineLambda.Body
+                    Return True
+                End If
+            ElseIf oldStatement Is _node Then ' Queries
+                newStatement = newLambdaBody._node
+                Return True
+            End If
+
+            newStatement = Nothing
+            Return False
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
@@ -3,11 +3,144 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
     Friend NotInheritable Class SyntaxUtilities
+        Public Shared Function CreateLambdaBody(node As SyntaxNode) As LambdaBody
+            Return New VisualBasicLambdaBody(node)
+        End Function
+
+        Public Shared Function TryGetDeclarationBody(node As SyntaxNode) As MemberBody
+            Select Case node.Kind
+                Case SyntaxKind.SubBlock,
+                    SyntaxKind.FunctionBlock,
+                    SyntaxKind.ConstructorBlock,
+                    SyntaxKind.OperatorBlock,
+                    SyntaxKind.GetAccessorBlock,
+                    SyntaxKind.SetAccessorBlock,
+                    SyntaxKind.AddHandlerAccessorBlock,
+                    SyntaxKind.RemoveHandlerAccessorBlock,
+                    SyntaxKind.RaiseEventAccessorBlock
+                    Return New MethodBody(DirectCast(node, MethodBlockBaseSyntax))
+
+                Case SyntaxKind.PropertyStatement
+                    Dim propertyStatement = DirectCast(node, PropertyStatementSyntax)
+                    If propertyStatement.Initializer IsNot Nothing Then
+                        Return New PropertyWithInitializerDeclarationBody(propertyStatement)
+                    End If
+
+                    If HasAsNewClause(propertyStatement) Then
+                        Return New PropertyWithNewClauseDeclarationBody(propertyStatement)
+                    End If
+
+                    Return Nothing
+
+                Case SyntaxKind.ModifiedIdentifier
+                    Dim modifiedIdentifier = DirectCast(node, ModifiedIdentifierSyntax)
+
+                    If Not node.IsParentKind(SyntaxKind.VariableDeclarator) Then
+                        ' parameter
+                        Return Nothing
+                    End If
+
+                    Dim variableDeclarator = DirectCast(node.Parent, VariableDeclaratorSyntax)
+                    Dim fieldDeclaration = DirectCast(variableDeclarator.Parent, FieldDeclarationSyntax)
+
+                    If fieldDeclaration.Modifiers.Any(SyntaxKind.ConstKeyword) Then
+                        Return Nothing
+                    End If
+
+                    Dim body As MemberBody = Nothing
+
+                    If IsFieldDeclaration(modifiedIdentifier) Then
+                        ' Dim a, b As New C()
+                        If HasAsNewClause(variableDeclarator) Then
+                            body = New FieldWithMultipleAsNewClauseDeclarationBody(modifiedIdentifier)
+                        End If
+
+                        ' Dim a(n), b(n) As Integer
+                        If modifiedIdentifier.ArrayBounds IsNot Nothing Then
+                            ' AsNew clause can be syntactically specified at the same time as array bounds can be  (it's a semantic error).
+                            ' Guard against such case to maintain consistency and set body to Nothing in that case.
+                            body = If(body Is Nothing, New FieldWithMultipleArrayBoundsDeclarationBody(modifiedIdentifier), Nothing)
+                        End If
+                    Else
+                        If variableDeclarator.Initializer IsNot Nothing Then
+                            ' Dim a = initializer
+                            body = New FieldWithInitializerDeclarationBody(variableDeclarator)
+                        ElseIf HasAsNewClause(variableDeclarator) Then
+                            ' Dim a As New T
+                            body = New FieldWithSingleAsNewClauseDeclarationBody(variableDeclarator)
+                        End If
+
+                        ' Dim a(n) As T
+                        Dim name = variableDeclarator.Names(0)
+
+                        If name.ArrayBounds IsNot Nothing Then
+                            ' Initializer and AsNew clause can't be syntactically specified at the same time, but array bounds can be (it's a semantic error).
+                            ' Guard against such case to maintain consistency and set body to Nothing in that case.
+                            body = If(body Is Nothing, New FieldWithSingleArrayBoundsDeclarationBody(variableDeclarator), Nothing)
+                        End If
+                    End If
+
+                    Return body
+
+                Case Else
+                    Return Nothing
+            End Select
+        End Function
+
+        Public Shared Function HasAsNewClause(variableDeclarator As VariableDeclaratorSyntax) As Boolean
+            Return variableDeclarator.AsClause IsNot Nothing AndAlso variableDeclarator.AsClause.IsKind(SyntaxKind.AsNewClause)
+        End Function
+
+        Public Shared Function HasAsNewClause(propertyStatement As PropertyStatementSyntax) As Boolean
+            Return propertyStatement.AsClause IsNot Nothing AndAlso propertyStatement.AsClause.IsKind(SyntaxKind.AsNewClause)
+        End Function
+
+        ''' <summary>
+        ''' Returns true if the <see cref="ModifiedIdentifierSyntax"/> node represents a field declaration.
+        ''' </summary>
+        Friend Shared Function IsFieldDeclaration(node As ModifiedIdentifierSyntax) As Boolean
+            Return node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso DirectCast(node.Parent, VariableDeclaratorSyntax).Names.Count > 1
+        End Function
+
+        ''' <summary>
+        ''' Returns true if the <see cref="VariableDeclaratorSyntax"/> node represents a field declaration.
+        ''' </summary>
+        Friend Shared Function IsFieldDeclaration(node As VariableDeclaratorSyntax) As Boolean
+            Return node.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso node.Names.Count = 1
+        End Function
+
+        Friend Shared Function GetArrayBoundsCapturedVariables(model As SemanticModel, arrayBounds As ArgumentListSyntax) As ImmutableArray(Of ISymbol)
+            ' Edge case, no need to be efficient, currently there can either be no captured variables or just "Me".
+            ' Dim a((Function(n) n + 1).Invoke(1), (Function(n) n + 2).Invoke(2)) As Integer
+            Return ImmutableArray.CreateRange(
+                    arrayBounds.Arguments.
+                        SelectMany(AddressOf GetArgumentExpressions).
+                        SelectMany(Function(expr) model.AnalyzeDataFlow(expr).Captured).
+                        Distinct())
+        End Function
+
+        Private Shared Iterator Function GetArgumentExpressions(argument As ArgumentSyntax) As IEnumerable(Of ExpressionSyntax)
+            Select Case argument.Kind
+                Case SyntaxKind.SimpleArgument
+                    Yield DirectCast(argument, SimpleArgumentSyntax).Expression
+
+                Case SyntaxKind.RangeArgument
+                    Dim range = DirectCast(argument, RangeArgumentSyntax)
+                    Yield range.LowerBound
+                    Yield range.UpperBound
+
+                Case SyntaxKind.OmittedArgument
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(argument.Kind)
+            End Select
+        End Function
+
         <Conditional("DEBUG")>
         Public Shared Sub AssertIsBody(syntax As SyntaxNode, allowLambda As Boolean)
             ' lambda/query
@@ -63,62 +196,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-        End Function
-
-        Public Shared Sub FindLeafNodeAndPartner(leftRoot As SyntaxNode,
-                                          leftPosition As Integer,
-                                          rightRoot As SyntaxNode,
-                                          <Out> ByRef leftNode As SyntaxNode,
-                                          <Out> ByRef rightNodeOpt As SyntaxNode)
-            leftNode = leftRoot
-            rightNodeOpt = rightRoot
-            While True
-                If rightNodeOpt IsNot Nothing AndAlso leftNode.RawKind <> rightNodeOpt.RawKind Then
-                    rightNodeOpt = Nothing
-                End If
-
-                Dim childIndex As Integer = 0
-                Dim leftChild = leftNode.ChildThatContainsPosition(leftPosition, childIndex)
-                If leftChild.IsToken Then
-                    Return
-                End If
-
-                If rightNodeOpt IsNot Nothing Then
-                    Dim rightNodeChildNodesAndTokens = rightNodeOpt.ChildNodesAndTokens()
-                    If childIndex >= 0 AndAlso childIndex < rightNodeChildNodesAndTokens.Count Then
-                        rightNodeOpt = rightNodeChildNodesAndTokens(childIndex).AsNode()
-                    Else
-                        rightNodeOpt = Nothing
-                    End If
-                End If
-
-                leftNode = leftChild.AsNode()
-            End While
-        End Sub
-
-        Public Shared Function FindPartner(leftRoot As SyntaxNode, rightRoot As SyntaxNode, leftNode As SyntaxNode) As SyntaxNode
-            ' Finding a partner of a zero-width node is complicated and not supported atm
-            Debug.Assert(leftNode.FullSpan.Length > 0)
-
-            Dim originalLeftNode = leftNode
-            Dim leftPosition = leftNode.SpanStart
-            leftNode = leftRoot
-            Dim rightNode = rightRoot
-
-            While leftNode IsNot originalLeftNode
-                Debug.Assert(leftNode.RawKind = rightNode.RawKind)
-
-                Dim childIndex = 0
-                Dim leftChild = leftNode.ChildThatContainsPosition(leftPosition, childIndex)
-
-                ' Can only happen when searching for zero-width node.
-                Debug.Assert(Not leftChild.IsToken)
-
-                rightNode = rightNode.ChildNodesAndTokens()(childIndex).AsNode()
-                leftNode = leftChild.AsNode()
-            End While
-
-            Return rightNode
         End Function
 
         Public Shared Function IsParameterlessConstructor(declaration As SyntaxNode) As Boolean

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                             Dim variableDeclarator = CType(current, VariableDeclaratorSyntax)
                             If variableDeclarator.Names.Count = 1 Then
-                                declarations = OneOrMany.Create(current)
+                                declarations = OneOrMany.Create(Of SyntaxNode)(variableDeclarator.Names(0))
                             Else
                                 declarations = OneOrMany.Create(variableDeclarator.Names.SelectAsArray(Function(n) CType(n, SyntaxNode)))
                             End If
@@ -90,20 +90,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return False
         End Function
 
-        ''' <summary>
-        ''' Returns true if the <see cref="ModifiedIdentifierSyntax"/> node represents a field declaration.
-        ''' </summary>
-        Private Shared Function IsFieldDeclaration(node As ModifiedIdentifierSyntax) As Boolean
-            Return node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso DirectCast(node.Parent, VariableDeclaratorSyntax).Names.Count > 1
-        End Function
-
-        ''' <summary>
-        ''' Returns true if the <see cref="VariableDeclaratorSyntax"/> node represents a field declaration.
-        ''' </summary>
-        Private Shared Function IsFieldDeclaration(node As VariableDeclaratorSyntax) As Boolean
-            Return node.Parent.IsKind(SyntaxKind.FieldDeclaration) AndAlso node.Names.Count = 1
-        End Function
-
         ''' <returns>
         ''' Given a node representing a declaration or a top-level edit node returns:
         ''' - <see cref="MethodBlockBaseSyntax"/> for methods, constructors, operators and accessors.
@@ -111,148 +97,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         ''' - <see cref="ArgumentListSyntax"/> for fields with array initializer, e.g. "Dim a(1) As Integer".
         ''' A null reference otherwise.
         ''' </returns>
-        Friend Overrides Function TryGetDeclarationBody(node As SyntaxNode) As SyntaxNode
-            Select Case node.Kind
-                Case SyntaxKind.SubBlock,
-                     SyntaxKind.FunctionBlock,
-                     SyntaxKind.ConstructorBlock,
-                     SyntaxKind.OperatorBlock,
-                     SyntaxKind.GetAccessorBlock,
-                     SyntaxKind.SetAccessorBlock,
-                     SyntaxKind.AddHandlerAccessorBlock,
-                     SyntaxKind.RemoveHandlerAccessorBlock,
-                     SyntaxKind.RaiseEventAccessorBlock
-                    ' the body is the Statements list of the block
-                    Return node
-
-                Case SyntaxKind.PropertyStatement
-                    ' the body is the initializer expression/new expression (if any)
-
-                    Dim propertyStatement = DirectCast(node, PropertyStatementSyntax)
-                    If propertyStatement.Initializer IsNot Nothing Then
-                        Return propertyStatement.Initializer.Value
-                    End If
-
-                    If HasAsNewClause(propertyStatement) Then
-                        Return DirectCast(propertyStatement.AsClause, AsNewClauseSyntax).NewExpression
-                    End If
-
-                    Return Nothing
-
-                Case SyntaxKind.VariableDeclarator
-                    If Not node.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                        Return Nothing
-                    End If
-
-                    Dim variableDeclarator = DirectCast(node, VariableDeclaratorSyntax)
-
-                    Dim body As SyntaxNode = Nothing
-
-                    If variableDeclarator.Initializer IsNot Nothing Then
-                        ' Dim a = initializer
-                        body = variableDeclarator.Initializer.Value
-                    ElseIf HasAsNewClause(variableDeclarator) Then
-                        ' Dim a As New T
-                        ' Dim a,b As New T
-                        body = DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
-                    End If
-
-                    ' Dim a(n) As T
-                    If variableDeclarator.Names.Count = 1 Then
-                        Dim name = variableDeclarator.Names(0)
-
-                        If name.ArrayBounds IsNot Nothing Then
-                            ' Initializer and AsNew clause can't be syntactically specified at the same time, but array bounds can be (it's a semantic error).
-                            ' Guard against such case to maintain consistency and set body to Nothing in that case.
-                            body = If(body Is Nothing, name.ArrayBounds, Nothing)
-                        End If
-                    End If
-
-                    Return body
-
-                Case SyntaxKind.ModifiedIdentifier
-                    If Not node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                        Return Nothing
-                    End If
-
-                    Dim modifiedIdentifier = CType(node, ModifiedIdentifierSyntax)
-                    Dim body As SyntaxNode = Nothing
-
-                    ' Dim a, b As New C()
-                    Dim variableDeclarator = DirectCast(node.Parent, VariableDeclaratorSyntax)
-                    If HasAsNewClause(variableDeclarator) Then
-                        body = DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression
-                    End If
-
-                    ' Dim a(n) As Integer
-                    ' Dim a(n), b(n) As Integer
-                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        ' AsNew clause can be syntactically specified at the same time as array bounds can be  (it's a semantic error).
-                        ' Guard against such case to maintain consistency and set body to Nothing in that case.
-                        body = If(body Is Nothing, modifiedIdentifier.ArrayBounds, Nothing)
-                    End If
-
-                    Return body
-
-                Case Else
-                    ' Note: A method without body is represented by a SubStatement.
-                    Return Nothing
-            End Select
+        Friend Overrides Function TryGetDeclarationBody(node As SyntaxNode) As MemberBody
+            Return SyntaxUtilities.TryGetDeclarationBody(node)
         End Function
 
         Friend Overrides Function IsDeclarationWithSharedBody(declaration As SyntaxNode) As Boolean
             If declaration.Kind = SyntaxKind.ModifiedIdentifier AndAlso declaration.Parent.Kind = SyntaxKind.VariableDeclarator Then
                 Dim variableDeclarator = CType(declaration.Parent, VariableDeclaratorSyntax)
-                Return variableDeclarator.Names.Count > 1 AndAlso variableDeclarator.Initializer IsNot Nothing OrElse HasAsNewClause(variableDeclarator)
+                Return variableDeclarator.Names.Count > 1 AndAlso variableDeclarator.Initializer IsNot Nothing OrElse SyntaxUtilities.HasAsNewClause(variableDeclarator)
             End If
 
             Return False
-        End Function
-
-        Protected Overrides Function GetCapturedVariables(model As SemanticModel, memberBody As SyntaxNode) As ImmutableArray(Of ISymbol)
-            Dim methodBlock = TryCast(memberBody, MethodBlockBaseSyntax)
-            If methodBlock IsNot Nothing Then
-                If methodBlock.Statements.IsEmpty Then
-                    Return ImmutableArray(Of ISymbol).Empty
-                End If
-
-                Return model.AnalyzeDataFlow(methodBlock.Statements.First, methodBlock.Statements.Last).Captured
-            End If
-
-            Dim expression = TryCast(memberBody, ExpressionSyntax)
-            If expression IsNot Nothing Then
-                Return model.AnalyzeDataFlow(expression).Captured
-            End If
-
-            ' Edge case, no need to be efficient, currently there can either be no captured variables or just "Me".
-            ' Dim a((Function(n) n + 1).Invoke(1), (Function(n) n + 2).Invoke(2)) As Integer
-            Dim arrayBounds = TryCast(memberBody, ArgumentListSyntax)
-            If arrayBounds IsNot Nothing Then
-                Return ImmutableArray.CreateRange(
-                    arrayBounds.Arguments.
-                        SelectMany(AddressOf GetArgumentExpressions).
-                        SelectMany(Function(expr) model.AnalyzeDataFlow(expr).Captured).
-                        Distinct())
-            End If
-
-            Throw ExceptionUtilities.UnexpectedValue(memberBody)
-        End Function
-
-        Private Shared Iterator Function GetArgumentExpressions(argument As ArgumentSyntax) As IEnumerable(Of ExpressionSyntax)
-            Select Case argument.Kind
-                Case SyntaxKind.SimpleArgument
-                    Yield DirectCast(argument, SimpleArgumentSyntax).Expression
-
-                Case SyntaxKind.RangeArgument
-                    Dim range = DirectCast(argument, RangeArgumentSyntax)
-                    Yield range.LowerBound
-                    Yield range.UpperBound
-
-                Case SyntaxKind.OmittedArgument
-
-                Case Else
-                    Throw ExceptionUtilities.UnexpectedValue(argument.Kind)
-            End Select
         End Function
 
         Friend Overrides Function HasParameterClosureScope(member As ISymbol) As Boolean
@@ -272,191 +127,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                    Where String.Equals(DirectCast(identifier.Identifier.Value, String), localOrParameter.Name, StringComparison.OrdinalIgnoreCase) AndAlso
                          If(model.GetSymbolInfo(identifier, cancellationToken).Symbol?.Equals(localOrParameter), False)
                    Select node
-        End Function
-
-        Private Shared Function HasAsNewClause(variableDeclarator As VariableDeclaratorSyntax) As Boolean
-            Return variableDeclarator.AsClause IsNot Nothing AndAlso variableDeclarator.AsClause.IsKind(SyntaxKind.AsNewClause)
-        End Function
-
-        Private Shared Function HasAsNewClause(propertyStatement As PropertyStatementSyntax) As Boolean
-            Return propertyStatement.AsClause IsNot Nothing AndAlso propertyStatement.AsClause.IsKind(SyntaxKind.AsNewClause)
-        End Function
-
-        ''' <returns>
-        ''' Methods, operators, constructors, property and event accessors:
-        ''' - We need to return the entire block declaration since the Begin and End statements are covered by breakpoint spans.
-        ''' Field declarations in form of "Dim a, b, c As New C()" 
-        ''' - Breakpoint spans cover "a", "b" and "c" and also "New C()" since the expression may contain lambdas.
-        '''   For simplicity we don't allow moving the new expression independently of the field name. 
-        ''' Field declarations with array initializers "Dim a(n), b(n) As Integer" 
-        ''' - Breakpoint spans cover "a(n)" and "b(n)".
-        ''' </returns>
-        Friend Overrides Function TryGetActiveTokens(node As SyntaxNode) As IEnumerable(Of SyntaxToken)
-            Select Case node.Kind
-                Case SyntaxKind.SubBlock,
-                     SyntaxKind.FunctionBlock,
-                     SyntaxKind.ConstructorBlock,
-                     SyntaxKind.OperatorBlock,
-                     SyntaxKind.GetAccessorBlock,
-                     SyntaxKind.SetAccessorBlock,
-                     SyntaxKind.AddHandlerAccessorBlock,
-                     SyntaxKind.RemoveHandlerAccessorBlock,
-                     SyntaxKind.RaiseEventAccessorBlock
-                    ' the body is the Statements list of the block
-                    Return node.DescendantTokens()
-
-                Case SyntaxKind.PropertyStatement
-                    ' Property: Attributes Modifiers [|Identifier AsClause Initializer|] ImplementsClause
-                    ' Property: Attributes Modifiers [|Identifier$ Initializer|] ImplementsClause
-                    Dim propertyStatement = DirectCast(node, PropertyStatementSyntax)
-                    If propertyStatement.Initializer IsNot Nothing Then
-                        Return SpecializedCollections.SingletonEnumerable(propertyStatement.Identifier).Concat(If(propertyStatement.AsClause?.DescendantTokens(),
-                                                                     Array.Empty(Of SyntaxToken))).Concat(propertyStatement.Initializer.DescendantTokens())
-                    End If
-
-                    If HasAsNewClause(propertyStatement) Then
-                        Return SpecializedCollections.SingletonEnumerable(propertyStatement.Identifier).Concat(propertyStatement.AsClause.DescendantTokens())
-                    End If
-
-                    Return Nothing
-
-                Case SyntaxKind.VariableDeclarator
-                    Dim variableDeclarator = DirectCast(node, VariableDeclaratorSyntax)
-                    If Not IsFieldDeclaration(variableDeclarator) Then
-                        Return Nothing
-                    End If
-
-                    ' Field: Attributes Modifiers Declarators
-                    Dim fieldDeclaration = DirectCast(node.Parent, FieldDeclarationSyntax)
-                    If fieldDeclaration.Modifiers.Any(SyntaxKind.ConstKeyword) Then
-                        Return Nothing
-                    End If
-
-                    ' Dim a = initializer
-                    If variableDeclarator.Initializer IsNot Nothing Then
-                        Return variableDeclarator.DescendantTokens()
-                    End If
-
-                    ' Dim a As New C()
-                    If HasAsNewClause(variableDeclarator) Then
-                        Return variableDeclarator.DescendantTokens()
-                    End If
-
-                    ' Dim a(n) As Integer
-                    Dim modifiedIdentifier = variableDeclarator.Names.Single()
-                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        Return variableDeclarator.DescendantTokens()
-                    End If
-
-                    Return Nothing
-
-                Case SyntaxKind.ModifiedIdentifier
-                    Dim modifiedIdentifier = DirectCast(node, ModifiedIdentifierSyntax)
-                    If Not IsFieldDeclaration(modifiedIdentifier) Then
-                        Return Nothing
-                    End If
-
-                    ' Dim a, b As New C()
-                    Dim variableDeclarator = DirectCast(node.Parent, VariableDeclaratorSyntax)
-                    If HasAsNewClause(variableDeclarator) Then
-                        Return node.DescendantTokens().Concat(DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax).NewExpression.DescendantTokens())
-                    End If
-
-                    ' Dim a(n), b(n) As Integer
-                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        Return node.DescendantTokens()
-                    End If
-
-                    Return Nothing
-
-                Case Else
-                    Return Nothing
-            End Select
-        End Function
-
-        Friend Overrides Function GetActiveSpanEnvelope(declaration As SyntaxNode) As (envelope As TextSpan, hole As TextSpan)
-            Select Case declaration.Kind
-                Case SyntaxKind.SubBlock,
-                     SyntaxKind.FunctionBlock,
-                     SyntaxKind.ConstructorBlock,
-                     SyntaxKind.OperatorBlock,
-                     SyntaxKind.GetAccessorBlock,
-                     SyntaxKind.SetAccessorBlock,
-                     SyntaxKind.AddHandlerAccessorBlock,
-                     SyntaxKind.RemoveHandlerAccessorBlock,
-                     SyntaxKind.RaiseEventAccessorBlock
-                    ' the body is the Statements list of the block
-                    Return (declaration.Span, Nothing)
-
-                Case SyntaxKind.PropertyStatement
-                    ' Property: Attributes Modifiers [|Identifier AsClause Initializer|] ImplementsClause
-                    ' Property: Attributes Modifiers [|Identifier$ Initializer|] ImplementsClause
-                    Dim propertyStatement = DirectCast(declaration, PropertyStatementSyntax)
-                    If propertyStatement.Initializer IsNot Nothing Then
-                        Return (TextSpan.FromBounds(propertyStatement.Identifier.Span.Start, propertyStatement.Initializer.Span.End), Nothing)
-                    End If
-
-                    If HasAsNewClause(propertyStatement) Then
-                        Return (TextSpan.FromBounds(propertyStatement.Identifier.Span.Start, propertyStatement.AsClause.Span.End), Nothing)
-                    End If
-
-                    Return Nothing
-
-                Case SyntaxKind.VariableDeclarator
-                    Dim variableDeclarator = DirectCast(declaration, VariableDeclaratorSyntax)
-                    If Not declaration.Parent.IsKind(SyntaxKind.FieldDeclaration) OrElse variableDeclarator.Names.Count > 1 Then
-                        Return Nothing
-                    End If
-
-                    ' Field: Attributes Modifiers Declarators
-                    Dim fieldDeclaration = DirectCast(declaration.Parent, FieldDeclarationSyntax)
-                    If fieldDeclaration.Modifiers.Any(SyntaxKind.ConstKeyword) Then
-                        Return Nothing
-                    End If
-
-                    ' Dim a = initializer
-                    If variableDeclarator.Initializer IsNot Nothing Then
-                        Return (variableDeclarator.Span, Nothing)
-                    End If
-
-                    ' Dim a As New C()
-                    If HasAsNewClause(variableDeclarator) Then
-                        Return (variableDeclarator.Span, Nothing)
-                    End If
-
-                    ' Dim a(n) As Integer
-                    Dim modifiedIdentifier = variableDeclarator.Names.Single()
-                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        Return (variableDeclarator.Span, Nothing)
-                    End If
-
-                    Return Nothing
-
-                Case SyntaxKind.ModifiedIdentifier
-                    If Not declaration.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                        Return Nothing
-                    End If
-
-                    ' Dim a, b As New C()
-                    Dim variableDeclarator = DirectCast(declaration.Parent, VariableDeclaratorSyntax)
-                    If HasAsNewClause(variableDeclarator) Then
-                        Dim asNewClause = DirectCast(variableDeclarator.AsClause, AsNewClauseSyntax)
-                        Return (envelope:=TextSpan.FromBounds(declaration.Span.Start, asNewClause.NewExpression.Span.End),
-                                hole:=TextSpan.FromBounds(declaration.Span.End, asNewClause.NewExpression.Span.Start))
-                    End If
-
-                    ' Dim a(n) As Integer
-                    ' Dim a(n), b(n) As Integer
-                    Dim modifiedIdentifier = DirectCast(declaration, ModifiedIdentifierSyntax)
-                    If modifiedIdentifier.ArrayBounds IsNot Nothing Then
-                        Return (declaration.Span, Nothing)
-                    End If
-
-                    Return Nothing
-
-                Case Else
-                    Return Nothing
-            End Select
         End Function
 
         Protected Overrides Function GetEncompassingAncestorImpl(bodyOrMatchRoot As SyntaxNode) As SyntaxNode
@@ -490,92 +160,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return bodyOrMatchRoot
         End Function
 
-        Protected Overrides Function FindStatementAndPartner(declarationBody As SyntaxNode,
-                                                             span As TextSpan,
-                                                             partnerDeclarationBodyOpt As SyntaxNode,
-                                                             <Out> ByRef partnerOpt As SyntaxNode,
-                                                             <Out> ByRef statementPart As Integer) As SyntaxNode
+        Friend Shared Function FindStatementAndPartner(
+            span As TextSpan,
+            body As SyntaxNode,
+            partnerBody As SyntaxNode,
+            <Out> ByRef partnerStatement As SyntaxNode,
+            <Out> ByRef statementPart As Integer) As SyntaxNode
+
             Dim position = span.Start
 
-            SyntaxUtilities.AssertIsBody(declarationBody, allowLambda:=False)
-            Debug.Assert(partnerDeclarationBodyOpt Is Nothing OrElse partnerDeclarationBodyOpt.RawKind = declarationBody.RawKind)
-
-            ' Only field and property initializers may have an [|active statement|] starting outside of the <<body>>.
-            ' Simple field initializers:         Dim [|a = <<expr>>|]
-            '                                    Dim [|a As Integer = <<expr>>|]
-            '                                    Dim [|a = <<expr>>|], [|b = <<expr>>|], [|c As Integer = <<expr>>|]
-            '                                    Dim [|a As <<New C>>|] 
-            ' Array initialized fields:          Dim [|a<<(array bounds)>>|] As Integer
-            ' Shared initializers:               Dim [|a|], [|b|] As <<New C(Function() [|...|])>>
-            ' Property initializers:             Property [|p As Integer = <<body>>|]
-            '                                    Property [|p As <<New C()>>|]
-            If position < declarationBody.SpanStart Then
-                If declarationBody.Parent.Parent.IsKind(SyntaxKind.PropertyStatement) Then
-                    ' Property [|p As Integer = <<body>>|]
-                    ' Property [|p As <<New C()>>|]
-
-                    If partnerDeclarationBodyOpt IsNot Nothing Then
-                        partnerOpt = partnerDeclarationBodyOpt.Parent.Parent
-                    End If
-
-                    Debug.Assert(declarationBody.Parent.Parent.IsKind(SyntaxKind.PropertyStatement))
-                    Return declarationBody.Parent.Parent
-                End If
-
-                If declarationBody.IsKind(SyntaxKind.ArgumentList) Then
-                    ' Dim a<<ArgumentList>> As Integer
-                    If partnerDeclarationBodyOpt IsNot Nothing Then
-                        partnerOpt = partnerDeclarationBodyOpt.Parent
-                    End If
-
-                    Debug.Assert(declarationBody.Parent.IsKind(SyntaxKind.ModifiedIdentifier))
-                    Return declarationBody.Parent
-                End If
-
-                If declarationBody.Parent.IsKind(SyntaxKind.AsNewClause) Then
-                    Dim variableDeclarator = DirectCast(declarationBody.Parent.Parent, VariableDeclaratorSyntax)
-                    If variableDeclarator.Names.Count > 1 Then
-                        ' Dim a, b, c As <<NewExpression>>
-                        Dim nameIndex = GetItemIndexByPosition(variableDeclarator.Names, position)
-
-                        If partnerDeclarationBodyOpt IsNot Nothing Then
-                            partnerOpt = DirectCast(partnerDeclarationBodyOpt.Parent.Parent, VariableDeclaratorSyntax).Names(nameIndex)
-                        End If
-
-                        Return variableDeclarator.Names(nameIndex)
-                    Else
-                        If partnerDeclarationBodyOpt IsNot Nothing Then
-                            partnerOpt = partnerDeclarationBodyOpt.Parent.Parent
-                        End If
-
-                        ' Dim a As <<NewExpression>>
-                        Return variableDeclarator
-                    End If
-                End If
-
-                If declarationBody.Parent.IsKind(SyntaxKind.EqualsValue) Then
-                    Debug.Assert(declarationBody.Parent.Parent.IsKind(SyntaxKind.VariableDeclarator) AndAlso
-                                 declarationBody.Parent.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration))
-
-                    If partnerDeclarationBodyOpt IsNot Nothing Then
-                        partnerOpt = partnerDeclarationBodyOpt.Parent.Parent
-                    End If
-
-                    Return declarationBody.Parent.Parent
-                End If
-            End If
-
-            If Not declarationBody.FullSpan.Contains(position) Then
+            If Not body.FullSpan.Contains(position) Then
                 ' invalid position, let's find a labeled node that encompasses the body:
-                position = declarationBody.SpanStart
+                position = body.SpanStart
             End If
 
             Dim node As SyntaxNode = Nothing
-            If partnerDeclarationBodyOpt IsNot Nothing Then
-                SyntaxUtilities.FindLeafNodeAndPartner(declarationBody, position, partnerDeclarationBodyOpt, node, partnerOpt)
+            If partnerBody IsNot Nothing Then
+                FindLeafNodeAndPartner(body, position, partnerBody, node, partnerStatement)
             Else
-                node = declarationBody.FindToken(position).Parent
-                partnerOpt = Nothing
+                node = body.FindToken(position).Parent
+                partnerStatement = Nothing
             End If
 
             ' In some cases active statements may start at the same position.
@@ -586,18 +190,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             ' Find the parent whose span starts at the same position but it's length is at least as long as the active span's length.
             While node.Span.Length < span.Length AndAlso node.Parent.SpanStart = position
                 node = node.Parent
-                partnerOpt = partnerOpt?.Parent
+                partnerStatement = partnerStatement?.Parent
             End While
 
             Debug.Assert(node IsNot Nothing)
 
-            While node IsNot declarationBody AndAlso
+            While node IsNot body AndAlso
                   Not SyntaxComparer.Statement.HasLabel(node) AndAlso
                   Not LambdaUtilities.IsLambdaBodyStatementOrExpression(node)
 
                 node = node.Parent
-                If partnerOpt IsNot Nothing Then
-                    partnerOpt = partnerOpt.Parent
+                If partnerStatement IsNot Nothing Then
+                    partnerStatement = partnerStatement.Parent
                 End If
             End While
 
@@ -613,43 +217,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return node
         End Function
 
-        Friend Overrides Function FindDeclarationBodyPartner(leftDeclaration As SyntaxNode, rightDeclaration As SyntaxNode, leftNode As SyntaxNode) As SyntaxNode
-            Debug.Assert(leftDeclaration.Kind = rightDeclaration.Kind)
-
-            ' Special case modified identifiers with AsNew clause - the node we are seeking can be in the AsNew clause. 
-            If leftDeclaration.Kind = SyntaxKind.ModifiedIdentifier Then
-                Dim leftDeclarator = CType(leftDeclaration.Parent, VariableDeclaratorSyntax)
-                Dim rightDeclarator = CType(rightDeclaration.Parent, VariableDeclaratorSyntax)
-
-                If leftDeclarator.AsClause IsNot Nothing AndAlso leftNode.SpanStart >= leftDeclarator.AsClause.SpanStart Then
-                    Return SyntaxUtilities.FindPartner(leftDeclarator.AsClause, rightDeclarator.AsClause, leftNode)
-                End If
-            End If
-
-            Return SyntaxUtilities.FindPartner(leftDeclaration, rightDeclaration, leftNode)
-        End Function
-
         Friend Overrides Function IsClosureScope(node As SyntaxNode) As Boolean
             Return LambdaUtilities.IsClosureScope(node)
         End Function
 
-        Protected Overrides Function FindEnclosingLambdaBody(containerOpt As SyntaxNode, node As SyntaxNode) As SyntaxNode
-            Dim root As SyntaxNode = GetEncompassingAncestor(containerOpt)
-
+        Protected Overrides Function FindEnclosingLambdaBody(root As SyntaxNode, node As SyntaxNode) As LambdaBody
             While node IsNot root And node IsNot Nothing
                 Dim body As SyntaxNode = Nothing
                 If LambdaUtilities.IsLambdaBodyStatementOrExpression(node, body) Then
-                    Return body
+                    Return SyntaxUtilities.CreateLambdaBody(body)
                 End If
 
                 node = node.Parent
             End While
 
             Return Nothing
-        End Function
-
-        Protected Overrides Function TryGetPartnerLambdaBody(oldBody As SyntaxNode, newLambda As SyntaxNode) As SyntaxNode
-            Return LambdaUtilities.GetCorrespondingLambdaBody(oldBody, newLambda)
         End Function
 
         Protected Overrides Function ComputeTopLevelMatch(oldCompilationUnit As SyntaxNode, newCompilationUnit As SyntaxNode) As Match(Of SyntaxNode)
@@ -696,145 +278,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
             Return (declaration.GetParameterList(), Nothing)
         End Function
-
-        Protected Overrides Function ComputeTopLevelDeclarationMatch(oldDeclaration As SyntaxNode, newDeclaration As SyntaxNode) As Match(Of SyntaxNode)
-            Contract.ThrowIfNull(oldDeclaration.Parent)
-            Contract.ThrowIfNull(newDeclaration.Parent)
-
-            ' Allow matching field declarations represented by a identitifer and the whole variable declarator
-            ' even when their node kinds do not match.
-            If oldDeclaration.IsKind(SyntaxKind.ModifiedIdentifier) AndAlso newDeclaration.IsKind(SyntaxKind.VariableDeclarator) Then
-                oldDeclaration = oldDeclaration.Parent
-            ElseIf oldDeclaration.IsKind(SyntaxKind.VariableDeclarator) AndAlso newDeclaration.IsKind(SyntaxKind.ModifiedIdentifier) Then
-                newDeclaration = newDeclaration.Parent
-            End If
-
-            Dim comparer = New SyntaxComparer(oldDeclaration.Parent, newDeclaration.Parent, {oldDeclaration}, {newDeclaration})
-            Return comparer.ComputeMatch(oldDeclaration.Parent, newDeclaration.Parent)
-        End Function
-
-        Protected Overrides Function ComputeBodyMatchImpl(oldBody As SyntaxNode, newBody As SyntaxNode, knownMatches As IEnumerable(Of KeyValuePair(Of SyntaxNode, SyntaxNode))) As Match(Of SyntaxNode)
-            SyntaxUtilities.AssertIsBody(oldBody, allowLambda:=True)
-            SyntaxUtilities.AssertIsBody(newBody, allowLambda:=True)
-
-            Debug.Assert((TypeOf oldBody.Parent Is LambdaExpressionSyntax) = (TypeOf oldBody.Parent Is LambdaExpressionSyntax))
-            Debug.Assert((TypeOf oldBody Is ExpressionSyntax) = (TypeOf newBody Is ExpressionSyntax))
-            Debug.Assert((TypeOf oldBody Is ArgumentListSyntax) = (TypeOf newBody Is ArgumentListSyntax))
-
-            If TypeOf oldBody.Parent Is LambdaExpressionSyntax Then
-                ' The root is a single/multi line sub/function lambda.
-                Return New SyntaxComparer(oldBody.Parent, newBody.Parent, oldBody.Parent.ChildNodes(), newBody.Parent.ChildNodes(), matchingLambdas:=True, compareStatementSyntax:=True).
-                       ComputeMatch(oldBody.Parent, newBody.Parent, knownMatches)
-            End If
-
-            If TypeOf oldBody Is ExpressionSyntax Then
-                ' Dim a = <Expression>
-                ' Dim a As <NewExpression>
-                ' Dim a, b, c As <NewExpression>
-                ' Queries: The root is a query clause, the body is the expression.
-                Return New SyntaxComparer(oldBody.Parent, newBody.Parent, {oldBody}, {newBody}, matchingLambdas:=False, compareStatementSyntax:=True).
-                       ComputeMatch(oldBody.Parent, newBody.Parent, knownMatches)
-            End If
-
-            ' Method, accessor, operator, etc. bodies are represented by the declaring block, which is also the root.
-            ' The body of an array initialized fields is an ArgumentListSyntax, which is the match root.
-            Return SyntaxComparer.Statement.ComputeMatch(oldBody, newBody, knownMatches)
-        End Function
-
-        Protected Overrides Function TryMatchActiveStatement(oldStatement As SyntaxNode,
-                                                             statementPart As Integer,
-                                                             oldBody As SyntaxNode,
-                                                             newBody As SyntaxNode,
-                                                             <Out> ByRef newStatement As SyntaxNode) As Boolean
-            SyntaxUtilities.AssertIsBody(oldBody, allowLambda:=True)
-            SyntaxUtilities.AssertIsBody(newBody, allowLambda:=True)
-
-            ' only statements in bodies of the same kind can be matched
-            Debug.Assert((TypeOf oldBody Is MethodBlockBaseSyntax) = (TypeOf newBody Is MethodBlockBaseSyntax))
-            Debug.Assert((TypeOf oldBody Is ExpressionSyntax) = (TypeOf newBody Is ExpressionSyntax))
-            Debug.Assert((TypeOf oldBody Is ArgumentListSyntax) = (TypeOf newBody Is ArgumentListSyntax))
-            Debug.Assert((TypeOf oldBody Is LambdaHeaderSyntax) = (TypeOf newBody Is LambdaHeaderSyntax))
-            Debug.Assert(oldBody.Parent.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) = newBody.Parent.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration))
-            Debug.Assert(oldBody.Parent.Parent.IsKind(SyntaxKind.PropertyStatement) = newBody.Parent.Parent.IsKind(SyntaxKind.PropertyStatement))
-
-            ' methods
-            If TypeOf oldBody Is MethodBlockBaseSyntax Then
-                newStatement = Nothing
-                Return False
-            End If
-
-            ' lambdas
-            If oldBody.IsKind(SyntaxKind.FunctionLambdaHeader) OrElse oldBody.IsKind(SyntaxKind.SubLambdaHeader) Then
-                Dim oldSingleLineLambda = TryCast(oldBody.Parent, SingleLineLambdaExpressionSyntax)
-                Dim newSingleLineLambda = TryCast(newBody.Parent, SingleLineLambdaExpressionSyntax)
-
-                If oldSingleLineLambda IsNot Nothing AndAlso
-                   newSingleLineLambda IsNot Nothing AndAlso
-                   oldStatement Is oldSingleLineLambda.Body Then
-
-                    newStatement = newSingleLineLambda.Body
-                    Return True
-                End If
-
-                newStatement = Nothing
-                Return False
-            End If
-
-            ' array initialized fields
-            If newBody.IsKind(SyntaxKind.ArgumentList) Then
-                ' the parent ModifiedIdentifier is the active statement
-                If oldStatement Is oldBody.Parent Then
-                    newStatement = newBody.Parent
-                    Return True
-                End If
-
-                newStatement = Nothing
-                Return False
-            End If
-
-            ' field and property initializers
-            If TypeOf newBody Is ExpressionSyntax Then
-                If newBody.Parent.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) Then
-                    ' field
-                    Dim newDeclarator = DirectCast(newBody.Parent.Parent, VariableDeclaratorSyntax)
-
-                    Dim oldName As SyntaxToken
-                    If oldStatement.IsKind(SyntaxKind.VariableDeclarator) Then
-                        oldName = DirectCast(oldStatement, VariableDeclaratorSyntax).Names.Single.Identifier
-                    Else
-                        oldName = DirectCast(oldStatement, ModifiedIdentifierSyntax).Identifier
-                    End If
-
-                    For Each newName In newDeclarator.Names
-                        If SyntaxFactory.AreEquivalent(newName.Identifier, oldName) Then
-                            newStatement = newName
-                            Return True
-                        End If
-                    Next
-
-                    newStatement = Nothing
-                    Return False
-                ElseIf newBody.Parent.Parent.IsKind(SyntaxKind.PropertyStatement) Then
-                    ' property
-                    If oldStatement Is oldBody.Parent.Parent Then
-                        newStatement = newBody.Parent.Parent
-                        Return True
-                    End If
-
-                    newStatement = newBody
-                    Return True
-                End If
-            End If
-
-            ' queries
-            If oldStatement Is oldBody Then
-                newStatement = newBody
-                Return True
-            End If
-
-            newStatement = Nothing
-            Return False
-        End Function
 #End Region
 
 #Region "Syntax And Semantic Utils"
@@ -853,10 +296,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Protected Overrides Function IsGlobalStatement(node As SyntaxNode) As Boolean
             Return False
-        End Function
-
-        Protected Overrides Function GetGlobalStatementDiagnosticSpan(node As SyntaxNode, editKind As EditKind) As TextSpan
-            Return Nothing
         End Function
 
         Protected Overrides Iterator Function GetTopLevelTypeDeclarations(compilationUnit As SyntaxNode) As IEnumerable(Of SyntaxNode)
@@ -910,16 +349,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Protected Overrides Function StatementLabelEquals(node1 As SyntaxNode, node2 As SyntaxNode) As Boolean
             Return SyntaxComparer.Statement.GetLabelImpl(node1) = SyntaxComparer.Statement.GetLabelImpl(node2)
-        End Function
-
-        Private Shared Function GetItemIndexByPosition(Of TNode As SyntaxNode)(list As SeparatedSyntaxList(Of TNode), position As Integer) As Integer
-            For i = list.SeparatorCount - 1 To 0 Step -1
-                If position > list.GetSeparator(i).SpanStart Then
-                    Return i + 1
-                End If
-            Next
-
-            Return 0
         End Function
 
         Private Shared Function ChildrenCompiledInBody(node As SyntaxNode) As Boolean
@@ -1019,13 +448,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End If
         End Function
 
-        Protected Overrides Function AreEquivalentLambdaBodies(oldLambda As SyntaxNode, oldLambdaBody As SyntaxNode, newLambda As SyntaxNode, newLambdaBody As SyntaxNode) As Boolean
-            Dim oldBodyTopMostNodes = LambdaUtilities.GetLambdaBodyExpressionsAndStatements(oldLambdaBody)
-            Dim newBodyTopMostNodes = LambdaUtilities.GetLambdaBodyExpressionsAndStatements(newLambdaBody)
-
-            Return oldBodyTopMostNodes.SequenceEqual(newBodyTopMostNodes, AddressOf SyntaxFactory.AreEquivalent)
-        End Function
-
         Private Shared Function AreEquivalentIgnoringLambdaBodies(left As SyntaxNode, right As SyntaxNode) As Boolean
             ' usual case
             If SyntaxFactory.AreEquivalent(left, right) Then
@@ -1109,11 +531,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         Friend Overrides Function IsDeclarationWithInitializer(declaration As SyntaxNode) As Boolean
             Select Case declaration.Kind
-                Case SyntaxKind.VariableDeclarator
-                    Dim declarator = DirectCast(declaration, VariableDeclaratorSyntax)
-                    Return GetInitializerExpression(declarator.Initializer, declarator.AsClause) IsNot Nothing OrElse
-                           declarator.Names.Any(Function(n) n.ArrayBounds IsNot Nothing)
-
                 Case SyntaxKind.ModifiedIdentifier
                     Debug.Assert(declaration.Parent.IsKind(SyntaxKind.VariableDeclarator) OrElse
                                  declaration.Parent.IsKind(SyntaxKind.Parameter))
@@ -1155,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
         ''' <summary>
         ''' VB symbols return references that represent the declaration statement.
-        ''' The node that represenets the whole declaration (the block) is the parent node if it exists.
+        ''' The node that represents the whole declaration (the block) is the parent node if it exists.
         ''' For example, a method with a body is represented by a SubBlock/FunctionBlock while a method without a body
         ''' is represented by its declaration statement.
         ''' </summary>
@@ -1237,8 +654,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Case SyntaxKind.ModifiedIdentifier
                     Contract.ThrowIfFalse(
                         parent.Parent.IsKind(SyntaxKind.FieldDeclaration) OrElse parent.Parent.IsKind(SyntaxKind.LocalDeclarationStatement))
-                    Dim variableDeclaration = CType(parent, VariableDeclaratorSyntax)
-                    Return If(variableDeclaration.Names.Count = 1, parent, syntax)
+                    Return syntax
 
                 Case SyntaxKind.VariableDeclarator
                     ' fields are represented by ModifiedIdentifier:
@@ -1349,6 +765,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     End If
 
                     Return OneOrMany.Create((oldSymbols(0).ContainingSymbol, newSymbols(0).ContainingSymbol, EditKind.Update))
+
                 Case EditKind.Delete
                     If Not TryGetSyntaxNodesForEdit(editKind, oldNode, oldModel, oldSymbols, cancellationToken) Then
                         Return OneOrMany(Of (ISymbol, ISymbol, EditKind)).Empty
@@ -1418,6 +835,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return False
 
                 Case SyntaxKind.VariableDeclarator
+                    ' Initializer or As clause update
                     Dim variableDeclarator = CType(node, VariableDeclaratorSyntax)
                     If variableDeclarator.Names.Count > 1 Then
                         symbols = OneOrMany.Create(variableDeclarator.Names.SelectAsArray(Function(n) GetDeclaredSymbol(model, n, cancellationToken)))
@@ -1427,6 +845,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     node = variableDeclarator.Names(0)
 
                 Case SyntaxKind.FieldDeclaration
+                    ' Attribute or modifier update
                     If editKind = EditKind.Update Then
                         Dim field = CType(node, FieldDeclarationSyntax)
                         If field.Declarators.Count = 1 AndAlso field.Declarators(0).Names.Count = 1 Then
@@ -1459,13 +878,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return True
         End Function
 
-        Friend Overrides Function ContainsLambda(declaration As SyntaxNode) As Boolean
-            Return declaration.DescendantNodes().Any(AddressOf LambdaUtilities.IsLambda)
-        End Function
-
-        Friend Overrides Function IsLambda(node As SyntaxNode) As Boolean
-            Return LambdaUtilities.IsLambda(node)
-        End Function
+        Friend Overrides ReadOnly Property IsLambda As Func(Of SyntaxNode, Boolean)
+            Get
+                Return AddressOf LambdaUtilities.IsLambda
+            End Get
+        End Property
 
         Friend Overrides Function IsNestedFunction(node As SyntaxNode) As Boolean
             Return TypeOf node Is LambdaExpressionSyntax
@@ -1479,16 +896,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return False
         End Function
 
-        Friend Overrides Function TryGetLambdaBodies(node As SyntaxNode, ByRef body1 As SyntaxNode, ByRef body2 As SyntaxNode) As Boolean
-            Return LambdaUtilities.TryGetLambdaBodies(node, body1, body2)
-        End Function
+        Friend Overrides Function TryGetLambdaBodies(node As SyntaxNode, <Out> ByRef body1 As LambdaBody, <Out> ByRef body2 As LambdaBody) As Boolean
+            Dim bodyNode1 As SyntaxNode = Nothing
+            Dim bodyNode2 As SyntaxNode = Nothing
+            If LambdaUtilities.TryGetLambdaBodies(node, bodyNode1, bodyNode2) Then
+                body1 = SyntaxUtilities.CreateLambdaBody(bodyNode1)
+                body2 = If(bodyNode2 IsNot Nothing, SyntaxUtilities.CreateLambdaBody(bodyNode2), Nothing)
+                Return True
+            End If
 
-        Friend Overrides Function GetLambda(lambdaBody As SyntaxNode) As SyntaxNode
-            Return LambdaUtilities.GetLambda(lambdaBody)
-        End Function
-
-        Protected Overrides Function GetLambdaBodyExpressionsAndStatements(lambdaBody As SyntaxNode) As IEnumerable(Of SyntaxNode)
-            Return LambdaUtilities.GetLambdaBodyExpressionsAndStatements(lambdaBody)
+            Return False
         End Function
 
         Friend Overrides Function GetLambdaExpressionSymbol(model As SemanticModel, lambdaExpression As SyntaxNode, cancellationToken As CancellationToken) As IMethodSymbol
@@ -2439,23 +1856,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 End Select
             End Sub
 
-            Public Sub ClassifyMemberOrLambdaBodyRudeUpdates(newBody As SyntaxNode)
-                For Each topMostBodyNode In If(LambdaUtilities.IsLambdaBody(newBody), LambdaUtilities.GetLambdaBodyExpressionsAndStatements(newBody), {newBody})
-                    For Each node In topMostBodyNode.DescendantNodesAndSelf(AddressOf LambdaUtilities.IsNotLambda)
-                        Select Case node.Kind()
-                            Case SyntaxKind.AggregateClause,
-                             SyntaxKind.GroupByClause,
-                             SyntaxKind.SimpleJoinClause,
-                             SyntaxKind.GroupJoinClause
-                                ReportError(RudeEditKind.ComplexQueryExpression, node, Me._newNode)
-                                Return
+            Public Sub ClassifyMemberOrLambdaBodyRudeUpdates(newBody As DeclarationBody)
+                For Each root In newBody.RootNodes
+                    Dim lambdaBody = TryCast(newBody, LambdaBody)
+                    For Each topMostBodyNode In If(lambdaBody IsNot Nothing, lambdaBody.GetExpressionsAndStatements(), {root})
+                        For Each node In topMostBodyNode.DescendantNodesAndSelf(AddressOf LambdaUtilities.IsNotLambda)
+                            Select Case node.Kind()
+                                Case SyntaxKind.AggregateClause,
+                                     SyntaxKind.GroupByClause,
+                                     SyntaxKind.SimpleJoinClause,
+                                     SyntaxKind.GroupJoinClause
+                                    ReportError(RudeEditKind.ComplexQueryExpression, node, Me._newNode)
+                                    Return
 
-                            Case SyntaxKind.LocalDeclarationStatement
-                                Dim declaration = DirectCast(node, LocalDeclarationStatementSyntax)
-                                If declaration.Modifiers.Any(SyntaxKind.StaticKeyword) Then
-                                    ReportError(RudeEditKind.UpdateStaticLocal)
-                                End If
-                        End Select
+                                Case SyntaxKind.LocalDeclarationStatement
+                                    Dim declaration = DirectCast(node, LocalDeclarationStatementSyntax)
+                                    If declaration.Modifiers.Any(SyntaxKind.StaticKeyword) Then
+                                        ReportError(RudeEditKind.UpdateStaticLocal)
+                                    End If
+                            End Select
+                        Next
                     Next
                 Next
             End Sub
@@ -2497,7 +1917,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             classifier.ClassifyEdit()
         End Sub
 
-        Friend Overrides Sub ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), newDeclaration As SyntaxNode, newBody As SyntaxNode, span As TextSpan?)
+        Friend Overrides Sub ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), newDeclaration As SyntaxNode, newBody As DeclarationBody, span As TextSpan?)
             Dim classifier = New EditClassifier(Me, diagnostics, Nothing, newDeclaration, EditKind.Update, span:=span)
             classifier.ClassifyMemberOrLambdaBodyRudeUpdates(newBody)
         End Sub
@@ -2696,7 +2116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                    SyntaxUtilities.IsIteratorMethodOrLambda(declaration)
         End Function
 
-        Friend Overrides Function GetStateMachineInfo(body As SyntaxNode) As StateMachineInfo
+        Friend Shared Function GetStateMachineInfo(body As SyntaxNode) As StateMachineInfo
             ' In VB declaration and body are represented by the same node for both lambdas and methods (unlike C#)
             If SyntaxUtilities.IsAsyncMethodOrLambda(body) Then
                 Return New StateMachineInfo(IsAsync:=True, IsIterator:=False, HasSuspensionPoints:=SyntaxUtilities.GetAwaitExpressions(body).Any())

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -775,46 +775,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
         }
 
-        /// <summary>
-        /// Returns child node or token that contains given position.
-        /// </summary>
-        /// <remarks>
-        /// This is a copy of <see cref="SyntaxNode.ChildThatContainsPosition"/> that also returns the index of the child node.
-        /// </remarks>
-        internal static SyntaxNodeOrToken ChildThatContainsPosition(this SyntaxNode self, int position, out int childIndex)
-        {
-            var childList = self.ChildNodesAndTokens();
-
-            var left = 0;
-            var right = childList.Count - 1;
-
-            while (left <= right)
-            {
-                var middle = left + ((right - left) / 2);
-                var node = childList[middle];
-
-                var span = node.FullSpan;
-                if (position < span.Start)
-                {
-                    right = middle - 1;
-                }
-                else if (position >= span.End)
-                {
-                    left = middle + 1;
-                }
-                else
-                {
-                    childIndex = middle;
-                    return node;
-                }
-            }
-
-            // we could check up front that index is within FullSpan,
-            // but we wan to optimize for the common case where position is valid.
-            Debug.Assert(!self.FullSpan.Contains(position), "Position is valid. How could we not find a child?");
-            throw new ArgumentOutOfRangeException(nameof(position));
-        }
-
         public static (SyntaxToken openParen, SyntaxToken closeParen) GetParentheses(this SyntaxNode node)
         {
             switch (node)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb
@@ -575,35 +575,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return Nothing
         End Function
 
-        ''' <summary>
-        ''' Returns child node or token that contains given position.
-        ''' </summary>
-        ''' <remarks>
-        ''' This is a copy of <see cref="SyntaxNode.ChildThatContainsPosition"/>  that also returns the index of the child node.
-        ''' </remarks>
-        <Extension>
-        Friend Function ChildThatContainsPosition(self As SyntaxNode, position As Integer, ByRef childIndex As Integer) As SyntaxNodeOrToken
-            Dim childList = self.ChildNodesAndTokens()
-            Dim left As Integer = 0
-            Dim right As Integer = childList.Count - 1
-            While left <= right
-                Dim middle As Integer = left + (right - left) \ 2
-                Dim node As SyntaxNodeOrToken = childList(middle)
-                Dim span = node.FullSpan
-                If position < span.Start Then
-                    right = middle - 1
-                ElseIf position >= span.End Then
-                    left = middle + 1
-                Else
-                    childIndex = middle
-                    Return node
-                End If
-            End While
-
-            Debug.Assert(Not self.FullSpan.Contains(position), "Position is valid. How could we not find a child?")
-            Throw New ArgumentOutOfRangeException(NameOf(position))
-        End Function
-
         <Extension()>
         Public Function ReplaceStatements(node As SyntaxNode,
                                           statements As SyntaxList(Of StatementSyntax),


### PR DESCRIPTION
The concept of a "member body" as a set of nodes that may contain a breakpoint/active statement isn't always aligned with syntax nodes of the language. The compiler can place sequence points in arbitrary source location.

For example, in C# a constructor with an implicit initializer has a sequence point associated with the "header" of the `ConstructorDeclarationSyntax` (e.g. `class C { [|public C()|] { } }`) but there is no syntax node that represents this sequence of tokens. In VB, a field initializer may have incontiguous body, e.g. 

```VB
Class C
  Dim [|a|], b As [|New T(expr)|]
End Class
```

IL corresponding to a syntax that belongs to a member declaration may also be emitted to the body of a different member (e.g. field initializers are emitted to one or more constructors).

Previously, the EnC analyzer handled all these cases in multiple places by specialized code.

In this PR we introduce the concept of an abstract `DeclarationBody`, which is either a `MemberBody` or `LambdaBody`. Both C# and VB then derive specific implementations that customize various behaviors for different forms of bodies.

This approach makes the core analysis cleaner and also easier to add a new form of a declaration body whenever the language adds a feature that needs special handling. 
