### PR TITLE
Reduce bool array allocations in MethodTypeInferrer.FixParameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -928,7 +928,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // dependent on anything. We need to first determine which parameters need to be 
             // fixed, and then fix them all at once.
 
-            var needsFixing = new bool[_methodTypeParameters.Length];
+            var needsFixing = BitVector.Create(_methodTypeParameters.Length);
             var result = InferenceResult.NoProgress;
             for (int param = 0; param < _methodTypeParameters.Length; param++)
             {


### PR DESCRIPTION
Address 1.1% allocations of boolean arrays in `MethodTypeInferrer.FixParameters`. Fixes https://github.com/dotnet/roslyn/issues/56012

![image](https://github.com/dotnet/roslyn/assets/31348972/80592b8a-d306-433e-b7ce-559cf856ae25)