### PR TITLE
DocumentSymbol name field cannot be empty

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var service = document.Project.Solution.Services.GetRequiredService<ILspSymbolInformationCreationService>();
             return service.Create(
-                item.Text,
+                GetDocumentSymbolName(item.Text),
                 containerName,
                 ProtocolConversions.GlyphToSymbolKind(item.Glyph),
                 new LSP.Location
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             return new RoslynDocumentSymbol
             {
-                Name = symbolItem.Name,
+                Name = GetDocumentSymbolName(symbolItem.Name),
                 Detail = item.Text,
                 Kind = ProtocolConversions.GlyphToSymbolKind(item.Glyph),
                 Glyph = (int)item.Glyph,
@@ -133,6 +133,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                 return list.ToArray();
             }
+        }
+
+        /// <summary>
+        /// DocumentSymbol name cannot be null or empty. Check if the name is invalid,
+        /// and return substitute string.
+        /// </summary>
+        /// <param name="proposedName"></param>
+        /// <returns></returns>
+        private static string GetDocumentSymbolName(string proposedName)
+        {
+            return String.IsNullOrEmpty(proposedName) ? "." : proposedName;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -137,10 +137,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
         /// <summary>
         /// DocumentSymbol name cannot be null or empty. Check if the name is invalid,
-        /// and return substitute string.
+        /// and if so return a substitute string.
         /// </summary>
-        /// <param name="proposedName"></param>
-        /// <returns></returns>
+        /// <param name="proposedName">Name proposed for DocumentSymbol</param>
+        /// <returns>Valid name for DocumentSymbol</returns>
         private static string GetDocumentSymbolName(string proposedName)
         {
             return String.IsNullOrEmpty(proposedName) ? "." : proposedName;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -92,6 +92,45 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
         }
 
         [Theory, CombinatorialData]
+        public async Task TestGetDocumentSymbolsAsync_EmptyName(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"namepsace NamespaceA
+{
+    public class
+";
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+            var results = await RunGetDocumentSymbolsAsync<LSP.SymbolInformation[]>(testLspServer).ConfigureAwait(false);
+            Assert.Equal(".", results.First().Name);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestGetDocumentSymbolsAsync_EmptyNameWithHierarchicalSupport(bool mutatingLspWorkspace)
+        {
+            var markup =
+@"namepsace NamespaceA
+{
+    public class
+";
+            var clientCapabilities = new LSP.ClientCapabilities()
+            {
+                TextDocument = new LSP.TextDocumentClientCapabilities()
+                {
+                    DocumentSymbol = new LSP.DocumentSymbolSetting()
+                    {
+                        HierarchicalDocumentSymbolSupport = true
+                    }
+                }
+            };
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, clientCapabilities);
+
+            var results = await RunGetDocumentSymbolsAsync<LSP.SymbolInformation[]>(testLspServer).ConfigureAwait(false);
+            Assert.Equal(".", results.First().Name);
+        }
+
+        [Theory, CombinatorialData]
         public async Task TestGetDocumentSymbolsAsync__NoSymbols(bool mutatingLspWorkspace)
         {
             await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace);


### PR DESCRIPTION
Per LSP DocumentSymbol [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol), the Name property cannot be empty. 

	/**
	 * The name of this symbol. Will be displayed in the user interface and
	 * therefore must not be an empty string or a string only consisting of
	 * white spaces.
	 */
	name: string;


When a class is incomplete, the Name property isn't complete.  Here is an example...
```
namespace DemoClass
{
    public class    
}
```

Currently Roslyn return `""`, which violates the LSP spec. Per suggestion from Cryus, now returning `"."`

Issues - https://github.com/dotnet/roslyn/issues/68742, https://github.com/dotnet/vscode-csharp/issues/5891