### PR TITLE
Fix assertion failure in semantic model for file-local extension methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4707,8 +4707,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref LookupResultKind resultKind,
             CSharpCompilation compilation)
         {
-            Debug.Assert(singleResult.Kind != LookupResultKind.Empty);
-            Debug.Assert((object)singleResult.Symbol != null);
+            if (singleResult.Symbol is null)
+            {
+                return;
+            }
+
             Debug.Assert(singleResult.Symbol.Kind == SymbolKind.Method);
 
             var singleKind = singleResult.Kind;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -3693,6 +3693,15 @@ public class FileModifierTests : CSharpTestBase
             // (1,5): error CS1061: 'string' does not contain a definition for 'M' and no accessible extension method 'M' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
             // "a".M(); // 1
             Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "M").WithArguments("string", "M").WithLocation(1, 5));
+
+        var tree = comp.SyntaxTrees[0];
+        var methodNameSyntax = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var symbolInfo = model.GetSymbolInfo(methodNameSyntax);
+        Assert.Null(symbolInfo.Symbol);
+        var aliasInfo = model.GetAliasInfo(methodNameSyntax);
+        Assert.Null(aliasInfo);
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -3700,6 +3700,9 @@ public class FileModifierTests : CSharpTestBase
 
         var symbolInfo = model.GetSymbolInfo(methodNameSyntax);
         Assert.Null(symbolInfo.Symbol);
+        Assert.Empty(symbolInfo.CandidateSymbols);
+        Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+
         var aliasInfo = model.GetAliasInfo(methodNameSyntax);
         Assert.Null(aliasInfo);
     }


### PR DESCRIPTION
Closes #67940

When lookup gives us a symbol contained in a file-local type, and the lookup is not occurring within the same file, we use CheckViability to essentially filter it out as though the symbol doesn't exist.

The semantic model isn't expecting extension method lookup to yield a symbol, which is then "eliminated" by CheckViability--it's only expecting lookup results which are either valid or that still yield the symbol but also indicate some error condition ("not accessible", etc.). This PR changes that to simply bail out when CheckViability filters out the symbol.

An alternative way to solve this would be to give a non-Empty LookupResultKind for an effectively file-local symbol from another file and an associated diagnostic. Instead of saying "XYZ symbol doesn't exist", the diagnostic would say "XYZ symbol is not in scope in this file" or something like that. Then the original change in this PR wouldn't be necessary as the candidate symbol would still be surfaced and used. That would be a wider-reaching change and could require adding public API, assuming we don't roll it up in the existing "inaccessible" lookup result.
