### PR TITLE
Update 'initialize member from parameter' to work with primary constructors.

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,1 +1,2 @@
 ﻿awaitable
+﻿Refactorings

--- a/src/Analyzers/CSharp/CodeFixes/AssignOutParameters/AbstractAssignOutParametersCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/AssignOutParameters/AbstractAssignOutParametersCodeFixProvider.cs
@@ -110,10 +110,10 @@ namespace Microsoft.CodeAnalysis.CSharp.AssignOutParameters
                 var parameterList = container.GetParameterList();
                 Contract.ThrowIfNull(parameterList);
 
-                var outParameters =
-                    parameterList.Parameters.Select(p => (IParameterSymbol)semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken))
-                                            .Where(p => p.RefKind == RefKind.Out)
-                                            .ToImmutableArray();
+                var outParameters = parameterList.Parameters
+                    .Select(p => semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken))
+                    .Where(p => p.RefKind == RefKind.Out)
+                    .ToImmutableArray();
 
                 var distinctExprsOrStatements = group.Select(t => t.exprOrStatement).Distinct();
                 foreach (var exprOrStatement in distinctExprsOrStatements)

--- a/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/PositionalParameterInfo.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertToRecord/PositionalParameterInfo.cs
@@ -41,8 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertToRecord
             using var _ = ArrayBuilder<PositionalParameterInfo>.GetInstance(out var resultBuilder);
 
             // get all declared property symbols, put inherited property symbols first
-            var symbols = properties
-                .SelectAsArray(p => (IPropertySymbol)semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken));
+            var symbols = properties.SelectAsArray(p => semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken));
 
             // add inherited properties from a potential base record first
             var inheritedProperties = GetInheritedPositionalParams(type, cancellationToken);

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -5,18 +5,15 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 {
-    using static InitializeParameterHelpers;
     using static InitializeParameterHelpersCore;
 
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromParameter), Shared]

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -16,10 +16,13 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 {
+    using static InitializeParameterHelpers;
+    using static InitializeParameterHelpersCore;
+
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromParameter), Shared]
     [ExtensionOrder(Before = nameof(CSharpAddParameterCheckCodeRefactoringProvider))]
     [ExtensionOrder(Before = PredefinedCodeRefactoringProviderNames.Wrapping)]
-    internal class CSharpInitializeMemberFromParameterCodeRefactoringProvider :
+    internal sealed class CSharpInitializeMemberFromParameterCodeRefactoringProvider :
         AbstractInitializeMemberFromParameterCodeRefactoringProvider<
             BaseTypeDeclarationSyntax,
             ParameterSyntax,
@@ -56,55 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             => InitializeParameterHelpers.GetBody(functionDeclaration);
 
         protected override SyntaxNode? GetAccessorBody(IMethodSymbol accessor, CancellationToken cancellationToken)
-        {
-            var node = accessor.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-            if (node is AccessorDeclarationSyntax accessorDeclaration)
-                return accessorDeclaration.ExpressionBody ?? (SyntaxNode?)accessorDeclaration.Body;
-
-            // `int Age => ...;`
-            if (node is ArrowExpressionClauseSyntax arrowExpression)
-                return arrowExpression;
-
-            return null;
-        }
+            => InitializeParameterHelpers.GetAccessorBody(accessor, cancellationToken);
 
         protected override SyntaxNode RemoveThrowNotImplemented(SyntaxNode node)
