### PR TITLE
Enable Binskim scan in CI builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -390,6 +390,8 @@ stages:
         enable: true
         params: >-
           -SourceToolsList @("policheck","credscan")
+          -ArtifactToolsList @("binskim")
+          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
           -TsaInstanceURL $(_TsaInstanceURL)
           -TsaProjectName $(_TsaProjectName)
           -TsaNotificationEmail $(_TsaNotificationEmail)


### PR DESCRIPTION
Enabling **BinSkim** scan over build artifacts in CI based on company requirements.

**This change is dependent on arcade version update:** https://github.com/dotnet/roslyn/pull/69016

We are required to run SDL tools on official builds and implement automated bug filling for the tools output. Currently we are running SDL checks over the source code in the nightly builds, inline in the builds for some of the product repos and in the .NET staging pipeline, but to be compliant we need to also run BinSkim over the produced artifacts.

This PRs is enabling **BinSkim** checks in the [Run SDL tool job](https://dev.azure.com/dnceng/internal/_build/results?buildId=2224142&view=logs&j=7d9eef18-6720-5c1f-4d30-89d7b76728e9) of `dotnet-roslyn CI`

More information is in the [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647)  