### PR TITLE
Allow default values for `ref readonly` parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4094,6 +4094,12 @@ You should consider suppressing the warning only if you're sure that you don't w
   <data name="WRN_DefaultValueForUnconsumedLocation_Title" xml:space="preserve">
     <value>The default value specified will have no effect because it applies to a member that is used in contexts that do not allow optional arguments</value>
   </data>
+  <data name="WRN_RefReadonlyParameterDefaultValue" xml:space="preserve">
+    <value>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</value>
+  </data>
+  <data name="WRN_RefReadonlyParameterDefaultValue_Title" xml:space="preserve">
+    <value>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</value>
+  </data>
   <data name="ERR_PublicKeyFileFailure" xml:space="preserve">
     <value>Error signing output with public key from file '{0}' -- {1}</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2247,6 +2247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadArgExtraRefLangVersion = 9505,
         WRN_ArgExpectedIn = 9506,
         ERR_OutAttrOnRefReadonlyParam = 9520,
+        WRN_RefReadonlyParameterDefaultValue = 9521,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -540,6 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_ArgExpectedRefOrIn:
                 case ErrorCode.WRN_RefReadonlyNotVariable:
                 case ErrorCode.WRN_ArgExpectedIn:
+                case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                     return 1;
                 default:
                     return 0;
@@ -2370,6 +2371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_BadArgExtraRefLangVersion:
                 case ErrorCode.WRN_ArgExpectedIn:
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
+                case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -323,6 +323,7 @@
                 case ErrorCode.WRN_ArgExpectedRefOrIn:
                 case ErrorCode.WRN_RefReadonlyNotVariable:
                 case ErrorCode.WRN_ArgExpectedIn:
+                case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 RefKind refKind;
                 return !IsParams && IsMetadataOptional &&
                        ((refKind = RefKind) == RefKind.None ||
-                        (refKind == RefKind.In) ||
+                        (refKind is RefKind.In or RefKind.RefReadOnlyParameter) ||
                         (refKind == RefKind.Ref && ContainingSymbol.ContainingType.IsComImport));
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -853,6 +853,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     parameterSyntax.Identifier.ValueText);
             }
 
+            if (refKind == RefKind.RefReadOnlyParameter)
+            {
+                // A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+                diagnostics.Add(ErrorCode.WRN_RefReadonlyParameterDefaultValue, parameterSyntax.Default.Value, parameterSyntax.Identifier.ValueText);
+            }
+
             return hasErrors;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -891,6 +891,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!value.IsBad)
             {
                 VerifyParamDefaultValueMatchesAttributeIfAny(value, syntax, diagnostics);
+
+                if (this.RefKind == RefKind.RefReadOnlyParameter && this.IsOptional && this.CSharpSyntaxNode.Default is null)
+                {
+                    // A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+                    diagnostics.Add(ErrorCode.WRN_RefReadonlyParameterDefaultValue, syntax, this.Name);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Tato funkce vrací místní {0} podle odkazu, ale nejedná se o místní odkaz</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Gibt die lokale Variable "{0}" als Verweis zurück, es handelt sich jedoch nicht um eine lokale ref-Variable.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Esto devuelve por referencia "{0}" de la variable local, pero no es una variable local de tipo ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Retourne une variable locale '{0}' par référence, mais il ne s'agit pas d'une variable locale de référence</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">In questo modo viene restituito il valore locale '{0}' per riferimento, ma non è un riferimento locale</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">これは、ローカル変数 '{0}' を参照渡しで返しますが、ref ローカル変数ではありません</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">참조로 로컬 '{0}'을(를) 반환하지만 참조 로컬이 아닙니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Spowoduje to zwrócenie lokalnego elementu „{0}” przez odwołanie, ale nie jest to odwołanie lokalne</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Isso retorna o local '{0}' por referência, mas não é um local de ref</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Это возвращает local "{0}" по ссылке, но это не ref local</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">Bu, referans olarak yerel '{0}' döndürür, ancak bir ref yerel değildir</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">这将按引用返回本地“{0}”，但它不是 ref 本地</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2712,6 +2712,16 @@
         <target state="new">Argument should be a variable because it is passed to a 'ref readonly' parameter</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue">
+        <source>A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter '{0}', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RefReadonlyParameterDefaultValue_Title">
+        <source>A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</source>
+        <target state="new">A default value is specified for 'ref readonly' parameter, but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefReturnLocal">
         <source>This returns local '{0}' by reference but it is not a ref local</source>
         <target state="translated">這會藉傳址方式傳回本機 '{0}'，但其非參考本機</target>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -2905,9 +2906,10 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             //         C.M(x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(7, 13);
         var comp = fromMetadata
-            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warning2)
-            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warning1, warning2);
+            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe)
+            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe);
         var verifier = CompileAndVerify(comp, expectedOutput: "1222");