-        {
-            if (node is PropertyDeclarationSyntax propertyDeclaration)
-            {
-                if (propertyDeclaration.ExpressionBody != null)
-                {
-                    var result = propertyDeclaration
-                        .WithExpressionBody(null)
-                        .WithSemicolonToken(default)
-                        .AddAccessorListAccessors(SyntaxFactory
-                            .AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
-                        .WithTrailingTrivia(propertyDeclaration.SemicolonToken.TrailingTrivia)
-                        .WithAdditionalAnnotations(Formatter.Annotation);
-                    return result;
-                }
-
-                if (propertyDeclaration.AccessorList != null)
-                {
-                    var accessors = propertyDeclaration.AccessorList.Accessors.Select(RemoveThrowNotImplemented);
-                    return propertyDeclaration.WithAccessorList(
-                        propertyDeclaration.AccessorList.WithAccessors(SyntaxFactory.List(accessors)));
-                }
-            }
-
-            return node;
-        }
-
-        private static AccessorDeclarationSyntax RemoveThrowNotImplemented(AccessorDeclarationSyntax accessorDeclaration)
-        {
-            var result = accessorDeclaration
-                .WithExpressionBody(null)
-                .WithBody(null)
-                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
-
-            return result.WithTrailingTrivia(accessorDeclaration.Body?.GetTrailingTrivia() ?? accessorDeclaration.SemicolonToken.TrailingTrivia);
-        }
+            => InitializeParameterHelpers.RemoveThrowNotImplemented(node);
 
         protected override bool TryUpdateTupleAssignment(
             IBlockOperation? blockStatement,

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -242,23 +242,20 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             ISymbol CreateField(IParameterSymbol parameter)
             {
                 var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
+                var accessibilityLevel = formattingOptions.AccessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault
+                    ? Accessibility.NotApplicable
+                    : Accessibility.Private;
 
                 foreach (var rule in rules)
                 {
                     if (rule.SymbolSpecification.AppliesTo(SymbolKind.Field, Accessibility.Private))
                     {
-                        var uniqueName = GenerateUniqueName(parameter, parameterNameParts, rule);
-
-                        var accessibilityLevel = formattingOptions.AccessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault
-                            ? Accessibility.NotApplicable
-                            : Accessibility.Private;
-
                         return CodeGenerationSymbolFactory.CreateFieldSymbol(
                             attributes: default,
                             accessibilityLevel,
                             DeclarationModifiers.ReadOnly,
                             parameter.Type,
-                            uniqueName,
+                            name: GenerateUniqueName(parameter, parameterNameParts, rule),
                             initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
                     }
                 }
@@ -276,26 +273,20 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 {
                     if (rule.SymbolSpecification.AppliesTo(SymbolKind.Property, Accessibility.Public))
                     {
-                        var uniqueName = GenerateUniqueName(parameter, parameterNameParts, rule);
-
-                        var accessibilityLevel = Accessibility.Public;
-
-                        var getMethod = CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                            attributes: default,
-                            Accessibility.Public,
-                            statements: default);
-
                         return CodeGenerationSymbolFactory.CreatePropertySymbol(
                             containingType: null,
                             attributes: default,
-                            accessibilityLevel,
-                            new DeclarationModifiers(),
+                            Accessibility.Public,
+                            modifiers: default,
                             parameter.Type,
                             RefKind.None,
                             explicitInterfaceImplementations: default,
-                            name: uniqueName,
+                            name: GenerateUniqueName(parameter, parameterNameParts, rule),
                             parameters: default,
-                            getMethod: getMethod,
+                            getMethod: CodeGenerationSymbolFactory.CreateAccessorSymbol(
+                                attributes: default,
+                                Accessibility.Public,
+                                statements: default),
                             setMethod: null,
                             initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
                     }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             // See if we're already assigning this parameter to a field/property in this type. If so, there's nothing
             // more for us to do.
-            var initializerValue = TryFindFieldOrPropertyInitializerValue(semanticModel.Compilation, parameter, cancellationToken);
+            var initializerValue = TryFindFieldOrPropertyInitializerValue(compilation, parameter, out _, cancellationToken);
             if (initializerValue != null)
                 return;
 
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             ImmutableArray<IParameterSymbol> GetParametersWithoutAssociatedMembers()
             {
-                using var _ = ArrayBuilder<IParameterSymbol>.GetInstance(out var result);
+                using var _1 = ArrayBuilder<IParameterSymbol>.GetInstance(out var result);
 
                 foreach (var parameter in constructor.Parameters)
                 {
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                     if (parameterNameParts.BaseName == "")
                         continue;
 
-                    var assignmentOp = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
+                    var assignmentOp = TryFindFieldOrPropertyInitializerValue(compilation, parameter, out _, cancellationToken);
                     if (assignmentOp != null)
                         continue;
 
@@ -559,12 +559,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 }
             }
         }
-
-        private static IOperation? TryFindFieldOrPropertyInitializerValue(
-            Compilation compilation,
-            IParameterSymbol parameter,
-            CancellationToken cancellationToken)
-            => TryFindFieldOrPropertyInitializerValue(compilation, parameter, out _, cancellationToken);
 
         private static IOperation? TryFindFieldOrPropertyInitializerValue(
             Compilation compilation,

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                             {
                                 var operation = semanticModel.GetOperation(propertyInitializer, cancellationToken);
                                 if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
-                                    return (operation, semanticModel.GetDeclaredSymbol(propertyDeclaration, cancellationToken));
+                                    return (operation, semanticModel.GetRequiredDeclaredSymbol(propertyDeclaration, cancellationToken));
                             }
                             else if (member is FieldDeclarationSyntax field)
                             {
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                                     {
                                         var operation = semanticModel.GetOperation(fieldInitializer, cancellationToken);
                                         if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
-                                            return (operation, semanticModel.GetDeclaredSymbol(varDecl, cancellationToken));
+                                            return (operation, semanticModel.GetRequiredDeclaredSymbol(varDecl, cancellationToken));
                                     }
                                 }
                             }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -71,54 +71,11 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 return;
             }
 
-            //// We shouldn't offer a refactoring if the compilation doesn't contain the ArgumentNullException type,
-            //// as we use it later on in our computations.
-            //var argumentNullExceptionType = typeof(ArgumentNullException).FullName;
-            //if (argumentNullExceptionType is null || semanticModel.Compilation.GetTypeByMetadataName(argumentNullExceptionType) is null)
-            //    return;
-
-            //if (CanOfferRefactoring(functionDeclaration, semanticModel, syntaxFacts, cancellationToken, out var blockStatementOpt))
-            //{
-            // Ok.  Looks like the selected parameter could be refactored. Defer to subclass to 
-            // actually determine if there are any viable refactorings here.
             var refactorings = await GetRefactoringsForSingleParameterAsync(
                 document, typeDeclaration, parameter, methodSymbol, context.Options, cancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(refactorings, context.Span);
-            // }
-
-            //// List with parameterNodes that pass all checks
-            //using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var listOfPotentiallyValidParametersNodes);
-            //foreach (var parameterNode in parameterNodes)
-            //{
-            //    if (!TryGetParameterSymbol(parameterNode, semanticModel, out parameter, cancellationToken))
-            //        return;
-
-            //    // Update the list of valid parameter nodes
-            //    listOfPotentiallyValidParametersNodes.Add(parameterNode);
-            //}
-
-            //if (listOfPotentiallyValidParametersNodes.Count > 1)
-            //{
-            //    // Looks like we can offer a refactoring for more than one parameter. Defer to subclass to 
-            //    // actually determine if there are any viable refactorings here.
-            //    var refactorings = await GetRefactoringsForAllParametersAsync(
-            //        document, functionDeclaration, methodSymbol, blockStatementOpt,
-            //        listOfPotentiallyValidParametersNodes.ToImmutable(), selectedParameter.Span, context.Options, cancellationToken).ConfigureAwait(false);
-            //    context.RegisterRefactorings(refactorings, context.Span);
-            //}
 
             return;
-
-            //static bool TryGetParameterSymbol(
-            //    SyntaxNode parameterNode,
-            //    SemanticModel semanticModel,
-            //    [NotNullWhen(true)] out IParameterSymbol? parameter,
-            //    CancellationToken cancellationToken)
-            //{
-            //    parameter = (IParameterSymbol?)semanticModel.GetDeclaredSymbol(parameterNode, cancellationToken);
-
-            //    return parameter is { Name: not "" };
-            //}
         }
 
         private async Task<ImmutableArray<CodeAction>> GetRefactoringsForSingleParameterAsync(
@@ -355,14 +312,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                     var accessibilityLevel = accessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault
                         ? Accessibility.NotApplicable
                         : Accessibility.Private;
-                    //if (accessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault)
-                    //{
-                    //    var defaultAccessibility = DetermineDefaultFieldAccessibility(parameter.ContainingType);
-                    //    if (defaultAccessibility == Accessibility.Private)
-                    //    {
-                    //        accessibilityLevel = Accessibility.NotApplicable;
-                    //    }
-                    //}
 
                     return CodeGenerationSymbolFactory.CreateFieldSymbol(
                         default,
@@ -571,34 +520,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             return solutionEditor.GetChangedSolution();
         }
 
-        //private void AddAssignment(
-        //    IParameterSymbol parameter,
-        //    ISymbol fieldOrProperty,
-        //    SyntaxEditor editor)
-        //{
-        //    //// First see if the user has `(_x, y) = (x, y);` and attempt to update that. 
-        //    //if (TryUpdateTupleAssignment(blockStatement, parameter, fieldOrProperty, editor))
-        //    //    return;
-
-        //    var generator = editor.Generator;
-
-        //    // Now that we've added any potential members, create an assignment between it
-        //    // and the parameter.
-        //    var initializationStatement = (StatementSyntax)generator.ExpressionStatement(
-        //        generator.AssignmentStatement(
-        //            generator.MemberAccessExpression(
-        //                generator.ThisExpression(),
-        //                generator.IdentifierName(fieldOrProperty.Name)),
-        //            generator.IdentifierName(parameter.Name)));
-
-        //    // Attempt to place the initialization in a good location in the constructor
-        //    // We'll want to keep initialization statements in the same order as we see
-        //    // parameters for the constructor.
-        //    var statementToAddAfter = TryGetStatementToAddInitializationAfter(parameter, blockStatement);
-
-        //    InsertStatement(editor, constructorDeclaration, returnsVoid: true, statementToAddAfter, initializationStatement);
-        //}
-
         private static (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>(
             Compilation compilation,
             IParameterSymbol parameter,
@@ -623,63 +544,11 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             return (symbol: null, syntax: null, CodeGenerationContext.Default);
         }
 
-        //private SyntaxNode? TryGetStatementToAddInitializationAfter(
-        //    IParameterSymbol parameter, IBlockOperation? blockStatement)
-        //{
-        //    // look for an existing assignment for a parameter that comes before/after us.
-        //    // If we find one, we'll add ourselves before/after that parameter check.
-        //    foreach (var (sibling, before) in GetSiblingParameters(parameter))
-        //    {
-        //        var statement = TryFindFieldOrPropertyAssignmentStatement(sibling, blockStatement);
-        //        if (statement != null)
-        //        {
-        //            if (before)
-        //            {
-        //                return statement.Syntax;
-        //            }
-        //            else
-        //            {
-        //                var statementIndex = blockStatement!.Operations.IndexOf(statement);
-        //                return statementIndex > 0 ? blockStatement.Operations[statementIndex - 1].Syntax : null;
-        //            }
-        //        }
-        //    }
-
-        //    // We couldn't find a reasonable location for the new initialization statement.
-        //    // Just place ourselves after the last statement in the constructor.
-        //    return TryGetLastStatement(blockStatement);
-        //}
-
         private static IOperation? TryFindFieldOrPropertyInitializerValue(
             Compilation compilation,
             IParameterSymbol parameter,
             CancellationToken cancellationToken)
             => TryFindFieldOrPropertyInitializerValue(compilation, parameter, out _, cancellationToken);
-
-        //protected static bool TryGetPartsOfTupleAssignmentOperation(
-        //    IOperation operation,
-        //    [NotNullWhen(true)] out ITupleOperation? targetTuple,
-        //    [NotNullWhen(true)] out ITupleOperation? valueTuple)
-        //{
-        //    if (operation is IExpressionStatementOperation
-        //        {
-        //            Operation: IDeconstructionAssignmentOperation
-        //            {
-        //                Target: ITupleOperation targetTupleTemp,
-        //                Value: IConversionOperation { Operand: ITupleOperation valueTupleTemp },
-        //            }
-        //        } &&
-        //        targetTupleTemp.Elements.Length == valueTupleTemp.Elements.Length)
-        //    {
-        //        targetTuple = targetTupleTemp;
-        //        valueTuple = valueTupleTemp;
-        //        return true;
-        //    }
-
-        //    targetTuple = null;
-        //    valueTuple = null;
-        //    return false;
-        //}
 
         private static IOperation? TryFindFieldOrPropertyInitializerValue(
             Compilation compilation,
@@ -722,36 +591,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                     }
                 }
             }
-
-            //if (blockStatement != null)
-            //{
-            //    var containingType = parameter.ContainingType;
-            //    foreach (var statement in blockStatement.Operations)
-            //    {
-            //        // look for something of the form:  "this.s = s" or "this.s = s ?? ..."
-            //        if (IsFieldOrPropertyAssignment(statement, containingType, out var assignmentExpression, out fieldOrProperty) &&
-            //            IsParameterReferenceOrCoalesceOfParameterReference(assignmentExpression, parameter))
-            //        {
-            //            return statement;
-            //        }
-
-            //        //// look inside the form `(this.s, this.t) = (s, t)`
-            //        //if (TryGetPartsOfTupleAssignmentOperation(statement, out var targetTuple, out var valueTuple))
-            //        //{
-            //        //    for (int i = 0, n = targetTuple.Elements.Length; i < n; i++)
-            //        //    {
-            //        //        var target = targetTuple.Elements[i];
-            //        //        var value = valueTuple.Elements[i];
-
-            //        //        if (IsFieldOrPropertyReference(target, containingType, out fieldOrProperty) &&
-            //        //            IsParameterReference(value, parameter))
-            //        //        {
-            //        //            return statement;
-            //        //        }
-            //        //    }
-            //        //}
-            //    }
-            //}
 
             fieldOrProperty = null;
             return null;
@@ -813,54 +652,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             // Couldn't find any existing member.  Just return nothing so we can offer to
             // create a member for them.
             return default;
-
-            //static bool ContainsMemberAssignment(IBlockOperation? blockStatement, ISymbol member)
-            //{
-            //    if (blockStatement != null)
-            //    {
-            //        foreach (var statement in blockStatement.Operations)
-            //        {
-            //            if (IsFieldOrPropertyAssignment(statement, member.ContainingType, out var assignmentExpression) &&
-            //                assignmentExpression.Target.UnwrapImplicitConversion() is IMemberReferenceOperation memberReference &&
-            //                member.Equals(memberReference.Member))
-            //            {
-            //                return true;
-            //            }
-            //        }
-            //    }
-
-            //    return false;
-            //}
-
-            //bool IsThrowNotImplementedProperty(IPropertySymbol property)
-            //{
-            //    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var accessors);
-
-            //    if (property.GetMethod != null)
-            //        accessors.AddIfNotNull(InitializeParameterHelpers.GetAccessorBody(property.GetMethod, cancellationToken));
-
-            //    if (property.SetMethod != null)
-            //        accessors.AddIfNotNull(InitializeParameterHelpers.GetAccessorBody(property.SetMethod, cancellationToken));
-
-            //    if (accessors.Count == 0)
-            //        return false;
-
-            //    foreach (var group in accessors.GroupBy(node => node.SyntaxTree))
-            //    {
-            //        var semanticModel = compilation.GetSemanticModel(group.Key);
-            //        foreach (var accessorBody in accessors)
-            //        {
-            //            var operation = semanticModel.GetOperation(accessorBody, cancellationToken);
-            //            if (operation is null)
-            //                return false;
-
-            //            if (!operation.IsSingleThrowNotImplementedOperation())
-            //                return false;
-            //        }
-            //    }
-
-            //    return true;
-            //}
         }
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             return;
         }
 
-        private async Task<ImmutableArray<CodeAction>> GetRefactoringsForSingleParameterAsync(
+        private static async Task<ImmutableArray<CodeAction>> GetRefactoringsForSingleParameterAsync(
             Document document,
             TypeDeclarationSyntax typeDeclaration,
             IParameterSymbol parameter,
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             return null;
         }
 
-        private async Task<(ISymbol?, bool isThrowNotImplementedProperty)> TryFindMatchingUninitializedFieldOrPropertySymbolAsync(
+        private static async Task<(ISymbol?, bool isThrowNotImplementedProperty)> TryFindMatchingUninitializedFieldOrPropertySymbolAsync(
             Document document, IParameterSymbol parameter, ImmutableArray<NamingRule> rules, ImmutableArray<string> parameterWords, CancellationToken cancellationToken)
         {
             // Look for a field/property that really looks like it corresponds to this parameter.

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 return;
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var compilation = semanticModel.Compilation;
-            var parameter = (IParameterSymbol)semanticModel.GetRequiredDeclaredSymbol(selectedParameter, cancellationToken);
+            var parameter = semanticModel.GetRequiredDeclaredSymbol(selectedParameter, cancellationToken);
             if (parameter?.Name is null or "")
                 return;
 
@@ -60,6 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             // See if we're already assigning this parameter to a field/property in this type. If so, there's nothing
             // more for us to do.
+            var compilation = semanticModel.Compilation;
             var (initializerValue, _) = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
             if (initializerValue != null)
                 return;

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -31,7 +31,8 @@ using static InitializeParameterHelpersCore;
 using static SyntaxFactory;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromPrimaryConstructorParameter), Shared]
-internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider
+    : CodeRefactoringProvider
 {
     [ImportingConstructor]
     [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             // See if we're already assigning this parameter to a field/property in this type. If so, there's nothing
             // more for us to do.
-            var assignmentExpression = TryFindFieldOrPropertyInitializerValue(semanticModel.Compilation, parameter, cancellationToken);
-            if (assignmentExpression != null)
+            var initializerValue = TryFindFieldOrPropertyInitializerValue(semanticModel.Compilation, parameter, cancellationToken);
+            if (initializerValue != null)
                 return;
 
             // Haven't initialized any fields/properties with this parameter.  Offer to assign to an existing matching

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
     internal sealed class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
     {
         [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider()
         {
         }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -4,9 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -15,9 +13,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -32,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
     using static SyntaxFactory;
 
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromPrimaryConstructorParameter), Shared]
-    internal sealed class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+    internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
     {
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
@@ -326,237 +322,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 // We place a special rule in s_builtInRules that matches all properties.  So we should 
                 // always find a matching rule.
                 throw ExceptionUtilities.Unreachable();
-            }
-        }
-
-        private static async Task<Solution> AddAllSymbolInitializationsAsync(
-            Document document,
-            TypeDeclarationSyntax typeDeclaration,
-            ImmutableArray<IParameterSymbol> parameters,
-            ImmutableArray<ISymbol> fieldsOrProperties,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
-        {
-            Debug.Assert(parameters.Length >= 2);
-            Debug.Assert(fieldsOrProperties.Length > 0);
-            Debug.Assert(parameters.Length == fieldsOrProperties.Length);
-
-            // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
-            // Then find all the current data in that updated document and move onto the next pair.
-
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var trackedRoot = root.TrackNodes(typeDeclaration);
-            var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
-
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                var parameter = parameters[i];
-                var fieldOrProperty = fieldsOrProperties[i];
-
-                var currentDocument = currentSolution.GetRequiredDocument(document.Id);
-                var currentSemanticModel = await currentDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var currentCompilation = currentSemanticModel.Compilation;
-                var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
-                if (currentTypeDeclaration == null)
-                    continue;
-
-                var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
-                if (currentParameter == null)
-                    continue;
-
-                // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
-
-                currentSolution = await AddSingleSymbolInitializationAsync(
-                    currentDocument,
-                    currentTypeDeclaration,
-                    currentParameter,
-                    fieldOrProperty,
-                    isThrowNotImplementedProperty: false,
-                    fallbackOptions,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            return currentSolution;
-        }
-
-        /// <summary>
-        /// This is the workhorse function that actually goes and handles each parameter and either creates a
-        /// field/property for it, or updates an existing field/property with it.  It's extracted out from the rest as
-        /// we do not want it capturing anything.  Specifically, this is called in a loop for each parameter we're
-        /// processing.  For each, we produce new solution snapshots and thus must ensure we're always pointing at the
-        /// new view of the world, not anything from the original view.
-        /// </summary>
-        private static async Task<Solution> AddSingleSymbolInitializationAsync(
-            Document document,
-            TypeDeclarationSyntax typeDeclaration,
-            IParameterSymbol parameter,
-            ISymbol fieldOrProperty,
-            bool isThrowNotImplementedProperty,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
-        {
-            var project = document.Project;
-            var solution = project.Solution;
-            var services = solution.Services;
-
-            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var parseOptions = root.SyntaxTree.Options;
-
-            var solutionEditor = new SolutionEditor(solution);
-            var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var codeGenerator = document.GetRequiredLanguageService<ICodeGenerationService>();
-
-            // We're assigning the parameter to a field/prop (either new or existing).  Convert all existing references
-            // to this primary constructor parameter (within this type) to refer to the field/prop now instead.
-            await UpdateParameterReferencesAsync().ConfigureAwait(false);
-
-            // Now, either add the new field/prop, or update the existing one by assigning the parameter to it.
-            if (fieldOrProperty.ContainingType == null)
-            {
-                await AddFieldOrPropertyAsync().ConfigureAwait(false);
-            }
-            else
-            {
-                await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
-            }
-
-            return solutionEditor.GetChangedSolution();
-
-            async Task UpdateParameterReferencesAsync()
-            {
-                var namedType = parameter.ContainingType;
-                var documents = namedType.DeclaringSyntaxReferences
-                    .Select(r => solution.GetDocument(r.SyntaxTree))
-                    .WhereNotNull()
-                    .ToImmutableHashSet();
-
-                var references = await SymbolFinder.FindReferencesAsync(parameter, solution, documents, cancellationToken).ConfigureAwait(false);
-                foreach (var group in references.SelectMany(r => r.Locations.Where(loc => !loc.IsImplicit).GroupBy(loc => loc.Document)))
-                {
-                    var editingDocument = group.Key;
-                    var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-
-                    foreach (var location in group)
-                    {
-                        var node = location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
-                        if (node is IdentifierNameSyntax { Parent: not NameColonSyntax } identifierName &&
-                            identifierName.Identifier.ValueText == parameter.Name)
-                        {
-                            // we may have things like `new MyType(x: ...)` we don't want to update `x` there to 'X'
-                            // just because we're generating a new property 'X' for the parameter to be assigned to.
-                            editor.ReplaceNode(
-                                identifierName,
-                                IdentifierName(fieldOrProperty.Name.EscapeIdentifier()).WithTriviaFrom(identifierName));
-                        }
-                    }
-                }
-            }
-
-            async Task AddFieldOrPropertyAsync()
-            {
-                // We're generating a new field/property.  Place into the containing type, ideally before/after a
-                // relevant existing member.
-                var (sibling, siblingSyntax, addContext) = fieldOrProperty switch
-                {
-                    IPropertySymbol => GetAddContext<IPropertySymbol>(),
-                    IFieldSymbol => GetAddContext<IFieldSymbol>(),
-                    _ => throw ExceptionUtilities.UnexpectedValue(fieldOrProperty),
-                };
-
-                var preferredTypeDeclaration = siblingSyntax?.GetAncestorOrThis<TypeDeclarationSyntax>() ?? typeDeclaration;
-
-                var editingDocument = solution.GetRequiredDocument(typeDeclaration.SyntaxTree);
-                var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-                editor.ReplaceNode(
-                    typeDeclaration,
-                    (currentTypeDecl, _) =>
-                    {
-                        if (fieldOrProperty is IPropertySymbol property)
-                        {
-                            return codeGenerator.AddProperty(
-                                currentTypeDecl, property,
-                                codeGenerator.GetInfo(addContext, options, parseOptions),
-                                cancellationToken);
-                        }
-                        else if (fieldOrProperty is IFieldSymbol field)
-                        {
-                            return codeGenerator.AddField(
-                                currentTypeDecl, field,
-                                codeGenerator.GetInfo(addContext, options, parseOptions),
-                                cancellationToken);
-                        }
-                        else
-                        {
-                            throw ExceptionUtilities.Unreachable();
-                        }
-                    });
-            }
-
-            (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>() where TSymbol : class, ISymbol
-            {
-                foreach (var (sibling, before) in GetSiblingParameters(parameter))
-                {
-                    var initializer = TryFindFieldOrPropertyInitializerValue(
-                        compilation, sibling, out var fieldOrProperty, cancellationToken);
-
-                    if (initializer != null &&
-                        fieldOrProperty is TSymbol { DeclaringSyntaxReferences: [var syntaxReference, ..] } symbol)
-                    {
-                        var syntax = syntaxReference.GetSyntax(cancellationToken);
-                        return (symbol, syntax, before
-                            ? new CodeGenerationContext(afterThisLocation: syntax.GetLocation())
-                            : new CodeGenerationContext(beforeThisLocation: syntax.GetLocation()));
-                    }
-                }
-
-                return (symbol: null, syntax: null, CodeGenerationContext.Default);
-            }
-
-            async Task UpdateFieldOrPropertyAsync()
-            {
-                // We're updating an exiting field/prop.
-                if (fieldOrProperty is IPropertySymbol property)
-                {
-                    foreach (var syntaxRef in property.DeclaringSyntaxReferences)
-                    {
-                        if (syntaxRef.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)
-                        {
-                            var editingDocument = solution.GetRequiredDocument(propertyDeclaration.SyntaxTree);
-                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-
-                            // If the user had a property that has 'throw NotImplementedException' in it, then remove those throws.
-                            var newPropertyDeclaration = isThrowNotImplementedProperty ? RemoveThrowNotImplemented(propertyDeclaration) : propertyDeclaration;
-                            editor.ReplaceNode(
-                                propertyDeclaration,
-                                newPropertyDeclaration.WithoutTrailingTrivia()
-                                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(newPropertyDeclaration.GetTrailingTrivia()))
-                                    .WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
-                        }
-                    }
-                }
-                else if (fieldOrProperty is IFieldSymbol field)
-                {
-                    foreach (var syntaxRef in field.DeclaringSyntaxReferences)
-                    {
-                        if (syntaxRef.GetSyntax(cancellationToken) is VariableDeclaratorSyntax variableDeclarator)
-                        {
-                            var editingDocument = solution.GetRequiredDocument(variableDeclarator.SyntaxTree);
-                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-                            editor.ReplaceNode(
-                                variableDeclarator,
-                                variableDeclarator.WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    throw ExceptionUtilities.Unreachable();
-                }
             }
         }
 

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             var formattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
 
-            var (fieldOrProperty, isThrowNotImplementedProperty) = await TryFindMatchingUninitializedFieldOrPropertySymbolAsync().ConfigureAwait(false);
+            var (fieldOrProperty, isThrowNotImplementedProperty) = TryFindMatchingUninitializedFieldOrPropertySymbol();
             var refactorings = fieldOrProperty != null
                 ? HandleExistingFieldOrProperty()
                 : await HandleNoExistingFieldOrPropertyAsync().ConfigureAwait(false);
@@ -84,14 +84,13 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             context.RegisterRefactorings(refactorings, context.Span);
             return;
 
-            async Task<(ISymbol?, bool isThrowNotImplementedProperty)> TryFindMatchingUninitializedFieldOrPropertySymbolAsync()
+            (ISymbol?, bool isThrowNotImplementedProperty) TryFindMatchingUninitializedFieldOrPropertySymbol()
             {
                 // Look for a field/property that really looks like it corresponds to this parameter. Use a variety of
                 // heuristics around the name/type to see if this is a match.
 
                 var parameterWords = parameterNameParts.BaseNameParts;
                 var containingType = parameter.ContainingType;
-                var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
 
                 // Walk through the naming rules against this parameter's name to see what name the user would like for
                 // it as a member in this type.  Note that we have some fallback rules that use the standard conventions

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -24,310 +24,309 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Naming;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
+namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter;
+
+using static InitializeParameterHelpers;
+using static InitializeParameterHelpersCore;
+using static SyntaxFactory;
+
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromPrimaryConstructorParameter), Shared]
+internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
 {
-    using static InitializeParameterHelpers;
-    using static InitializeParameterHelpersCore;
-    using static SyntaxFactory;
-
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.InitializeMemberFromPrimaryConstructorParameter), Shared]
-    internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+    [ImportingConstructor]
+    [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+    public CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider()
     {
-        [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider()
-        {
-        }
+    }
 
-        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
-        {
-            var (document, _, cancellationToken) = context;
+    public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+    {
+        var (document, _, cancellationToken) = context;
 
-            var selectedParameter = await context.TryGetRelevantNodeAsync<ParameterSyntax>().ConfigureAwait(false);
-            if (selectedParameter == null)
-                return;
-
-            if (selectedParameter.Parent is not ParameterListSyntax { Parent: TypeDeclarationSyntax(kind: SyntaxKind.ClassDeclaration or SyntaxKind.StructDeclaration) typeDeclaration })
-                return;
-
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var parameter = semanticModel.GetRequiredDeclaredSymbol(selectedParameter, cancellationToken);
-            if (parameter?.Name is null or "")
-                return;
-
-            if (parameter.ContainingSymbol is not IMethodSymbol { MethodKind: MethodKind.Constructor } constructor)
-                return;
-
-            // See if we're already assigning this parameter to a field/property in this type. If so, there's nothing
-            // more for us to do.
-            var compilation = semanticModel.Compilation;
-            var (initializerValue, _) = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
-            if (initializerValue != null)
-                return;
-
-            // Haven't initialized any fields/properties with this parameter.  Offer to assign to an existing matching
-            // field/prop if we can find one, or add a new field/prop if we can't.
-            var fallbackOptions = context.Options;
-            var rules = await document.GetNamingRulesAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules);
-            if (parameterNameParts.BaseName == "")
-                return;
-
-            var formattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-
-            var (fieldOrProperty, isThrowNotImplementedProperty) = TryFindMatchingUninitializedFieldOrPropertySymbol();
-            var refactorings = fieldOrProperty == null
-                ? HandleNoExistingFieldOrProperty()
-                : HandleExistingFieldOrProperty();
-
-            context.RegisterRefactorings(refactorings.ToImmutableArray(), context.Span);
+        var selectedParameter = await context.TryGetRelevantNodeAsync<ParameterSyntax>().ConfigureAwait(false);
+        if (selectedParameter == null)
             return;
 
-            (ISymbol?, bool isThrowNotImplementedProperty) TryFindMatchingUninitializedFieldOrPropertySymbol()
+        if (selectedParameter.Parent is not ParameterListSyntax { Parent: TypeDeclarationSyntax(kind: SyntaxKind.ClassDeclaration or SyntaxKind.StructDeclaration) typeDeclaration })
+            return;
+
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var parameter = semanticModel.GetRequiredDeclaredSymbol(selectedParameter, cancellationToken);
+        if (parameter?.Name is null or "")
+            return;
+
+        if (parameter.ContainingSymbol is not IMethodSymbol { MethodKind: MethodKind.Constructor } constructor)
+            return;
+
+        // See if we're already assigning this parameter to a field/property in this type. If so, there's nothing
+        // more for us to do.
+        var compilation = semanticModel.Compilation;
+        var (initializerValue, _) = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
+        if (initializerValue != null)
+            return;
+
+        // Haven't initialized any fields/properties with this parameter.  Offer to assign to an existing matching
+        // field/prop if we can find one, or add a new field/prop if we can't.
+        var fallbackOptions = context.Options;
+        var rules = await document.GetNamingRulesAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+        var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules);
+        if (parameterNameParts.BaseName == "")
+            return;
+
+        var formattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+
+        var (fieldOrProperty, isThrowNotImplementedProperty) = TryFindMatchingUninitializedFieldOrPropertySymbol();
+        var refactorings = fieldOrProperty == null
+            ? HandleNoExistingFieldOrProperty()
+            : HandleExistingFieldOrProperty();
+
+        context.RegisterRefactorings(refactorings.ToImmutableArray(), context.Span);
+        return;
+
+        (ISymbol?, bool isThrowNotImplementedProperty) TryFindMatchingUninitializedFieldOrPropertySymbol()
+        {
+            // Look for a field/property that really looks like it corresponds to this parameter. Use a variety of
+            // heuristics around the name/type to see if this is a match.
+
+            var parameterWords = parameterNameParts.BaseNameParts;
+            var containingType = parameter.ContainingType;
+
+            // Walk through the naming rules against this parameter's name to see what name the user would like for
+            // it as a member in this type.  Note that we have some fallback rules that use the standard conventions
+            // around properties /fields so that can still find things even if the user has no naming preferences
+            // set.
+
+            foreach (var rule in rules)
             {
-                // Look for a field/property that really looks like it corresponds to this parameter. Use a variety of
-                // heuristics around the name/type to see if this is a match.
-
-                var parameterWords = parameterNameParts.BaseNameParts;
-                var containingType = parameter.ContainingType;
-
-                // Walk through the naming rules against this parameter's name to see what name the user would like for
-                // it as a member in this type.  Note that we have some fallback rules that use the standard conventions
-                // around properties /fields so that can still find things even if the user has no naming preferences
-                // set.
-
-                foreach (var rule in rules)
+                var memberName = rule.NamingStyle.CreateName(parameterWords);
+                foreach (var memberWithName in containingType.GetMembers(memberName))
                 {
-                    var memberName = rule.NamingStyle.CreateName(parameterWords);
-                    foreach (var memberWithName in containingType.GetMembers(memberName))
+                    // We found members in our type with that name.  If it's a writable field that we could assign
+                    // this parameter to, and it's not already been assigned to, then this field is a good candidate
+                    // for us to hook up to.
+                    if (memberWithName is IFieldSymbol { IsConst: false, DeclaringSyntaxReferences: [var syntaxRef1, ..] } field &&
+                        IsImplicitConversion(compilation, source: parameter.Type, destination: field.Type) &&
+                        syntaxRef1.GetSyntax(cancellationToken) is VariableDeclaratorSyntax { Initializer: null })
                     {
-                        // We found members in our type with that name.  If it's a writable field that we could assign
-                        // this parameter to, and it's not already been assigned to, then this field is a good candidate
-                        // for us to hook up to.
-                        if (memberWithName is IFieldSymbol { IsConst: false, DeclaringSyntaxReferences: [var syntaxRef1, ..] } field &&
-                            IsImplicitConversion(compilation, source: parameter.Type, destination: field.Type) &&
-                            syntaxRef1.GetSyntax(cancellationToken) is VariableDeclaratorSyntax { Initializer: null })
-                        {
-                            return (field, isThrowNotImplementedProperty: false);
-                        }
+                        return (field, isThrowNotImplementedProperty: false);
+                    }
 
-                        // If it's a writable property that we could assign this parameter to, and it's not already been
-                        // assigned to, then this property is a good candidate for us to hook up to.
-                        if (memberWithName is IPropertySymbol { DeclaringSyntaxReferences: [var syntaxRef2, ..] } property &&
-                            IsImplicitConversion(compilation, source: parameter.Type, destination: property.Type) &&
-                            syntaxRef2.GetSyntax(cancellationToken) is PropertyDeclarationSyntax { Initializer: null })
-                        {
-                            // We also allow assigning into a property of the form `=> throw new
-                            // NotImplementedException()`. That way users can easily spit out those methods, but then
-                            // convert them to be normal properties with ease.
-                            if (IsThrowNotImplementedProperty(compilation, property, cancellationToken))
-                                return (property, isThrowNotImplementedProperty: true);
+                    // If it's a writable property that we could assign this parameter to, and it's not already been
+                    // assigned to, then this property is a good candidate for us to hook up to.
+                    if (memberWithName is IPropertySymbol { DeclaringSyntaxReferences: [var syntaxRef2, ..] } property &&
+                        IsImplicitConversion(compilation, source: parameter.Type, destination: property.Type) &&
+                        syntaxRef2.GetSyntax(cancellationToken) is PropertyDeclarationSyntax { Initializer: null })
+                    {
+                        // We also allow assigning into a property of the form `=> throw new
+                        // NotImplementedException()`. That way users can easily spit out those methods, but then
+                        // convert them to be normal properties with ease.
+                        if (IsThrowNotImplementedProperty(compilation, property, cancellationToken))
+                            return (property, isThrowNotImplementedProperty: true);
 
-                            if (property.IsWritableInConstructor())
-                                return (property, isThrowNotImplementedProperty: false);
-                        }
+                        if (property.IsWritableInConstructor())
+                            return (property, isThrowNotImplementedProperty: false);
                     }
                 }
-
-                // Couldn't find any existing member.  Just return nothing so we can offer to create a member for them.
-                return default;
             }
 
-            static CodeAction CreateCodeAction(string title, Func<CancellationToken, Task<Solution>> createSolution)
-                => CodeAction.Create(title, createSolution, title);
+            // Couldn't find any existing member.  Just return nothing so we can offer to create a member for them.
+            return default;
+        }
 
-            IEnumerable<CodeAction> HandleExistingFieldOrProperty()
+        static CodeAction CreateCodeAction(string title, Func<CancellationToken, Task<Solution>> createSolution)
+            => CodeAction.Create(title, createSolution, title);
+
+        IEnumerable<CodeAction> HandleExistingFieldOrProperty()
+        {
+            // Found a field/property that this parameter should be assigned to. Just offer the simple assignment to it.
+            yield return CreateCodeAction(
+                string.Format(fieldOrProperty.Kind == SymbolKind.Field ? FeaturesResources.Initialize_field_0 : FeaturesResources.Initialize_property_0, fieldOrProperty.Name),
+                cancellationToken => AddSingleSymbolInitializationAsync(
+                    document, typeDeclaration, parameter, fieldOrProperty, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+        }
+
+        IEnumerable<CodeAction> HandleNoExistingFieldOrProperty()
+        {
+            // Didn't find a field/prop that this parameter could be assigned to. Offer to create new one and assign to that.
+
+            // Check if the surrounding parameters are assigned to another field in this class.  If so, offer to
+            // make this parameter into a field as well.  Otherwise, default to generating a property
+            var siblingFieldOrProperty = TryFindSiblingFieldOrProperty();
+            var (fieldAction, propertyAction) = AddSpecificParameterInitializationActions();
+
+            yield return siblingFieldOrProperty is IFieldSymbol ? fieldAction : propertyAction;
+            yield return siblingFieldOrProperty is IFieldSymbol ? propertyAction : fieldAction;
+
+            var (allFieldsAction, allPropertiesAction) = AddAllParameterInitializationActions();
+            if (allFieldsAction != null && allPropertiesAction != null)
             {
-                // Found a field/property that this parameter should be assigned to. Just offer the simple assignment to it.
-                yield return CreateCodeAction(
-                    string.Format(fieldOrProperty.Kind == SymbolKind.Field ? FeaturesResources.Initialize_field_0 : FeaturesResources.Initialize_property_0, fieldOrProperty.Name),
-                    cancellationToken => AddSingleSymbolInitializationAsync(
-                        document, typeDeclaration, parameter, fieldOrProperty, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
-            }
-
-            IEnumerable<CodeAction> HandleNoExistingFieldOrProperty()
-            {
-                // Didn't find a field/prop that this parameter could be assigned to. Offer to create new one and assign to that.
-
-                // Check if the surrounding parameters are assigned to another field in this class.  If so, offer to
-                // make this parameter into a field as well.  Otherwise, default to generating a property
-                var siblingFieldOrProperty = TryFindSiblingFieldOrProperty();
-                var (fieldAction, propertyAction) = AddSpecificParameterInitializationActions();
-
-                yield return siblingFieldOrProperty is IFieldSymbol ? fieldAction : propertyAction;
-                yield return siblingFieldOrProperty is IFieldSymbol ? propertyAction : fieldAction;
-
-                var (allFieldsAction, allPropertiesAction) = AddAllParameterInitializationActions();
-                if (allFieldsAction != null && allPropertiesAction != null)
-                {
-                    yield return siblingFieldOrProperty is IFieldSymbol ? allFieldsAction : allPropertiesAction;
-                    yield return siblingFieldOrProperty is IFieldSymbol ? allPropertiesAction : allFieldsAction;
-                }
-            }
-
-            ISymbol? TryFindSiblingFieldOrProperty()
-            {
-                foreach (var (siblingParam, _) in InitializeParameterHelpersCore.GetSiblingParameters(parameter))
-                {
-                    var (_, sibling) = TryFindFieldOrPropertyInitializerValue(compilation, siblingParam, cancellationToken);
-                    if (sibling != null)
-                        return sibling;
-                }
-
-                return null;
-            }
-
-            (CodeAction fieldAction, CodeAction propertyAction) AddSpecificParameterInitializationActions()
-            {
-                var field = CreateField(parameter);
-                var property = CreateProperty(parameter);
-
-                // we're generating the field or property, so we don't have to handle throwing versions of them.
-                var isThrowNotImplementedProperty = false;
-
-                var fieldAction = CreateCodeAction(
-                    string.Format(FeaturesResources.Create_and_assign_field_0, field.Name),
-                    cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, field, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
-                var propertyAction = CreateCodeAction(
-                    string.Format(FeaturesResources.Create_and_assign_property_0, property.Name),
-                    cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, property, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
-
-                return (fieldAction, propertyAction);
-            }
-
-            (CodeAction? fieldAction, CodeAction? propertyAction) AddAllParameterInitializationActions()
-            {
-                var parameters = GetParametersWithoutAssociatedMembers();
-                if (parameters.Length < 2)
-                    return default;
-
-                var allFieldsAction = CodeAction.Create(
-                    FeaturesResources.Create_and_assign_remaining_as_fields,
-                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateField), fallbackOptions, cancellationToken));
-                var allPropertiesAction = CodeAction.Create(
-                    FeaturesResources.Create_and_assign_remaining_as_properties,
-                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateProperty), fallbackOptions, cancellationToken));
-
-                return (allFieldsAction, allPropertiesAction);
-            }
-
-            ImmutableArray<IParameterSymbol> GetParametersWithoutAssociatedMembers()
-            {
-                using var result = TemporaryArray<IParameterSymbol>.Empty;
-
-                foreach (var parameter in constructor.Parameters)
-                {
-                    var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules);
-                    if (parameterNameParts.BaseName == "")
-                        continue;
-
-                    var (assignmentOp, _) = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
-                    if (assignmentOp != null)
-                        continue;
-
-                    result.Add(parameter);
-                }
-
-                return result.ToImmutableAndClear();
-            }
-
-            ISymbol CreateField(IParameterSymbol parameter)
-            {
-                var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
-                var accessibilityLevel = formattingOptions.AccessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault
-                    ? Accessibility.NotApplicable
-                    : Accessibility.Private;
-
-                foreach (var rule in rules)
-                {
-                    if (rule.SymbolSpecification.AppliesTo(SymbolKind.Field, Accessibility.Private))
-                    {
-                        return CodeGenerationSymbolFactory.CreateFieldSymbol(
-                            attributes: default,
-                            accessibilityLevel,
-                            DeclarationModifiers.ReadOnly,
-                            parameter.Type,
-                            name: GenerateUniqueName(parameter, parameterNameParts, rule),
-                            initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
-                    }
-                }
-
-                // We place a special rule in s_builtInRules that matches all fields.  So we should 
-                // always find a matching rule.
-                throw ExceptionUtilities.Unreachable();
-            }
-
-            ISymbol CreateProperty(IParameterSymbol parameter)
-            {
-                var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
-
-                foreach (var rule in rules)
-                {
-                    if (rule.SymbolSpecification.AppliesTo(SymbolKind.Property, Accessibility.Public))
-                    {
-                        return CodeGenerationSymbolFactory.CreatePropertySymbol(
-                            containingType: null,
-                            attributes: default,
-                            Accessibility.Public,
-                            modifiers: default,
-                            parameter.Type,
-                            RefKind.None,
-                            explicitInterfaceImplementations: default,
-                            name: GenerateUniqueName(parameter, parameterNameParts, rule),
-                            parameters: default,
-                            getMethod: CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                                attributes: default,
-                                Accessibility.Public,
-                                statements: default),
-                            setMethod: null,
-                            initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
-                    }
-                }
-
-                // We place a special rule in s_builtInRules that matches all properties.  So we should 
-                // always find a matching rule.
-                throw ExceptionUtilities.Unreachable();
+                yield return siblingFieldOrProperty is IFieldSymbol ? allFieldsAction : allPropertiesAction;
+                yield return siblingFieldOrProperty is IFieldSymbol ? allPropertiesAction : allFieldsAction;
             }
         }
 
-        private static (IOperation? initializer, ISymbol? fieldOrProperty) TryFindFieldOrPropertyInitializerValue(
-            Compilation compilation,
-            IParameterSymbol parameter,
-            CancellationToken cancellationToken)
+        ISymbol? TryFindSiblingFieldOrProperty()
         {
-            foreach (var group in parameter.ContainingType.DeclaringSyntaxReferences.GroupBy(r => r.SyntaxTree))
+            foreach (var (siblingParam, _) in InitializeParameterHelpersCore.GetSiblingParameters(parameter))
             {
-                var semanticModel = compilation.GetSemanticModel(group.Key);
-                foreach (var syntaxReference in group)
+                var (_, sibling) = TryFindFieldOrPropertyInitializerValue(compilation, siblingParam, cancellationToken);
+                if (sibling != null)
+                    return sibling;
+            }
+
+            return null;
+        }
+
+        (CodeAction fieldAction, CodeAction propertyAction) AddSpecificParameterInitializationActions()
+        {
+            var field = CreateField(parameter);
+            var property = CreateProperty(parameter);
+
+            // we're generating the field or property, so we don't have to handle throwing versions of them.
+            var isThrowNotImplementedProperty = false;
+
+            var fieldAction = CreateCodeAction(
+                string.Format(FeaturesResources.Create_and_assign_field_0, field.Name),
+                cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, field, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+            var propertyAction = CreateCodeAction(
+                string.Format(FeaturesResources.Create_and_assign_property_0, property.Name),
+                cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, property, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+
+            return (fieldAction, propertyAction);
+        }
+
+        (CodeAction? fieldAction, CodeAction? propertyAction) AddAllParameterInitializationActions()
+        {
+            var parameters = GetParametersWithoutAssociatedMembers();
+            if (parameters.Length < 2)
+                return default;
+
+            var allFieldsAction = CodeAction.Create(
+                FeaturesResources.Create_and_assign_remaining_as_fields,
+                cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateField), fallbackOptions, cancellationToken));
+            var allPropertiesAction = CodeAction.Create(
+                FeaturesResources.Create_and_assign_remaining_as_properties,
+                cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateProperty), fallbackOptions, cancellationToken));
+
+            return (allFieldsAction, allPropertiesAction);
+        }
+
+        ImmutableArray<IParameterSymbol> GetParametersWithoutAssociatedMembers()
+        {
+            using var result = TemporaryArray<IParameterSymbol>.Empty;
+
+            foreach (var parameter in constructor.Parameters)
+            {
+                var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules);
+                if (parameterNameParts.BaseName == "")
+                    continue;
+
+                var (assignmentOp, _) = TryFindFieldOrPropertyInitializerValue(compilation, parameter, cancellationToken);
+                if (assignmentOp != null)
+                    continue;
+
+                result.Add(parameter);
+            }
+
+            return result.ToImmutableAndClear();
+        }
+
+        ISymbol CreateField(IParameterSymbol parameter)
+        {
+            var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
+            var accessibilityLevel = formattingOptions.AccessibilityModifiersRequired is AccessibilityModifiersRequired.Never or AccessibilityModifiersRequired.OmitIfDefault
+                ? Accessibility.NotApplicable
+                : Accessibility.Private;
+
+            foreach (var rule in rules)
+            {
+                if (rule.SymbolSpecification.AppliesTo(SymbolKind.Field, Accessibility.Private))
                 {
-                    if (syntaxReference.GetSyntax(cancellationToken) is TypeDeclarationSyntax typeDeclaration)
+                    return CodeGenerationSymbolFactory.CreateFieldSymbol(
+                        attributes: default,
+                        accessibilityLevel,
+                        DeclarationModifiers.ReadOnly,
+                        parameter.Type,
+                        name: GenerateUniqueName(parameter, parameterNameParts, rule),
+                        initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
+                }
+            }
+
+            // We place a special rule in s_builtInRules that matches all fields.  So we should 
+            // always find a matching rule.
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        ISymbol CreateProperty(IParameterSymbol parameter)
+        {
+            var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
+
+            foreach (var rule in rules)
+            {
+                if (rule.SymbolSpecification.AppliesTo(SymbolKind.Property, Accessibility.Public))
+                {
+                    return CodeGenerationSymbolFactory.CreatePropertySymbol(
+                        containingType: null,
+                        attributes: default,
+                        Accessibility.Public,
+                        modifiers: default,
+                        parameter.Type,
+                        RefKind.None,
+                        explicitInterfaceImplementations: default,
+                        name: GenerateUniqueName(parameter, parameterNameParts, rule),
+                        parameters: default,
+                        getMethod: CodeGenerationSymbolFactory.CreateAccessorSymbol(
+                            attributes: default,
+                            Accessibility.Public,
+                            statements: default),
+                        setMethod: null,
+                        initializer: IdentifierName(parameter.Name.EscapeIdentifier()));
+                }
+            }
+
+            // We place a special rule in s_builtInRules that matches all properties.  So we should 
+            // always find a matching rule.
+            throw ExceptionUtilities.Unreachable();
+        }
+    }
+
+    private static (IOperation? initializer, ISymbol? fieldOrProperty) TryFindFieldOrPropertyInitializerValue(
+        Compilation compilation,
+        IParameterSymbol parameter,
+        CancellationToken cancellationToken)
+    {
+        foreach (var group in parameter.ContainingType.DeclaringSyntaxReferences.GroupBy(r => r.SyntaxTree))
+        {
+            var semanticModel = compilation.GetSemanticModel(group.Key);
+            foreach (var syntaxReference in group)
+            {
+                if (syntaxReference.GetSyntax(cancellationToken) is TypeDeclarationSyntax typeDeclaration)
+                {
+                    foreach (var member in typeDeclaration.Members)
                     {
-                        foreach (var member in typeDeclaration.Members)
+                        if (member is PropertyDeclarationSyntax { Initializer.Value: var propertyInitializer } propertyDeclaration)
                         {
-                            if (member is PropertyDeclarationSyntax { Initializer.Value: var propertyInitializer } propertyDeclaration)
+                            var operation = semanticModel.GetOperation(propertyInitializer, cancellationToken);
+                            if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
+                                return (operation, semanticModel.GetRequiredDeclaredSymbol(propertyDeclaration, cancellationToken));
+                        }
+                        else if (member is FieldDeclarationSyntax field)
+                        {
+                            foreach (var varDecl in field.Declaration.Variables)
                             {
-                                var operation = semanticModel.GetOperation(propertyInitializer, cancellationToken);
-                                if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
-                                    return (operation, semanticModel.GetRequiredDeclaredSymbol(propertyDeclaration, cancellationToken));
-                            }
-                            else if (member is FieldDeclarationSyntax field)
-                            {
-                                foreach (var varDecl in field.Declaration.Variables)
+                                if (varDecl is { Initializer.Value: var fieldInitializer })
                                 {
-                                    if (varDecl is { Initializer.Value: var fieldInitializer })
-                                    {
-                                        var operation = semanticModel.GetOperation(fieldInitializer, cancellationToken);
-                                        if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
-                                            return (operation, semanticModel.GetRequiredDeclaredSymbol(varDecl, cancellationToken));
-                                    }
+                                    var operation = semanticModel.GetOperation(fieldInitializer, cancellationToken);
+                                    if (IsParameterReferenceOrCoalesceOfParameterReference(operation, parameter))
+                                        return (operation, semanticModel.GetRequiredDeclaredSymbol(varDecl, cancellationToken));
                                 }
                             }
                         }
                     }
                 }
             }
-
-            return default;
         }
+
+        return default;
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.InitializeParameter;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Naming;

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -141,8 +141,8 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
             // Found a field/property that this parameter should be assigned to. Just offer the simple assignment to it.
             yield return CreateCodeAction(
                 string.Format(fieldOrProperty.Kind == SymbolKind.Field ? FeaturesResources.Initialize_field_0 : FeaturesResources.Initialize_property_0, fieldOrProperty.Name),
-                cancellationToken => AddSingleSymbolInitializationAsync(
-                    document, typeDeclaration, parameter, fieldOrProperty, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+                cancellationToken => UpdateExistingMemberAsync(
+                    document, parameter, fieldOrProperty, isThrowNotImplementedProperty, cancellationToken));
         }
 
         IEnumerable<CodeAction> HandleNoExistingFieldOrProperty()
@@ -182,15 +182,12 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
             var field = CreateField(parameter);
             var property = CreateProperty(parameter);
 
-            // we're generating the field or property, so we don't have to handle throwing versions of them.
-            var isThrowNotImplementedProperty = false;
-
             var fieldAction = CreateCodeAction(
                 string.Format(FeaturesResources.Create_and_assign_field_0, field.Name),
-                cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, field, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+                cancellationToken => AddSingleMemberAsync(document, typeDeclaration, parameter, field, fallbackOptions, cancellationToken));
             var propertyAction = CreateCodeAction(
                 string.Format(FeaturesResources.Create_and_assign_property_0, property.Name),
-                cancellationToken => AddSingleSymbolInitializationAsync(document, typeDeclaration, parameter, property, isThrowNotImplementedProperty, fallbackOptions, cancellationToken));
+                cancellationToken => AddSingleMemberAsync(document, typeDeclaration, parameter, property, fallbackOptions, cancellationToken));
 
             return (fieldAction, propertyAction);
         }
@@ -203,10 +200,10 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
 
             var allFieldsAction = CodeAction.Create(
                 FeaturesResources.Create_and_assign_remaining_as_fields,
-                cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateField), fallbackOptions, cancellationToken));
+                cancellationToken => AddMultipleMembersAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateField), fallbackOptions, cancellationToken));
             var allPropertiesAction = CodeAction.Create(
                 FeaturesResources.Create_and_assign_remaining_as_properties,
-                cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateProperty), fallbackOptions, cancellationToken));
+                cancellationToken => AddMultipleMembersAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateProperty), fallbackOptions, cancellationToken));
 
             return (allFieldsAction, allPropertiesAction);
         }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -229,16 +229,13 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 if (parameters.Length < 2)
                     return default;
 
