### PR TITLE
Avoid giving 'no best type' error when one of the types contains error types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (type is { })
                 {
-                    if (type.IsErrorType())
+                    if (type.ContainsErrorType())
                     {
                         inferredFromFunctionType = false;
                         return type;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -758,6 +758,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Enum:
                         return null;
 
+                    case TypeKindInternal.FunctionType:
+                        if (((FunctionTypeSymbol)current).GetInternalDelegateType() is not { } delegateType)
+                        {
+                            return null;
+                        }
+
+                        current = delegateType;
+                        goto case TypeKind.Delegate;
+
                     case TypeKind.Error:
                     case TypeKind.Class:
                     case TypeKind.Struct:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypeArraysTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypeArraysTests.cs
@@ -101,7 +101,6 @@ class C
             Assert.NotNull(typeInfo.ConvertedType);
         }
 
-
         [Fact]
         public void BestType_NestedError()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypeArraysTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ImplicitlyTypeArraysTests.cs
@@ -100,29 +100,5 @@ class C
             Assert.NotNull(typeInfo.Type);
             Assert.NotNull(typeInfo.ConvertedType);
         }
-
-        [Fact]
-        public void BestType_NestedError()
-        {
-            var source = """
-                public class C {
-                    public void M0() {
-                        M1(new[] { ERROR, 1 });
-                        M2(new[] { (ERROR, 1), (1, 2) });
-                    }
-
-                    public void M1(int[] arr) { }
-                    public void M2((int, int)[] arr) { }
-                }
-                """;
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (3,20): error CS0103: The name 'ERROR' does not exist in the current context
-                //         M1(new[] { ERROR, 1 });
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(3, 20),
-                // (4,21): error CS0103: The name 'ERROR' does not exist in the current context
-                //         M2(new[] { (ERROR, 1), (1, 2) });
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(4, 21));
-        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -24669,5 +24669,149 @@ unsafe class C<T, U, V, X, Y, Z> where T : byte*
                     // class A<T> where T : object[] {}
                     Diagnostic(ErrorCode.ERR_BadConstraintType, "object[]").WithLocation(1, 22));
         }
