### PR TITLE
Detect rude edits in trivia-only changes

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             var md = ModuleMetadata.CreateFromImage(verifier.EmittedAssemblyData);
             _disposables.Add(md);
 
-            var baseline = EmitBaseline.CreateInitialBaseline(md, EditAndContinueTestBase.EmptyLocalsProvider);
+            var baseline = EmitBaseline.CreateInitialBaseline(md, verifier.CreateSymReader().GetEncMethodDebugInfo);
 
             _generations.Add(new GenerationInfo(compilation, md.MetadataReader, diff: null, verifier, baseline, validator));
             _sources.Add(source);

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             TargetFramework targetFramework = TargetFramework.Standard,
             Verification? verification = null)
         {
-            _options = options ?? TestOptions.DebugDll;
+            _options = options ?? EditAndContinueTestBase.ComSafeDebugDll;
             _targetFramework = targetFramework;
             _parseOptions = parseOptions ?? TestOptions.Regular.WithNoRefSafetyRulesAttribute();
             _verification = verification ?? Verification.Passes;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
     public abstract class EditAndContinueTestBase : EmitMetadataTestBase
     {
         // PDB reader can only be accessed from a single thread, so avoid concurrent compilation:
-        protected readonly CSharpCompilationOptions ComSafeDebugDll = TestOptions.DebugDll.WithConcurrentBuild(false);
+        internal static readonly CSharpCompilationOptions ComSafeDebugDll = TestOptions.DebugDll.WithConcurrentBuild(false);
 
         internal static readonly Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> EmptyLocalsProvider = handle => default(EditAndContinueMethodDebugInformation);
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -16764,7 +16764,7 @@ file class C
         [Fact]
         public void StackAlloc()
         {
-            using var _ = new EditAndContinueTest(targetFramework: TargetFramework.Net80, verification: Verification.Fails)
+            using var _ = new EditAndContinueTest(targetFramework: TargetFramework.NetCoreApp, verification: Verification.Fails)
                 .AddBaseline(
                     source: MarkedSource($$"""
                         using System;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -16764,7 +16764,7 @@ file class C
         [Fact]
         public void StackAlloc()
         {
-            using var _ = new EditAndContinueTest(targetFramework: TargetFramework.NetLatest, verification: Verification.Fails)
+            using var _ = new EditAndContinueTest(targetFramework: TargetFramework.Net80, verification: Verification.Fails)
                 .AddBaseline(
                     source: MarkedSource($$"""
                         using System;

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
@@ -654,7 +654,7 @@ class C
     }
 }";
 
-            // TODO: https://github.com/dotnet/roslyn/issues/69027
+            // TODO: https://github.com/dotnet/roslyn/issues/67307
             // When we allow updating non-active bodies with stack alloc we will need to pass active statements to VerifyLineEdits
             var edits = GetTopEdits(src1, src2);
             edits.VerifyLineEdits(

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
@@ -156,34 +156,6 @@ class Program
         }
 
         [Fact]
-        public void Method_Update()
-        {
-            var src1 = @"
-class C
-{
-    static void Bar()
-    {
-        Console.ReadLine(1);
-    }
-}
-";
-            var src2 = @"
-class C
-{
-    static void Bar()
-    {
-
-
-        Console.ReadLine(2);
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                Array.Empty<SequencePointUpdates>(),
-                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar")) });
-        }
-
-        [Fact]
         public void Method_MultilineBreakpointSpans()
         {
             var src1 = @"
@@ -215,7 +187,7 @@ class C
         }
 
         [Fact]
-        public void Method_LineChange1()
+        public void Method_BlockBody_EntireBody1()
         {
             var src1 = @"
 class C
@@ -242,7 +214,7 @@ class C
         }
 
         [Fact]
-        public void Method_LineChange2()
+        public void Method_BlockBody_EntireBody2()
         {
             var src1 = @"
 class C
@@ -268,7 +240,7 @@ class C
         }
 
         [Fact]
-        public void Method_LineChange3()
+        public void Method_BlockBody1()
         {
             var src1 = @"
 class C
@@ -294,60 +266,7 @@ class C
         }
 
         [Fact]
-        public void Method_LineChange4()
-        {
-            var src1 = @"
-class C
-{
-    static int X() => 1;
-
-    static int Y() => 1;
-}
-";
-            var src2 = @"
-class C
-{
-
-    static int X() => 1;
-    static int Y() => 1;
-}";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                new[]
-                {
-                    new SourceLineUpdate(3, 4),
-                    new SourceLineUpdate(4, 4)
-                });
-        }
-
-        [Fact]
-        public void Method_Recompile1()
-        {
-            var src1 = @"
-class C
-{
-    static void Bar()
-    {
-        Console.ReadLine(2);
-    }
-}
-";
-            var src2 = @"
-class C
-{
-    static void Bar()
-    {
-        /**/Console.ReadLine(2);
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                Array.Empty<SequencePointUpdates>(),
-                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar")) });
-        }
-
-        [Fact]
-        public void Method_PartialBodyLineUpdate1()
+        public void Method_BlockBody2()
         {
             var src1 = @"
 class C
@@ -373,7 +292,7 @@ class C
         }
 
         [Fact]
-        public void Method_PartialBodyLineUpdate2()
+        public void Method_BlockBody3()
         {
             var src1 = @"
 class C
@@ -400,7 +319,133 @@ class C
         }
 
         [Fact]
-        public void Method_Recompile4()
+        public void Method_BlockBody4()
+        {
+            var src1 = @"
+class C
+{
+    static void Bar()
+    {
+        Console.ReadLine(2);
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static void Bar()
+    {
+        Console.ReadLine(2);
+
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(6, 7) });
+        }
+
+        [Fact]
+        public void Method_BlockBody5()
+        {
+            var src1 = @"
+class C
+{
+    static void Bar()
+    {
+        if (F())
+        {
+            Console.ReadLine(2);
+        }
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static void Bar()
+    {
+        if (F())
+        {
+            Console.ReadLine(2);
+
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(8, 9) });
+        }
+
+        [Fact]
+        public void Method_BlockBody_Recompile()
+        {
+            var src1 = @"
+class C { static void Bar() { } }
+";
+            var src2 = @"
+class C { /*--*/static void Bar() { } }";
+
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar")) });
+        }
+
+        [Fact]
+        public void Method_ExpressionBody_EntireBody()
+        {
+            var src1 = @"
+class C
+{
+    static int X() => 1;
+
+    static int Y() => 1;
+}
+";
+            var src2 = @"
+class C
+{
+
+    static int X() => 1;
+    static int Y() => 1;
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[]
+                {
+                    new SourceLineUpdate(3, 4),
+                    new SourceLineUpdate(4, 4)
+                });
+        }
+
+        [Fact]
+        public void Method_Statement_Recompile1()
+        {
+            var src1 = @"
+class C
+{
+    static void Bar()
+    {
+        Console.ReadLine(2);
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static void Bar()
+    {
+        /**/Console.ReadLine(2);
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar")) });
+        }
+
+        [Fact]
+        public void Method_Statement_Recompile2()
         {
             var src1 = @"
 class C
@@ -437,22 +482,7 @@ class C
         }
 
         [Fact]
-        public void Method_Recompile5()
-        {
-            var src1 = @"
-class C { static void Bar() { } }
-";
-            var src2 = @"
-class C { /*--*/static void Bar() { } }";
-
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                Array.Empty<SequencePointUpdates>(),
-                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar")) });
-        }
-
-        [Fact]
-        public void Method_RudeRecompile1()
+        public void Method_GenericType_LineChange()
         {
             var src1 = @"
 class C<T>
@@ -479,7 +509,7 @@ class C<T>
         }
 
         [Fact]
-        public void Method_RudeRecompile2()
+        public void Method_GenericType_Recompile()
         {
             var src1 = @"
 class C<T>
@@ -513,7 +543,7 @@ class C<T>
         }
 
         [Fact]
-        public void Method_RudeRecompile3()
+        public void Method_GenericMethod_Recompile()
         {
             var src1 = @"
 class C
@@ -546,7 +576,7 @@ class C
         }
 
         [Fact]
-        public void Method_RudeRecompile4()
+        public void Method_Async_Recompile()
         {
             var src1 = @"
 class C
@@ -572,6 +602,99 @@ class C
             edits.VerifyLineEdits(
                 Array.Empty<SequencePointUpdates>(),
                 semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Bar"), preserveLocalVariables: true) });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69027")]
+        public void Method_StackAlloc_LineChange()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        Span<bool> x = stackalloc bool[64];
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+
+        Span<bool> x = stackalloc bool[64];
+    }
+}";
+
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(5, 6) });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69027")]
+        public void Method_StackAlloc_Recompile()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    <AS:0>{</AS:0>
+        <N:0.0>Span<bool> x = stackalloc bool[64];</N:0.0>
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    void F()
+    <AS:0>{</AS:0>
+        /**/<N:0.0>Span<bool> x = stackalloc bool[64];</N:0.0>
+    }
+}";
+
+            // TODO: https://github.com/dotnet/roslyn/issues/69027
+            // When we allow updating non-active bodies with stack alloc we will need to pass active statements to VerifyLineEdits
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
+
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                active,
+                new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69027")]
+        public void Method_StackAlloc_NonActive()
+        {
+            var src1 = @"
+class C
+{
+    void F()
+    {
+        Span<bool> x = stackalloc bool[64];
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    void F()
+    {
+        /**/Span<bool> x = stackalloc bool[64];
+    }
+}";
+
+            // TODO: consider allowing change in non-active members
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
         }
 
         [Fact]
@@ -1691,49 +1814,7 @@ class C
         }
 
         [Fact]
-        public void EventAdder_LineChangeAndRecompile1()
-        {
-            var src1 = @"
-class C
-{
-    event Action E { add {
-                           } remove { } }
-}
-";
-            var src2 = @"
-class C
-{
-    event Action E { add { } remove { } }
-}";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                new[] { new SourceLineUpdate(4, 3) },
-                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<IEventSymbol>("C.E").AddMethod) });
-        }
-
-        [Fact]
-        public void EventRemover_Recompile1()
-        {
-            var src1 = @"
-class C
-{
-    event Action E { add { } remove {
-                                      } }
-}
-";
-            var src2 = @"
-class C
-{
-    event Action E { add { } remove { } }
-}";
-            var edits = GetTopEdits(src1, src2);
-            edits.VerifyLineEdits(
-                Array.Empty<SequencePointUpdates>(),
-                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<IEventSymbol>("C.E").RemoveMethod) });
-        }
-
-        [Fact]
-        public void EventAdder_LineChange1()
+        public void Event_LineChange2()
         {
             var src1 = @"
 class C
@@ -1753,7 +1834,47 @@ class C
         }
 
         [Fact]
-        public void EventRemover_LineChange1()
+        public void Event_LineChange3()
+        {
+            var src1 = @"
+class C
+{
+    event Action E { add {
+                           } remove { } }
+}
+";
+            var src2 = @"
+class C
+{
+    event Action E { add { } remove { } }
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(4, 3) });
+        }
+
+        [Fact]
+        public void Event_LineChange4()
+        {
+            var src1 = @"
+class C
+{
+    event Action E { add { } remove {
+                                      } }
+}
+";
+            var src2 = @"
+class C
+{
+    event Action E { add { } remove { } }
+}";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                new[] { new SourceLineUpdate(4, 3) });
+        }
+
+        [Fact]
+        public void Event_Recompile1()
         {
             var src1 = @"
 class C
@@ -1766,6 +1887,28 @@ class C
 {
     event Action E { add { } remove 
                                     { } }
+}";
+            // we can only apply one delta per line, but that would affect add and remove differently, so need to recompile
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyLineEdits(
+                Array.Empty<SequencePointUpdates>(),
+                semanticEdits: new[] { SemanticEdit(SemanticEditKind.Update, c => c.GetMember<IEventSymbol>("C.E").RemoveMethod) });
+        }
+
+        [Fact]
+        public void Event_Recompile2()
+        {
+            var src1 = @"
+class C
+{
+    event Action E { add { } remove { } }
+}
+";
+            var src2 = @"
+class C
+{
+    event Action E { add { } remove {
+                                      } }
 }";
             // we can only apply one delta per line, but that would affect add and remove differently, so need to recompile
             var edits = GetTopEdits(src1, src2);

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/LineEditTests.vb
@@ -410,7 +410,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub Method_RudeRecompile4()
+        Public Sub Method_Async_Recompile()
             Dim src1 = "
 Class C
     Shared Async Function Bar() As Task(Of Integer)
@@ -432,6 +432,58 @@ End Class
             edits.VerifyLineEdits(
                 Array.Empty(Of SequencePointUpdates),
                 {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember("C.Bar"), preserveLocalVariables:=True)})
+        End Sub
+
+        <Fact>
+        Public Sub Method_StaticLocal_LineChange()
+            Dim src1 = "
+Class C
+    Shared Sub F()
+        Static a = 0
+        a = 1
+    End Sub
+End Class
+"
+
+            Dim src2 = "
+Class C
+    Shared Sub F()
+
+        Static a = 0
+        a = 1
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifyLineEdits({New SourceLineUpdate(3, 4)}, {})
+        End Sub
+
+        <Fact>
+        Public Sub Method_StaticLocal_Recompile()
+            Dim src1 = "
+Class C
+    Shared Sub F()
+        Static a = 0
+        a = 1
+    End Sub
+End Class
+"
+
+            Dim src2 = "
+Class C
+    Shared Sub F()
+             Static a = 0
+        a = 1
+    End Sub
+End Class
+"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyLineEdits(
+                Array.Empty(Of SequencePointUpdates),
+                diagnostics:={Diagnostic(RudeEditKind.UpdateStaticLocal, "Static a = 0", GetResource("method"))})
         End Sub
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -5522,7 +5522,7 @@ End Interface
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.UpdateStaticLocal, "Sub Main()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.UpdateStaticLocal, "Static a = 0", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -5532,7 +5532,7 @@ End Interface
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.UpdateStaticLocal, "Sub Main()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.UpdateStaticLocal, "Static a = 0", FeaturesResources.method))
         End Sub
 
         <Fact>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal abstract void ReportTopLevelSyntacticRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, Edit<SyntaxNode> edit, Dictionary<SyntaxNode, EditKind> editMap);
         internal abstract void ReportEnclosingExceptionHandlingRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, IEnumerable<Edit<SyntaxNode>> exceptionHandlingEdits, SyntaxNode oldStatement, TextSpan newStatementSpan);
         internal abstract void ReportOtherRudeEditsAroundActiveStatement(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode oldStatement, SyntaxNode newStatement, bool isNonLeaf);
