### PR TITLE
Fix lossy error message when lexer encounters certain characters

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalErrorTests.cs
@@ -445,6 +445,35 @@ class Test
         }
 
         [Fact]
+        public void CS1056ERR_UnpairedSurrogate()
+        {
+            var test = """
+                using System;
+                class Test
+                {
+                    public static void Main()
+                    {
+                        int 𫓧龦 = 1;
+                    }
+                }
+                """;
+
+            ParserErrorMessageTests.ParseAndValidate(test,
+                // (6,13): error CS1001: Identifier expected
+                //         int 𫓧龦 = 1;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "\ud86d").WithLocation(6, 13),
+                // (6,13): error CS1056: Unexpected character '\uD86D'
+                //         int 𫓧龦 = 1;
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "").WithArguments(@"\uD86D").WithLocation(6, 13),
+                // (6,14): error CS1056: Unexpected character '\uDCE7'
+                //         int 𫓧龦 = 1;
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "").WithArguments(@"\uDCE7").WithLocation(6, 14),
+                // (6,15): error CS1002: ; expected
+                //         int 𫓧龦 = 1;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "龦").WithLocation(6, 15));
+        }
+
+        [Fact]
         public void CS8967ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString1()
         {
             var test = @"


### PR DESCRIPTION
Fixes issue currently being discussed in global readiness thread.

Before, you would get:

![image](https://github.com/dotnet/roslyn/assets/4564579/89d21b0a-cac6-495d-ba9d-7ab06baf54dd)

Now you get:

![image](https://github.com/dotnet/roslyn/assets/4564579/5115739c-236e-4011-b299-cbe2e9c1a96f)

This is because our prior way of representing this (putting the invalid character directly in the .Net message string) isn't something that roundtrips effectively to/from a Unicode string.  This previously was never an issue for us as .Net is totally fine with these strings and we were .Net top-to-bottom.  However, with the introduction of cross-process communication we now serialize these sorts of strings to/from an external process back to the VS process.  These serialization systems use lossy-encoding systems for strings, where strings that are not legal *unicode* get characters replaced in them.  

To resolve this systemically is something that is being looked into.  However, in the meantime, this spotfixes a core place where we are commonly making such an error, and instead embedded an escaping of that character instead of the character itself.  