+
+        [Fact]
+        public void BestType_NestedError_ArrayCreation()
+        {
+            var source = """
+                public class C {
+                    public void M0() {
+                        M1(new[] { ERROR, 1 });
+                        M2(new[] { (ERROR, 1), (1, 2) });
+                    }
+
+                    public void M1(int[] arr) { }
+                    public void M2((int, int)[] arr) { }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (3,20): error CS0103: The name 'ERROR' does not exist in the current context
+                //         M1(new[] { ERROR, 1 });
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(3, 20),
+                // (4,21): error CS0103: The name 'ERROR' does not exist in the current context
+                //         M2(new[] { (ERROR, 1), (1, 2) });
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(4, 21));
+        }
+
+        [Fact]
+        public void BestType_NestedError_StackallocArrayCreation()
+        {
+            var source = """
+                using System;
+
+                public class C {
+                    public void M0() {
+                        M1(stackalloc int[] { ERROR, 1 });
+                        M2(stackalloc (int, int)[] { (ERROR, 1), (1, 2) });
+                    }
+
+                    public void M1(Span<int> arr) { }
+                    public void M2(Span<(int, int)> arr) { }
+                }
+                """;
+            var comp = CreateCompilationWithSpan(source);
+            comp.VerifyDiagnostics(
+                // (5,31): error CS0103: The name 'ERROR' does not exist in the current context
+                //         M1(stackalloc int[] { ERROR, 1 });
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(5, 31),
+                // (6,39): error CS0103: The name 'ERROR' does not exist in the current context
+                //         M2(stackalloc (int, int)[] { (ERROR, 1), (1, 2) });
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(6, 39));
+        }
+
+        [Fact]
+        public void BestType_NestedError_SwitchExpr()
+        {
+            var source = """
+                public class C {
+                    public int M0() {
+                        return 1 switch
+                        {
+                            1 => ERROR,
+                            _ => 1
+                        };
+                    }
+
+                    public (int, int) M1() {
+                        return 1 switch
+                        {
+                            1 => (ERROR, 1),
+                            _ => (1, 2)
+                        };
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (5,18): error CS0103: The name 'ERROR' does not exist in the current context
+                //             1 => ERROR,
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(5, 18),
+                // (13,19): error CS0103: The name 'ERROR' does not exist in the current context
+                //             1 => (ERROR, 1),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(13, 19));
+        }
+
+        [Fact]
+        public void BestType_NestedError_ConditionalExpr()
+        {
+            var source = """
+                public class C {
+                    public int M0() {
+                        return 1 == 1 ? ERROR : 1;
+                    }
+
+                    public (int, int) M1() {
+                        return 1 == 1 ? (ERROR, 1) : (1, 2);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (3,25): error CS0103: The name 'ERROR' does not exist in the current context
+                //         return 1 == 1 ? ERROR : 1;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(3, 25),
+                // (7,26): error CS0103: The name 'ERROR' does not exist in the current context
+                //         return 1 == 1 ? (ERROR, 1) : (1, 2);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(7, 26));
+        }
+
+        [Fact]
+        public void BestType_NestedError_LambdaReturns()
+        {
+            var source = """
+                using System;
+
+                public class C {
+                    public void M0() {
+                        Func<bool, int> fn1 = flag =>
+                        {
+                            if (flag) return ERROR;
+                            return 1;
+                        };
+
+                        Func<bool, int> fn2 = flag =>
+                        {
+                            if (flag) return (ERROR, 1);
+                            return (1, 2);
+                        };
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS0103: The name 'ERROR' does not exist in the current context
+                //             if (flag) return ERROR;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(7, 30),
+                // (13,31): error CS0103: The name 'ERROR' does not exist in the current context
+                //             if (flag) return (ERROR, 1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "ERROR").WithArguments("ERROR").WithLocation(13, 31),
+                // (14,20): error CS0029: Cannot implicitly convert type '(int, int)' to 'int'
+                //             return (1, 2);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(1, 2)").WithArguments("(int, int)", "int").WithLocation(14, 20),
+                // (14,20): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+                //             return (1, 2);
+                Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "(1, 2)").WithArguments("lambda expression").WithLocation(14, 20));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -12006,7 +12006,7 @@ namespace Test
 
             Assert.Equal("?[,,]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
-            Assert.Equal("?", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal("?[,,]", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 
@@ -12041,7 +12041,7 @@ namespace Test
 
             Assert.Equal("?[,,]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
-            Assert.Equal("?", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal("?[,,]", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 
@@ -12077,7 +12077,7 @@ public class C
 
             Assert.Equal("System.Int32[]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
-            Assert.Equal("?", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal("?[]", semanticInfo.ConvertedType.ToTestDisplayString());
             Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -12007,8 +12007,8 @@ namespace Test
             Assert.Equal("?[,,]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
             Assert.Equal("?[,,]", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
-            Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
+            Assert.Equal(TypeKind.Array, semanticInfo.ConvertedType.TypeKind);
+            Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
             Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
@@ -12042,8 +12042,8 @@ namespace Test
             Assert.Equal("?[,,]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
             Assert.Equal("?[,,]", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
-            Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
+            Assert.Equal(TypeKind.Array, semanticInfo.ConvertedType.TypeKind);
+            Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);
             Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
@@ -12078,7 +12078,7 @@ public class C
             Assert.Equal("System.Int32[]", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Array, semanticInfo.Type.TypeKind);
             Assert.Equal("?[]", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(TypeKind.Error, semanticInfo.ConvertedType.TypeKind);
+            Assert.Equal(TypeKind.Array, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 
             Assert.Null(semanticInfo.Symbol);


### PR DESCRIPTION
Closes #67751

Moving to draft while I build out the test coverage.