### PR TITLE
Cache RetargetingParameterSymbol.TypeWithAnnotations to avoid ~8.3% allocations in a trace

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingParameterSymbol.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         /// </summary>
         private ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
 
+        private TypeWithAnnotations? _lazyTypeWithAnnotations;
+
         protected RetargetingParameterSymbol(ParameterSymbol underlyingParameter)
             : base(underlyingParameter)
         {
@@ -38,7 +40,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         {
             get
             {
-                return this.RetargetingModule.RetargetingTranslator.Retarget(_underlyingParameter.TypeWithAnnotations, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
+                if (!_lazyTypeWithAnnotations.HasValue)
+                {
+                    _lazyTypeWithAnnotations = this.RetargetingModule.RetargetingTranslator.Retarget(_underlyingParameter.TypeWithAnnotations, RetargetOptions.RetargetPrimitiveTypesByTypeCode);
+                }
+
+                return _lazyTypeWithAnnotations.Value;
             }
         }
 


### PR DESCRIPTION
In the trace from https://developercommunity.visualstudio.com/t/Performance-trace-for-Roslyn-team/10413054, there are too many `TypeWithAnnotations[]` allocations happening in RetargetingParameterSymbol (thanks @sharwell for the investigation).

![image](https://github.com/dotnet/roslyn/assets/31348972/7dae3eed-29b6-4210-840d-f811d65f84f0)

I re-profiled the scenario with a locally built version of the compiler that adds some logging to CodeAnalysisEventSource, and @sharwell figured out that on average, there are 76 calls to the exact same `RetargetingParameterSymbol` instance. So we think caching might be beneficial here.

I don't know if that will solve the problem completely, we might need to get another trace with the change from this PR and see if there are more bottlenecks, but at least, this seems like a good first step.

Edit:

The previous screenshot from trace shows 3.5% allocations for TypewithAnnotions arrays, however, there is **also** the following in the same trace:

![image](https://github.com/dotnet/roslyn/assets/31348972/7f140aec-4cff-4a94-b690-beb8a711b860)

which is 4.8% of allocations. So total is 8.3%, and there are probably more allocations happening during the evaluation of this property.