### PR TITLE
[Infra] Publish 17.8 P1 VS PRs

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -169,7 +169,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.8P1]"
     },
     "dev/jorobich/fix-pr-val": {


### PR DESCRIPTION
Takes 17.8 P1 PRs out of draft mode. This enables more checks to run by default.