### PR TITLE
Remove host specific args from CommandLineArgs

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Fills the provided CommandLineBuilderExtension with those switches and other information that can go into a response file.
         /// </summary>
-        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
+        protected override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/lib:", AdditionalLibPaths, ",");
             commandLine.AppendPlusOrMinusSwitch("/unsafe", _store, nameof(AllowUnsafeBlocks));

--- a/src/Compilers/Core/MSBuildTask/Csi.cs
+++ b/src/Compilers/Core/MSBuildTask/Csi.cs
@@ -25,6 +25,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         #endregion
 
         #region Interactive Compiler Members
+
+        protected override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
+        {
+            // Nothing to add
+        }
+
         protected override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/lib:", AdditionalLibPaths, ",");

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -184,15 +184,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        // See ManagedCompiler.cs on the logic of this property
-        private bool HasToolBeenOverridden => !(string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName);
-
-        protected sealed override bool IsManagedTool => !HasToolBeenOverridden;
-
-        protected sealed override string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
-
-        protected sealed override string PathToNativeTool => Path.Combine(ToolPath ?? "", ToolExe);
-
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
             if (ProvideCommandLineArgs)

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -188,47 +188,18 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             if (ProvideCommandLineArgs)
             {
-                CommandLineArgs = GetArguments(commandLineCommands, responseFileCommands).Select(arg => new TaskItem(arg)).ToArray();
+                CommandLineArgs = GenerateCommandLineArgsTaskItems(responseFileCommands);
             }
 
             return (SkipInteractiveExecution) ? 0 : base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
         }
 
-        public string GenerateCommandLineContents() => GenerateCommandLineCommands();
-
-        protected sealed override string ToolArguments
-        {
-            get
-            {
-                var builder = new CommandLineBuilderExtension();
-                AddCommandLineCommands(builder);
-                return builder.ToString();
-            }
-        }
-
-        public string GenerateResponseFileContents() => GenerateResponseFileCommands();
-
-        protected sealed override string GenerateResponseFileCommands()
-        {
-            var commandLineBuilder = new CommandLineBuilderExtension();
-            AddResponseFileCommands(commandLineBuilder);
-            return commandLineBuilder.ToString();
-        }
-
         #endregion
-
-        /// <summary>
-        /// Fills the provided CommandLineBuilderExtension with those switches and other information that can't go into a response file and
-        /// must go directly onto the command line.
-        /// </summary>
-        protected virtual void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
-        {
-        }
 
         /// <summary>
         /// Fills the provided CommandLineBuilderExtension with those switches and other information that can go into a response file.
         /// </summary>
-        protected virtual void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
+        protected override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitch("/i-");
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -477,15 +477,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #endregion
 
-        // ToolExe delegates back to ToolName if the override is not
-        // set.  So, if ToolExe == ToolName, we know ToolExe is not
-        // explicitly overridden.  So, if both ToolPath is unset and
-        // ToolExe == ToolName, we know nothing is overridden, and
-        // we can use our own csc.
-        private bool HasToolBeenOverridden => !(string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName);
-
-        protected sealed override bool IsManagedTool => !HasToolBeenOverridden;
-
         /// <summary>
         /// Method for testing only
         /// </summary>
@@ -493,10 +484,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             return GenerateFullPathToTool();
         }
