### PR TITLE
Disallow test compositions with include/exclude parts overlapping

### DIFF
--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -93,7 +93,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 AddParts(extraExportedTypes)
 
             If includeFormatCommandHandler Then
-                composition = composition.AddParts(GetType(FormatCommandHandler))
+                ' FormatCommandHandler would generally be included in the catalog, but is excluded from tests by adding
+                ' it to the list of excluded part types. Here we validate the input state and restore the default
+                ' behavior of the catalog by removing FormatCommandHandler from the excluded parts list.
+                Assert.Contains(GetType(FormatCommandHandler).Assembly, composition.Assemblies)
+                Assert.Contains(GetType(FormatCommandHandler), composition.ExcludedPartTypes)
+                composition = composition.RemoveExcludedPartTypes(GetType(FormatCommandHandler))
             End If
 
             Return composition

--- a/src/Workspaces/CoreTestUtilities/MEF/TestComposition.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/TestComposition.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Composition;
 using Roslyn.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -125,7 +126,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             => Assemblies.Contains(typeof(Remote.BrokeredServiceBase).Assembly);
 
         private ComposableCatalog GetCatalog()
-            => ExportProviderCache.CreateAssemblyCatalog(Assemblies, ExportProviderCache.CreateResolver()).WithoutPartsOfTypes(ExcludedPartTypes).WithParts(Parts);
+        {
+            // Compositions should not be realized if they contain the same part in both the explicit include list and
+            // the explicit exclude list.
+            var configurationOverlap = Parts.Intersect(ExcludedPartTypes);
+            Assert.Empty(configurationOverlap);
+
+            return ExportProviderCache.CreateAssemblyCatalog(Assemblies, ExportProviderCache.CreateResolver()).WithoutPartsOfTypes(ExcludedPartTypes).WithParts(Parts);
+        }
 
         public CompositionConfiguration GetCompositionConfiguration()
             => CompositionConfiguration.Create(GetCatalog());


### PR DESCRIPTION
Avoids a situation that led to unclear test failure in local testing (I paired `AddParts` with `AddExcludedPartTypes` when it should have instead been paired with `RemoveParts`).