### PR TITLE
Reduce `TypeConversions` allocations by caching them in AssemblySymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)corLibrary != null);
             Debug.Assert(otherNullabilityOpt == null || includeNullability != otherNullabilityOpt.IncludeNullability);
             Debug.Assert(otherNullabilityOpt == null || currentRecursionDepth == otherNullabilityOpt.currentRecursionDepth);
+            Debug.Assert(corLibrary == corLibrary.CorLibrary);
 
             this.corLibrary = corLibrary;
             this.currentRecursionDepth = currentRecursionDepth;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.UsingsFromOptionsAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.UsingsFromOptionsAndDiagnostics.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(diagnostics.DependenciesBag is object);
 
                 var corLibrary = compilation.SourceAssembly.CorLibrary;
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 foreach (var @using in UsingNamespacesOrTypes)
                 {
                     diagnostics.Clear();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 idisposableTypeSymbol = disposeMethod.ContainingType;
                 Debug.Assert(_factory.CurrentFunction is { });
-                var conversions = new TypeConversions(_factory.CurrentFunction.ContainingAssembly.CorLibrary);
+                var conversions = _factory.CurrentFunction.ContainingAssembly.CorLibrary.TypeConversions;
 
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
                 isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteInfo).IsImplicit;

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((object?)target != null && Locations.Length > 0)
             {
                 var corLibrary = this.ContainingAssembly.CorLibrary;
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 target.CheckAllConstraints(DeclaringCompilation, conversions, GetFirstLocation(), diagnostics);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.PortableExecutable;
-using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private AssemblySymbol _corLibrary;
 
-        private TypeConversions _lazyTypeConversions;
-
         /// <summary>
         /// The system assembly, which provides primitive types like Object, String, etc., e.g. mscorlib.dll. 
         /// The value is MissingAssemblySymbol if none of the referenced assemblies can be used as a source for the 
@@ -56,23 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal TypeConversions TypeConversions
-        {
-            get
-            {
-                if (this != _corLibrary)
-                {
-                    return _corLibrary.TypeConversions;
-                }
-
-                if (_lazyTypeConversions is null)
-                {
-                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
-                }
-
-                return _lazyTypeConversions;
-            }
-        }
+        internal abstract TypeConversions TypeConversions { get; }
 
         /// <summary>
         /// A helper method for ReferenceManager to set the system assembly, which provides primitive 

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.PortableExecutable;
+using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
@@ -39,6 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private AssemblySymbol _corLibrary;
 
+        private TypeConversions _lazyTypeConversions;
+
         /// <summary>
         /// The system assembly, which provides primitive types like Object, String, etc., e.g. mscorlib.dll. 
         /// The value is MissingAssemblySymbol if none of the referenced assemblies can be used as a source for the 
@@ -50,6 +53,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return _corLibrary;
+            }
+        }
+
+        internal TypeConversions TypeConversions
+        {
+            get
+            {
+                if (_lazyTypeConversions is null)
+                {
+                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
+                }
+
+                return _lazyTypeConversions;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (this != _corLibrary)
+                {
+                    return _corLibrary.TypeConversions;
+                }
+
                 if (_lazyTypeConversions is null)
                 {
                     Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var constraintTypesBuilder = ArrayBuilder<TypeWithAnnotations>.GetInstance();
                 var interfacesBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(template);
 
                 // Resolve base types, determine the effective base class and

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
                     bool isCallerLineNumber = HasCallerLineNumberAttribute
-                        && new TypeConversions(ContainingAssembly).HasCallerLineNumberConversion(this.Type, ref discardedUseSiteInfo);
+                        && ContainingAssembly.TypeConversions.HasCallerLineNumberConversion(this.Type, ref discardedUseSiteInfo);
 
                     value = _packedFlags.SetWellKnownAttribute(flag, isCallerLineNumber);
                 }
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
                     bool isCallerFilePath = !HasCallerLineNumberAttribute
                         && HasCallerFilePathAttribute
-                        && new TypeConversions(ContainingAssembly).HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
+                        && ContainingAssembly.TypeConversions.HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
 
                     value = _packedFlags.SetWellKnownAttribute(flag, isCallerFilePath);
                 }
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     bool isCallerMemberName = !HasCallerLineNumberAttribute
                         && !HasCallerFilePathAttribute
                         && HasCallerMemberNameAttribute
-                        && new TypeConversions(ContainingAssembly).HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
+                        && ContainingAssembly.TypeConversions.HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
 
                     value = _packedFlags.SetWellKnownAttribute(flag, isCallerMemberName);
                 }
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     && !HasCallerLineNumberAttribute
                     && !HasCallerFilePathAttribute
                     && !HasCallerMemberNameAttribute
