### PR TITLE
Honor Concord's TruncatedString flag to reduce memory usage

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private bool HasUnderlyingString(DkmClrValue value, DkmInspectionContext inspectionContext)
         {
-            return GetUnderlyingString(value, inspectionContext) != null;
+            return value.EvalFlags.HasFlag(DkmEvaluationResultFlags.TruncatedString) || GetUnderlyingString(value, inspectionContext) != null;
         }
 
         private string GetUnderlyingString(DkmClrValue value, DkmInspectionContext inspectionContext)
@@ -236,6 +236,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             if (lmrType.IsString())
             {
+                if (value.EvalFlags.HasFlag(DkmEvaluationResultFlags.TruncatedString))
+                {
+                    var extendedInspectionContext = inspectionContext.With(DkmEvaluationFlags.IncreaseMaxStringSize);
+                    return value.EvaluateToString(extendedInspectionContext);
+                }
+
                 return (string)value.HostObjectValue;
             }
             else if (!IsPredefinedType(lmrType))

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DkmEvaluationResultFlagsExtensions.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/DkmEvaluationResultFlagsExtensions.cs
@@ -17,19 +17,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal static DkmInspectionContext With(this DkmInspectionContext inspectionContext, DkmEvaluationFlags flags)
         {
-            return DkmInspectionContext.Create(
-                inspectionContext.InspectionSession,
-                inspectionContext.RuntimeInstance,
-                inspectionContext.Thread,
+            return inspectionContext.WithProperties(
                 inspectionContext.Timeout,
                 inspectionContext.EvaluationFlags | flags,
                 inspectionContext.FuncEvalFlags,
-                inspectionContext.Radix,
-                inspectionContext.Language,
-                inspectionContext.ReturnValue,
-                inspectionContext.AdditionalVisualizationData,
-                inspectionContext.AdditionalVisualizationDataPriority,
-                inspectionContext.ReturnValues);
+                inspectionContext.Radix
+                );
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationFlags.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationFlags.cs
@@ -29,5 +29,6 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         NoExpansion = 65536,
         FilterToFavorites = 0x40000,
         UseSimpleDisplayString = 0x80000,
+        IncreaseMaxStringSize = 0x100000
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationResultFlags.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmEvaluationResultFlags.cs
@@ -46,5 +46,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         HasFavorites = 0x4000000,
         IsObjectReplaceable = 0x8000000,
         ExpansionHasSideEffects = 0x10000000,
+        CanEvaluateWithoutOptimization = 0x20000000,
+        TruncatedString = 0x40000000
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmInspectionContext.cs
@@ -64,6 +64,15 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         {
             return InspectionSession.InvokeFormatter(this, MethodId.GetTypeName, f => f.GetTypeName(this, ClrType, CustomTypeInfo, FormatSpecifiers));
         }
+
+        public DkmInspectionContext WithProperties(uint Timeout, DkmEvaluationFlags EvaluationFlags, DkmFuncEvalFlags FuncEvalFlags, uint Radix)
+        {
+            return new DkmInspectionContext(
+                this.InspectionSession,
+                EvaluationFlags,
+                Radix,
+                this.RuntimeInstance);
+        }
     }
 
     public enum DkmFuncEvalFlags


### PR DESCRIPTION
Concord is going to begin limiting the amount of memory it pulls from the target process for strings. Any string result that has been truncated is marked with a new flag, such that APIs like GetUnderlyingString can still work for things like string visualizers in order to surface the full bytes of the string. 

This adds concords new flag as a temporary constant and ensures that HasUnderlyingValue and GetUnderlyingValue both still work without pulling in the full string memory unnecessarily. 