### PR TITLE
Suppress `ref readonly` warning for extension method receiver

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3276,16 +3276,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
+                        var argNumber = invokedAsExtensionMethod ? arg : arg + 1;
+
                         // Warn for `ref`/`in` or None/`ref readonly` mismatch.
                         if (argRefKind == RefKind.Ref)
                         {
                             if (GetCorrespondingParameter(ref result, parameters, arg).RefKind == RefKind.In)
                             {
+                                Debug.Assert(argNumber > 0);
                                 // The 'ref' modifier for argument {0} corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
                                 diagnostics.Add(
                                     ErrorCode.WRN_BadArgRef,
                                     argument.Syntax,
-                                    arg + 1);
+                                    argNumber);
                             }
                         }
                         else if (argRefKind == RefKind.None &&
@@ -3293,21 +3296,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (!this.CheckValueKind(argument.Syntax, argument, BindValueKind.RefersToLocation, checkingReceiver: false, BindingDiagnosticBag.Discarded))
                             {
+                                Debug.Assert(argNumber >= 0); // can be 0 for receiver of extension method
                                 // Argument {0} should be a variable because it is passed to a 'ref readonly' parameter
                                 diagnostics.Add(
                                     ErrorCode.WRN_RefReadonlyNotVariable,
                                     argument.Syntax,
-                                    arg + 1);
+                                    argNumber);
                             }
                             else if (!invokedAsExtensionMethod || arg != 0)
                             {
+                                Debug.Assert(argNumber > 0);
                                 if (this.CheckValueKind(argument.Syntax, argument, BindValueKind.Assignable, checkingReceiver: false, BindingDiagnosticBag.Discarded))
                                 {
                                     // Argument {0} should be passed with 'ref' or 'in' keyword
                                     diagnostics.Add(
                                         ErrorCode.WRN_ArgExpectedRefOrIn,
                                         argument.Syntax,
-                                        arg + 1);
+                                        argNumber);
                                 }
                                 else
                                 {
@@ -3315,7 +3320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     diagnostics.Add(
                                         ErrorCode.WRN_ArgExpectedIn,
                                         argument.Syntax,
-                                        arg + 1);
+                                        argNumber);
                                 }
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3299,9 +3299,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     argument.Syntax,
                                     arg + 1);
                             }
-                            else if (this.CheckValueKind(argument.Syntax, argument, BindValueKind.Assignable, checkingReceiver: false, BindingDiagnosticBag.Discarded))
+                            else if (!invokedAsExtensionMethod || arg != 0)
                             {
-                                if (!invokedAsExtensionMethod)
+                                if (this.CheckValueKind(argument.Syntax, argument, BindValueKind.Assignable, checkingReceiver: false, BindingDiagnosticBag.Discarded))
                                 {
                                     // Argument {0} should be passed with 'ref' or 'in' keyword
                                     diagnostics.Add(
@@ -3309,14 +3309,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         argument.Syntax,
                                         arg + 1);
                                 }
-                            }
-                            else
-                            {
-                                // Argument {0} should be passed with the 'in' keyword
-                                diagnostics.Add(
-                                    ErrorCode.WRN_ArgExpectedIn,
-                                    argument.Syntax,
-                                    arg + 1);
+                                else
+                                {
+                                    // Argument {0} should be passed with the 'in' keyword
+                                    diagnostics.Add(
+                                        ErrorCode.WRN_ArgExpectedIn,
+                                        argument.Syntax,
+                                        arg + 1);
+                                }
                             }
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1072,7 +1072,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
-            this.CheckAndCoerceArguments(methodResult, analyzedArguments, diagnostics, receiver);
+            this.CheckAndCoerceArguments(methodResult, analyzedArguments, diagnostics, receiver, invokedAsExtensionMethod: invokedAsExtensionMethod);
 
             var expanded = methodResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
             var argsToParams = methodResult.Result.ArgsToParamsOpt;
@@ -2102,7 +2102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             methodsBuilder.Free();
 
             MemberResolutionResult<FunctionPointerMethodSymbol> methodResult = overloadResolutionResult.ValidResult;
-            CheckAndCoerceArguments(methodResult, analyzedArguments, diagnostics, receiver: null);
+            CheckAndCoerceArguments(methodResult, analyzedArguments, diagnostics, receiver: null, invokedAsExtensionMethod: false);
 
             var args = analyzedArguments.Arguments.ToImmutable();
             var refKinds = analyzedArguments.RefKinds.ToImmutableOrNull();

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3100,9 +3100,15 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
+            // (9,14): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            //         x.M1(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(9, 14),
             // (11,15): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
             //         M1(x, x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(11, 15),
