### PR TITLE
Find compatible substituted implicit extensions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7692,6 +7692,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (analyzedArguments == null)
                 {
+                    // Without arguments (for scenarios such as `nameof` or conversion to non-delegate/dynamic type)
+                    // we can still prune the inapplicable extension methods using the receiver type
                     for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
                     {
                         if ((object)methodGroup.Methods[i].ReduceExtensionMethod(left.Type, binder.Compilation) == null)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -229,8 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isCompatible(NamedTypeSymbol extension, TypeSymbol type, [NotNullWhen(true)] out NamedTypeSymbol? substitutedExtension)
             {
                 Debug.Assert(!type.IsExtension);
-                var extended = extension.ExtendedTypeNoUseSiteDiagnostics;
-                if (extended is null)
+                if (extension.ExtendedTypeNoUseSiteDiagnostics is null)
                 {
                     substitutedExtension = null;
                     return false;
@@ -239,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var baseType = type;
                 do
                 {
-                    if (TypeUnification.CanImplicitlyExtend(extended, baseType, out var map))
+                    if (TypeUnification.CanImplicitlyExtend(extension, baseType, out AbstractTypeParameterMap? map))
                     {
                         substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
                         return true;
@@ -251,7 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var implementedInterface in type.AllInterfacesNoUseSiteDiagnostics)
                 {
-                    if (TypeUnification.CanImplicitlyExtend(extended, implementedInterface, out var map))
+                    if (TypeUnification.CanImplicitlyExtend(extension, implementedInterface, out AbstractTypeParameterMap? map))
                     {
                         substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
                         return true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -185,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!type.IsTypeParameter());
 
             var compatibleExtensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-            getCompatibleExtensions(binder, type, compatibleExtensions);
+            getCompatibleExtensions(binder, type, compatibleExtensions, basesBeingResolved);
             // PROTOTYPE test use-site diagnostics
             var tempResult = LookupResult.GetInstance();
             foreach (NamedTypeSymbol extension in compatibleExtensions)
@@ -203,36 +204,44 @@ namespace Microsoft.CodeAnalysis.CSharp
             compatibleExtensions.Free();
             return;
 
-            void getCompatibleExtensions(Binder binder, TypeSymbol type, ArrayBuilder<NamedTypeSymbol> compatibleExtensions)
+            void getCompatibleExtensions(Binder binder, TypeSymbol type, ArrayBuilder<NamedTypeSymbol> compatibleExtensions, ConsList<TypeSymbol>? basesBeingResolved)
             {
                 var extensions = ArrayBuilder<NamedTypeSymbol>.GetInstance();
                 binder.GetImplicitExtensionTypes(extensions, originalBinder: this);
 
                 foreach (var extension in extensions)
                 {
-                    // PROTOTYPE deal with generic extensions
-                    if (isCompatible(extension, type))
+                    if (basesBeingResolved?.Contains(extension) == true)
+                    {
+                        continue;
+                    }
+
+                    if (isCompatible(extension, type, out NamedTypeSymbol? substitutedExtension))
                     {
                         // PROTOTYPE should we deal with duplicate or near-duplicate extensions here instead of in merging/hiding logic?
-                        compatibleExtensions.Add(extension);
+                        compatibleExtensions.Add(substitutedExtension);
                     }
                 }
 
                 extensions.Free();
             }
 
-            bool isCompatible(TypeSymbol extension, TypeSymbol type)
+            bool isCompatible(NamedTypeSymbol extension, TypeSymbol type, [NotNullWhen(true)] out NamedTypeSymbol? substitutedExtension)
             {
                 Debug.Assert(!type.IsExtension);
                 var extended = extension.ExtendedTypeNoUseSiteDiagnostics;
                 if (extended is null)
+                {
+                    substitutedExtension = null;
                     return false;
+                }
 
                 var baseType = type;
                 do
                 {
-                    if (matches(extended, baseType))
+                    if (TypeUnification.CanImplicitlyExtend(extended, baseType, out var map))
                     {
+                        substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
                         return true;
                     }
 
@@ -242,18 +251,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var implementedInterface in type.AllInterfacesNoUseSiteDiagnostics)
                 {
-                    if (matches(extended, implementedInterface))
+                    if (TypeUnification.CanImplicitlyExtend(extended, implementedInterface, out var map))
                     {
+                        substitutedExtension = map is not null ? (NamedTypeSymbol)map.SubstituteType(extension).Type : extension;
                         return true;
                     }
                 }
 
+                substitutedExtension = null;
                 return false;
-            }
-
-            static bool matches(TypeSymbol extended, TypeSymbol baseType)
-            {
-                return extended.Equals(baseType, TypeCompareKind.CLRSignatureCompareOptions);
             }
         }
 #nullable disable

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7730,4 +7730,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_MalformedExtensionInMetadata" xml:space="preserve">
     <value>Extension marker method on type '{0}' is malformed.</value>
   </data>
+  <data name="ERR_UnderspecifiedImplicitExtension" xml:space="preserve">
+    <value>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             get
             {
-                return UnderlyingNamedType.IsValueType; // PROTOTYPE
+                return UnderlyingNamedType.IsValueType || UnderlyingNamedType.IsExtension;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2259,6 +2259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DuplicateExtensionInBaseList = 9220,
         ERR_ExtensionMethodInExtension = 9221,
         ERR_MalformedExtensionInMetadata = 9222,
+        ERR_UnderspecifiedImplicitExtension = 9228,
         #endregion
 
         // Note: you will need to do the following after adding warnings:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2380,6 +2380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_DuplicateExtensionInBaseList:
                 case ErrorCode.ERR_ExtensionMethodInExtension:
                 case ErrorCode.ERR_MalformedExtensionInMetadata:
+                case ErrorCode.ERR_UnderspecifiedImplicitExtension:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Symbols/MutableTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MutableTypeMap.cs
@@ -4,11 +4,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
@@ -24,6 +19,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal void Add(TypeParameterSymbol key, TypeWithAnnotations value)
         {
             this.Mapping.Add(key, value);
+        }
+
+        internal bool Contains(TypeParameterSymbol key)
+        {
+            return this.Mapping.ContainsKey(key);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -64,14 +64,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!IsExplicitExtension)
                 {
+                    var usedTypeParameters = PooledHashSet<TypeParameterSymbol>.GetInstance();
+                    underlyingType.VisitType(collectTypeParameters, arg: usedTypeParameters);
+
                     foreach (var typeParameter in TypeParameters)
                     {
-                        if (!TypeUnification.Contains(underlyingType, typeParameter))
+                        if (!usedTypeParameters.Contains(typeParameter))
                         {
                             diagnostics.Add(ErrorCode.ERR_UnderspecifiedImplicitExtension, location, underlyingType, this, typeParameter);
                         }
                     }
+
+                    usedTypeParameters.Free();
                 }
+            }
+
+            return;
+
+            static bool collectTypeParameters(TypeSymbol type, PooledHashSet<TypeParameterSymbol> typeParameters, bool b)
+            {
+                if (type is TypeParameterSymbol typeParameter)
+                {
+                    typeParameters.Add(typeParameter);
+                }
+
+                return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceExtensionTypeSymbol.cs
@@ -61,6 +61,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var location = singleDeclaration.NameLocation;
 
                 underlyingType.CheckAllConstraints(DeclaringCompilation, conversions, location, diagnostics);
+
+                if (!IsExplicitExtension)
+                {
+                    foreach (var typeParameter in TypeParameters)
+                    {
+                        if (!TypeUnification.Contains(underlyingType, typeParameter))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_UnderspecifiedImplicitExtension, location, underlyingType, this, typeParameter);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -702,6 +702,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Enum:
                     case TypeKind.Delegate:
                     case TypeKind.Extension:
+                    case TypeKind.Error:
                         {
                             var containingType = current.ContainingType;
                             if ((object)containingType != null)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -104,7 +104,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     arg: substitution);
                 return foundTypeParameter is not null;
             }
-
         }
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
@@ -16,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Determine whether there is any substitution of type parameters that will
         /// make two types identical.
         /// </summary>
-        public static bool CanUnify(TypeSymbol t1, TypeSymbol t2)
+        public static bool CanUnify(TypeSymbol? t1, TypeSymbol? t2)
         {
             if (TypeSymbol.Equals(t1, t2, TypeCompareKind.CLRSignatureCompareOptions))
             {
@@ -42,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Determines a substitution of type parameters on <paramref name="extensionUnderlyingType"/>
         /// that yields <paramref name="type"/>.
         /// </summary>
-        public static bool CanImplicitlyExtend(TypeSymbol extensionUnderlyingType, TypeSymbol type, out AbstractTypeParameterMap? map)
+        public static bool CanImplicitlyExtend(TypeSymbol? extensionUnderlyingType, TypeSymbol? type, out AbstractTypeParameterMap? map)
         {
             // PROTOTYPE we'll want to adjust the handling for differences that aren't relevant to the CLR, such as object/dynamic
             if (TypeSymbol.Equals(extensionUnderlyingType, type, TypeCompareKind.CLRSignatureCompareOptions))

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -94,15 +94,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static bool hasSubstitutionForContainingTypeTypeParameter(NamedTypeSymbol? containingType, MutableTypeMap? substitution)
             {
-                if (containingType is null || substitution is null)
+                if (substitution is null)
                 {
                     return false;
                 }
 
-                TypeSymbol? foundTypeParameter = containingType.VisitType(
-                    (type, substitution, _) => type is TypeParameterSymbol typeParameter ? substitution.Contains(typeParameter) : false,
-                    arg: substitution);
-                return foundTypeParameter is not null;
+                while (containingType is not null)
+                {
+                    foreach (var typeParameter in containingType.TypeParameters)
+                    {
+                        if (substitution.Contains(typeParameter))
+                        {
+                            return true;
+                        }
+                    }
+
+                    containingType = containingType.ContainingType;
+                }
+
+                return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -164,6 +164,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static bool CanUnifyWith(this TypeSymbol thisType, TypeSymbol otherType)
         {
+            Debug.Assert(thisType is not null);
+            Debug.Assert(otherType is not null);
+
             return TypeUnification.CanUnify(thisType, otherType);
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Neočekávaný seznam parametrů.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Unerwartete Parameterliste.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Lista de parámetros inesperada.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Liste de paramètres inattendue.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Elenco parametri imprevisto.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">予期しないパラメーター リストです。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">예기치 않은 매개 변수 목록입니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Nieoczekiwana lista parametrów.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Lista de parâmetros inesperada.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Неожиданный список параметров.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">Beklenmeyen parametre listesi.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">意外的参数列表。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2007,6 +2007,11 @@
         <target state="new">Extension '{0}' extends '{1}' but base extension '{2}' extends '{3}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnderspecifiedImplicitExtension">
+        <source>The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</source>
+        <target state="new">The underlying type '{0}' of implicit extension '{1}' must reference all the type parameters declared by the extension, but type parameter '{2}' is missing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_UnexpectedParameterList">
         <source>Unexpected parameter list.</source>
         <target state="translated">未預期的參數清單。</target>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExtensionTypeTests.cs
@@ -18977,8 +18977,25 @@ implicit extension E<T1, T2> for C<T1>.Nested<T2>
         Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
     }
 
-    [ConditionalFact(typeof(CoreClrOnly))]
+    [Fact]
     public void GenericExtension_Tuples()
+    {
+        var src = """
+string s = (string, string).Nested.f;
+""";
+        var comp = CreateCompilation(src, targetFramework: TargetFramework.Net70);
+        comp.VerifyDiagnostics(
+            // (1,13): error CS1525: Invalid expression term 'string'
+            // string s = (string, string).Nested.f;
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "string").WithArguments("string").WithLocation(1, 13),
+            // (1,21): error CS1525: Invalid expression term 'string'
+            // string s = (string, string).Nested.f;
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "string").WithArguments("string").WithLocation(1, 21)
+            );
+    }
+
+    [ConditionalFact(typeof(CoreClrOnly))]
+    public void GenericExtension_NestedTuples()
     {
         var src = """
 string s = C<(string, string)>.Nested<(int, int)>.f;

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -4448,12 +4448,15 @@ public class B : A
             Assert.Equal(classAnother, rightInfo.CandidateSymbols.Single());
 
             compilation.VerifyDiagnostics(
-                // (12,14): error CS0060: Inconsistent accessibility: base type 'A' is less accessible than class 'B'
+                // (12,14): error CS0060: Inconsistent accessibility: base class 'A' is less accessible than class 'B'
                 // public class B : A
-                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "B").WithArguments("B", "A"),
+                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "B").WithArguments("B", "A").WithLocation(12, 14),
+                // (14,27): error CS0052: Inconsistent accessibility: field type 'A.Nested.Another' is less accessible than field 'B.a'
+                //     public Nested.Another a;
+                Diagnostic(ErrorCode.ERR_BadVisFieldType, "a").WithArguments("B.a", "A.Nested.Another").WithLocation(14, 27),
                 // (14,12): error CS0122: 'A.Nested' is inaccessible due to its protection level
                 //     public Nested.Another a;
-                Diagnostic(ErrorCode.ERR_BadAccess, "Nested").WithArguments("A.Nested"));
+                Diagnostic(ErrorCode.ERR_BadAccess, "Nested").WithArguments("A.Nested").WithLocation(14, 12));
         }
 
         [WorkItem(633340, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633340")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -785,8 +785,15 @@ class A : A.B.B.I
 ";
 
             CreateCompilation(text).VerifyDiagnostics(
-                Diagnostic(ErrorCode.ERR_CircularBase, "A").WithArguments("A", "A.B"),
-                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "B").WithArguments("B", "A.B"));
+                // (4,23): error CS0146: Circular base type dependency involving 'A' and 'A.B'
+                //     private class B : A
+                Diagnostic(ErrorCode.ERR_CircularBase, "A").WithArguments("A", "A.B").WithLocation(4, 23),
+                // (2,15): error CS0426: The type name 'B' does not exist in the type 'A.B'
+                // class A : A.B.B.I
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "B").WithArguments("B", "A.B").WithLocation(2, 15),
+                // (2,7): error CS0060: Inconsistent accessibility: base class 'A.B.B.I' is less accessible than class 'A'
+                // class A : A.B.B.I
+                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "A").WithArguments("A", "A.B.B.I").WithLocation(2, 7));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeUnificationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeUnificationTests.cs
@@ -94,9 +94,6 @@ class C
                     }
                 }
             }
-
-            AssertCanUnify(null, null);
-            AssertCannotUnify(classType, null);
         }
 
         [Fact]


### PR DESCRIPTION
Implements the generic portion of the [compatible substituted extension type](https://github.com/jcouv/csharplang/blob/roles-spec/proposals/extensions.md#compatible-substituted-extension-type) section.

## Cycles
I ran into some cycles. For example:
```
implicit extension E<T1, T2> for C<T1>.Nested<T2>
{
    public class Nested<U> { }
}
```
In that scenario, when we want to bind the underlying type `C<T1>.Nested<T2>`, we first look in `C` and if that fails we look for a compatible extension, but to find compatible extensions we need to bind underlying types... I blocked this scenario to resolve the cycle, but we can discuss whether a better solution would be possible.

## Ambiguities
It's possible to have a non-unique substitution that makes an extension compatible with a given type. We'll need to discuss in WG, but doing something like `MergeEquivalentTypes` should solve the problem.

For example:
```
string s = C<object, dynamic>.f;

class C<T ,U> { }

implicit extension E<T> for C<T ,T>
{
    public static string f = "hi";
}
```

## Modopts

I tried cooking up some scenarios where we'd end up with a modopt in type argument to an extension (`E<modopt(object) int>`), but didn't manage to.

Relates to test plan https://github.com/dotnet/roslyn/issues/66722