### PR TITLE
Add support for IDE scenarios related to `ref readonly` parameters

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -3112,6 +3112,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("enum      C       ;    ", "enum C;");
         }
 
+        [Fact]
+        public void RefReadonlyParameters()
+        {
+            TestNormalizeDeclaration("""
+                class   C  {  int  this  [  ref  readonly   int  x ,  ref  readonly  int  y ]  {  get  ;  } 
+                void  M ( ref  readonly  int  x ,  ref  readonly  int  y ) ; }
+                """, """
+                class C
+                {
+                  int this[ref readonly int x, ref readonly int y] { get; }
+
+                  void M(ref readonly int x, ref readonly int y);
+                }
+                """);
+        }
+
         [Fact, WorkItem(23618, "https://github.com/dotnet/roslyn/issues/23618")]
         public void TestSpacingOnInvocationLikeKeywords()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -494,6 +494,21 @@ class C
             await VerifyItemExistsAsync(text, "MyMethod(in int)");
         }
 
+        [Fact]
+        public async Task CRef_RefReadonlyParameter()
+        {
+            var text = $$"""
+                using System;
+                class C 
+                { 
+                    /// <see cref="C.My$$
+                    public void MyMethod(ref readonly int x) { }
+                }
+                """;
+
+            await VerifyItemExistsAsync(text, "MyMethod(ref readonly int)");
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/22626")]
         public async Task ValueTuple1()
         {

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -2575,6 +2575,19 @@ void Method(int i = 0)
         }
 
         [Fact]
+        public async Task Method_RefReadonly()
+        {
+            await TestInClassAsync(
+                """
+                void Goo(ref readonly DateTime dt, ref readonly System.IO.FileInfo fi, params int[] numbers)
+                {
+                    Go$$o(in DateTime.Now, in fi, 32);
+                }
+                """,
+                MainDescription("void C.Goo(ref readonly DateTime dt, ref readonly System.IO.FileInfo fi, params int[] numbers)"));
+        }
+
+        [Fact]
         public async Task Constructor()
         {
             await TestInClassAsync(

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ReadOnlyKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ReadOnlyKeywordRecommenderTests.cs
@@ -422,9 +422,9 @@ $$");
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestRefReadonlyNotAsParameterModifierInMethods()
+        public async Task TestRefReadonlyAsParameterModifierInMethods()
         {
-            await VerifyAbsenceAsync(@"
+            await VerifyKeywordAsync(@"
 class Program
 {
     public static void Test(ref $$ p) { }
@@ -433,9 +433,9 @@ class Program
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestRefReadonlyNotAsParameterModifierInSecondParameter()
+        public async Task TestRefReadonlyAsParameterModifierInSecondParameter()
         {
-            await VerifyAbsenceAsync(@"
+            await VerifyKeywordAsync(@"
 class Program
 {
     public static void Test(int p1, ref $$ p2) { }
@@ -444,47 +444,42 @@ class Program
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestRefReadonlyNotAsParameterModifierInDelegates()
+        public async Task TestRefReadonlyAsParameterModifierInDelegates()
         {
-            await VerifyAbsenceAsync(@"
+            await VerifyKeywordAsync(@"
 public delegate int Delegate(ref $$ int p);");
         }
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
         [CombinatorialData]
-        public async Task TestRefReadonlyNotAsParameterModifierInLocalFunctions(bool topLevelStatement)
+        public async Task TestRefReadonlyAsParameterModifierInLocalFunctions(bool topLevelStatement)
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
+            await VerifyKeywordAsync(AddInsideMethod(
 @"void localFunc(ref $$ int p) { }", topLevelStatement: topLevelStatement), options: CSharp9ParseOptions);
         }
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestRefReadonlyNotAsParameterModifierInLambdaExpressions()
+        public async Task TestRefReadonlyAsParameterModifierInLambdaExpressions()
         {
-            await VerifyAbsenceAsync(@"
+            await VerifyKeywordAsync(@"
 public delegate int Delegate(ref int p);
 
 class Program
 {
     public static void Test()
     {
-        // This is bad. We can't put 'ref $ int p' like in the other tests here because in this scenario:
-        // 'Delegate lambda = (ref r int p) => p;' (partially written 'readonly' keyword),
-        // the syntax tree is completely broken and there is no lambda expression at all here.
-        // 'ref' starts a new local declaration and therefore we do offer 'readonly'.
-        // Fixing that would have to involve either changing the parser or doing some really nasty hacks.
-        // Delegate lambda = (ref $$ int p) => p;
+        Delegate lambda = (ref $$ int p) => p;
     }
 }");
         }
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestRefReadonlyNotAsParameterModifierInAnonymousMethods()
+        public async Task TestRefReadonlyAsParameterModifierInAnonymousMethods()
         {
-            await VerifyAbsenceAsync(@"
+            await VerifyKeywordAsync(@"
 public delegate int Delegate(ref int p);
 
 class Program
@@ -575,7 +570,18 @@ class Program
         public async Task TestRefReadonlyNotInRefExpression(bool topLevelStatement)
         {
             await VerifyAbsenceAsync(AddInsideMethod(
-@"ref int x = ref $$", topLevelStatement: topLevelStatement), options: CSharp9ParseOptions);
+@"ref int x = ref $$", topLevelStatement: topLevelStatement), options: CSharp9ParseOptions,
+                // Top level statement with script tested below, so skip it here.
+                scriptOptions: topLevelStatement ? CSharp9ParseOptions : null);
+        }
+
+        [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestRefReadonlyInRefExpression_TopLevelStatementScript()
+        {
+            // Recognized as parameter context, so readonly keyword is suggested.
+            await VerifyKeywordAsync(AddInsideMethod(
+@"ref int x = ref $$", topLevelStatement: true), options: CSharp9ParseOptions.WithKind(SourceCodeKind.Script));
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -319,6 +319,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                                 RefKind.Ref => "ref ",
                                 RefKind.Out => "out ",
                                 RefKind.In => "in ",
+                                RefKind.RefReadOnlyParameter => "ref readonly ",
                                 _ => "",
                             });
                             builder.Append(p.Type.ToMinimalDisplayString(semanticModel, position, MinimalParameterTypeFormat));

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ReadOnlyKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ReadOnlyKeywordRecommender.cs
@@ -43,7 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         private static bool IsRefReadOnlyContext(CSharpSyntaxContext context)
             => context.TargetToken.IsKind(SyntaxKind.RefKeyword) &&
-               (context.TargetToken.Parent.IsKind(SyntaxKind.RefType) || context.IsFunctionPointerTypeArgumentContext);
+               (context.TargetToken.Parent.IsKind(SyntaxKind.RefType) ||
+                context.IsParameterTypeContext ||
+                context.IsPossibleLambdaOrAnonymousMethodParameterTypeContext ||
+                context.IsFunctionPointerTypeArgumentContext);
 
         private static bool IsValidContextForType(CSharpSyntaxContext context, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1838,27 +1838,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementAbstractClass
                 """, parameters: new TestParameters(globalOptions: options));
         }
 
-        [Fact]
-        public async Task TestInWithMethod_Parameters()
+        [Theory, CombinatorialData]
+        public async Task TestRefWithMethod_Parameters([CombinatorialValues("ref", "in", "ref readonly")] string modifier)
         {
             await TestInRegularAndScriptAsync(
-                """
+                $$"""
                 abstract class TestParent
                 {
-                    public abstract void Method(in int p);
+                    public abstract void Method({{modifier}} int p);
                 }
                 public class [|Test|] : TestParent
                 {
                 }
                 """,
-                """
+                $$"""
                 abstract class TestParent
                 {
-                    public abstract void Method(in int p);
+                    public abstract void Method({{modifier}} int p);
                 }
                 public class Test : TestParent
                 {
-                    public override void Method(in int p)
+                    public override void Method({{modifier}} int p)
                     {
                         throw new System.NotImplementedException();
                     }
@@ -1919,27 +1919,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementAbstractClass
                 """);
         }
 
-        [Fact]
-        public async Task TestInWithIndexer_Parameters()
+        [Theory, CombinatorialData]
+        public async Task TestRefWithIndexer_Parameters([CombinatorialValues("ref", "in", "ref readonly")] string modifier)
         {
             await TestInRegularAndScriptAsync(
-                """
+                $$"""
                 abstract class TestParent
                 {
-                    public abstract int this[in int p] { set; }
+                    public abstract int this[{{modifier}} int p] { set; }
                 }
                 public class [|Test|] : TestParent
                 {
                 }
                 """,
-                """
+                $$"""
                 abstract class TestParent
                 {
-                    public abstract int this[in int p] { set; }
+                    public abstract int this[{{modifier}} int p] { set; }
                 }
                 public class Test : TestParent
                 {
-                    public override int this[in int p] { set => throw new System.NotImplementedException(); }
+                    public override int this[{{modifier}} int p] { set => throw new System.NotImplementedException(); }
                 }
                 """);
         }

--- a/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests_ThroughMember.cs
+++ b/src/Features/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests_ThroughMember.cs
@@ -129,6 +129,69 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementAbstractClass
                 """, index: 1, title: string.Format(FeaturesResources.Implement_through_0, "inner"));
         }
 
+        [Fact]
+        public async Task RefParameters_Method()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                abstract class Base
+                {
+                    public abstract void Method(int a, ref int b, in int c, ref readonly int d, out int e);
+                }
+
+                class [|Derived|] : Base
+                {
+                    Derived inner;
+                }
+                """,
+                """
+                abstract class Base
+                {
+                    public abstract void Method(int a, ref int b, in int c, ref readonly int d, out int e);
+                }
+
+                class Derived : Base
+                {
+                    Derived inner;
+
+                    public override void Method(int a, ref int b, in int c, ref readonly int d, out int e)
+                    {
+                        inner.Method(a, ref b, c, in d, out e);
+                    }
+                }
+                """, index: 1, title: string.Format(FeaturesResources.Implement_through_0, "inner"));
+        }
+
+        [Fact]
+        public async Task RefParameters_Indexer()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                abstract class Base
+                {
+                    public abstract int this[int a, in int b, ref readonly int c, out int d] { get; }
+                }
+
+                class [|Derived|] : Base
+                {
+                    Derived inner;
+                }
+                """,
+                """
+                abstract class Base
+                {
+                    public abstract int this[int a, in int b, ref readonly int c, out int d] { get; }
+                }
+
+                class Derived : Base
+                {
+                    Derived inner;
+
+                    public override int this[int a, in int b, ref readonly int c, out int d] => inner[a, b, in c, out d];
+                }
+                """, index: 1, title: string.Format(FeaturesResources.Implement_through_0, "inner"));
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/41420")]
         public async Task SkipInaccessibleMember()
         {

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -798,6 +798,34 @@ class Program
 }", "System.Int32");
         }
 
+        [Fact]
+        public async Task TestRefReadonlyParameter_Ref()
+        {
+            await TestAsync(
+                """
+                class C
+                {
+                    void M(r[||]ef readonly int x)
+                    {
+                    }
+                }
+                """, "ref_CSharpKeyword");
+        }
+
+        [Fact]
+        public async Task TestRefReadonlyParameter_ReadOnly()
+        {
+            await TestAsync(
+                """
+                class C
+                {
+                    void M(ref read[||]only int x)
+                    {
+                    }
+                }
+                """, "readonly_CSharpKeyword");
+        }
+
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/862420")]
         public async Task TestArgumentType()
         {

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -219,6 +219,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return SyntaxFactory.Token(SyntaxKind.OutKeyword);
                 case RefKind.Ref:
                     return SyntaxFactory.Token(SyntaxKind.RefKeyword);
+                case RefKind.RefReadOnlyParameter:
+                    return SyntaxFactory.Token(SyntaxKind.InKeyword);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(refKind);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -3933,6 +3933,26 @@ public       void       Method      (       )           {
             await AssertFormatAsync(expected, code);
         }
 
+        [Fact]
+        public async Task RefReadonlyParameters()
+        {
+            var code = """
+                class C
+                {
+                    int   this  [   ref     readonly    int      x   ,   ref    readonly   int   y   ]   {   get ;   set ;  }
+                    void    M  (   ref    readonly     int   x    ,   ref    readonly   int   y   )  {   }
+                }
+                """;
+            var expected = """
+                class C
+                {
+                    int this[ref readonly int x, ref readonly int y] { get; set; }
+                    void M(ref readonly int x, ref readonly int y) { }
+                }
+                """;
+            await AssertFormatAsync(expected, code);
+        }
+
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539259")]
         public async Task BugFix5143()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -128,6 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 // The return parameter must use ref readonly, like regular methods.
                 RefKind.In when !forFunctionPointerReturnParameter => SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.InKeyword)),
                 RefKind.RefReadOnly when forFunctionPointerReturnParameter => SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.RefKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)),
+                RefKind.RefReadOnlyParameter => SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.RefKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)),
                 _ => throw ExceptionUtilities.UnexpectedValue(refKind),
             };
 


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/68056