-                var fields = parameters.SelectAsArray(p => (ISymbol)CreateField(p));
-                var properties = parameters.SelectAsArray(p => (ISymbol)CreateProperty(p));
-
                 var allFieldsAction = CodeAction.Create(
                     FeaturesResources.Create_and_assign_remaining_as_fields,
-                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, fields, fallbackOptions, cancellationToken),
+                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateField), fallbackOptions, cancellationToken),
                     nameof(FeaturesResources.Create_and_assign_remaining_as_fields));
                 var allPropertiesAction = CodeAction.Create(
                     FeaturesResources.Create_and_assign_remaining_as_properties,
-                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, properties, fallbackOptions, cancellationToken),
+                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, parameters.SelectAsArray(CreateProperty), fallbackOptions, cancellationToken),
                     nameof(FeaturesResources.Create_and_assign_remaining_as_properties));
 
                 return (allFieldsAction, allPropertiesAction);
@@ -264,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 return result.ToImmutable();
             }
 
-            IFieldSymbol CreateField(IParameterSymbol parameter)
+            ISymbol CreateField(IParameterSymbol parameter)
             {
                 var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
 
@@ -293,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 throw ExceptionUtilities.Unreachable();
             }
 
-            IPropertySymbol CreateProperty(IParameterSymbol parameter)
+            ISymbol CreateProperty(IParameterSymbol parameter)
             {
                 var parameterNameParts = IdentifierNameParts.CreateIdentifierNameParts(parameter, rules).BaseNameParts;
 

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -157,30 +157,14 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 var siblingFieldOrProperty = TryFindSiblingFieldOrProperty();
                 var (fieldAction, propertyAction) = AddSpecificParameterInitializationActions();
 
-                if (siblingFieldOrProperty is IFieldSymbol)
-                {
-                    allActions.Add(fieldAction);
-                    allActions.Add(propertyAction);
-                }
-                else
-                {
-                    allActions.Add(propertyAction);
-                    allActions.Add(fieldAction);
-                }
+                allActions.Add(siblingFieldOrProperty is IFieldSymbol ? fieldAction : propertyAction);
+                allActions.Add(siblingFieldOrProperty is IFieldSymbol ? propertyAction : fieldAction);
 
                 var (allFieldsAction, allPropertiesAction) = AddAllParameterInitializationActions();
                 if (allFieldsAction != null && allPropertiesAction != null)
                 {
-                    if (siblingFieldOrProperty is IFieldSymbol)
-                    {
-                        allActions.Add(allFieldsAction);
-                        allActions.Add(allPropertiesAction);
-                    }
-                    else
-                    {
-                        allActions.Add(allPropertiesAction);
-                        allActions.Add(allFieldsAction);
-                    }
+                    allActions.Add(siblingFieldOrProperty is IFieldSymbol ? allFieldsAction : allPropertiesAction);
+                    allActions.Add(siblingFieldOrProperty is IFieldSymbol ? allPropertiesAction : allFieldsAction);
                 }
 
                 return allActions.ToImmutableAndClear();

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -234,11 +234,11 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
                 var allFieldsAction = CodeAction.Create(
                     FeaturesResources.Create_and_assign_remaining_as_fields,
-                    cancellationToken => AddAllSymbolInitializationsAsync(parameters, fields, cancellationToken),
+                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, fields, fallbackOptions, cancellationToken),
                     nameof(FeaturesResources.Create_and_assign_remaining_as_fields));
                 var allPropertiesAction = CodeAction.Create(
                     FeaturesResources.Create_and_assign_remaining_as_properties,
-                    cancellationToken => AddAllSymbolInitializationsAsync(parameters, properties, cancellationToken),
+                    cancellationToken => AddAllSymbolInitializationsAsync(document, typeDeclaration, parameters, properties, fallbackOptions, cancellationToken),
                     nameof(FeaturesResources.Create_and_assign_remaining_as_properties));
 
                 return (allFieldsAction, allPropertiesAction);