-
-        protected sealed override string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
-
-        protected sealed override string PathToNativeTool => Path.Combine(ToolPath ?? "", ToolExe);
 
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
@@ -526,7 +513,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 string? tempDirectory = BuildServerConnection.GetTempPath(workingDirectory);
 
                 if (!UseSharedCompilation ||
-                    HasToolBeenOverridden ||
+                    !IsManagedTool ||
                     !BuildServerConnection.IsCompilerServerSupported)
                 {
                     LogCompilationMessage(logger, requestId, CompilationKind.Tool, $"using command line tool by design '{pathToTool}'");

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -11,7 +11,18 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 {
     public abstract class ManagedToolTask : ToolTask
     {
-        protected abstract bool IsManagedTool { get; }
+        /// <summary>
+        /// Is the standard tool being used here? When false the developer has specified a custom tool
+        /// to be run by this task
+        /// </summary>
+        /// <remarks>
+        /// ToolExe delegates back to ToolName if the override is not
+        /// set.  So, if ToolExe == ToolName, we know ToolExe is not
+        /// explicitly overridden.  So, if both ToolPath is unset and
+        /// ToolExe == ToolName, we know nothing is overridden, and
+        /// we can use our own csc.
+        /// </remarks>
+        protected bool IsManagedTool => string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName;
 
         /// <summary>
         /// ToolArguments are the arguments intended to be passed to the tool,
@@ -19,7 +30,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected abstract string ToolArguments { get; }
 
-        protected abstract string PathToManagedTool { get; }
+        protected string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
 
         protected string PathToManagedToolWithoutExtension
         {
@@ -34,7 +45,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// Note: "Native" here does not necessarily mean "native binary".
         /// "Native" in this context means "native invocation", and running the executable directly.
         /// </summary>
-        protected abstract string PathToNativeTool { get; }
+        protected string PathToNativeTool => Path.Combine(ToolPath ?? "", ToolExe);
 
         protected ManagedToolTask(ResourceManager resourceManager)
             : base(resourceManager)
@@ -79,7 +90,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <remarks>
         /// We *cannot* actually call IsManagedTool in the implementation of this method,
         /// as the implementation of IsManagedTool calls this property. See the comment in
-        /// <see cref="ManagedCompiler.HasToolBeenOverridden"/>.
+        /// <see cref="ManagedToolTask.IsManagedTool"/>.
         /// </remarks>
         protected sealed override string ToolName => $"{ToolNameWithoutExtension}.{RuntimeHostInfo.ToolExtension}";
     }

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -29,14 +29,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         protected bool IsManagedTool => string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName;
 
         /// <summary>
-        /// ToolArguments are the arguments intended to be passed to the tool,
-        /// without taking into account any runtime-specific modifications.
+        /// Generate the arguments to pass directly to the managed tool. These do not include
+        /// arguments in the response file.
         /// </summary>
         /// <remarks>
         /// This will be the same value whether the build occurs on .NET Core or .NET Framework. 
-        /// There will be no 'dotnet' or 'exec' values inserted here for those purposes.
         /// </remarks>
-        protected string ToolArguments
+        internal string ToolArguments
         {
             get
             {
@@ -46,9 +45,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
         }
 
-        protected internal string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
+        internal string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
 
-        protected string PathToManagedToolWithoutExtension
+        internal string PathToManagedToolWithoutExtension
         {
             get
             {
@@ -63,9 +62,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// GenerateCommandLineCommands generates the actual OS-level arguments:
-        /// if dotnet needs to be executed and the managed assembly is the first argument,
-        /// then this will contain the managed assembly followed by ToolArguments
+        /// <see cref="GenerateCommandLineContents" />
         /// </summary>
         protected sealed override string GenerateCommandLineCommands()
         {
@@ -78,6 +75,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return commandLineArguments;
         }
 
+        /// <summary>
+        /// <see cref="GenerateResponseFileContents"/>
+        /// </summary>
         protected sealed override string GenerateResponseFileCommands()
         {
             var commandLineBuilder = new CommandLineBuilderExtension();
@@ -85,8 +85,21 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return commandLineBuilder.ToString();
         }
 
+        /// <summary>
+        /// Generate the arguments to pass directly to the managed tool. These do not include
+        /// arguments in the response file.
+        /// </summary>
+        /// <remarks>
+        /// This will include target specific arguments like 'exec'
+        /// </remarks>
         internal string GenerateCommandLineContents() => GenerateCommandLineCommands();
 
+        /// <summary>
+        /// Generate the arguments to pass via a response file. 
+        /// </summary>
+        /// <remarks>
+        /// This will be the same value whether the build occurs on .NET Core or .NET Framework. 
+        /// </remarks>
         internal string GenerateResponseFileContents() => GenerateResponseFileCommands();
 
         /// <summary>
@@ -136,6 +149,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// Generates the <see cref="ITaskItem"/> entries for the CommandLineArgs output ItemGroup
         /// for our tool tasks
         /// </summary>
+        /// <remarks>
+        /// This does not include any runtime specific arguments like 'dotnet' or 'exec'.
+        /// </remarks>
         protected internal ITaskItem[] GenerateCommandLineArgsTaskItems(string responseFileCommands) =>
             GenerateCommandLineArgsTaskItems(GenerateCommandLineArgsList(responseFileCommands));
 

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -175,11 +175,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             var buildTask = typeof(Utilities).GetTypeInfo().Assembly;
             var assemblyPath = buildTask.Location;
-            var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
+            var assemblyDirectory = Path.GetDirectoryName(assemblyPath)!;
 
             return RuntimeHostInfo.IsDesktopRuntime
-                ? Path.Combine(assemblyDirectory!, toolName)
-                : Path.Combine(assemblyDirectory!, "bincore", toolName);
+                ? Path.Combine(assemblyDirectory, toolName)
+                : Path.Combine(assemblyDirectory, "bincore", toolName);
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -171,15 +171,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Generate the full path to the tool that is deployed with our build tasks.
         /// </summary>
-        internal static string GenerateFullPathToTool(string toolName)
+        internal static string GenerateFullPathToTool(string toolFileName)
         {
             var buildTask = typeof(Utilities).GetTypeInfo().Assembly;
             var assemblyPath = buildTask.Location;
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath)!;
 
             return RuntimeHostInfo.IsDesktopRuntime
-                ? Path.Combine(assemblyDirectory, toolName)
-                : Path.Combine(assemblyDirectory, "bincore", toolName);
+                ? Path.Combine(assemblyDirectory, toolFileName)
+                : Path.Combine(assemblyDirectory, "bincore", toolFileName);
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// Looks at all the parameters that have been set, and builds up the string
         /// containing all the command-line switches.
         /// </summary>
-        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
+        protected override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/baseaddress:", this.GetBaseAddressInHex());
             commandLine.AppendSwitchIfNotNull("/libpath:", this.AdditionalLibPaths, ",");

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -533,8 +533,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 Sources = MSBuildUtil.CreateTaskItems("test.cs"),
             };
 
-            Assert.Equal(new[] { "/out:test.exe", "test.cs" }, csc.Generate!.Select(x => x.ItemSpec));
-            TaskTestUtil.AssertCommandLine(csc, "/out:test.exe test.cs");
+            TaskTestUtil.AssertCommandLine(csc, "/out:test.exe", "test.cs");
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -528,12 +528,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [Fact]
         public void CommandLineArgsNoRuntimeInfo()
         {
+            var engine = new MockEngine();
             var csc = new Csc()
             {
+                BuildEngine = engine,
                 Sources = MSBuildUtil.CreateTaskItems("test.cs"),
             };
 
-            TaskTestUtil.AssertCommandLine(csc, "/out:test.exe", "test.cs");
+            TaskTestUtil.AssertCommandLine(csc, engine, "/out:test.exe", "test.cs");
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -434,13 +434,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.ToolPath = "";
             csc.ToolExe = Path.Combine("path", "to", "custom_csc");
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal("", csc.GenerateCommandLineContents());
             Assert.Equal(Path.Combine("path", "to", "custom_csc"), csc.GeneratePathToTool());
 
             csc = new Csc();
             csc.ToolExe = Path.Combine("path", "to", "custom_csc");
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal("", csc.GenerateCommandLineContents());
             Assert.Equal(Path.Combine("path", "to", "custom_csc"), csc.GeneratePathToTool());
         }
 
@@ -451,14 +451,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.ToolPath = Path.Combine("path", "to", "custom_csc");
             csc.ToolExe = "";
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal("", csc.GenerateCommandLineContents());
             // StartsWith because it can be csc.exe or csc.dll
             Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
 
             csc = new Csc();
             csc.ToolPath = Path.Combine("path", "to", "custom_csc");
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal("", csc.GenerateCommandLineContents());
             Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
         }
 
@@ -523,6 +523,18 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             var csc = new Csc();
             csc.ReportIVTs = true;
             AssertEx.Equal("/reportivts", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void CommandLineArgsNoRuntimeInfo()
+        {
+            var csc = new Csc()
+            {
+                Sources = MSBuildUtil.CreateTaskItems("test.cs"),
+            };
+
+            Assert.Equal(new[] { "/out:test.exe", "test.cs" }, csc.Generate!.Select(x => x.ItemSpec));
+            TaskTestUtil.AssertCommandLine(csc, "/out:test.exe test.cs");
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/MockEngine.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/MockEngine.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.Build.Framework;
 

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/MockEngine.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/MockEngine.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
     {
         private StringBuilder _log = new StringBuilder();
         public MessageImportance MinimumMessageImportance = MessageImportance.Low;
+        public List<BuildMessageEventArgs> BuildMessages = new List<BuildMessageEventArgs>();
 
         internal string Log
         {
@@ -47,6 +48,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         public void LogMessageEvent(BuildMessageEventArgs eventArgs)
         {
             _log.AppendLine(eventArgs.Message);
+            BuildMessages.Add(eventArgs);
         }
 
         public string ProjectFileOfTaskNode => "";

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
+
+internal static class TaskTestUtil
+{
+    public static void AssertCommandLine(
+        ManagedToolTask task,
+        params string[] expected)
+    {
+        var line = string.Join(' ', expected);
+        Assert.Equal(line, task.GenerateResponseFileContents());
+
+        if (RuntimeHostInfo.IsCoreClrRuntime)
+        {
+            line = $"{RuntimeHostInfo.GetDotNetPathOrDefault()} exec \"{task.PathToManagedTool}\" {line}";
+        }
+
+        Assert.Equal("/noconfig", task.GenerateCommandLineContents());
+    }
+}

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis
         internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
 
         internal static string ToolExtension => IsCoreClrRuntime ? "dll" : "exe";
-        private static string NativeToolSuffix => PlatformInformation.IsWindows ? ".exe" : "";
 
         /// <summary>
         /// This gets information about invoking a tool on the current runtime. This will attempt to 
@@ -30,7 +29,8 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(!toolFilePathWithoutExtension.EndsWith(".dll") && !toolFilePathWithoutExtension.EndsWith(".exe"));
 
-            var nativeToolFilePath = $"{toolFilePathWithoutExtension}{NativeToolSuffix}";
+            var nativeToolSuffix = PlatformInformation.IsWindows ? ".exe" : "";
+            var nativeToolFilePath = $"{toolFilePathWithoutExtension}{nativeToolSuffix}";
             if (IsCoreClrRuntime && File.Exists(nativeToolFilePath))
             {
                 return (nativeToolFilePath, commandLineArguments, nativeToolFilePath);

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis
         /// Get the path to the dotnet executable. In the case the host did not provide this information
         /// in the environment this will return simply "dotnet".
         /// </summary>
-        private static string GetDotNetPathOrDefault()
+        internal static string GetDotNetPathOrDefault()
         {
             var pathToDotNet = Environment.GetEnvironmentVariable(DotNetHostPathEnvironmentName);
             return pathToDotNet ?? "dotnet";


### PR DESCRIPTION
This changes our build tasks to remove the host specific args, namely the `exec ...\csc.dll`, from the `CommandLineArgs` property. That `ITaskItem[]` is meant for the IDE consumption and doesn't need host specific information. 

As a part of fixing this bug I cleaned up a lot of unnecessary member inheritance in the build tasks. There were several `virtual` members where every implementation had the same code. Moved all that up to the base and cleaned up the comments to make the intent clearer. 

closes #67102