### PR TITLE
Only produce string-subspans for spell checking when they contain an escape character

### DIFF
--- a/src/EditorFeatures/CSharpTest/SpellCheck/SpellCheckSpanTests.cs
+++ b/src/EditorFeatures/CSharpTest/SpellCheck/SpellCheckSpanTests.cs
@@ -101,7 +101,7 @@ class {|Identifier:C|}
         [Fact]
         public async Task TestString1()
         {
-            await TestAsync(@""" {|String:goo|} """);
+            await TestAsync(@"{|String:"" goo ""|}");
         }
 
         [Fact]
@@ -114,7 +114,7 @@ class {|Identifier:C|}
         public async Task TestString3()
         {
             await TestAsync(@"
-"" {|String:goo|} """);
+{|String:"" goo ""|}");
         }
 
         [Fact]
@@ -128,7 +128,7 @@ class {|Identifier:C|}
         public async Task TestString5()
         {
             await TestAsync(@"
-@"" {|String:goo|} """);
+{|String:@"" goo ""|}");
         }
 
         [Fact]
@@ -141,7 +141,7 @@ class {|Identifier:C|}
         [Fact]
         public async Task TestString7()
         {
-            await TestAsync(@""""""" {|String:goo|} """"""");
+            await TestAsync(@"{|String:"""""" goo """"""|}");
         }
 
         [Fact]
@@ -165,9 +165,9 @@ class {|Identifier:C|}
         [Fact]
         public async Task TestString11()
         {
-            await TestAsync(@"""""""
-    {|String:goo|} 
-    """"""");
+            await TestAsync(@"{|String:""""""
+    goo 
+    """"""|}");
         }
 
         [Fact]
@@ -198,28 +198,28 @@ class {|Identifier:C|}
         public async Task TestString15()
         {
             await TestAsync(@"
-$"" {|String:goo|} """);
+$""{|String: goo |}""");
         }
 
         [Fact]
         public async Task TestString16()
         {
             await TestAsync(@"
-$"" {|String:goo|} {0} {|String:bar|} """);
+$""{|String: goo |}{0}{|String: bar |}""");
         }
 
         [Fact]
         public async Task TestString17()
         {
             await TestAsync(@"
-$"""""" {|String:goo|} {0} {|String:bar|} """"""");
+$""""""{|String: goo |}{0}{|String: bar |}""""""");
         }
 
         [Fact]
         public async Task TestString18()
         {
             await TestAsync(@"
-$"""""" {|String:goo|} {0:abcd} {|String:bar|} """"""");
+$""""""{|String: goo |}{0:abcd}{|String: bar |}""""""");
         }
 
         [Fact]
@@ -249,7 +249,7 @@ $"""""" {|String:goo|} {0:abcd} {|String:bar|} """"""");
         [Fact]
         public async Task TestEscapedString5()
         {
-            await TestAsync(""" @" {|String:C|}:\{|String:tests|} " """);
+            await TestAsync(""" {|String:@" C:\tests "|} """);
         }
 
         [Fact]
@@ -267,7 +267,19 @@ $"""""" {|String:goo|} {0:abcd} {|String:bar|} """"""");
         [Fact]
         public async Task TestEscapedString8()
         {
-            await TestAsync(""" @" {|String:C|}:\{|String:tests|}\{|String:goo|} " """);
+            await TestAsync(""" {|String:@" C:\tests\goo "|} """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString9()
+        {
+            await TestAsync(""" $" {|String:C|}:\\{|String:tests|}\\{|String:goo|} {0} {|String:C|}:\\{|String:tests|}\\{|String:bar|} " """);
+        }
+
+        [Fact]
+        public async Task TestEscapedString10()
+        {
+            await TestAsync(""" $@"{|String: C:\tests\goo |}{0}{|String: C:\tests\bar |}" """);
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/SpellCheck/CSharpSpellCheckSpanService.cs
+++ b/src/Features/CSharp/Portable/SpellCheck/CSharpSpellCheckSpanService.cs
@@ -7,15 +7,11 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.SpellCheck;
 
-namespace Microsoft.CodeAnalysis.CSharp.SpellCheck
+namespace Microsoft.CodeAnalysis.CSharp.SpellCheck;
+
+[ExportLanguageService(typeof(ISpellCheckSpanService), LanguageNames.CSharp), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class CSharpSpellCheckSpanService() : AbstractSpellCheckSpanService('\\')
 {
-    [ExportLanguageService(typeof(ISpellCheckSpanService), LanguageNames.CSharp), Shared]
-    internal class CSharpSpellCheckSpanService : AbstractSpellCheckSpanService
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpSpellCheckSpanService()
-        {
-        }
-    }
 }

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
@@ -125,6 +125,9 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 // First, see if there's actually the presence of an escape character in the string token.  If not, we
                 // can just provide the entire string as-is to the caller to spell check since there's no escapes for
                 // them to be confused by.
+                //
+                // Note: .Text on a string token is non-allocating.  It is captured at the time of token creation and
+                // held by the token.
                 var escapeChar = _spellCheckSpanService._escapeCharacter;
                 if (canContainEscapes &&
                     escapeChar != null &&

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
 
                 if (_syntaxFacts.IsStringLiteral(token))
                 {
-                    AddStringSpans(token, canContainEscapes: !syntaxFacts.IsVerbatimStringLiteral(token));
+                    AddStringSpans(token, canContainEscapes: !_syntaxFacts.IsVerbatimStringLiteral(token));
                 }
                 else if (
                     token.RawKind == _syntaxKinds.SingleLineRawStringLiteralToken ||
@@ -103,7 +104,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 else if (token.RawKind == _syntaxKinds.InterpolatedStringTextToken &&
                          token.Parent?.RawKind == _syntaxKinds.InterpolatedStringText)
                 {
-                    AddStringSpans(token, canContainEscapes: !syntaxFacts.IsVerbatimInterpolatedStringExpression(token.Parent.Parent));
+                    AddStringSpans(token, canContainEscapes: !_syntaxFacts.IsVerbatimInterpolatedStringExpression(token.Parent.Parent));
                 }
                 else if (token.RawKind == _syntaxKinds.IdentifierToken)
                 {

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,35 +16,42 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.SpellCheck
 {
-    internal abstract class AbstractSpellCheckSpanService : ISpellCheckSpanService
+    internal abstract class AbstractSpellCheckSpanService(char? escapeCharacter) : ISpellCheckSpanService
     {
+        private readonly char? _escapeCharacter = escapeCharacter;
+#if NETSTANDARD2_0
+        private readonly string? _escapeString = escapeCharacter?.ToString();
+#endif
+
         public async Task<ImmutableArray<SpellCheckSpan>> GetSpansAsync(Document document, CancellationToken cancellationToken)
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            return GetSpans();
 
-            return GetSpans(document, root, cancellationToken);
-        }
+            // Broken into its own method as it uses a ref-struct, which isn't allowed with the async call above.
+            ImmutableArray<SpellCheckSpan> GetSpans()
+            {
+                var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+                var classifier = document.GetRequiredLanguageService<ISyntaxClassificationService>();
+                var virtualCharService = document.GetRequiredLanguageService<IVirtualCharLanguageService>();
 
-        private static ImmutableArray<SpellCheckSpan> GetSpans(Document document, SyntaxNode root, CancellationToken cancellationToken)
-        {
-            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-            var classifier = document.GetRequiredLanguageService<ISyntaxClassificationService>();
-            var virtualCharService = document.GetRequiredLanguageService<IVirtualCharLanguageService>();
+                using var _ = ArrayBuilder<SpellCheckSpan>.GetInstance(out var spans);
 
-            using var _ = ArrayBuilder<SpellCheckSpan>.GetInstance(out var spans);
+                var worker = new Worker(this, syntaxFacts, classifier, virtualCharService, spans);
+                worker.Recurse(root, cancellationToken);
 
-            var worker = new Worker(syntaxFacts, classifier, virtualCharService, spans);
-            worker.Recurse(root, cancellationToken);
-
-            return spans.ToImmutable();
+                return spans.ToImmutable();
+            }
         }
 
         private readonly ref struct Worker(
+            AbstractSpellCheckSpanService spellCheckSpanService,
             ISyntaxFactsService syntaxFacts,
             ISyntaxClassificationService classifier,
             IVirtualCharLanguageService virtualCharService,
             ArrayBuilder<SpellCheckSpan> spans)
         {
+            private readonly AbstractSpellCheckSpanService _spellCheckSpanService = spellCheckSpanService;
             private readonly ISyntaxFactsService _syntaxFacts = syntaxFacts;
             private readonly ISyntaxKinds _syntaxKinds = syntaxFacts.SyntaxKinds;
             private readonly ISyntaxClassificationService _classifier = classifier;
@@ -89,12 +97,12 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                     token.RawKind == _syntaxKinds.SingleLineRawStringLiteralToken ||
                     token.RawKind == _syntaxKinds.MultiLineRawStringLiteralToken)
                 {
-                    AddStringSubSpans(token);
+                    AddStringSpans(token);
                 }
                 else if (token.RawKind == _syntaxKinds.InterpolatedStringTextToken &&
                          token.Parent?.RawKind == _syntaxKinds.InterpolatedStringText)
                 {
-                    AddStringSubSpans(token);
+                    AddStringSpans(token);
                 }
                 else if (token.RawKind == _syntaxKinds.IdentifierToken)
                 {
@@ -102,6 +110,39 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 }
 
                 ProcessTriviaList(token.TrailingTrivia, cancellationToken);
+            }
+
+            private void AddStringSpans(SyntaxToken token)
+            {
+                // Don't bother with strings that are in error.  This is both because we can't properly break them into
+                // pieces, and also because a string in error often may be grabbing more of the file than intended, and
+                // we don't want to start spell checking normal code that is caught up in the middle of being edited.
+                if (token.ContainsDiagnostics)
+                    return;
+
+                // First, see if there's actually the presence of an escape character in the string token.  If not, we
+                // can just provide the entire string as-is to the caller to spell check since there's no escapes for
+                // them to be confused by.
+                var escapeChar = _spellCheckSpanService._escapeCharacter;
+                if (escapeChar != null &&
+#if NETSTANDARD2_0
+                    token.Text.Contains(_spellCheckSpanService._escapeString!)
+#else
+                    token.Text.Contains(escapeChar.Value)
+#endif
+                    )
+                {
+#if NETSTANDARD2_0
+                    ReadOnlySpan<char> c = default;
+                    c.Contains('c');
+#else
+                    AddStringSubSpans(token);
+                }
+                else
+                {
+                    // Just add the full string span as is and let the client handle it.
+                    AddSpan(new SpellCheckSpan(token.Span, SpellCheckKind.String));
+                }
             }
 
             private void AddStringSubSpans(SyntaxToken token)

--- a/src/Features/Core/Portable/SpellCheck/ISpellCheckingSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/ISpellCheckingSpanService.cs
@@ -2,15 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.SpellCheck
 {

--- a/src/Features/VisualBasic/Portable/SpellCheck/VisualBasicSpellCheckSpanService.vb
+++ b/src/Features/VisualBasic/Portable/SpellCheck/VisualBasicSpellCheckSpanService.vb
@@ -5,8 +5,6 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.SpellCheck
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Classification
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.SpellCheck
     <ExportLanguageService(GetType(ISpellCheckSpanService), LanguageNames.VisualBasic), [Shared]>
@@ -16,6 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SpellCheck
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
+            MyBase.New(escapeCharacter:=Nothing)
         End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasicTest/SpellCheck/SpellCheckSpanTests.vb
+++ b/src/Features/VisualBasicTest/SpellCheck/SpellCheckSpanTests.vb
@@ -53,7 +53,7 @@ end class")
         <Fact>
         Public Async Function TestString1() As Task
             Await TestAsync("
-dim {|Identifier:x|} = "" {|String:goo|} """)
+dim {|Identifier:x|} = {|String:"" goo ""|}")
         End Function
 
         <Fact>
