### PR TITLE
Improve detection of ambiguous type-or-value receiver when it possibly refers to a captured primary constructor parameter

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1523,13 +1523,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (lookupResult.IsMultiViable)
                     {
-                        var conversions = Conversions;
-
                         foreach (var symbol in lookupResult.Symbols)
                         {
                             var method = (MethodSymbol)symbol;
-                            var conversion = conversions.ConvertExtensionMethodThisArg(method.Parameters[0].Type, receiverType, ref useSiteInfo);
-                            if (conversion.Exists)
+                            if (method.ReduceExtensionMethod(receiverType, Compilation) is not null)
                             {
                                 haveInstanceCandidates = true;
                                 break;


### PR DESCRIPTION
Instead of simply checking convertibility to `this` parameter of an extension method, try to reduce the method, which might succeed due to generic type argument inference.

Fixes #68796.