### PR TITLE
Reduce `HashSet<TypeWithAnnotations>` allocations in MethodTypeInferrer.Fix

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2733,11 +2733,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (containsFunctionTypes(lower) &&
                 (containsNonFunctionTypes(lower) || containsNonFunctionTypes(exact) || containsNonFunctionTypes(upper)))
             {
-                lower = removeTypes(lower, static type => isFunctionType(type, out _));
+                removeTypes(lower, static type => isFunctionType(type, out _));
             }
-
-            // Remove any function types with no delegate type.
-            lower = removeTypes(lower, static type => isFunctionType(type, out var functionType) && functionType.GetInternalDelegateType() is null);
+            else
+            {
+                // Remove any function types with no delegate type.
+                removeTypes(lower, static type => isFunctionType(type, out var functionType) && functionType.GetInternalDelegateType() is null);
+            }
 
             // Optimization: if we have one exact bound then we need not add any
             // inexact bounds; we're just going to remove them anyway.
@@ -2878,22 +2880,9 @@ OuterBreak:
                 return false;
             }
 
-            static HashSet<TypeWithAnnotations>? removeTypes(HashSet<TypeWithAnnotations>? types, Func<TypeWithAnnotations, bool> predicate)
+            static void removeTypes(HashSet<TypeWithAnnotations>? types, Predicate<TypeWithAnnotations> predicate)
             {
-                if (types is null)
-                {
-                    return null;
-                }
-                HashSet<TypeWithAnnotations>? updated = null;
-                foreach (var type in types)
-                {
-                    if (!predicate(type))
-                    {
-                        updated ??= new HashSet<TypeWithAnnotations>(TypeWithAnnotations.EqualsComparer.ConsiderEverythingComparer);
-                        updated.Add(type);
-                    }
-                }
-                return updated;
+                types?.RemoveWhere(predicate);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2734,12 +2734,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (containsFunctionTypes(lower) &&
                 (containsNonFunctionTypes(lower) || containsNonFunctionTypes(exact) || containsNonFunctionTypes(upper)))
             {
-                lowerPredicate = static type => isFunctionType(type, out _);
+                lowerPredicate = static type => !isFunctionType(type, out _);
             }
             else
             {
                 // Remove any function types with no delegate type.
-                lowerPredicate = static type => isFunctionType(type, out var functionType) && functionType.GetInternalDelegateType() is null;
+                lowerPredicate = static type => !isFunctionType(type, out var functionType) || functionType.GetInternalDelegateType() is not null;
             }
 
             // Optimization: if we have one exact bound then we need not add any


### PR DESCRIPTION
Address 1.4% allocations of `HashSet<TypeWithAnnotations>` in `removeTypes` local function in `MethodTypeInferrer.FixParameters`

![image](https://github.com/dotnet/roslyn/assets/31348972/a792d8e2-1bf4-4b48-892f-d53f2638c214)