-        internal abstract void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, DeclarationBody newBody, TextSpan? span);
+        internal abstract void ReportMemberOrLambdaBodyUpdateRudeEditsImpl(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode newDeclaration, DeclarationBody newBody);
         internal abstract void ReportInsertedMemberSymbolRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newSymbol, SyntaxNode newNode, bool insertingIntoExistingContainingType);
         internal abstract void ReportStateMachineSuspensionPointRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode);
 
@@ -1902,6 +1902,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var oldTree = topMatch.OldRoot.SyntaxTree;
             var newTree = topMatch.NewRoot.SyntaxTree;
 
+            // We enumerate tokens of the body and split them into segments. Every matched member body will have at least one segment.
+            // Each segment has sequence points mapped to the same file and also all lines the segment covers map to the same line delta.
+            // The first token of a segment must be the first token that starts on the line. If the first segment token was in the middle line 
+            // the previous token on the same line would have different line delta and we wouldn't be able to map both of them at the same time.
+            // All segments are included in the segments list regardless of their line delta (even when it's 0 - i.e. the lines did not change).
+            // This is necessary as we need to detect collisions of multiple segments with different deltas later on.
+            //
             // note: range [oldStartLine, oldEndLine] is end-inclusive
             using var _ = ArrayBuilder<(string filePath, int oldStartLine, int oldEndLine, int delta, SyntaxNode oldNode, SyntaxNode newNode)>.GetInstance(out var segments);
 