@@ -262,56 +262,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 }
 
                 return result.ToImmutable();
-            }
-
-            async Task<Solution> AddAllSymbolInitializationsAsync(
-                ImmutableArray<IParameterSymbol> parameters,
-                ImmutableArray<ISymbol> fieldsOrProperties,
-                CancellationToken cancellationToken)
-            {
-                Debug.Assert(parameters.Length >= 2);
-                Debug.Assert(fieldsOrProperties.Length > 0);
-                Debug.Assert(parameters.Length == fieldsOrProperties.Length);
-
-                // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
-                // Then find all the current data in that updated document and move onto the next pair.
-
-                var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                var trackedRoot = root.TrackNodes(typeDeclaration);
-                var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
-
-                for (var i = 0; i < parameters.Length; i++)
-                {
-                    var parameter = parameters[i];
-                    var fieldOrProperty = fieldsOrProperties[i];
-
-                    var currentDocument = currentSolution.GetRequiredDocument(document.Id);
-                    var currentSemanticModel = await currentDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                    var currentCompilation = currentSemanticModel.Compilation;
-                    var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                    var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
-                    if (currentTypeDeclaration == null)
-                        continue;
-
-                    var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
-                    if (currentParameter == null)
-                        continue;
-
-                    // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
-
-                    currentSolution = await AddSingleSymbolInitializationAsync(
-                        currentDocument,
-                        currentTypeDeclaration,
-                        currentParameter,
-                        fieldOrProperty,
-                        isThrowNotImplementedProperty: false,
-                        fallbackOptions,
-                        cancellationToken).ConfigureAwait(false);
-                }
-
-                return currentSolution;
             }
         }
 
@@ -385,6 +335,59 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             // We place a special rule in s_builtInRules that matches all properties.  So we should 
             // always find a matching rule.
             throw ExceptionUtilities.Unreachable();