+        verifier.VerifyDiagnostics(fromMetadata ? new[] { warning2 } : new[] { warning1, warning2 });
         verifier.VerifyIL("D.M2", """
             {
               // Code size       10 (0xa)
@@ -2955,9 +2957,10 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             //         C.M(x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(7, 13);
         var comp = fromMetadata
-            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warning2)
-            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warning1, warning2);
+            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe)
+            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe);
         var verifier = CompileAndVerify(comp, expectedOutput: "1222");
+        verifier.VerifyDiagnostics(fromMetadata ? new[] { warning2 } : new[] { warning1, warning2 });
         verifier.VerifyIL("D.M2", """
             {
               // Code size       10 (0xa)
@@ -3092,8 +3095,8 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "y").WithArguments("1").WithLocation(13, 14)
         };
         var comp = fromMetadata
-            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warnings1).EmitToImageReference() }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warnings2)
-            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warnings1.Concat(warnings2).ToArray());
+            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warnings1).EmitToImageReference() }, options: TestOptions.ReleaseExe)
+            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe);
         var verifier = CompileAndVerify(comp, expectedOutput: """
             M1 1.1
             M1 2.2
@@ -3104,6 +3107,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             M2 3.3
             M2 3.3
             """);
+        verifier.VerifyDiagnostics(fromMetadata ? warnings2 : warnings1.Concat(warnings2).ToArray());
         verifier.VerifyIL("D.M3", """
             {
               // Code size       20 (0x14)
@@ -3192,9 +3196,10 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         var comp = fromMetadata
-            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe).VerifyDiagnostics()
-            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe).VerifyDiagnostics(warning1);
+            ? CreateCompilation(source2, new[] { CreateCompilation(source1).VerifyDiagnostics(warning1).EmitToImageReference() }, options: TestOptions.ReleaseExe)
+            : CreateCompilation(new[] { source1, source2 }, options: TestOptions.ReleaseExe);
         var verifier = CompileAndVerify(comp, expectedOutput: "100");
+        verifier.VerifyDiagnostics(fromMetadata ? Array.Empty<DiagnosticDescription>() : new[] { warning1 });
         verifier.VerifyIL("D.Main", """
             {
               // Code size       17 (0x11)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -2874,6 +2874,322 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
     }
 
     [Fact]
+    public void DefaultParameterValue_EqualsValue()
+    {
+        var source = """
+            class C
+            {
+                static void M(ref readonly int i = 1) => System.Console.Write(i);
+                static void Main()
+                {
+                    int x = 2;
+                    M();
+                    M(x);
+                    M(ref x);
+                    M(in x);
+                }
+                static void M2() => M();
+            }
+            """;
+        var verifier = CompileAndVerify(source, expectedOutput: "1222").VerifyDiagnostics(
+            // (3,40): warning CS9521: A default value is specified for 'ref readonly' parameter 'i', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M(ref readonly int i = 1) => System.Console.Write(i);
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1").WithArguments("i").WithLocation(3, 40),
+            // (8,11): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(8, 11));
+        verifier.VerifyIL("C.M2", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              .locals init (int V_0)
+              IL_0000:  ldc.i4.1
+              IL_0001:  stloc.0
+              IL_0002:  ldloca.s   V_0
+              IL_0004:  call       "void C.M(ref readonly int)"
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void DefaultParameterValue_Attribute()
+    {
+        var source = """
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M([Optional, DefaultParameterValue(1)] ref readonly int i) => System.Console.Write(i);
+                static void Main()
+                {
+                    int x = 2;
+                    M();
+                    M(x);
+                    M(ref x);
+                    M(in x);
+                }
+                static void M2() => M();
+            }
+            """;
+        var verifier = CompileAndVerify(source, expectedOutput: "1222").VerifyDiagnostics(
+            // (4,30): warning CS9521: A default value is specified for 'ref readonly' parameter 'i', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M([Optional, DefaultParameterValue(1)] ref readonly int i) => System.Console.Write(i);
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "DefaultParameterValue(1)").WithArguments("i").WithLocation(4, 30),
+            // (9,11): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(9, 11));
+        verifier.VerifyIL("C.M2", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              .locals init (int V_0)
+              IL_0000:  ldc.i4.1
+              IL_0001:  stloc.0
+              IL_0002:  ldloca.s   V_0
+              IL_0004:  call       "void C.M(ref readonly int)"
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void DefaultParameterValue_AttributeAndEqualsValue()
+    {
+        var source = """
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M([DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (4,20): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+            //     static void M([DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(4, 20),
+            // (4,67): warning CS9521: A default value is specified for 'ref readonly' parameter 'i', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M([DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1").WithArguments("i").WithLocation(4, 67),
+            // (4,67): error CS8017: The parameter has multiple distinct default values.
+            //     static void M([DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "1").WithLocation(4, 67));
+    }
+
+    [Fact]
+    public void DefaultParameterValue_OptionalAndEqualsValue()
+    {
+        var source = """
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M([Optional] ref readonly int i = 1) => throw null;
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (4,20): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+            //     static void M([Optional] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "Optional").WithLocation(4, 20),
+            // (4,51): warning CS9521: A default value is specified for 'ref readonly' parameter 'i', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M([Optional] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1").WithArguments("i").WithLocation(4, 51));
+    }
+
+    [Fact]
+    public void DefaultParameterValue_All()
+    {
+        var source = """
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M([Optional, DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (4,20): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+            //     static void M([Optional, DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "Optional").WithLocation(4, 20),
+            // (4,30): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+            //     static void M([Optional, DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(4, 30),
+            // (4,77): warning CS9521: A default value is specified for 'ref readonly' parameter 'i', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M([Optional, DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1").WithArguments("i").WithLocation(4, 77),
+            // (4,77): error CS8017: The parameter has multiple distinct default values.
+            //     static void M([Optional, DefaultParameterValue(1)] ref readonly int i = 1) => throw null;
+            Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "1").WithLocation(4, 77));
+    }
+
+    [Fact]
+    public void DefaultParameterValue_DecimalConstant_Valid()
+    {
+        var source = """
+            using System;
+            using System.Globalization;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M1([Optional, DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d) => Console.WriteLine("M1 " + d.ToString(CultureInfo.InvariantCulture));
+                static void M2(ref readonly decimal d = 1.1m) => Console.WriteLine("M2 " + d.ToString(CultureInfo.InvariantCulture));
+                static void Main()
+                {
+                    decimal x = 2.2m;
+                    M1();
+                    M1(x);
+                    M1(ref x);
+                    M1(in x);
+
+                    decimal y = 3.3m;
+                    M2();
+                    M2(y);
+                    M2(ref y);
+                    M2(in y);
+                }
+                static void M3() => M1();
+                static void M4() => M2();
+            }
+            """;
+        var verifier = CompileAndVerify(source, expectedOutput: """
+            M1 1.1
+            M1 2.2
+            M1 2.2
+            M1 2.2
+            M2 1.1
+            M2 3.3
+            M2 3.3
+            M2 3.3
+            """).VerifyDiagnostics(
+            // (7,31): warning CS9521: A default value is specified for 'ref readonly' parameter 'd', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M1([Optional, DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d) => Console.WriteLine("M1 " + d.ToString(CultureInfo.InvariantCulture));
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "DecimalConstant(1, 0, 0u, 0u, 11u)").WithArguments("d").WithLocation(7, 31),
+            // (8,45): warning CS9521: A default value is specified for 'ref readonly' parameter 'd', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M2(ref readonly decimal d = 1.1m) => Console.WriteLine("M2 " + d.ToString(CultureInfo.InvariantCulture));
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1.1m").WithArguments("d").WithLocation(8, 45),
+            // (13,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M1(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(13, 12),
+            // (19,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M2(y);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "y").WithArguments("1").WithLocation(19, 12));
+        verifier.VerifyIL("C.M3", """
+            {
+              // Code size       20 (0x14)
+              .maxstack  5
+              .locals init (decimal V_0)
+              IL_0000:  ldc.i4.s   11
+              IL_0002:  ldc.i4.0
+              IL_0003:  ldc.i4.0
+              IL_0004:  ldc.i4.0
+              IL_0005:  ldc.i4.1
+              IL_0006:  newobj     "decimal..ctor(int, int, int, bool, byte)"
+              IL_000b:  stloc.0
+              IL_000c:  ldloca.s   V_0
+              IL_000e:  call       "void C.M1(ref readonly decimal)"
+              IL_0013:  ret
+            }
+            """);
+        verifier.VerifyIL("C.M4", """
+            {
+              // Code size       20 (0x14)
+              .maxstack  5
+              .locals init (decimal V_0)
+              IL_0000:  ldc.i4.s   11
+              IL_0002:  ldc.i4.0
+              IL_0003:  ldc.i4.0
+              IL_0004:  ldc.i4.0
+              IL_0005:  ldc.i4.1
+              IL_0006:  newobj     "decimal..ctor(int, int, int, bool, byte)"
+              IL_000b:  stloc.0
+              IL_000c:  ldloca.s   V_0
+              IL_000e:  call       "void C.M2(ref readonly decimal)"
+              IL_0013:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void DefaultParameterValue_DecimalConstant_Invalid()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M1([DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d) => throw null;
+                static void M2([Optional, DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d = 1.1m) => throw null;
+                static void Main()
+                {
+                    M1();
+                    M2();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (6,21): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+            //     static void M2([Optional, DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d = 1.1m) => throw null;
+            Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "Optional").WithLocation(6, 21),
+            // (6,92): warning CS9521: A default value is specified for 'ref readonly' parameter 'd', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M2([Optional, DecimalConstant(1, 0, 0u, 0u, 11u)] ref readonly decimal d = 1.1m) => throw null;
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "1.1m").WithArguments("d").WithLocation(6, 92),
+            // (9,9): error CS7036: There is no argument given that corresponds to the required parameter 'd' of 'C.M1(ref readonly decimal)'
+            //         M1();
+            Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M1").WithArguments("d", "C.M1(ref readonly decimal)").WithLocation(9, 9));
+    }
+
+    [Fact]
+    public void DefaultParameterValue_DateTimeConstant_Valid()
+    {
+        var source = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            class C
+            {
+                static void M([Optional, DateTimeConstant(100L)] ref readonly DateTime d) => Console.Write(d.Ticks);
+                static void Main() => M();
+            }
+            """;
+        var verifier = CompileAndVerify(source, expectedOutput: "100").VerifyDiagnostics(
+            // (6,30): warning CS9521: A default value is specified for 'ref readonly' parameter 'd', but 'ref readonly' should be used only for references. Consider declaring the parameter as 'in'.
+            //     static void M([Optional, DateTimeConstant(100L)] ref readonly DateTime d) => Console.Write(d.Ticks);
+            Diagnostic(ErrorCode.WRN_RefReadonlyParameterDefaultValue, "DateTimeConstant(100L)").WithArguments("d").WithLocation(6, 30));
+        verifier.VerifyIL("C.Main", """
+            {
+              // Code size       17 (0x11)
+              .maxstack  1
+              .locals init (System.DateTime V_0)
+              IL_0000:  ldc.i4.s   100
+              IL_0002:  conv.i8
+              IL_0003:  newobj     "System.DateTime..ctor(long)"
+              IL_0008:  stloc.0
+              IL_0009:  ldloca.s   V_0
+              IL_000b:  call       "void C.M(ref readonly System.DateTime)"
+              IL_0010:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void DefaultParameterValue_DateTimeConstant_Invalid()
+    {
+        var source = """
+            using System;
+            using System.Runtime.CompilerServices;
+            class C
+            {
+                static void M([DateTimeConstant(100L)] ref readonly DateTime d) => throw null;
+                static void Main()
+                {
+                    M();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,9): error CS7036: There is no argument given that corresponds to the required parameter 'd' of 'C.M(ref readonly DateTime)'
+            //         M();
+            Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("d", "C.M(ref readonly System.DateTime)").WithLocation(8, 9));
+    }
+
+    [Fact]
     public void Invocation_VirtualMethod()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -312,6 +312,7 @@ class X
                         case ErrorCode.WRN_ArgExpectedRefOrIn:
                         case ErrorCode.WRN_RefReadonlyNotVariable:
                         case ErrorCode.WRN_ArgExpectedIn:
+                        case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:


### PR DESCRIPTION
Speclet: https://github.com/dotnet/csharplang/blob/05ed9dcfba84a038e02301a9b267516edfe14159/proposals/ref-readonly-parameters.md#default-parameter-values
Test plan: https://github.com/dotnet/roslyn/issues/68056