@@ -1934,20 +1941,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var newTokensEnum = newTokens.GetEnumerator();
                 var oldTokensEnum = oldTokens.GetEnumerator();
 
-                // We enumerate tokens of the body and split them into segments.
-                // Each segment has sequence points mapped to the same file and also all lines the segment covers map to the same line delta.
-                // The first token of a segment must be the first token that starts on the line. If the first segment token was in the middle line 
-                // the previous token on the same line would have different line delta and we wouldn't be able to map both of them at the same time.
-                // All segments are included in the segments list regardless of their line delta (even when it's 0 - i.e. the lines did not change).
-                // This is necessary as we need to detect collisions of multiple segments with different deltas later on.
-
                 var lastNewToken = default(SyntaxToken);
                 var lastOldStartLine = -1;
                 var lastOldFilePath = (string?)null;
                 var requiresUpdate = false;
 
                 var firstSegmentIndex = segments.Count;
-                var currentSegment = (path: (string?)null, oldStartLine: 0, delta: 0, firstOldNode: (SyntaxNode?)null, firstNewNode: (SyntaxNode?)null);
+                var currentSegment = (path: (string?)null, oldStartLine: 0, delta: 0, firstOldToken: default(SyntaxToken), firstNewToken: default(SyntaxToken));
                 var rudeEditSpan = default(TextSpan);
 
                 // Check if the breakpoint span that covers the first node of the segment can be translated from the old to the new by adding a line delta.