@@ -65,9 +65,9 @@ dim {|Identifier:x|} = "" goo ")
         <Fact>
         Public Async Function TestString3() As Task
             Await TestAsync("
-dim {|Identifier:x|} = ""
-    {|String:goo|}
-""")
+dim {|Identifier:x|} = {|String:""
+    goo
+""|}")
         End Function
 
         <Fact>
@@ -81,21 +81,21 @@ dim {|Identifier:x|} = ""
         <Fact>
         Public Async Function TestString5() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $"" {|String:goo|} """)
+dim {|Identifier:x|} = $""{|String: goo |}""")
         End Function
 
         <Fact>
         Public Async Function TestString6() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $""
-    {|String:goo|}
-""")
+dim {|Identifier:x|} = $""{|String:
+    goo
+|}""")
         End Function
 
         <Fact>
         Public Async Function TestString7() As Task
             Await TestAsync("
-dim {|Identifier:x|} = $"" {|String:goo|} {0} {|String:bar|} """)
+dim {|Identifier:x|} = $""{|String: goo |}{0}{|String: bar |}""")
         End Function
 
         <Fact>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1514,9 +1514,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
         public SyntaxNode GetTypeOfTypePattern(SyntaxNode node)
             => ((TypePatternSyntax)node).Type;
 
-        public bool IsVerbatimInterpolatedStringExpression(SyntaxNode node)
-            => node is InterpolatedStringExpressionSyntax interpolatedString &&
-                interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken);
+        public bool IsVerbatimInterpolatedStringExpression([NotNullWhen(true)] SyntaxNode? node)
+            => node is InterpolatedStringExpressionSyntax { StringStartToken: (kind: SyntaxKind.InterpolatedVerbatimStringStartToken) } interpolatedString;
 
         public bool IsInInactiveRegion(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         void GetPartsOfTupleExpression<TArgumentSyntax>(SyntaxNode node,
             out SyntaxToken openParen, out SeparatedSyntaxList<TArgumentSyntax> arguments, out SyntaxToken closeParen) where TArgumentSyntax : SyntaxNode;
 
-        bool IsVerbatimInterpolatedStringExpression(SyntaxNode node);
+        bool IsVerbatimInterpolatedStringExpression([NotNullWhen(true)] SyntaxNode? node);
 
         // Left side of = assignment.
         bool IsLeftSideOfAssignment([NotNullWhen(true)] SyntaxNode? node);


### PR DESCRIPTION
Fixes [AB#1851060](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1851060).

A prior change went in where we would break strings up into subspans to help the spell checking client out.  This was because the client doesn't know things like if `\t` should be considered a normal slash-followed-by-t (like in a verbatim string) or a tab (like in a normal string.  

However, the prior change made us to this for all strings, which was massive overkill given that most strings don't even contain escaped characters in the first place.  The new change has only do this for:

1. strings that can even have escaped letter characters in the first place (verbatim and raw strings cannot)
2. strings that actually have an escape char (`\`) in them

If either of the above do not hold, we just return the entire span of the string (like we did before) and allow the spell checking client to manage it.  It will break these strings up correctly already, giving good spell checking results.