+        }
+
+        private static async Task<Solution> AddAllSymbolInitializationsAsync(
+            Document document,
+            TypeDeclarationSyntax typeDeclaration,
+            ImmutableArray<IParameterSymbol> parameters,
+            ImmutableArray<ISymbol> fieldsOrProperties,
+            CodeGenerationOptionsProvider fallbackOptions,
+            CancellationToken cancellationToken)
+        {
+            Debug.Assert(parameters.Length >= 2);
+            Debug.Assert(fieldsOrProperties.Length > 0);
+            Debug.Assert(parameters.Length == fieldsOrProperties.Length);
+
+            // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
+            // Then find all the current data in that updated document and move onto the next pair.
+
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var trackedRoot = root.TrackNodes(typeDeclaration);
+            var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                var fieldOrProperty = fieldsOrProperties[i];
+
+                var currentDocument = currentSolution.GetRequiredDocument(document.Id);
+                var currentSemanticModel = await currentDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var currentCompilation = currentSemanticModel.Compilation;
+                var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+                var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
+                if (currentTypeDeclaration == null)
+                    continue;
+
+                var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
+                if (currentParameter == null)
+                    continue;
+
+                // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
+
+                currentSolution = await AddSingleSymbolInitializationAsync(
+                    currentDocument,
+                    currentTypeDeclaration,
+                    currentParameter,
+                    fieldOrProperty,
+                    isThrowNotImplementedProperty: false,
+                    fallbackOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return currentSolution;
         }
 
         /// <summary>

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -96,7 +96,6 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
             // it as a member in this type.  Note that we have some fallback rules that use the standard conventions
             // around properties /fields so that can still find things even if the user has no naming preferences
             // set.
-
             foreach (var rule in rules)
             {
                 var memberName = rule.NamingStyle.CreateName(parameterWords);

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -139,14 +139,10 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             ImmutableArray<CodeAction> HandleExistingFieldOrProperty()
             {
-                // Found a field/property that this parameter should be assigned to.
-                // Just offer the simple assignment to it.
-
-                var resource = fieldOrProperty.Kind == SymbolKind.Field
+                // Found a field/property that this parameter should be assigned to. Just offer the simple assignment to it.
+                var title = string.Format(fieldOrProperty.Kind == SymbolKind.Field
                     ? FeaturesResources.Initialize_field_0
-                    : FeaturesResources.Initialize_property_0;
-
-                var title = string.Format(resource, fieldOrProperty.Name);
+                    : FeaturesResources.Initialize_property_0, fieldOrProperty.Name);
 
                 return ImmutableArray.Create(CodeAction.Create(
                     title,

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -184,10 +184,10 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
 
             var fieldAction = CreateCodeAction(
                 string.Format(FeaturesResources.Create_and_assign_field_0, field.Name),
-                cancellationToken => AddSingleMemberAsync(document, typeDeclaration, parameter, field, fallbackOptions, cancellationToken));
+                cancellationToken => AddMultipleMembersAsync(document, typeDeclaration, ImmutableArray.Create(parameter), ImmutableArray.Create(field), fallbackOptions, cancellationToken));
             var propertyAction = CreateCodeAction(
                 string.Format(FeaturesResources.Create_and_assign_property_0, property.Name),
-                cancellationToken => AddSingleMemberAsync(document, typeDeclaration, parameter, property, fallbackOptions, cancellationToken));
+                cancellationToken => AddMultipleMembersAsync(document, typeDeclaration, ImmutableArray.Create(parameter), ImmutableArray.Create(property), fallbackOptions, cancellationToken));
 
             return (fieldAction, propertyAction);
         }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Naming;
 using Roslyn.Utilities;
@@ -239,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
             ImmutableArray<IParameterSymbol> GetParametersWithoutAssociatedMembers()
             {
-                using var _1 = ArrayBuilder<IParameterSymbol>.GetInstance(out var result);
+                using var result = TemporaryArray<IParameterSymbol>.Empty;
 
                 foreach (var parameter in constructor.Parameters)
                 {
@@ -254,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                     result.Add(parameter);
                 }
 
-                return result.ToImmutable();
+                return result.ToImmutableAndClear();
             }
 
             ISymbol CreateField(IParameterSymbol parameter)

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -23,7 +23,7 @@ using static InitializeParameterHelpers;
 using static InitializeParameterHelpersCore;
 using static SyntaxFactory;
 
-internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider
 {
     private static async Task<Solution> AddMultipleMembersAsync(
         Document document,
@@ -71,6 +71,10 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
         }
 
         return currentSolution;
+
+        // Intentionally static so that we do not capture outer state.  This function is called in a loop with a fresh
+        // fork of the solution after each change that has been made.  This ensures we don't accidentally refer to the
+        // original state in any way.
 
         static async Task<Solution> AddSingleMemberAsync(
             Document document,

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -17,232 +17,231 @@ using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
+namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter;
+
+using static InitializeParameterHelpers;
+using static InitializeParameterHelpersCore;
+using static SyntaxFactory;
+
+internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
 {
-    using static InitializeParameterHelpers;
-    using static InitializeParameterHelpersCore;
-    using static SyntaxFactory;
+    /// This functions are the workhorses that actually go and handle each parameter (either creating a
+    /// field/property for it, or updates an existing field/property with it).  They are extracted out from the rest
+    /// as we do not want it capturing anything.  Specifically, AddSingleSymbolInitializationAsync is called in a
+    /// loop from AddAllSymbolInitializationsAsync for each parameter we're processing.  For each, we produce new
+    /// solution snapshots and thus must ensure we're always pointing at the new view of the world, not anything
+    /// from the original view.
 
-    internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+    private static async Task<Solution> AddAllSymbolInitializationsAsync(
+        Document document,
+        TypeDeclarationSyntax typeDeclaration,
+        ImmutableArray<IParameterSymbol> parameters,
+        ImmutableArray<ISymbol> fieldsOrProperties,
+        CodeGenerationOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
     {
-        /// This functions are the workhorses that actually go and handle each parameter (either creating a
-        /// field/property for it, or updates an existing field/property with it).  They are extracted out from the rest
-        /// as we do not want it capturing anything.  Specifically, AddSingleSymbolInitializationAsync is called in a
-        /// loop from AddAllSymbolInitializationsAsync for each parameter we're processing.  For each, we produce new
-        /// solution snapshots and thus must ensure we're always pointing at the new view of the world, not anything
-        /// from the original view.
+        Debug.Assert(parameters.Length >= 2);
+        Debug.Assert(fieldsOrProperties.Length > 0);
+        Debug.Assert(parameters.Length == fieldsOrProperties.Length);
 
-        private static async Task<Solution> AddAllSymbolInitializationsAsync(
-            Document document,
-            TypeDeclarationSyntax typeDeclaration,
-            ImmutableArray<IParameterSymbol> parameters,
-            ImmutableArray<ISymbol> fieldsOrProperties,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
+        // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
+        // Then find all the current data in that updated document and move onto the next pair.
+
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var trackedRoot = root.TrackNodes(typeDeclaration);
+        var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
+
+        foreach (var (parameter, fieldOrProperty) in parameters.Zip(fieldsOrProperties, static (a, b) => (a, b)))
         {
-            Debug.Assert(parameters.Length >= 2);
-            Debug.Assert(fieldsOrProperties.Length > 0);
-            Debug.Assert(parameters.Length == fieldsOrProperties.Length);
+            var currentDocument = currentSolution.GetRequiredDocument(document.Id);
+            var currentCompilation = await currentDocument.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-            // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
-            // Then find all the current data in that updated document and move onto the next pair.
+            var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
+            if (currentTypeDeclaration == null)
+                continue;
 
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
+            if (currentParameter == null)
+                continue;
 
-            var trackedRoot = root.TrackNodes(typeDeclaration);
-            var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
+            // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
 
-            foreach (var (parameter, fieldOrProperty) in parameters.Zip(fieldsOrProperties, static (a, b) => (a, b)))
-            {
-                var currentDocument = currentSolution.GetRequiredDocument(document.Id);
-                var currentCompilation = await currentDocument.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
-                if (currentTypeDeclaration == null)
-                    continue;
-
-                var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
-                if (currentParameter == null)
-                    continue;
-
-                // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
-
-                currentSolution = await AddSingleSymbolInitializationAsync(
-                    currentDocument,
-                    currentTypeDeclaration,
-                    currentParameter,
-                    fieldOrProperty,
-                    isThrowNotImplementedProperty: false,
-                    fallbackOptions,
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            return currentSolution;
+            currentSolution = await AddSingleSymbolInitializationAsync(
+                currentDocument,
+                currentTypeDeclaration,
+                currentParameter,
+                fieldOrProperty,
+                isThrowNotImplementedProperty: false,
+                fallbackOptions,
+                cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<Solution> AddSingleSymbolInitializationAsync(
-            Document document,
-            TypeDeclarationSyntax typeDeclaration,
-            IParameterSymbol parameter,
-            ISymbol fieldOrProperty,
-            bool isThrowNotImplementedProperty,
-            CodeGenerationOptionsProvider fallbackOptions,
-            CancellationToken cancellationToken)
+        return currentSolution;
+    }
+
+    private static async Task<Solution> AddSingleSymbolInitializationAsync(
+        Document document,
+        TypeDeclarationSyntax typeDeclaration,
+        IParameterSymbol parameter,
+        ISymbol fieldOrProperty,
+        bool isThrowNotImplementedProperty,
+        CodeGenerationOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+        var services = solution.Services;
+
+        var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+        var parseOptions = document.DocumentState.ParseOptions!;
+
+        var solutionEditor = new SolutionEditor(solution);
+        var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+        var codeGenerator = document.GetRequiredLanguageService<ICodeGenerationService>();
+
+        // We're assigning the parameter to a field/prop (either new or existing).  Convert all existing references
+        // to this primary constructor parameter (within this type) to refer to the field/prop now instead.
+        await UpdateParameterReferencesAsync().ConfigureAwait(false);
+
+        // Now, either add the new field/prop, or update the existing one by assigning the parameter to it.
+        return fieldOrProperty.ContainingType == null
+            ? await AddFieldOrPropertyAsync().ConfigureAwait(false)
+            : await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
+
+        async Task UpdateParameterReferencesAsync()
         {
-            var project = document.Project;
-            var solution = project.Solution;
-            var services = solution.Services;
+            var namedType = parameter.ContainingType;
+            var documents = namedType.DeclaringSyntaxReferences
+                .Select(r => solution.GetRequiredDocument(r.SyntaxTree))
+                .ToImmutableHashSet();
 
-            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var parseOptions = document.DocumentState.ParseOptions!;
-
-            var solutionEditor = new SolutionEditor(solution);
-            var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var codeGenerator = document.GetRequiredLanguageService<ICodeGenerationService>();
-
-            // We're assigning the parameter to a field/prop (either new or existing).  Convert all existing references
-            // to this primary constructor parameter (within this type) to refer to the field/prop now instead.
-            await UpdateParameterReferencesAsync().ConfigureAwait(false);
-
-            // Now, either add the new field/prop, or update the existing one by assigning the parameter to it.
-            return fieldOrProperty.ContainingType == null
-                ? await AddFieldOrPropertyAsync().ConfigureAwait(false)
-                : await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
-
-            async Task UpdateParameterReferencesAsync()
+            var references = await SymbolFinder.FindReferencesAsync(parameter, solution, documents, cancellationToken).ConfigureAwait(false);
+            foreach (var group in references.SelectMany(r => r.Locations.Where(loc => !loc.IsImplicit).GroupBy(loc => loc.Document)))
             {
-                var namedType = parameter.ContainingType;
-                var documents = namedType.DeclaringSyntaxReferences
-                    .Select(r => solution.GetRequiredDocument(r.SyntaxTree))
-                    .ToImmutableHashSet();
-
-                var references = await SymbolFinder.FindReferencesAsync(parameter, solution, documents, cancellationToken).ConfigureAwait(false);
-                foreach (var group in references.SelectMany(r => r.Locations.Where(loc => !loc.IsImplicit).GroupBy(loc => loc.Document)))
+                var editor = await solutionEditor.GetDocumentEditorAsync(group.Key.Id, cancellationToken).ConfigureAwait(false);
+                foreach (var location in group)
                 {
-                    var editor = await solutionEditor.GetDocumentEditorAsync(group.Key.Id, cancellationToken).ConfigureAwait(false);
-                    foreach (var location in group)
+                    var node = location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
+                    if (node is IdentifierNameSyntax { Parent: not NameColonSyntax } identifierName &&
+                        identifierName.Identifier.ValueText == parameter.Name)
                     {
-                        var node = location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
-                        if (node is IdentifierNameSyntax { Parent: not NameColonSyntax } identifierName &&
-                            identifierName.Identifier.ValueText == parameter.Name)
-                        {
-                            // we may have things like `new MyType(x: ...)` we don't want to update `x` there to 'X'
-                            // just because we're generating a new property 'X' for the parameter to be assigned to.
-                            editor.ReplaceNode(
-                                identifierName,
-                                IdentifierName(fieldOrProperty.Name.EscapeIdentifier()).WithTriviaFrom(identifierName));
-                        }
+                        // we may have things like `new MyType(x: ...)` we don't want to update `x` there to 'X'
+                        // just because we're generating a new property 'X' for the parameter to be assigned to.
+                        editor.ReplaceNode(
+                            identifierName,
+                            IdentifierName(fieldOrProperty.Name.EscapeIdentifier()).WithTriviaFrom(identifierName));
                     }
                 }
             }
+        }
 
-            async ValueTask<Solution> AddFieldOrPropertyAsync()
+        async ValueTask<Solution> AddFieldOrPropertyAsync()
+        {
+            // We're generating a new field/property.  Place into the containing type, ideally before/after a
+            // relevant existing member.
+            var (sibling, siblingSyntax, addContext) = fieldOrProperty switch
             {
-                // We're generating a new field/property.  Place into the containing type, ideally before/after a
-                // relevant existing member.
-                var (sibling, siblingSyntax, addContext) = fieldOrProperty switch
+                IPropertySymbol => GetAddContext<IPropertySymbol>(),
+                IFieldSymbol => GetAddContext<IFieldSymbol>(),
+                _ => throw ExceptionUtilities.UnexpectedValue(fieldOrProperty),
+            };
+
+            var preferredTypeDeclaration = siblingSyntax?.GetAncestorOrThis<TypeDeclarationSyntax>() ?? typeDeclaration;
+
+            var editingDocument = solution.GetRequiredDocument(preferredTypeDeclaration.SyntaxTree);
+            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+            editor.ReplaceNode(
+                preferredTypeDeclaration,
+                (currentTypeDecl, _) =>
                 {
-                    IPropertySymbol => GetAddContext<IPropertySymbol>(),
-                    IFieldSymbol => GetAddContext<IFieldSymbol>(),
-                    _ => throw ExceptionUtilities.UnexpectedValue(fieldOrProperty),
-                };
-
-                var preferredTypeDeclaration = siblingSyntax?.GetAncestorOrThis<TypeDeclarationSyntax>() ?? typeDeclaration;
-
-                var editingDocument = solution.GetRequiredDocument(preferredTypeDeclaration.SyntaxTree);
-                var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-                editor.ReplaceNode(
-                    preferredTypeDeclaration,
-                    (currentTypeDecl, _) =>
+                    if (fieldOrProperty is IPropertySymbol property)
                     {
-                        if (fieldOrProperty is IPropertySymbol property)
-                        {
-                            return codeGenerator.AddProperty(
-                                currentTypeDecl, property,
-                                codeGenerator.GetInfo(addContext, options, parseOptions),
-                                cancellationToken);
-                        }
-                        else if (fieldOrProperty is IFieldSymbol field)
-                        {
-                            return codeGenerator.AddField(
-                                currentTypeDecl, field,
-                                codeGenerator.GetInfo(addContext, options, parseOptions),
-                                cancellationToken);
-                        }
-                        else
-                        {
-                            throw ExceptionUtilities.Unreachable();
-                        }
-                    });
+                        return codeGenerator.AddProperty(
+                            currentTypeDecl, property,
+                            codeGenerator.GetInfo(addContext, options, parseOptions),
+                            cancellationToken);
+                    }
+                    else if (fieldOrProperty is IFieldSymbol field)
+                    {
+                        return codeGenerator.AddField(
+                            currentTypeDecl, field,
+                            codeGenerator.GetInfo(addContext, options, parseOptions),
+                            cancellationToken);
+                    }
+                    else
+                    {
+                        throw ExceptionUtilities.Unreachable();
+                    }
+                });
 
-                return solutionEditor.GetChangedSolution();
+            return solutionEditor.GetChangedSolution();
+        }
+
+        (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>() where TSymbol : class, ISymbol
+        {
+            foreach (var (sibling, before) in GetSiblingParameters(parameter))
+            {
+                var (initializer, fieldOrProperty) = TryFindFieldOrPropertyInitializerValue(
+                    compilation, sibling, cancellationToken);
+
+                if (initializer != null &&
+                    fieldOrProperty is TSymbol { DeclaringSyntaxReferences: [var syntaxReference, ..] } symbol)
+                {
+                    var syntax = syntaxReference.GetSyntax(cancellationToken);
+                    return (symbol, syntax, before
+                        ? new CodeGenerationContext(afterThisLocation: syntax.GetLocation())
+                        : new CodeGenerationContext(beforeThisLocation: syntax.GetLocation()));
+                }
             }
 
-            (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>() where TSymbol : class, ISymbol
-            {
-                foreach (var (sibling, before) in GetSiblingParameters(parameter))
-                {
-                    var (initializer, fieldOrProperty) = TryFindFieldOrPropertyInitializerValue(
-                        compilation, sibling, cancellationToken);
+            return (symbol: null, syntax: null, CodeGenerationContext.Default);
+        }
 
-                    if (initializer != null &&
-                        fieldOrProperty is TSymbol { DeclaringSyntaxReferences: [var syntaxReference, ..] } symbol)
+        async ValueTask<Solution> UpdateFieldOrPropertyAsync()
+        {
+            // We're updating an exiting field/prop.
+            if (fieldOrProperty is IPropertySymbol property)
+            {
+                foreach (var syntaxRef in property.DeclaringSyntaxReferences)
+                {
+                    if (syntaxRef.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)
                     {
-                        var syntax = syntaxReference.GetSyntax(cancellationToken);
-                        return (symbol, syntax, before
-                            ? new CodeGenerationContext(afterThisLocation: syntax.GetLocation())
-                            : new CodeGenerationContext(beforeThisLocation: syntax.GetLocation()));
+                        var editingDocument = solution.GetRequiredDocument(propertyDeclaration.SyntaxTree);
+                        var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+
+                        // If the user had a property that has 'throw NotImplementedException' in it, then remove those throws.
+                        var newPropertyDeclaration = isThrowNotImplementedProperty ? RemoveThrowNotImplemented(propertyDeclaration) : propertyDeclaration;
+                        editor.ReplaceNode(
+                            propertyDeclaration,
+                            newPropertyDeclaration.WithoutTrailingTrivia()
+                                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(newPropertyDeclaration.GetTrailingTrivia()))
+                                .WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
                     }
                 }
-
-                return (symbol: null, syntax: null, CodeGenerationContext.Default);
+            }
+            else if (fieldOrProperty is IFieldSymbol field)
+            {
+                foreach (var syntaxRef in field.DeclaringSyntaxReferences)
+                {
+                    if (syntaxRef.GetSyntax(cancellationToken) is VariableDeclaratorSyntax variableDeclarator)
+                    {
+                        var editingDocument = solution.GetRequiredDocument(variableDeclarator.SyntaxTree);
+                        var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+                        editor.ReplaceNode(
+                            variableDeclarator,
+                            variableDeclarator.WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                throw ExceptionUtilities.Unreachable();
             }
 
-            async ValueTask<Solution> UpdateFieldOrPropertyAsync()
-            {
-                // We're updating an exiting field/prop.
-                if (fieldOrProperty is IPropertySymbol property)
-                {
-                    foreach (var syntaxRef in property.DeclaringSyntaxReferences)
-                    {
-                        if (syntaxRef.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)
-                        {
-                            var editingDocument = solution.GetRequiredDocument(propertyDeclaration.SyntaxTree);
-                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-
-                            // If the user had a property that has 'throw NotImplementedException' in it, then remove those throws.
-                            var newPropertyDeclaration = isThrowNotImplementedProperty ? RemoveThrowNotImplemented(propertyDeclaration) : propertyDeclaration;
-                            editor.ReplaceNode(
-                                propertyDeclaration,
-                                newPropertyDeclaration.WithoutTrailingTrivia()
-                                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(newPropertyDeclaration.GetTrailingTrivia()))
-                                    .WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
-                        }
-                    }
-                }
-                else if (fieldOrProperty is IFieldSymbol field)
-                {
-                    foreach (var syntaxRef in field.DeclaringSyntaxReferences)
-                    {
-                        if (syntaxRef.GetSyntax(cancellationToken) is VariableDeclaratorSyntax variableDeclarator)
-                        {
-                            var editingDocument = solution.GetRequiredDocument(variableDeclarator.SyntaxTree);
-                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-                            editor.ReplaceNode(
-                                variableDeclarator,
-                                variableDeclarator.WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    throw ExceptionUtilities.Unreachable();
-                }
-
-                return solutionEditor.GetChangedSolution();
-            }
+            return solutionEditor.GetChangedSolution();
         }
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -196,8 +196,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             {
                 foreach (var (sibling, before) in GetSiblingParameters(parameter))
                 {
-                    var initializer = TryFindFieldOrPropertyInitializerValue(
-                        compilation, sibling, out var fieldOrProperty, cancellationToken);
+                    var (initializer, fieldOrProperty) = TryFindFieldOrPropertyInitializerValue(
+                        compilation, sibling, cancellationToken);
 
                     if (initializer != null &&
                         fieldOrProperty is TSymbol { DeclaringSyntaxReferences: [var syntaxReference, ..] } symbol)

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -150,10 +150,10 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 
                 var preferredTypeDeclaration = siblingSyntax?.GetAncestorOrThis<TypeDeclarationSyntax>() ?? typeDeclaration;
 
-                var editingDocument = solution.GetRequiredDocument(typeDeclaration.SyntaxTree);
+                var editingDocument = solution.GetRequiredDocument(preferredTypeDeclaration.SyntaxTree);
                 var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
                 editor.ReplaceNode(
-                    typeDeclaration,
+                    preferredTypeDeclaration,
                     (currentTypeDecl, _) =>
                     {
                         if (fieldOrProperty is IPropertySymbol property)

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -95,8 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             var services = solution.Services;
 
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var parseOptions = root.SyntaxTree.Options;
+            var parseOptions = document.DocumentState.ParseOptions;
 
             var solutionEditor = new SolutionEditor(solution);
             var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -201,6 +201,7 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
         var solution = project.Solution;
 
         var solutionEditor = new SolutionEditor(solution);
+        var initializer = EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()));
 
         // We're assigning the parameter to a field/prop.  Convert all existing references to this primary constructor
         // parameter (within this type) to refer to the field/prop now instead.
@@ -223,7 +224,8 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
                         propertyDeclaration,
                         newPropertyDeclaration.WithoutTrailingTrivia()
                             .WithSemicolonToken(Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(newPropertyDeclaration.GetTrailingTrivia()))
-                            .WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
+                            .WithInitializer(initializer));
+                    break;
                 }
             }
         }
@@ -237,7 +239,7 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
                     var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
                     editor.ReplaceNode(
                         variableDeclarator,
-                        variableDeclarator.WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
+                        variableDeclarator.WithInitializer(initializer));
                     break;
                 }
             }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -114,16 +114,13 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             {
                 var namedType = parameter.ContainingType;
                 var documents = namedType.DeclaringSyntaxReferences
-                    .Select(r => solution.GetDocument(r.SyntaxTree))
-                    .WhereNotNull()
+                    .Select(r => solution.GetRequiredDocument(r.SyntaxTree))
                     .ToImmutableHashSet();
 
                 var references = await SymbolFinder.FindReferencesAsync(parameter, solution, documents, cancellationToken).ConfigureAwait(false);
                 foreach (var group in references.SelectMany(r => r.Locations.Where(loc => !loc.IsImplicit).GroupBy(loc => loc.Document)))
                 {
-                    var editingDocument = group.Key;
-                    var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
-
+                    var editor = await solutionEditor.GetDocumentEditorAsync(group.Key.Id, cancellationToken).ConfigureAwait(false);
                     foreach (var location in group)
                     {
                         var node = location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -198,7 +198,6 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
         Document document,
         IParameterSymbol parameter,
         ISymbol fieldOrProperty,
-        bool isThrowNotImplementedProperty,
         CancellationToken cancellationToken)
     {
         var project = document.Project;
@@ -215,6 +214,9 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
         // We're updating an exiting field/prop.
         if (fieldOrProperty is IPropertySymbol property)
         {
+            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var isThrowNotImplementedProperty = IsThrowNotImplementedProperty(compilation, property, cancellationToken);
+
             foreach (var syntaxRef in property.DeclaringSyntaxReferences)
             {
                 if (syntaxRef.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -106,16 +106,9 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             await UpdateParameterReferencesAsync().ConfigureAwait(false);
 
             // Now, either add the new field/prop, or update the existing one by assigning the parameter to it.
-            if (fieldOrProperty.ContainingType == null)
-            {
-                await AddFieldOrPropertyAsync().ConfigureAwait(false);
-            }
-            else
-            {
-                await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
-            }
-
-            return solutionEditor.GetChangedSolution();
+            return fieldOrProperty.ContainingType == null
+                ? await AddFieldOrPropertyAsync().ConfigureAwait(false)
+                : await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
 
             async Task UpdateParameterReferencesAsync()
             {
@@ -147,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 }
             }
 
-            async Task AddFieldOrPropertyAsync()
+            async Task<Solution> AddFieldOrPropertyAsync()
             {
                 // We're generating a new field/property.  Place into the containing type, ideally before/after a
                 // relevant existing member.
@@ -185,6 +178,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                             throw ExceptionUtilities.Unreachable();
                         }
                     });
+
+                return solutionEditor.GetChangedSolution();
             }
 
             (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>() where TSymbol : class, ISymbol
@@ -207,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 return (symbol: null, syntax: null, CodeGenerationContext.Default);
             }
 
-            async Task UpdateFieldOrPropertyAsync()
+            async Task<Solution> UpdateFieldOrPropertyAsync()
             {
                 // We're updating an exiting field/prop.
                 if (fieldOrProperty is IPropertySymbol property)
@@ -248,6 +243,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 {
                     throw ExceptionUtilities.Unreachable();
                 }
+
+                return solutionEditor.GetChangedSolution();
             }
         }
     }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             var services = solution.Services;
 
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var parseOptions = document.DocumentState.ParseOptions;
+            var parseOptions = document.DocumentState.ParseOptions!;
 
             var solutionEditor = new SolutionEditor(solution);
             var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 }
             }
 
-            async Task<Solution> AddFieldOrPropertyAsync()
+            async ValueTask<Solution> AddFieldOrPropertyAsync()
             {
                 // We're generating a new field/property.  Place into the containing type, ideally before/after a
                 // relevant existing member.
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 return (symbol: null, syntax: null, CodeGenerationContext.Default);
             }
 
-            async Task<Solution> UpdateFieldOrPropertyAsync()
+            async ValueTask<Solution> UpdateFieldOrPropertyAsync()
             {
                 // We're updating an exiting field/prop.
                 if (fieldOrProperty is IPropertySymbol property)

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -1,0 +1,259 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.InitializeParameter;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
+{
+    using static InitializeParameterHelpers;
+    using static InitializeParameterHelpersCore;
+    using static SyntaxFactory;
+
+    internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        /// This functions are the workhorses that actually go and handle each parameter (either creating a
+        /// field/property for it, or updates an existing field/property with it).  They are extracted out from the rest
+        /// as we do not want it capturing anything.  Specifically, AddSingleSymbolInitializationAsync is called in a
+        /// loop from AddAllSymbolInitializationsAsync for each parameter we're processing.  For each, we produce new
+        /// solution snapshots and thus must ensure we're always pointing at the new view of the world, not anything
+        /// from the original view.
+
+        private static async Task<Solution> AddAllSymbolInitializationsAsync(
+            Document document,
+            TypeDeclarationSyntax typeDeclaration,
+            ImmutableArray<IParameterSymbol> parameters,
+            ImmutableArray<ISymbol> fieldsOrProperties,
+            CodeGenerationOptionsProvider fallbackOptions,
+            CancellationToken cancellationToken)
+        {
+            Debug.Assert(parameters.Length >= 2);
+            Debug.Assert(fieldsOrProperties.Length > 0);
+            Debug.Assert(parameters.Length == fieldsOrProperties.Length);
+
+            // Process each param+field/prop in order.  Apply the pair to the document getting the updated document.
+            // Then find all the current data in that updated document and move onto the next pair.
+
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var trackedRoot = root.TrackNodes(typeDeclaration);
+            var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                var fieldOrProperty = fieldsOrProperties[i];
+
+                var currentDocument = currentSolution.GetRequiredDocument(document.Id);
+                var currentSemanticModel = await currentDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var currentCompilation = currentSemanticModel.Compilation;
+                var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+                var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);
+                if (currentTypeDeclaration == null)
+                    continue;
+
+                var currentParameter = (IParameterSymbol?)parameter.GetSymbolKey(cancellationToken).Resolve(currentCompilation, cancellationToken: cancellationToken).GetAnySymbol();
+                if (currentParameter == null)
+                    continue;
+
+                // fieldOrProperty is a new member.  So we don't have to track it to this edit we're making.
+
+                currentSolution = await AddSingleSymbolInitializationAsync(
+                    currentDocument,
+                    currentTypeDeclaration,
+                    currentParameter,
+                    fieldOrProperty,
+                    isThrowNotImplementedProperty: false,
+                    fallbackOptions,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return currentSolution;
+        }
+
+        private static async Task<Solution> AddSingleSymbolInitializationAsync(
+            Document document,
+            TypeDeclarationSyntax typeDeclaration,
+            IParameterSymbol parameter,
+            ISymbol fieldOrProperty,
+            bool isThrowNotImplementedProperty,
+            CodeGenerationOptionsProvider fallbackOptions,
+            CancellationToken cancellationToken)
+        {
+            var project = document.Project;
+            var solution = project.Solution;
+            var services = solution.Services;
+
+            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var parseOptions = root.SyntaxTree.Options;
+
+            var solutionEditor = new SolutionEditor(solution);
+            var options = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+            var codeGenerator = document.GetRequiredLanguageService<ICodeGenerationService>();
+
+            // We're assigning the parameter to a field/prop (either new or existing).  Convert all existing references
+            // to this primary constructor parameter (within this type) to refer to the field/prop now instead.
+            await UpdateParameterReferencesAsync().ConfigureAwait(false);
+
+            // Now, either add the new field/prop, or update the existing one by assigning the parameter to it.
+            if (fieldOrProperty.ContainingType == null)
+            {
+                await AddFieldOrPropertyAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                await UpdateFieldOrPropertyAsync().ConfigureAwait(false);
+            }
+
+            return solutionEditor.GetChangedSolution();
+
+            async Task UpdateParameterReferencesAsync()
+            {
+                var namedType = parameter.ContainingType;
+                var documents = namedType.DeclaringSyntaxReferences
+                    .Select(r => solution.GetDocument(r.SyntaxTree))
+                    .WhereNotNull()
+                    .ToImmutableHashSet();
+
+                var references = await SymbolFinder.FindReferencesAsync(parameter, solution, documents, cancellationToken).ConfigureAwait(false);
+                foreach (var group in references.SelectMany(r => r.Locations.Where(loc => !loc.IsImplicit).GroupBy(loc => loc.Document)))
+                {
+                    var editingDocument = group.Key;
+                    var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+
+                    foreach (var location in group)
+                    {
+                        var node = location.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
+                        if (node is IdentifierNameSyntax { Parent: not NameColonSyntax } identifierName &&
+                            identifierName.Identifier.ValueText == parameter.Name)
+                        {
+                            // we may have things like `new MyType(x: ...)` we don't want to update `x` there to 'X'
+                            // just because we're generating a new property 'X' for the parameter to be assigned to.
+                            editor.ReplaceNode(
+                                identifierName,
+                                IdentifierName(fieldOrProperty.Name.EscapeIdentifier()).WithTriviaFrom(identifierName));
+                        }
+                    }
+                }
+            }
+
+            async Task AddFieldOrPropertyAsync()
+            {
+                // We're generating a new field/property.  Place into the containing type, ideally before/after a
+                // relevant existing member.
+                var (sibling, siblingSyntax, addContext) = fieldOrProperty switch
+                {
+                    IPropertySymbol => GetAddContext<IPropertySymbol>(),
+                    IFieldSymbol => GetAddContext<IFieldSymbol>(),
+                    _ => throw ExceptionUtilities.UnexpectedValue(fieldOrProperty),
+                };
+
+                var preferredTypeDeclaration = siblingSyntax?.GetAncestorOrThis<TypeDeclarationSyntax>() ?? typeDeclaration;
+
+                var editingDocument = solution.GetRequiredDocument(typeDeclaration.SyntaxTree);
+                var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+                editor.ReplaceNode(
+                    typeDeclaration,
+                    (currentTypeDecl, _) =>
+                    {
+                        if (fieldOrProperty is IPropertySymbol property)
+                        {
+                            return codeGenerator.AddProperty(
+                                currentTypeDecl, property,
+                                codeGenerator.GetInfo(addContext, options, parseOptions),
+                                cancellationToken);
+                        }
+                        else if (fieldOrProperty is IFieldSymbol field)
+                        {
+                            return codeGenerator.AddField(
+                                currentTypeDecl, field,
+                                codeGenerator.GetInfo(addContext, options, parseOptions),
+                                cancellationToken);
+                        }
+                        else
+                        {
+                            throw ExceptionUtilities.Unreachable();
+                        }
+                    });
+            }
+
+            (ISymbol? symbol, SyntaxNode? syntax, CodeGenerationContext context) GetAddContext<TSymbol>() where TSymbol : class, ISymbol
+            {
+                foreach (var (sibling, before) in GetSiblingParameters(parameter))
+                {
+                    var initializer = TryFindFieldOrPropertyInitializerValue(
+                        compilation, sibling, out var fieldOrProperty, cancellationToken);
+
+                    if (initializer != null &&
+                        fieldOrProperty is TSymbol { DeclaringSyntaxReferences: [var syntaxReference, ..] } symbol)
+                    {
+                        var syntax = syntaxReference.GetSyntax(cancellationToken);
+                        return (symbol, syntax, before
+                            ? new CodeGenerationContext(afterThisLocation: syntax.GetLocation())
+                            : new CodeGenerationContext(beforeThisLocation: syntax.GetLocation()));
+                    }
+                }
+
+                return (symbol: null, syntax: null, CodeGenerationContext.Default);
+            }
+
+            async Task UpdateFieldOrPropertyAsync()
+            {
+                // We're updating an exiting field/prop.
+                if (fieldOrProperty is IPropertySymbol property)
+                {
+                    foreach (var syntaxRef in property.DeclaringSyntaxReferences)
+                    {
+                        if (syntaxRef.GetSyntax(cancellationToken) is PropertyDeclarationSyntax propertyDeclaration)
+                        {
+                            var editingDocument = solution.GetRequiredDocument(propertyDeclaration.SyntaxTree);
+                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+
+                            // If the user had a property that has 'throw NotImplementedException' in it, then remove those throws.
+                            var newPropertyDeclaration = isThrowNotImplementedProperty ? RemoveThrowNotImplemented(propertyDeclaration) : propertyDeclaration;
+                            editor.ReplaceNode(
+                                propertyDeclaration,
+                                newPropertyDeclaration.WithoutTrailingTrivia()
+                                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken).WithTrailingTrivia(newPropertyDeclaration.GetTrailingTrivia()))
+                                    .WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
+                        }
+                    }
+                }
+                else if (fieldOrProperty is IFieldSymbol field)
+                {
+                    foreach (var syntaxRef in field.DeclaringSyntaxReferences)
+                    {
+                        if (syntaxRef.GetSyntax(cancellationToken) is VariableDeclaratorSyntax variableDeclarator)
+                        {
+                            var editingDocument = solution.GetRequiredDocument(variableDeclarator.SyntaxTree);
+                            var editor = await solutionEditor.GetDocumentEditorAsync(editingDocument.Id, cancellationToken).ConfigureAwait(false);
+                            editor.ReplaceNode(
+                                variableDeclarator,
+                                variableDeclarator.WithInitializer(EqualsValueClause(IdentifierName(parameter.Name.EscapeIdentifier()))));
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    throw ExceptionUtilities.Unreachable();
+                }
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -52,14 +52,10 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
             var trackedRoot = root.TrackNodes(typeDeclaration);
             var currentSolution = document.WithSyntaxRoot(trackedRoot).Project.Solution;
 
-            for (var i = 0; i < parameters.Length; i++)
+            foreach (var (parameter, fieldOrProperty) in parameters.Zip(fieldsOrProperties, static (a, b) => (a, b)))
             {
-                var parameter = parameters[i];
-                var fieldOrProperty = fieldsOrProperties[i];
-
                 var currentDocument = currentSolution.GetRequiredDocument(document.Id);
-                var currentSemanticModel = await currentDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var currentCompilation = currentSemanticModel.Compilation;
+                var currentCompilation = await currentDocument.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var currentRoot = await currentDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
                 var currentTypeDeclaration = currentRoot.GetCurrentNode(typeDeclaration);

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider_Update.cs
@@ -236,10 +236,6 @@ internal sealed partial class CSharpInitializeMemberFromPrimaryConstructorParame
                     }
                 }
             }
-            else
-            {
-                throw ExceptionUtilities.Unreachable();
-            }
 
             return solutionEditor.GetChangedSolution();
         }

--- a/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
@@ -5,13 +5,17 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.InitializeParameter;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
@@ -137,6 +141,87 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
                 ExpressionSyntax expression => expression.TryConvertToStatement(semicolonToken, createReturnStatementForExpression, out statement),
                 _ => throw ExceptionUtilities.UnexpectedValue(body),
             };
+        }
+
+        public static SyntaxNode? GetAccessorBody(IMethodSymbol accessor, CancellationToken cancellationToken)
+        {
+            var node = accessor.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
+            if (node is AccessorDeclarationSyntax accessorDeclaration)
+                return accessorDeclaration.ExpressionBody ?? (SyntaxNode?)accessorDeclaration.Body;
+
+            // `int Age => ...;`
+            if (node is ArrowExpressionClauseSyntax arrowExpression)
+                return arrowExpression;
+
+            return null;
+        }
+
+        public static SyntaxNode RemoveThrowNotImplemented(SyntaxNode node)
+        {
+            if (node is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                if (propertyDeclaration.ExpressionBody != null)
+                {
+                    var result = propertyDeclaration
+                        .WithExpressionBody(null)
+                        .WithSemicolonToken(default)
+                        .AddAccessorListAccessors(SyntaxFactory
+                            .AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
+                        .WithTrailingTrivia(propertyDeclaration.SemicolonToken.TrailingTrivia)
+                        .WithAdditionalAnnotations(Formatter.Annotation);
+                    return result;
+                }
+
+                if (propertyDeclaration.AccessorList != null)
+                {
+                    var accessors = propertyDeclaration.AccessorList.Accessors.Select(RemoveThrowNotImplemented);
+                    return propertyDeclaration.WithAccessorList(
+                        propertyDeclaration.AccessorList.WithAccessors(SyntaxFactory.List(accessors)));
+                }
+            }
+
+            return node;
+        }
+
+        private static AccessorDeclarationSyntax RemoveThrowNotImplemented(AccessorDeclarationSyntax accessorDeclaration)
+        {
+            var result = accessorDeclaration
+                .WithExpressionBody(null)
+                .WithBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+
+            return result.WithTrailingTrivia(accessorDeclaration.Body?.GetTrailingTrivia() ?? accessorDeclaration.SemicolonToken.TrailingTrivia);
+        }
+
+        public static bool IsThrowNotImplementedProperty(Compilation compilation, IPropertySymbol property, CancellationToken cancellationToken)
+        {
+            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var accessors);
+
+            if (property.GetMethod != null)
+                accessors.AddIfNotNull(GetAccessorBody(property.GetMethod, cancellationToken));
+
+            if (property.SetMethod != null)
+                accessors.AddIfNotNull(GetAccessorBody(property.SetMethod, cancellationToken));
+
+            if (accessors.Count == 0)
+                return false;
+
+            foreach (var group in accessors.GroupBy(node => node.SyntaxTree))
+            {
+                var semanticModel = compilation.GetSemanticModel(group.Key);
+                foreach (var accessorBody in accessors)
+                {
+                    var operation = semanticModel.GetOperation(accessorBody, cancellationToken);
+                    if (operation is null)
+                        return false;
+
+                    if (!operation.IsSingleThrowNotImplementedOperation())
+                        return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/InitializeParameterHelpers.cs
@@ -157,31 +157,31 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         }
 
         public static SyntaxNode RemoveThrowNotImplemented(SyntaxNode node)
-        {
-            if (node is PropertyDeclarationSyntax propertyDeclaration)
-            {
-                if (propertyDeclaration.ExpressionBody != null)
-                {
-                    var result = propertyDeclaration
-                        .WithExpressionBody(null)
-                        .WithSemicolonToken(default)
-                        .AddAccessorListAccessors(SyntaxFactory
-                            .AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
-                        .WithTrailingTrivia(propertyDeclaration.SemicolonToken.TrailingTrivia)
-                        .WithAdditionalAnnotations(Formatter.Annotation);
-                    return result;
-                }
+            => node is PropertyDeclarationSyntax propertyDeclaration ? RemoveThrowNotImplemented(propertyDeclaration) : node;
 
-                if (propertyDeclaration.AccessorList != null)
-                {
-                    var accessors = propertyDeclaration.AccessorList.Accessors.Select(RemoveThrowNotImplemented);
-                    return propertyDeclaration.WithAccessorList(
-                        propertyDeclaration.AccessorList.WithAccessors(SyntaxFactory.List(accessors)));
-                }
+        public static PropertyDeclarationSyntax RemoveThrowNotImplemented(PropertyDeclarationSyntax propertyDeclaration)
+        {
+            if (propertyDeclaration.ExpressionBody != null)
+            {
+                var result = propertyDeclaration
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(default)
+                    .AddAccessorListAccessors(SyntaxFactory
+                        .AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
+                    .WithTrailingTrivia(propertyDeclaration.SemicolonToken.TrailingTrivia)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+                return result;
             }
 
-            return node;
+            if (propertyDeclaration.AccessorList != null)
+            {
+                var accessors = propertyDeclaration.AccessorList.Accessors.Select(RemoveThrowNotImplemented);
+                return propertyDeclaration.WithAccessorList(
+                    propertyDeclaration.AccessorList.WithAccessors(SyntaxFactory.List(accessors)));
+            }
+
+            return propertyDeclaration;
         }
 
         private static AccessorDeclarationSyntax RemoveThrowNotImplemented(AccessorDeclarationSyntax accessorDeclaration)

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -146,9 +146,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """
                 class C(string s)
                 {
-                    private string S => null;
-
                     public string S1 { get; } = s;
+
+                    private string S => null;
                 }
                 """);
         }
@@ -166,8 +166,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """
                 class C(string s)
                 {
-                    private string T { get; }
                     public string S { get; } = s;
+                    private string T { get; }
                 }
                 """);
         }
@@ -285,11 +285,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private string s;
                     private string t = t;
-
-                    public C
-                    {
-                        this.t = t;
-                    }
                 }
                 """,
                 """
@@ -475,6 +470,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = s;
                 }
+
                 """);
         }
 
@@ -490,6 +486,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string s = s;
                 }
+
                 """,
                 index: 1);
         }
@@ -795,7 +792,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """
                 class C(string p_s_End)
                 {
-                    private readonly string _s = p_s_End
+                    private readonly string _s = p_s_End;
                 }
                 """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
@@ -863,7 +860,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """
                 class C(string t_s)
                 {
-                    public string S { get; } = t_s
+                    public string S { get; } = t_s;
                 }
                 """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
         }
@@ -984,7 +981,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 }
                 """,
                 """
-                class CC(string t_p_s_End)
+                class C(string t_p_s_End)
                 {
                     private readonly string _s = t_p_s_End;
                 }
@@ -1602,7 +1599,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """
                 class C(int i, int j, int k)
                 {
-                    private readonly int i;
+                    private readonly int i = i;
 
                     public int J { get; } = j;
                     public int K { get; } = k;
@@ -1835,9 +1832,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
 
                 class C(string s)
                 {
-                    private string S => throw new InvalidOperationException();
-
                     public string S1 { get; } = s;
+
+                    private string S => throw new InvalidOperationException();
                 }
                 """);
         }

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -1,0 +1,1887 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.InitializeParameter;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+    public partial class InitializeMemberFromPrimaryConstructorParameterTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider();
+
+        private readonly NamingStylesTestOptionSets options = new NamingStylesTestOptionSets(LanguageNames.CSharp);
+
+        [Fact]
+        public async Task TestInitializeFieldWithSameName()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private string s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestEndOfParameter1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s[||])
+                {
+                    private string s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestEndOfParameter2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s[||], string t)
+                {
+                    private string s;
+                }
+                """,
+                """
+                class C(string s, string t)
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeFieldWithUnderscoreName()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private string _s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string _s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeWritableProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private string S { get; }
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeFieldWithDifferentName()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C([||]string s)
+                {
+                    private string t;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string t;
+
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeNonWritableProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private string S => null;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string S => null;
+
+                    public string S1 { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeDoesNotUsePropertyWithUnrelatedName()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C([||]string s)
+                {
+                    private string T { get; }
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string T { get; }
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeFieldWithWrongType1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private int s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private int s;
+
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeFieldWithWrongType2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private int s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private readonly string s1 = s;
+                    private int s;
+                }
+                """, index: 1);
+        }
+
+        [Fact]
+        public async Task TestInitializeFieldWithConvertibleType()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C([||]string s)
+                {
+                    private object s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private object s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestWhenAlreadyInitialized1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C([||]string s)
+                {
+                    private int s;
+                    private int x = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestWhenAlreadyInitialized2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C([||]string s)
+                {
+                    private int s;
+                    private int x = s ?? throw new Exception();
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestWhenAlreadyInitialized3()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private int s = 0;
+                }
+                """,
+
+                """
+                class C([||]string s)
+                {
+                    private int s = 0;
+
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInsertionLocation1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s, string t)
+                {
+                    private string s;
+                    private string t = t;
+
+                    public C
+                    {
+                        this.t = t;
+                    }
+                }
+                """,
+                """
+                class C(string s, string t)
+                {
+                    private string s = s;
+                    private string t = t;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInsertionLocation2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s, [||]string t)
+                {
+                    private string s = s;
+                    private string t;
+                }
+                """,
+                """
+                class C(string s, string t)
+                {
+                    private string s = s;
+                    private string t = t;
+                }
+                """);
+        }
+
+        //[Fact]
+        //public async Task TestInsertionLocation3()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+
+        //            public C([||]string s)
+        //            {
+        //                if (true) { } 
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+
+        //            public C(string s)
+        //            {
+        //                if (true) { }
+
+        //                this.s = s;
+        //            }
+        //        }
+        //        """);
+        //}
+
+        [Fact]
+        public async Task TestNotInMethod()
+        {
+            await TestMissingInRegularAndScriptAsync(
+                """
+                class C
+                {
+                    private string s;
+
+                    public void M([||]string s)
+                    {
+                    }
+                }
+                """);
+        }
+
+        //[Fact]
+        //public async Task TestInsertionLocation4()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+        //            private string t;
+
+        //            public C(string s, [||]string t)
+        //                => this.s = s;   
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+        //            private string t;
+
+        //            public C(string s, string t)
+        //            {
+        //                this.s = s;
+        //                this.t = t;
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact]
+        //public async Task TestInsertionLocation5()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+        //            private string t;
+
+        //            public C([||]string s, string t)
+        //                => this.t = t;   
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private string s;
+        //            private string t;
+
+        //            public C(string s, string t)
+        //            {
+        //                this.s = s;
+        //                this.t = t;
+        //            }
+        //        }
+        //        """);
+        //}
+
+        [Fact]
+        public async Task TestInsertionLocation6()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s, [||]string t)
+                {
+                    public string S { get; } = s;
+                }
+                """,
+                """
+                class C(string s, string t)
+                {
+                    public string S { get; } = s;
+                    public string T { get; } = t;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInsertionLocation7()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s, string t)
+                {
+                    public string T { get; } = t;
+                }
+                """,
+                """
+                class C(string s, string t)
+                {
+                    public string S { get; } = s;
+                    public string T { get; } = t;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19956")]
+        public async Task TestNoBlock1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s[||])
+                """,
+                """
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19956")]
+        public async Task TestNoBlock2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s[||])
+                """,
+                """
+                class C(string s)
+                {
+                    private readonly string s = s;
+                }
+                """,
+                index: 1);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/29190")]
+        public async Task TestInitializeFieldWithParameterNameSelected1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string [|s|])
+                {
+                    private string s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/29190")]
+        public async Task TestInitializeField_ParameterNameSelected2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string [|s|], int i)
+                {
+                    private string s;
+                }
+                """,
+                """
+                class C(string s, int i)
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassProperty_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+
+                    public int Test2 { get; } = test2;
+                }
+                """, index: 0, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassProperty_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+
+                    public int Test2 { get; } = test2;
+                }
+                """, index: 0, parameters: Never_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassProperty_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+
+                    public int Test2 { get; } = test2;
+                }
+                """, index: 0, parameters: Always_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassField_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+                    readonly int test2 = test2;
+                }
+                """, index: 1, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassField_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+                    readonly int test2 = test2;
+                }
+                """, index: 1, parameters: Never_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeClassField_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int test, int [|test2|])
+                {
+                    readonly int test = 5;
+                }
+                """,
+                """
+                class C(int test, int test2)
+                {
+                    readonly int test = 5;
+                    private readonly int test2 = test2;
+                }
+                """, index: 1, parameters: Always_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    public int Test { get; } = test;
+                }
+                """, index: 0, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    public int Test { get; } = test;
+                }
+                """, index: 0, parameters: Never_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructProperty_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    public int Test { get; } = test;
+                }
+                """, index: 0, parameters: Always_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructField_RequiredAccessibilityOmitIfDefault()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    readonly int test = test;
+                }
+                """, index: 1, parameters: OmitIfDefault_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructField_RequiredAccessibilityNever()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    readonly int test = test;
+                }
+                """, index: 1, parameters: Never_Warning);
+        }
+
+        [Fact]
+        public async Task TestInitializeStructField_RequiredAccessibilityAlways()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                struct S(int [|test|])
+                {
+                }
+                """,
+                """
+                struct S(int test)
+                {
+                    private readonly int test = test;
+                }
+                """, index: 1, parameters: Always_Warning);
+        }
+
+        [Fact]
+        public async Task TestNoParameterNamingStyle_CreateAndInitField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private readonly string _s = s;
+                }
+                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
+
+        [Fact]
+        public async Task TestCommonParameterNamingStyle_CreateAndInitField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_s)
+                {
+                }
+                """,
+                """
+                class C(string t_s)
+                {
+                    private readonly string _s = t_s;
+                }
+                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
+
+        [Fact]
+        public async Task TestSpecifiedParameterNamingStyle_CreateAndInitField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_s_End)
+                {
+                }
+                """,
+                """
+                class C(string p_s_End)
+                {
+                    private readonly string _s = p_s_End
+                }
+                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle_CreateAndInitField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_p_s_End)
+                {
+                }
+                """,
+                """
+                class C(string t_p_s_End)
+                {
+                    private readonly string _s = t_p_s_End;
+                }
+                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle2_CreateAndInitField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_t_s)
+                {
+                }
+                """,
+                """
+                class C([||]string p_t_s)
+                {
+                    private readonly string _s = p_t_s;
+                }
+                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefix)));
+        }
+
+        [Fact]
+        public async Task TestNoParameterNamingStyle_CreateAndInitProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                }
+                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+        }
+
+        [Fact]
+        public async Task TestCommonParameterNamingStyle_CreateAndInitProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_s)
+                {
+                }
+                """,
+                """
+                class C(string t_s)
+                {
+                    public string S { get; } = t_s
+                }
+                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+        }
+
+        [Fact]
+        public async Task TestSpecifiedParameterNamingStyle_CreateAndInitProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_s_End)
+                {
+                }
+                """,
+                """
+                class C(string p_s_End)
+                {
+                    public string S { get; } = p_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle_CreateAndInitProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_p_s_End)
+                {
+                }
+                """,
+                """
+                class C(string t_p_s_End)
+                {
+                    public string S { get; } = t_p_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle2_CreateAndInitProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_t_s_End)
+                {
+                }
+                """,
+                """
+                class C(string p_t_s_End)
+                {
+                    public string S { get; } = p_t_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestNoParameterNamingStyle_InitializeField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    private readonly string _s;
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    private readonly string _s = s;
+                }
+                """, index: 0, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
+
+        [Fact]
+        public async Task TestCommonParameterNamingStyle_InitializeField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_s)
+                {
+                    private readonly string _s;
+                }
+                """,
+                """
+                class C(string t_s)
+                {
+                    private readonly string _s = t_s;
+                }
+                """, index: 0, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
+
+        [Fact]
+        public async Task TestSpecifiedParameterNamingStyle_InitializeField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_s_End)
+                {
+                    private readonly string _s;
+                }
+                """,
+                """
+                class C(string p_s_End)
+                {
+                    private readonly string _s = p_s_End;
+                }
+                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle_InitializeField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_p_s_End)
+                {
+                    private readonly string _s;
+                }
+                """,
+                """
+                class CC(string t_p_s_End)
+                {
+                    private readonly string _s = t_p_s_End;
+                }
+                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle2_InitializeField()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_t_s_End)
+                {
+                    private readonly string _s;
+                }
+                """,
+                """
+                class C([||]string p_t_s_End)
+                {
+                    private readonly string _s = p_t_s_End;
+                }
+                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestNoParameterNamingStyle_InitializeProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s)
+                {
+                    public string S { get; }
+                }
+                """,
+                """
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                }
+                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+        }
+
+        [Fact]
+        public async Task TestCommonParameterNamingStyle_InitializeProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_s)
+                {
+                    public string S { get; }
+                }
+                """,
+                """
+                class C(string t_s)
+                {
+                    public string S { get; } = t_s;
+                }
+                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+        }
+
+        [Fact]
+        public async Task TestSpecifiedParameterNamingStyle_InitializeProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_s_End)
+                {
+                    public string S { get; }
+                }
+                """,
+                """
+                class C(string p_s_End)
+                {
+                    public string S { get; } = p_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle_InitializeProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string t_p_s_End)
+                {
+                    public string S { get; }
+                }
+                """,
+                """
+                class C(string t_p_s_End)
+                {
+                    public string S { get; } = t_p_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestCommonAndSpecifiedParameterNamingStyle2_InitializeProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string p_t_s_End)
+                {
+                    public string S { get; }
+                }
+                """,
+                """
+                class C([||]string p_t_s_End)
+                {
+                    public string S { get; } = p_t_s_End;
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestBaseNameEmpty()
+        {
+            await TestMissingAsync(
+                """
+                class C([||]string p__End)
+                {
+                    public string S { get; }
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        [Fact]
+        public async Task TestSomeBaseNamesEmpty()
+        {
+            // Currently, this case does not offer a refactoring because selecting multiple parameters 
+            // is not supported. If multiple parameters are supported in the future, this case should 
+            // be updated to verify that only the parameter name that does not have an empty base is offered.
+            await TestMissingAsync(
+                """
+                class C([|string p__End, string p_test_t|])
+                {
+                }
+                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+        }
+
+        private TestParameters OmitIfDefault_Warning => new TestParameters(options: Option(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption2.Warning));
+        private TestParameters Never_Warning => new TestParameters(options: Option(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Never, NotificationOption2.Warning));
+        private TestParameters Always_Warning => new TestParameters(options: Option(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Always, NotificationOption2.Warning));
+
+        [Fact]
+        public async Task TestCreateFieldWithTopLevelNullability()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                #nullable enable
+                class C([||]string? s)
+                {
+                }
+                """,
+                """
+                #nullable enable
+                class C(string? s)
+                {
+                    private readonly string? _s = s;
+                }
+                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
+
+        [Fact]
+        public async Task TestCreatePropertyWithTopLevelNullability()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                #nullable enable
+                class C([||]string? s)
+                {
+                }
+                """,
+                """
+                #nullable enable
+                class C(string? s)
+                {
+                    public string? S { get; } = s;
+                }
+                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24526")]
+        public async Task TestSingleLineBlock_BraceOnNextLine()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]string s) { }
+                """,
+                """
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24526")]
+        public async Task TestSingleLineBlock_BraceOnSameLine()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                class C([||]string s) { }
+                """,
+                """
+                class C(string s) {
+                    public string S { get; } = s;
+                }
+                """, options: this.Option(CSharpFormattingOptions2.NewLineBeforeOpenBrace, NewLineBeforeOpenBracePlacement.All & ~NewLineBeforeOpenBracePlacement.Types));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(string s, [||]int i)
+                {
+                    private readonly string s = s;
+                }
+                """,
+                """
+                class C(string s, int i)
+                {
+                    private readonly string s = s;
+                    private readonly int i = i;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        public async Task TestGenerateFieldIfParameterPrecedesExistingFieldAssignment()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, string s)
+                {
+                    private readonly string s = s;
+                }
+                """,
+                """
+                class C(int i, string s)
+                {
+                    private readonly int i = i;
+                    private readonly string s = s;
+                }
+                """);
+        }
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment1()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(string s, string t, [||]int i)
+        //            {
+        //                (this.s, this.t) = (s, t);
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+        //            private readonly int i;
+
+        //            public C(string s, string t, int i)
+        //            {
+        //                (this.s, this.t, this.i) = (s, t, i);
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment2()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(string s, string t, [||]int i) =>
+        //                (this.s, this.t) = (s, t);
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+        //            private readonly int i;
+
+        //            public C(string s, string t, int i) =>
+        //                (this.s, this.t, this.i) = (s, t, i);
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment3()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(string s, string t, [||]int i)
+        //            {
+        //                if (s is null) throw new ArgumentNullException();
+        //                (this.s, this.t) = (s, t);
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+        //            private readonly int i;
+
+        //            public C(string s, string t, int i)
+        //            {
+        //                if (s is null) throw new ArgumentNullException();
+        //                (this.s, this.t, this.i) = (s, t, i);
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterPrecedesExistingFieldAssignment_TupleAssignment1()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C([||]int i, string s, string t)
+        //            {
+        //                (this.s, this.t) = (s, t);
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly int i;
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(int i, string s, string t)
+        //            {
+        //                (this.i, this.s, this.t) = (i, s, t);
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterPrecedesExistingFieldAssignment_TupleAssignment2()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C([||]int i, string s, string t) =>
+        //                (this.s, this.t) = (s, t);
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly int i;
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(int i, string s, string t) =>
+        //                (this.i, this.s, this.t) = (i, s, t);
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterInMiddleOfExistingFieldAssignment_TupleAssignment1()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(string s, [||]int i, string t)
+        //            {
+        //                (this.s, this.t) = (s, t);
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly int i;
+        //            private readonly string t;
+
+        //            public C(string s, int i, string t)
+        //            {
+        //                (this.s, this.i, this.t) = (s, i, t);
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGenerateFieldIfParameterInMiddleOfExistingFieldAssignment_TupleAssignment2()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly string t;
+
+        //            public C(string s, [||]int i, string t) =>
+        //                (this.s, this.t) = (s, t);
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            private readonly string s;
+        //            private readonly int i;
+        //            private readonly string t;
+
+        //            public C(string s, int i, string t) =>
+        //                (this.s, this.i, this.t) = (s, i, t);
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
+        //public async Task TestGeneratePropertyIfParameterFollowsExistingPropertyAssignment_TupleAssignment1()
+        //{
+        //    await TestInRegularAndScript1Async(
+        //        """
+        //        class C
+        //        {
+        //            public string S { get; }
+        //            public string T { get; }
+
+        //            public C(string s, string t, [||]int i)
+        //            {
+        //                (S, T) = (s, t);
+        //            }
+        //        }
+        //        """,
+        //        """
+        //        class C
+        //        {
+        //            public string S { get; }
+        //            public string T { get; }
+        //            public int I { get; }
+
+        //            public C(string s, string t, int i)
+        //            {
+        //                (S, T, I) = (s, t, i);
+        //            }
+        //        }
+        //        """);
+        //}
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/41824")]
+        //public async Task TestMissingInArgList()
+        //{
+        //    await TestMissingInRegularAndScriptAsync(
+        //        """
+        //        class C
+        //        {
+        //            private static void M()
+        //            {
+        //                M2(__arglist(1, 2, 3, 5, 6));
+        //            }
+
+        //            public static void M2([||]__arglist)
+        //            {
+        //            }
+        //        }
+        //        """);
+        //}
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingFields1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int i = i;
+                    private readonly int j = j;
+                    private readonly int k = k;
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingFields2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int i, [||]int j, int k)
+                {
+                    private readonly int i = i;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int i = i;
+                    private readonly int j = j;
+                    private readonly int k = k;
+                }
+                """, index: 2);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingFields3()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                    private readonly int j = j;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int i = i;
+                    private readonly int j = j;
+                    private readonly int k = k;
+                }
+                """, index: 2);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingFields4()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                    private readonly int k = k;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int i = i;
+                    private readonly int j = j;
+                    private readonly int k = k;
+                }
+                """, index: 2);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingProperties1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    public int I { get; } = i;
+                    public int J { get; } = j;
+                    public int K { get; } = k;
+                }
+                """, index: 2);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingProperties2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C(int i, [||]int j, int k)
+                {
+                    private readonly int i = i;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int i;
+
+                    public int J { get; } = j;
+                    public int K { get; } = k;
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingProperties3()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                    private readonly int j = j;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int j = j;
+
+                    public int I { get; } = i;
+                    public int K { get; } = k;
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
+        public async Task TestGenerateRemainingProperties4()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                class C([||]int i, int j, int k)
+                {
+                    private readonly int k = k;
+                }
+                """,
+                """
+                class C(int i, int j, int k)
+                {
+                    private readonly int k = k;
+
+                    public int I { get; } = i;
+                    public int J { get; } = j;
+                }
+                """, index: 3);
+        }
+
+        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/53467")]
+        //public async Task TestMissingWhenTypeNotInCompilation()
+        //{
+        //    await TestMissingInRegularAndScriptAsync(
+        //        """
+        //        <Workspace>
+        //            <Project Language="C#" AssemblyName="Assembly1">
+        //                <Document>
+        //        public class Goo
+        //        {
+        //            public Goo(int prop1)
+        //            {
+        //                Prop1 = prop1;
+        //            }
+
+        //            public int Prop1 { get; }
+        //        }
+
+        //        public class Bar : Goo
+        //        {
+        //            public Bar(int prop1, int [||]prop2) : base(prop1) { }
+        //        }
+        //                </Document>
+        //            </Project>
+        //        </Workspace>
+        //        """);
+        //}
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S => throw new NotImplementedException();
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S { get; } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S
+                    {
+                        get => throw new NotImplementedException();
+                    }
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S
+                    {
+                        get;
+                    } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty3()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S
+                    {
+                        get { throw new NotImplementedException(); }
+                    }
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S
+                    {
+                        get;
+                    } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty4()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S
+                    {
+                        get => throw new NotImplementedException();
+                        set => throw new NotImplementedException();
+                    }
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S
+                    {
+                        get;
+                        set;
+                    } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty5()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S
+                    {
+                        get { throw new NotImplementedException(); }
+                        set { throw new NotImplementedException(); }
+                    }
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S
+                    {
+                        get;
+                        set;
+                    } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty6()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string S => throw new InvalidOperationException();
+                }
+                """,
+                """
+                using System;
+
+                class C(string s)
+                {
+                    private string S => throw new InvalidOperationException();
+
+                    public string S1 { get; } = s;
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeThrowingProperty_DifferentFile1()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string [||]name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Name => throw new NotImplementedException();
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Name { get; } = name;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """);
+        }
+    }
+}

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -316,36 +316,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """);
         }
 
