### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.1.2-beta1.23357.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <!-- Versions used by several individual references below -->
     <RoslynDiagnosticsNugetPackageVersion>3.11.0-beta1.23356.2</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23356.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23323.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23357.1</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.6.0</CodeStyleAnalyzerVersion>

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -145,20 +145,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 CodeActionsVerifier?.Invoke(actions);
                 return base.FilterCodeActions(actions);
             }
-
-            protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics(IEnumerable<(Project project, Diagnostic diagnostic)> diagnostics)
-            {
-                var baseResult = base.SortDistinctDiagnostics(diagnostics);
-                if (typeof(DiagnosticSuppressor).IsAssignableFrom(typeof(TAnalyzer)))
-                {
-                    // Include suppressed diagnostics when testing diagnostic suppressors
-                    return baseResult;
-                }
-
-                // Treat suppressed diagnostics as non-existent. Normally this wouldn't be necessary, but some of the
-                // tests include diagnostics reported in code wrapped in '#pragma warning disable'.
-                return baseResult.WhereAsArray(diagnostic => !diagnostic.diagnostic.IsSuppressed);
-            }
         }
     }
 }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeFixVerifier`2+Test.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
@@ -101,20 +100,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             {
                 return DiagnosticSelector?.Invoke(fixableDiagnostics)
                     ?? base.TrySelectDiagnosticToFix(fixableDiagnostics);
-            }
-
-            protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics(IEnumerable<(Project project, Diagnostic diagnostic)> diagnostics)
-            {
-                var baseResult = base.SortDistinctDiagnostics(diagnostics);
-                if (typeof(DiagnosticSuppressor).IsAssignableFrom(typeof(TAnalyzer)))
-                {
-                    // Include suppressed diagnostics when testing diagnostic suppressors
-                    return baseResult;
-                }
-
-                // Treat suppressed diagnostics as non-existent. Normally this wouldn't be necessary, but some of the
-                // tests include diagnostics reported in code wrapped in '#Disable Warning'.
-                return baseResult.WhereAsArray(diagnostic => !diagnostic.diagnostic.IsSuppressed);
             }
         }
     }


### PR DESCRIPTION
Removes workarounds from #68888 which are no longer necessary.