@@ -1955,14 +1955,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // The first node of the segment can be the first node on its line but the breakpoint span might start on the previous line.
                 bool IsCurrentSegmentBreakpointSpanMappable()
                 {
-                    var oldNode = currentSegment.firstOldNode;
-                    var newNode = currentSegment.firstNewNode;
-                    Contract.ThrowIfNull(oldNode);
-                    Contract.ThrowIfNull(newNode);
+                    var oldToken = currentSegment.firstOldToken;
+                    var newToken = currentSegment.firstNewToken;
+                    Contract.ThrowIfNull(oldToken.Parent);
+                    Contract.ThrowIfNull(newToken.Parent);
 
                     // Some nodes (e.g. const local declaration) may not be covered by a breakpoint span.
-                    if (!TryGetEnclosingBreakpointSpan(oldNode, oldNode.SpanStart, out var oldBreakpointSpan) ||
-                        !TryGetEnclosingBreakpointSpan(newNode, newNode.SpanStart, out var newBreakpointSpan))
+                    if (!TryGetEnclosingBreakpointSpan(oldToken.Parent, oldToken.SpanStart, out var oldBreakpointSpan) ||
+                        !TryGetEnclosingBreakpointSpan(newToken.Parent, newToken.SpanStart, out var newBreakpointSpan))
                     {
                         return true;
                     }
@@ -2063,7 +2063,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         }
 
                         // start new segment:
-                        currentSegment = (oldMappedSpan.Path, oldStartLine, lineDelta, oldTokensEnum.Current.Parent, newTokensEnum.Current.Parent);
+                        currentSegment = (oldMappedSpan.Path, oldStartLine, lineDelta, oldTokensEnum.Current, newTokensEnum.Current);
                     }
 
                     lastNewToken = newTokensEnum.Current;
@@ -3239,6 +3239,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                             syntaxMap = isActiveMember ? CreateSyntaxMapForEquivalentNodes(oldBody, newBody) : null;
 
+                            ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics, newDeclaration, newBody);
+
                             var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newSymbol, cancellationToken);
                             var isDeclarationWithInitializer = IsDeclarationWithInitializer(newDeclaration);
 
@@ -3909,7 +3911,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             StateMachineInfo oldStateMachineInfo,
             StateMachineInfo newStateMachineInfo)
         {
-            ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics, newDeclaration, newBody, span: null);
+            ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics, newDeclaration, newBody);
 
             if (oldStateMachineInfo.IsStateMachine)
             {
@@ -5286,27 +5288,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                         // Report an error if the updated constructor's declaration is in the current document 
                         // and its body edit is disallowed (e.g. contains stackalloc).
-                        if (oldCtor != null && newDeclaration.SyntaxTree == newSyntaxTree && anyInitializerUpdatesInCurrentDocument)
+                        // If the declaration represents a primary constructor the body will be null.
+                        if (oldCtor != null &&
+                            newDeclaration.SyntaxTree == newSyntaxTree &&
+                            anyInitializerUpdatesInCurrentDocument &&
+                            TryGetDeclarationBody(newDeclaration) is { } newBody)
                         {
-                            var newBody = TryGetDeclarationBody(newDeclaration);
-
-                            // If the declaration represents a primary constructor the body will be null.
-                            if (newBody != null)
-                            {
-                                // attribute rude edit to one of the modified members
-                                var firstSpan = updatesInCurrentDocument.ChangedDeclarations.Keys.Where(IsDeclarationWithInitializer).Aggregate(
-                                    (min: int.MaxValue, span: default(TextSpan)),
-                                    (accumulate, node) => (node.SpanStart < accumulate.min) ? (node.SpanStart, node.Span) : accumulate).span;
-
-                                // span may be empty if the only edits are deletes of members with initializers
-                                if (firstSpan.IsEmpty)
-                                {
-                                    Debug.Assert(updatesInCurrentDocument.HasDeletedMemberInitializer);
-                                    firstSpan = newDeclaration.Span;
-                                }
-
-                                ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics, newDeclaration, newBody, firstSpan);
-                            }
+                            ReportMemberOrLambdaBodyUpdateRudeEditsImpl(diagnostics, newDeclaration, newBody);
                         }
                     }
                     else


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69027

Two issues:
1) When calculating line deltas we didn't handle correctly cases where a new line is added inside block (or other node that has multiple breakpoint spans). These led to unnecessary recompilations.

2) We did not report rude edits when a body containing `stackalloc` is recompiled due to trivial-only changes.