-        //[Fact]
-        //public async Task TestInsertionLocation3()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-
-        //            public C([||]string s)
-        //            {
-        //                if (true) { } 
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-
-        //            public C(string s)
-        //            {
-        //                if (true) { }
-
-        //                this.s = s;
-        //            }
-        //        }
-        //        """);
-        //}
-
         [Fact]
         public async Task TestNotInMethod()
         {
@@ -361,64 +331,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 }
                 """);
         }
-
-        //[Fact]
-        //public async Task TestInsertionLocation4()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-        //            private string t;
-
-        //            public C(string s, [||]string t)
-        //                => this.s = s;   
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-        //            private string t;
-
-        //            public C(string s, string t)
-        //            {
-        //                this.s = s;
-        //                this.t = t;
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact]
-        //public async Task TestInsertionLocation5()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-        //            private string t;
-
-        //            public C([||]string s, string t)
-        //                => this.t = t;   
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private string s;
-        //            private string t;
-
-        //            public C(string s, string t)
-        //            {
-        //                this.s = s;
-        //                this.t = t;
-        //            }
-        //        }
-        //        """);
-        //}
 
         [Fact]
         public async Task TestInsertionLocation6()

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new CSharpInitializeMemberFromPrimaryConstructorParameterCodeRefactoringProvider();
 