+            // (13,14): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            //         x.M2(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(13, 14),
             // (14,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
             //         M2(x, in x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 12),
@@ -3147,12 +3153,6 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             // (10,15): warning CS9506: Argument 2 should be passed with the 'in' keyword
             //         M1(x, x);
             Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(10, 15),
-            // (11,9): warning CS9506: Argument 1 should be passed with the 'in' keyword
-            //         x.M2(in x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(11, 9),
-            // (12,9): warning CS9506: Argument 1 should be passed with the 'in' keyword
-            //         x.M2(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(12, 9),
             // (12,14): warning CS9506: Argument 2 should be passed with the 'in' keyword
             //         x.M2(x);
             Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(12, 14),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3100,15 +3100,15 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (9,14): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            // (9,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
             //         x.M1(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(9, 14),
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(9, 14),
             // (11,15): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
             //         M1(x, x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(11, 15),
-            // (13,14): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            // (13,14): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
             //         x.M2(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(13, 14),
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(13, 14),
             // (14,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
             //         M2(x, in x);
             Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 12),
@@ -3147,15 +3147,15 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (8,14): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            // (8,14): warning CS9506: Argument 1 should be passed with the 'in' keyword
             //         x.M1(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(8, 14),
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(8, 14),
             // (10,15): warning CS9506: Argument 2 should be passed with the 'in' keyword
             //         M1(x, x);
             Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(10, 15),
-            // (12,14): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            // (12,14): warning CS9506: Argument 1 should be passed with the 'in' keyword
             //         x.M2(x);
-            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(12, 14),
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(12, 14),
             // (13,12): warning CS9506: Argument 1 should be passed with the 'in' keyword
             //         M2(x, in x);
             Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(13, 12),