-                    && new TypeConversions(ContainingAssembly).HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
+                    && ContainingAssembly.TypeConversions.HasCallerInfoStringConversion(this.Type, ref discardedUseSiteInfo);
 
                 if (isCallerArgumentExpression)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -26,6 +26,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private NamedTypeSymbol[] _lazySpecialTypes;
 
+        private TypeConversions _lazyTypeConversions;
+
         /// <summary>
         /// How many Cor types have we cached so far.
         /// </summary>
@@ -270,6 +272,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_assembliesToWhichInternalAccessHasBeenAnalyzed == null)
                     Interlocked.CompareExchange(ref _assembliesToWhichInternalAccessHasBeenAnalyzed, new ConcurrentDictionary<AssemblySymbol, IVTConclusion>(), null);
                 return _assembliesToWhichInternalAccessHasBeenAnalyzed;
+            }
+        }
+
+        internal override TypeConversions TypeConversions
+        {
+            get
+            {
+                if (this != CorLibrary)
+                {
+                    return CorLibrary.TypeConversions;
+                }
+
+                if (_lazyTypeConversions is null)
+                {
+                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
+                }
+
+                return _lazyTypeConversions;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override TypeConversions TypeConversions
+        internal sealed override TypeConversions TypeConversions
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override TypeConversions TypeConversions => throw ExceptionUtilities.Unreachable();
+        internal override TypeConversions TypeConversions => CorLibrary.TypeConversions;
 
         public override AssemblyMetadata GetMetadata() => null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -203,6 +203,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override TypeConversions TypeConversions => throw ExceptionUtilities.Unreachable();
+
         public override AssemblyMetadata GetMetadata() => null;
 
         internal sealed override IEnumerable<NamedTypeSymbol> GetAllTopLevelForwardedTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
@@ -22,12 +22,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal static readonly MissingCorLibrarySymbol Instance = new MissingCorLibrarySymbol();
 
+        internal override TypeConversions TypeConversions
+        {
+            get
+            {
+                Debug.Assert(this == CorLibrary);
+
+                if (_lazyTypeConversions is null)
+                {
+                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
+                }
+
+                return _lazyTypeConversions;
+            }
+        }
+
         /// <summary>
         /// An array of cached Cor types defined in this assembly.
         /// Lazily filled by GetDeclaredSpecialType method.
         /// </summary>
         /// <remarks></remarks>
         private NamedTypeSymbol[] _lazySpecialTypes;
+
+        private TypeConversions _lazyTypeConversions;
 
         private MissingCorLibrarySymbol()
             : base(new AssemblyIdentity("<Missing Core Assembly>"))

--- a/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
@@ -22,21 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal static readonly MissingCorLibrarySymbol Instance = new MissingCorLibrarySymbol();
 
-        internal override TypeConversions TypeConversions
-        {
-            get
-            {
-                Debug.Assert(this == CorLibrary);
-
-                if (_lazyTypeConversions is null)
-                {
-                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
-                }
-
-                return _lazyTypeConversions;
-            }
-        }
-
         /// <summary>
         /// An array of cached Cor types defined in this assembly.
         /// Lazily filled by GetDeclaredSpecialType method.
@@ -50,6 +35,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             : base(new AssemblyIdentity("<Missing Core Assembly>"))
         {
             this.SetCorLibrary(this);
+        }
+
+        internal override TypeConversions TypeConversions
+        {
+            get
+            {
+                Debug.Assert(this == CorLibrary);
+
+                if (_lazyTypeConversions is null)
+                {
+                    Interlocked.CompareExchange(ref _lazyTypeConversions, new TypeConversions(this), null);
+                }
+
+                return _lazyTypeConversions;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            var conversions = new TypeConversions(method.ContainingAssembly.CorLibrary);
+            var conversions = method.ContainingAssembly.CorLibrary.TypeConversions;
             var conversion = conversions.ConvertExtensionMethodThisArg(method.Parameters[0].Type, receiverType, ref useSiteInfo);
             if (!conversion.Exists)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var containingAssembly = method.ContainingAssembly;
             var errorNamespace = containingAssembly.GlobalNamespace;
-            var conversions = new TypeConversions(containingAssembly.CorLibrary);
+            var conversions = containingAssembly.CorLibrary.TypeConversions;
 
             // There is absolutely no plausible syntax/tree that we could use for these
             // synthesized literals.  We could be speculatively binding a call to a PE method.

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get { return null; }
         }
 
-        internal override TypeConversions TypeConversions => throw ExceptionUtilities.Unreachable();
+        internal override TypeConversions TypeConversions => CorLibrary.TypeConversions;
 
         internal override bool GetGuidString(out string guidString)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -278,6 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             get { return null; }
         }
 
+        internal override TypeConversions TypeConversions => throw ExceptionUtilities.Unreachable();
+
         internal override bool GetGuidString(out string guidString)
         {
             return _underlyingAssembly.GetGuidString(out guidString);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2225,7 +2225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void CheckSpecialMemberErrors(BindingDiagnosticBag diagnostics)
         {
-            var conversions = new TypeConversions(this.ContainingAssembly.CorLibrary);
+            var conversions = this.ContainingAssembly.CorLibrary.TypeConversions;
             foreach (var member in this.GetMembersUnordered())
             {
                 member.AfterAddingTypeMembersChecks(conversions, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (singleDeclaration != null)
             {
                 var corLibrary = this.ContainingAssembly.CorLibrary;
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 var location = singleDeclaration.NameLocation;
 
                 localBase.CheckAllConstraints(DeclaringCompilation, conversions, location, diagnostics);
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (singleDeclaration != null)
             {
                 var corLibrary = this.ContainingAssembly.CorLibrary;
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 var location = singleDeclaration.NameLocation;
 
                 foreach (var pair in interfaces)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.AliasesAndUsings.cs
@@ -997,7 +997,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var corLibrary = compilation.SourceAssembly.CorLibrary;
-                var conversions = new TypeConversions(corLibrary);
+                var conversions = corLibrary.TypeConversions;
                 foreach (var @using in usingsAndDiagnostics.UsingNamespacesOrTypes)
                 {
                     if (@using.UsingDirectiveReference!.SyntaxTree != declarationSyntax.SyntaxTree)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -1460,7 +1460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 if (parameters.Length > 0)
                                 {
                                     var diagnostics = BindingDiagnosticBag.GetInstance();
-                                    var conversions = new TypeConversions(this.ContainingAssembly.CorLibrary);
+                                    var conversions = this.ContainingAssembly.CorLibrary.TypeConversions;
                                     foreach (var parameter in this.Parameters)
                                     {
                                         parameter.ForceComplete(locationOpt, cancellationToken);
@@ -1489,7 +1489,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (_state.NotePartComplete(CompletionPart.StartPropertyType))
                             {
                                 var diagnostics = BindingDiagnosticBag.GetInstance();
-                                var conversions = new TypeConversions(this.ContainingAssembly.CorLibrary);
+                                var conversions = this.ContainingAssembly.CorLibrary.TypeConversions;
                                 this.Type.CheckAllConstraints(DeclaringCompilation, conversions, Location, diagnostics);
 
                                 ValidatePropertyType(diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var args = ConstraintsHelper.CheckConstraintsArgsBoxed.Allocate(
-                DeclaringCompilation, new TypeConversions(ContainingAssembly.CorLibrary), _locations[0], diagnostics);
+                DeclaringCompilation, ContainingAssembly.CorLibrary.TypeConversions, _locations[0], diagnostics);
             foreach (var constraintType in constraintTypes)
             {
                 if (!diagnostics.ReportUseSite(constraintType.Type, args.Args.Location))

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
@@ -35,6 +35,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             get { throw new NotImplementedException(); }
         }
 
+        internal override TypeConversions TypeConversions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public override ImmutableArray<ModuleSymbol> Modules
         {
             get { return ImmutableArray.Create<ModuleSymbol>(); }


### PR DESCRIPTION
Reduce `TypeConversions` allocations by caching this to the AssemblySymbol. Fixes https://github.com/dotnet/roslyn/issues/68997