-        private readonly NamingStylesTestOptionSets options = new NamingStylesTestOptionSets(LanguageNames.CSharp);
+        private readonly NamingStylesTestOptionSets _options = new(LanguageNames.CSharp);
 
         [Fact]
         public async Task TestInitializeFieldWithSameName()
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = s;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 1, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = t_s;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 1, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = p_s_End;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, index: 1, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -811,7 +811,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = t_p_s_End;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, index: 1, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = p_t_s;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefix)));
+                """, index: 1, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefix)));
         }
 
         [Fact]
@@ -845,7 +845,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = s;
                 }
-                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+                """, parameters: new TestParameters(options: _options.PropertyNamesArePascalCase));
         }
 
         [Fact]
@@ -862,7 +862,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = t_s;
                 }
-                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+                """, parameters: new TestParameters(options: _options.PropertyNamesArePascalCase));
         }
 
         [Fact]
@@ -879,7 +879,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = p_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -896,7 +896,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = t_p_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -913,7 +913,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = p_t_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -931,7 +931,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = s;
                 }
-                """, index: 0, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 0, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]
@@ -949,7 +949,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = t_s;
                 }
-                """, index: 0, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 0, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]
@@ -967,7 +967,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = p_s_End;
                 }
-                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, index: 0, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -985,7 +985,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = t_p_s_End;
                 }
-                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, index: 0, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1003,7 +1003,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string _s = p_t_s_End;
                 }
-                """, index: 0, parameters: new TestParameters(options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, index: 0, parameters: new TestParameters(options: _options.MergeStyles(_options.FieldNamesAreCamelCaseWithUnderscorePrefix, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1021,7 +1021,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = s;
                 }
-                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+                """, parameters: new TestParameters(options: _options.PropertyNamesArePascalCase));
         }
 
         [Fact]
@@ -1039,7 +1039,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = t_s;
                 }
-                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+                """, parameters: new TestParameters(options: _options.PropertyNamesArePascalCase));
         }
 
         [Fact]