@@ -3185,9 +3185,9 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """;
         var verifier = CompileAndVerify(source, expectedOutput: "5");
         verifier.VerifyDiagnostics(
-            // (6,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            // (6,9): warning CS9504: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
             //         5.M();
-            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(6, 9));
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("0").WithLocation(6, 9));
         verifier.VerifyIL("C.Main", """
             {
               // Code size       10 (0xa)
@@ -3223,27 +3223,27 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (7,14): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            // (7,14): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
             //         5.M1(111);
-            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(7, 14),
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("1").WithLocation(7, 14),
             // (8,15): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
             //         M1(5, 111);
             Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(8, 15),
-            // (9,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            // (9,9): warning CS9504: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
             //         5.M2(111);
-            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(9, 9),
-            // (9,14): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("0").WithLocation(9, 9),
+            // (9,14): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
             //         5.M2(111);
-            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(9, 14),
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("1").WithLocation(9, 14),
             // (10,12): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
             //         M2(5, 111);
             Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(10, 12),
             // (10,15): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
             //         M2(5, 111);
             Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(10, 15),
-            // (11,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            // (11,9): warning CS9504: Argument 0 should be a variable because it is passed to a 'ref readonly' parameter
             //         5.M2(in 111);
-            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(11, 9),
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("0").WithLocation(11, 9),
             // (11,17): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
             //         5.M2(in 111);
             Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "111").WithLocation(11, 17),

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -3075,6 +3075,192 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
             """);
     }
 
+    [Fact]
+    public void Invocation_ExtensionMethod_SecondParameter()
+    {
+        var source = """
+            static class C
+            {
+                static void M1(this int x, ref readonly int y) { }
+                static void M2(this ref readonly int x, ref readonly int y) { }
+                static void M3()
+                {
+                    var x = 1;
+                    x.M1(in x);
+                    x.M1(x);
+                    M1(x, in x);
+                    M1(x, x);
+                    x.M2(in x);
+                    x.M2(x);
+                    M2(x, in x);
+                    M2(x, x);
+                    M2(in x, in x);
+                    M2(in x, x);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (11,15): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            //         M1(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(11, 15),
+            // (14,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M2(x, in x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(14, 12),
+            // (15,12): warning CS9503: Argument 1 should be passed with 'ref' or 'in' keyword
+            //         M2(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("1").WithLocation(15, 12),
+            // (15,15): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            //         M2(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(15, 15),
+            // (17,18): warning CS9503: Argument 2 should be passed with 'ref' or 'in' keyword
+            //         M2(in x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedRefOrIn, "x").WithArguments("2").WithLocation(17, 18));
+    }
+
+    [Fact]
+    public void Invocation_ExtensionMethod_SecondParameter_ReadOnly()
+    {
+        var source = """
+            static class C
+            {
+                static void M1(this int x, ref readonly int y) { }
+                static void M2(this ref readonly int x, ref readonly int y) { }
+                static void M3(ref readonly int x)
+                {
+                    x.M1(in x);
+                    x.M1(x);
+                    M1(x, in x);
+                    M1(x, x);
+                    x.M2(in x);
+                    x.M2(x);
+                    M2(x, in x);
+                    M2(x, x);
+                    M2(in x, in x);
+                    M2(in x, x);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,14): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            //         x.M1(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(8, 14),
+            // (10,15): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            //         M1(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(10, 15),
+            // (11,9): warning CS9506: Argument 1 should be passed with the 'in' keyword
+            //         x.M2(in x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(11, 9),
+            // (12,9): warning CS9506: Argument 1 should be passed with the 'in' keyword
+            //         x.M2(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(12, 9),
+            // (12,14): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            //         x.M2(x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(12, 14),
+            // (13,12): warning CS9506: Argument 1 should be passed with the 'in' keyword
+            //         M2(x, in x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(13, 12),
+            // (14,12): warning CS9506: Argument 1 should be passed with the 'in' keyword
+            //         M2(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("1").WithLocation(14, 12),
+            // (14,15): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            //         M2(x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(14, 15),
+            // (16,18): warning CS9506: Argument 2 should be passed with the 'in' keyword
+            //         M2(in x, x);
+            Diagnostic(ErrorCode.WRN_ArgExpectedIn, "x").WithArguments("2").WithLocation(16, 18));
+    }
+
+    [Fact]
+    public void Invocation_ExtensionMethod_RValue()
+    {
+        var source = """
+            static class C
+            {
+                static void M(this ref readonly int x) => System.Console.Write(x);
+                static void Main()
+                {
+                    5.M();
+                }
+            }
+            """;
+        var verifier = CompileAndVerify(source, expectedOutput: "5");
+        verifier.VerifyDiagnostics(
+            // (6,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            //         5.M();
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(6, 9));
+        verifier.VerifyIL("C.Main", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              .locals init (int V_0)
+              IL_0000:  ldc.i4.5
+              IL_0001:  stloc.0
+              IL_0002:  ldloca.s   V_0
+              IL_0004:  call       "void C.M(ref readonly int)"
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void Invocation_ExtensionMethod_RValue_SecondParameter()
+    {
+        var source = """
+            static class C
+            {
+                static void M1(this int x, ref readonly int y) { }
+                static void M2(this ref readonly int x, ref readonly int y) => System.Console.Write(x + y);
+                static void M3()
+                {
+                    5.M1(111);
+                    M1(5, 111);
+                    5.M2(111);
+                    M2(5, 111);
+                    5.M2(in 111);
+                    M2(in 5, 111);
+                    M2(in 5, in 111);
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (7,14): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            //         5.M1(111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(7, 14),
+            // (8,15): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            //         M1(5, 111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(8, 15),
+            // (9,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            //         5.M2(111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(9, 9),
+            // (9,14): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            //         5.M2(111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(9, 14),
+            // (10,12): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            //         M2(5, 111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(10, 12),
+            // (10,15): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            //         M2(5, 111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(10, 15),
+            // (11,9): warning CS9504: Argument 1 should be a variable because it is passed to a 'ref readonly' parameter
+            //         5.M2(in 111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "5").WithArguments("1").WithLocation(11, 9),
+            // (11,17): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         5.M2(in 111);
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "111").WithLocation(11, 17),
+            // (12,15): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         M2(in 5, 111);
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "5").WithLocation(12, 15),
+            // (12,18): warning CS9504: Argument 2 should be a variable because it is passed to a 'ref readonly' parameter
+            //         M2(in 5, 111);
+            Diagnostic(ErrorCode.WRN_RefReadonlyNotVariable, "111").WithArguments("2").WithLocation(12, 18),
+            // (13,15): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         M2(in 5, in 111);
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "5").WithLocation(13, 15),
+            // (13,21): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            //         M2(in 5, in 111);
+            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "111").WithLocation(13, 21));
+    }
+
     [Theory, CombinatorialData]
     public void Invocation_ExtensionMethod_Pointer([CombinatorialValues("ref readonly", "ref", "in")] string modifier)
     {


### PR DESCRIPTION
Speclet: [the relevant section (second paragraph)](https://github.com/dotnet/csharplang/blob/3daa6f86510906df8ad29875659d0359d1a88b94/proposals/ref-readonly-parameters.md#overload-resolution) · [PR](https://github.com/dotnet/csharplang/pull/7350)
Test plan: https://github.com/dotnet/roslyn/issues/68056