### PR TITLE
Fix incremental build issue with CompilerApiVersion

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -100,7 +100,7 @@
       <_CompilerVersionTargetsFileContent>
 <![CDATA[<Project>
   <PropertyGroup>
-    <CompilerApiVersion>roslyn$(CompilerApiVersion)</CompilerApiVersion>
+    <CompilerApiVersion>roslyn$(_CompilerApiVersion)</CompilerApiVersion>
   </PropertyGroup>
 </Project>]]>
       </_CompilerVersionTargetsFileContent>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -93,22 +93,22 @@
   </Target>
 
   <Target Name="GenerateCompilerVersionTargetsFile"
-          Inputs="$(MSBuildThisFileFullPath)"
           Outputs="$(CompilerVersionTargetsFileIntermediatePath)">
 
     <PropertyGroup>
-      <CompilerApiVersion>$([System.Version]::Parse($(VersionPrefix)).Major).$([System.Version]::Parse($(VersionPrefix)).Minor)</CompilerApiVersion>
-      <CompilerVersionTargetsFileContent>
+      <_CompilerApiVersion>$([System.Version]::Parse($(VersionPrefix)).Major).$([System.Version]::Parse($(VersionPrefix)).Minor)</_CompilerApiVersion>
+      <_CompilerVersionTargetsFileContent>
 <![CDATA[<Project>
   <PropertyGroup>
     <CompilerApiVersion>roslyn$(CompilerApiVersion)</CompilerApiVersion>
   </PropertyGroup>
 </Project>]]>
-      </CompilerVersionTargetsFileContent>
+      </_CompilerVersionTargetsFileContent>
     </PropertyGroup>
 
     <WriteLinesToFile File="$(CompilerVersionTargetsFileIntermediatePath)"
-                      Lines="$(CompilerVersionTargetsFileContent)"
-                      Overwrite="true" />
+                      Lines="$(_CompilerVersionTargetsFileContent)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
   </Target>
 </Project>


### PR DESCRIPTION
The target GenerateCompilerVersionTargetsFile depends only on MSBuild properties. That means incrementality cannot be achieved via `Input=` as that only looks at files on disk. Instead the target needs to use the `WriteOnlyWhenDifferent` property. That means the target will run on every build but the output will only change if the content of the property does.

Removed the existing `Input=$(MSBuildThisFileFullPath)` as that is implicit for the target.

closes #68961