@@ -1057,7 +1057,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = p_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = t_p_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1093,7 +1093,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; } = p_t_s_End;
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1105,7 +1105,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string S { get; }
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         [Fact]
@@ -1119,7 +1119,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 class C([|string p__End, string p_test_t|])
                 {
                 }
-                """, parameters: new TestParameters(options: options.MergeStyles(options.PropertyNamesArePascalCase, options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
+                """, parameters: new TestParameters(options: _options.MergeStyles(_options.PropertyNamesArePascalCase, _options.ParameterNamesAreCamelCaseWithPUnderscorePrefixAndUnderscoreEndSuffix)));
         }
 
         private TestParameters OmitIfDefault_Warning => new TestParameters(options: Option(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.OmitIfDefault, NotificationOption2.Warning));
@@ -1142,7 +1142,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private readonly string? _s = s;
                 }
-                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 1, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]
@@ -1161,7 +1161,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     public string? S { get; } = s;
                 }
-                """, parameters: new TestParameters(options: options.PropertyNamesArePascalCase));
+                """, parameters: new TestParameters(options: _options.PropertyNamesArePascalCase));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/24526")]
@@ -1793,7 +1793,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                         var v = new C(s: "");
                     }
                 }
-                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+                """, index: 1, parameters: new TestParameters(options: _options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
 
         [Fact]

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -2080,5 +2080,57 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 }
                 """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
         }
+
+        [Fact]
+        public async Task TestInitializeIntoFieldInDifferentPart()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                partial class C([||]string s)
+                {
+                }
+
+                partial class C
+                {
+                    private string s;
+                }
+                """,
+                """
+                partial class C(string s)
+                {
+                }
+                
+                partial class C
+                {
+                    private string s = s;
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestInitializeIntoPropertyInDifferentPart()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                partial class C([||]string s)
+                {
+                }
+
+                partial class C
+                {
+                    private string S { get; }
+                }
+                """,
+                """
+                partial class C(string s)
+                {
+                }
+                
+                partial class C
+                {
+                    private string S { get; } = s;
+                }
+                """);
+        }
     }
 }

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -1880,5 +1880,205 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 </Workspace>
                 """);
         }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceExistingField1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string _s;
+
+                    private void M()
+                    {
+                        Console.WriteLine(s);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    private string _s = s;
+                
+                    private void M()
+                    {
+                        Console.WriteLine(_s);
+                        var v = new C(s: "");
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceExistingField2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private string _s;
+
+                    private void M()
+                    {
+                        Console.WriteLine(/*t*/ s /*t2*/);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    private string _s = s;
+                
+                    private void M()
+                    {
+                        Console.WriteLine(/*t*/ _s /*t2*/);
+                        var v = new C(s: "");
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceExistingProperty()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    public string S { get; }
+
+                    private void M()
+                    {
+                        Console.WriteLine(s);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                
+                    private void M()
+                    {
+                        Console.WriteLine(S);
+                        var v = new C(s: "");
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceExistingProperty2()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    public string S { get; }
+
+                    private void M()
+                    {
+                        Console.WriteLine(/*t*/ s /*t2*/);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    public string S { get; } = s;
+                
+                    private void M()
+                    {
+                        Console.WriteLine(/*t*/ S /*t2*/);
+                        var v = new C(s: "");
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceNewProperty1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private void M()
+                    {
+                        Console.WriteLine(s);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    public string S { get; } = s;
+
+                    private void M()
+                    {
+                        Console.WriteLine(S);
+                        var v = new C(s: "");
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUpdateCodeToReferenceNewField1()
+        {
+            await TestInRegularAndScript1Async(
+                """
+                using System;
+
+                class C([||]string s)
+                {
+                    private void M()
+                    {
+                        Console.WriteLine(s);
+                        var v = new C(s: "");
+                    }
+                }
+                """,
+                """
+                using System;
+                
+                class C(string s)
+                {
+                    private readonly string _s = s;
+
+                    private void M()
+                    {
+                        Console.WriteLine(_s);
+                        var v = new C(s: "");
+                    }
+                }
+                """, index: 1, parameters: new TestParameters(options: options.FieldNamesAreCamelCaseWithUnderscorePrefix));
+        }
     }
 }

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -1231,263 +1231,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 """);
         }
 
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment1()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(string s, string t, [||]int i)
-        //            {
-        //                (this.s, this.t) = (s, t);
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-        //            private readonly int i;
-
-        //            public C(string s, string t, int i)
-        //            {
-        //                (this.s, this.t, this.i) = (s, t, i);
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment2()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(string s, string t, [||]int i) =>
-        //                (this.s, this.t) = (s, t);
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-        //            private readonly int i;
-
-        //            public C(string s, string t, int i) =>
-        //                (this.s, this.t, this.i) = (s, t, i);
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterFollowsExistingFieldAssignment_TupleAssignment3()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(string s, string t, [||]int i)
-        //            {
-        //                if (s is null) throw new ArgumentNullException();
-        //                (this.s, this.t) = (s, t);
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-        //            private readonly int i;
-
-        //            public C(string s, string t, int i)
-        //            {
-        //                if (s is null) throw new ArgumentNullException();
-        //                (this.s, this.t, this.i) = (s, t, i);
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterPrecedesExistingFieldAssignment_TupleAssignment1()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C([||]int i, string s, string t)
-        //            {
-        //                (this.s, this.t) = (s, t);
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly int i;
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(int i, string s, string t)
-        //            {
-        //                (this.i, this.s, this.t) = (i, s, t);
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterPrecedesExistingFieldAssignment_TupleAssignment2()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C([||]int i, string s, string t) =>
-        //                (this.s, this.t) = (s, t);
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly int i;
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(int i, string s, string t) =>
-        //                (this.i, this.s, this.t) = (i, s, t);
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterInMiddleOfExistingFieldAssignment_TupleAssignment1()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(string s, [||]int i, string t)
-        //            {
-        //                (this.s, this.t) = (s, t);
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly int i;
-        //            private readonly string t;
-
-        //            public C(string s, int i, string t)
-        //            {
-        //                (this.s, this.i, this.t) = (s, i, t);
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGenerateFieldIfParameterInMiddleOfExistingFieldAssignment_TupleAssignment2()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly string t;
-
-        //            public C(string s, [||]int i, string t) =>
-        //                (this.s, this.t) = (s, t);
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            private readonly string s;
-        //            private readonly int i;
-        //            private readonly string t;
-
-        //            public C(string s, int i, string t) =>
-        //                (this.s, this.i, this.t) = (s, i, t);
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23308")]
-        //public async Task TestGeneratePropertyIfParameterFollowsExistingPropertyAssignment_TupleAssignment1()
-        //{
-        //    await TestInRegularAndScript1Async(
-        //        """
-        //        class C
-        //        {
-        //            public string S { get; }
-        //            public string T { get; }
-
-        //            public C(string s, string t, [||]int i)
-        //            {
-        //                (S, T) = (s, t);
-        //            }
-        //        }
-        //        """,
-        //        """
-        //        class C
-        //        {
-        //            public string S { get; }
-        //            public string T { get; }
-        //            public int I { get; }
-
-        //            public C(string s, string t, int i)
-        //            {
-        //                (S, T, I) = (s, t, i);
-        //            }
-        //        }
-        //        """);
-        //}
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/41824")]
-        //public async Task TestMissingInArgList()
-        //{
-        //    await TestMissingInRegularAndScriptAsync(
-        //        """
-        //        class C
-        //        {
-        //            private static void M()
-        //            {
-        //                M2(__arglist(1, 2, 3, 5, 6));
-        //            }
-
-        //            public static void M2([||]__arglist)
-        //            {
-        //            }
-        //        }
-        //        """);
-        //}
-
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35665")]
         public async Task TestGenerateRemainingFields1()
         {
@@ -1648,34 +1391,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 }
                 """, index: 3);
         }
-
-        //[Fact, WorkItem("https://github.com/dotnet/roslyn/issues/53467")]
-        //public async Task TestMissingWhenTypeNotInCompilation()
-        //{
-        //    await TestMissingInRegularAndScriptAsync(
-        //        """
-        //        <Workspace>
-        //            <Project Language="C#" AssemblyName="Assembly1">
-        //                <Document>
-        //        public class Goo
-        //        {
-        //            public Goo(int prop1)
-        //            {
-        //                Prop1 = prop1;
-        //            }
-
-        //            public int Prop1 { get; }
-        //        }
-
-        //        public class Bar : Goo
-        //        {
-        //            public Bar(int prop1, int [||]prop2) : base(prop1) { }
-        //        }
-        //                </Document>
-        //            </Project>
-        //        </Workspace>
-        //        """);
-        //}
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
         public async Task TestInitializeThrowingProperty1()
@@ -2130,6 +1845,176 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
                 {
                     private string S { get; } = s;
                 }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeProperty_DifferentFile1()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string [||]name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Name { get; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Name { get; } = name;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeProperty_DifferentFile2()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string x, string [||]y)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string X { get; } = x;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string x, string y)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string X { get; } = x;
+                    public string Y { get; } = y;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeProperty_DifferentFile3()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string [||]x, string y)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Y { get; } = y;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string x, string y)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string X { get; } = x;
+                    public string Y { get; } = y;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeField_DifferentFile1()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string [||]name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    private readonly string name;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string name)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    private readonly string name = name;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
                 """);
         }
     }

--- a/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/InitializeMemberFromPrimaryConstructorParameterTests.cs
@@ -1977,6 +1977,50 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InitializeParameter
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
+        public async Task TestInitializeProperty_DifferentFile4()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string [||]x, string y, string z)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string Y { get; } = y;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """,
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                public partial class Goo(string x, string y, string z)
+                {
+                }
+                        </Document>
+                        <Document>
+                using System;
+                public partial class Goo
+                {
+                    public string X { get; } = x;
+                    public string Y { get; } = y;
+                    public string Z { get; } = z;
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """, index: 2);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36998")]
         public async Task TestInitializeField_DifferentFile1()
         {
             await TestInRegularAndScriptAsync(

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public const string ImplementInterfaceExplicitly = nameof(ImplementInterfaceExplicitly);
         public const string ImplementInterfaceImplicitly = nameof(ImplementInterfaceImplicitly);
         public const string InitializeMemberFromParameter = nameof(InitializeMemberFromParameter);
+        public const string InitializeMemberFromPrimaryConstructorParameter = nameof(InitializeMemberFromPrimaryConstructorParameter);
         public const string InlineMethod = "Inline Method Code Action Provider";
         public const string InlineTemporary = "Inline Temporary Code Action Provider";
         public const string IntroduceLocalForExpression = nameof(IntroduceLocalForExpression);

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -23,6 +23,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.InitializeParameter
 {
+    using static InitializeParameterHelpersCore;
+
     internal abstract class AbstractAddParameterCheckCodeRefactoringProvider<
         TTypeDeclarationSyntax,
         TParameterSyntax,
@@ -198,7 +200,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 var operation = semanticModel.GetOperation(coalesceNode, cancellationToken);
                 if (operation is ICoalesceOperation coalesceExpression)
                 {
-                    if (IsParameterReference(coalesceExpression.Value, parameter) &&
+                    if (InitializeParameterHelpersCore.IsParameterReference(coalesceExpression.Value, parameter) &&
                         syntaxFacts.IsThrowExpression(coalesceExpression.WhenNull.Syntax))
                     {
                         return true;

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 var operation = semanticModel.GetOperation(coalesceNode, cancellationToken);
                 if (operation is ICoalesceOperation coalesceExpression)
                 {
-                    if (InitializeParameterHelpersCore.IsParameterReference(coalesceExpression.Value, parameter) &&
+                    if (IsParameterReference(coalesceExpression.Value, parameter) &&
                         syntaxFacts.IsThrowExpression(coalesceExpression.WhenNull.Syntax))
                     {
                         return true;

--- a/src/Features/Core/Portable/InitializeParameter/InitializeParameterHelpersCore.cs
+++ b/src/Features/Core/Portable/InitializeParameter/InitializeParameterHelpersCore.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.InitializeParameter
+{
+    internal static class InitializeParameterHelpersCore
+    {
+        public static ImmutableArray<(IParameterSymbol parameter, bool before)> GetSiblingParameters(IParameterSymbol parameter)
+        {
+            using var _ = ArrayBuilder<(IParameterSymbol, bool before)>.GetInstance(out var siblings);
+
+            if (parameter.ContainingSymbol is IMethodSymbol method)
+            {
+                var parameterIndex = method.Parameters.IndexOf(parameter);
+
+                // look for an existing assignment for a parameter that comes before us.
+                // If we find one, we'll add ourselves after that parameter check.
+                for (var i = parameterIndex - 1; i >= 0; i--)
+                    siblings.Add((method.Parameters[i], before: true));
+
+                // look for an existing check for a parameter that comes before us.
+                // If we find one, we'll add ourselves after that parameter check.
+                for (var i = parameterIndex + 1; i < method.Parameters.Length; i++)
+                    siblings.Add((method.Parameters[i], before: false));
+            }
+
+            return siblings.ToImmutable();
+        }
+
+        public static bool IsParameterReference(IOperation? operation, IParameterSymbol parameter)
+            => operation.UnwrapImplicitConversion() is IParameterReferenceOperation parameterReference &&
+               parameter.Equals(parameterReference.Parameter);
+
+        public static bool IsParameterReferenceOrCoalesceOfParameterReference(
+           IOperation? value, IParameterSymbol parameter)
+        {
+            if (IsParameterReference(value, parameter))
+            {
+                // We already have a member initialized with this parameter like:
+                //      this.field = parameter
+                return true;
+            }
+
+            if (value.UnwrapImplicitConversion() is ICoalesceOperation coalesceExpression &&
+                IsParameterReference(coalesceExpression.Value, parameter))
+            {
+                // We already have a member initialized with this parameter like:
+                //      this.field = parameter ?? ...
+                return true;
+            }
+
+            return false;
+        }
+
+        public static string GenerateUniqueName(IParameterSymbol parameter, ImmutableArray<string> parameterNameParts, NamingRule rule)
+        {
+            // Determine an appropriate name to call the new field.
+            var containingType = parameter.ContainingType;
+            var baseName = rule.NamingStyle.CreateName(parameterNameParts);
+
+            // Ensure that the name is unique in the containing type so we
+            // don't stomp on an existing member.
+            var uniqueName = NameGenerator.GenerateUniqueName(
+                baseName, n => containingType.GetMembers(n).IsEmpty);
+            return uniqueName;
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SemanticModelExtensions.cs
@@ -451,21 +451,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return null;
         }
 
-        public static INamedTypeSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax declaration, CancellationToken cancellationToken)
+        public static INamedTypeSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax syntax, CancellationToken cancellationToken)
         {
-            return semanticModel.GetDeclaredSymbol(declaration, cancellationToken)
+            return semanticModel.GetDeclaredSymbol(syntax, cancellationToken)
                 ?? throw new InvalidOperationException();
         }
 
-        public static IMethodSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ConstructorDeclarationSyntax declaration, CancellationToken cancellationToken)
+        public static IMethodSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ConstructorDeclarationSyntax syntax, CancellationToken cancellationToken)
         {
-            return semanticModel.GetDeclaredSymbol(declaration, cancellationToken)
+            return semanticModel.GetDeclaredSymbol(syntax, cancellationToken)
                 ?? throw new InvalidOperationException();
         }
 
-        public static IParameterSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ParameterSyntax parameter, CancellationToken cancellationToken)
+        public static IParameterSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ParameterSyntax syntax, CancellationToken cancellationToken)
         {
-            return semanticModel.GetDeclaredSymbol(parameter, cancellationToken)
+            return semanticModel.GetDeclaredSymbol(syntax, cancellationToken)
+                ?? throw new InvalidOperationException();
+        }
+
+        public static IPropertySymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, PropertyDeclarationSyntax syntax, CancellationToken cancellationToken)
+        {
+            return semanticModel.GetDeclaredSymbol(syntax, cancellationToken)
                 ?? throw new InvalidOperationException();
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SemanticModelExtensions.cs
@@ -451,15 +451,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return null;
         }
 
-        public static INamedTypeSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax declarationSyntax, CancellationToken cancellationToken)
+        public static INamedTypeSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
-            return semanticModel.GetDeclaredSymbol(declarationSyntax, cancellationToken)
+            return semanticModel.GetDeclaredSymbol(declaration, cancellationToken)
                 ?? throw new InvalidOperationException();
         }
 
-        public static IMethodSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ConstructorDeclarationSyntax declarationSyntax, CancellationToken cancellationToken)
+        public static IMethodSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ConstructorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
-            return semanticModel.GetDeclaredSymbol(declarationSyntax, cancellationToken)
+            return semanticModel.GetDeclaredSymbol(declaration, cancellationToken)
+                ?? throw new InvalidOperationException();
+        }
+
+        public static IParameterSymbol GetRequiredDeclaredSymbol(this SemanticModel semanticModel, ParameterSyntax parameter, CancellationToken cancellationToken)
+        {
+            return semanticModel.GetDeclaredSymbol(parameter, cancellationToken)
                 ?? throw new InvalidOperationException();
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
@@ -124,7 +124,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 identifier: property.Name.ToIdentifierToken(),
                 accessorList: accessorList,
                 expressionBody: null,
-                initializer: initializer);
+                initializer: initializer,
+                semicolonToken: initializer is null ? default : SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
             propertyDeclaration = UseExpressionBodyIfDesired(info, propertyDeclaration);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/68817

Looks like this:

![image](https://github.com/dotnet/roslyn/assets/4564579/f022e027-1900-4549-ad31-54c2f59e7c46)

QOL for people using primary constructors.  Just like witha  normal constructor, we want to make it easy to be writing the constructor and then have the user go and create fields/props easily.

Fixes #68817