### PR TITLE
Run ref safety analysis for field initializers on bound nodes transformed to assignments to the target fields.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1053,7 +1053,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         analyzedInitializers = InitializerRewriter.RewriteConstructor(processedInitializers.BoundInitializers, methodSymbol);
                         processedInitializers.HasErrors = processedInitializers.HasErrors || analyzedInitializers.HasAnyErrors;
 
-                        RefSafetyAnalysis.Analyze(_compilation, methodSymbol, processedInitializers.BoundInitializers, diagsForCurrentMethod);
+                        RefSafetyAnalysis.Analyze(_compilation, methodSymbol,
+                                                  new BoundBlock(analyzedInitializers.Syntax, ImmutableArray<LocalSymbol>.Empty, analyzedInitializers.Statements), // The block is necessary to establish the right local scope for the analysis 
+                                                  diagsForCurrentMethod);
                     }
 
                     body = BindMethodBody(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
@@ -17742,5 +17742,44 @@ class C1(int p1) : Base1
             comp.VerifyDiagnostics(expected);
             comp.VerifyEmitDiagnostics(expected);
         }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/67371")]
+        public void AssignToRefField_01()
+        {
+            var source = @"
+ref struct S1
+{
+    public ref int R1;
+
+    public S1(ref int x)
+    {
+        R1 = ref x;
+    }
+}
+
+ref struct S2
+{
+    public ref int R2;
+
+    public S2([System.Diagnostics.CodeAnalysis.UnscopedRef] ref int x)
+    {
+        R2 = ref x;
+    }
+}
+
+ref struct S3(ref int x)
+{
+    public ref int R3 = ref x;
+}
+
+ref struct S4([System.Diagnostics.CodeAnalysis.UnscopedRef] ref int x)
+{
+    public ref int R4 = ref x;
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PrimaryConstructorTests.cs
@@ -17777,9 +17777,153 @@ ref struct S4([System.Diagnostics.CodeAnalysis.UnscopedRef] ref int x)
 {
     public ref int R4 = ref x;
 }
+
+ref struct S5
+{
+    public ref int R5;
+
+    public S5(scoped ref int x)
+    {
+        R5 = ref x;
+    }
+}
+
+ref struct S6(scoped ref int x)
+{
+    public ref int R6 = ref x;
+}
 ";
             var comp = CreateCompilation(source, options: TestOptions.ReleaseDll, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (38,9): error CS8374: Cannot ref-assign 'x' to 'R5' because 'x' has a narrower escape scope than 'R5'.
+                //         R5 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "R5 = ref x").WithArguments("R5", "x").WithLocation(38, 9),
+                // (44,25): error CS8374: Cannot ref-assign 'x' to 'R6' because 'x' has a narrower escape scope than 'R6'.
+                //     public ref int R6 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref x").WithArguments("R6", "x").WithLocation(44, 25)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/67371")]
+        public void AssignToRefField_02()
+        {
+            var source = @"
+ref struct S1
+{
+    public ref readonly int R1;
+
+    public S1(ref int x)
+    {
+        R1 = ref x;
+    }
+}
+
+ref struct S2
+{
+    public ref readonly int R2;
+
+    public S2([System.Diagnostics.CodeAnalysis.UnscopedRef] ref int x)
+    {
+        R2 = ref x;
+    }
+}
+
+ref struct S3(ref int x)
+{
+    public ref readonly int R3 = ref x;
+}
+
+ref struct S4([System.Diagnostics.CodeAnalysis.UnscopedRef] ref int x)
+{
+    public ref readonly int R4 = ref x;
+}
+
+ref struct S5
+{
+    public ref readonly int R5;
+
+    public S5(scoped ref int x)
+    {
+        R5 = ref x;
+    }
+}
+
+ref struct S6(scoped ref int x)
+{
+    public ref readonly int R6 = ref x;
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (38,9): error CS8374: Cannot ref-assign 'x' to 'R5' because 'x' has a narrower escape scope than 'R5'.
+                //         R5 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "R5 = ref x").WithArguments("R5", "x").WithLocation(38, 9),
+                // (44,34): error CS8374: Cannot ref-assign 'x' to 'R6' because 'x' has a narrower escape scope than 'R6'.
+                //     public ref readonly int R6 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref x").WithArguments("R6", "x").WithLocation(44, 34)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/67371")]
+        public void AssignToRefField_03()
+        {
+            var source = @"
+ref struct S1
+{
+    public ref readonly int R1;
+
+    public S1(in int x)
+    {
+        R1 = ref x;
+    }
+}
+
+ref struct S2
+{
+    public ref readonly int R2;
+
+    public S2([System.Diagnostics.CodeAnalysis.UnscopedRef] in int x)
+    {
+        R2 = ref x;
+    }
+}
+
+ref struct S3(in int x)
+{
+    public ref readonly int R3 = ref x;
+}
+
+ref struct S4([System.Diagnostics.CodeAnalysis.UnscopedRef] in int x)
+{
+    public ref readonly int R4 = ref x;
+}
+
+ref struct S5
+{
+    public ref readonly int R5;
+
+    public S5(scoped in int x)
+    {
+        R5 = ref x;
+    }
+}
+
+ref struct S6(scoped in int x)
+{
+    public ref readonly int R6 = ref x;
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (38,9): error CS8374: Cannot ref-assign 'x' to 'R5' because 'x' has a narrower escape scope than 'R5'.
+                //         R5 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "R5 = ref x").WithArguments("R5", "x").WithLocation(38, 9),
+                // (44,34): error CS8374: Cannot ref-assign 'x' to 'R6' because 'x' has a narrower escape scope than 'R6'.
+                //     public ref readonly int R6 = ref x;
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref x").WithArguments("R6", "x").WithLocation(44, 34)
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -27820,18 +27820,13 @@ ref struct R
 }";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // (4,31): error CS8347: Cannot use a result of 'R.F(Span<byte>)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
+                // (4,27): error CS8374: Cannot ref-assign 'F(stackalloc byte[1])' to '_f1' because 'F(stackalloc byte[1])' has a narrower escape scope than '_f1'.
                 //     public ref byte _f1 = ref F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F(stackalloc byte[1])").WithArguments("R.F(System.Span<byte>)", "s").WithLocation(4, 31),
-                // (4,33): error CS8353: A result of a stackalloc expression of type 'Span<byte>' cannot be used in this context because it may be exposed outside of the containing method
-                //     public ref byte _f1 = ref F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc byte[1]").WithArguments("System.Span<byte>").WithLocation(4, 33),
-                // (5,40): error CS8347: Cannot use a result of 'R.F(Span<byte>)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref F(stackalloc byte[1])").WithArguments("_f1", "F(stackalloc byte[1])").WithLocation(4, 27),
+                // (5,36): error CS8374: Cannot ref-assign 'F(stackalloc byte[1])' to '_f2' because 'F(stackalloc byte[1])' has a narrower escape scope than '_f2'.
                 //     public ref readonly byte _f2 = ref F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F(stackalloc byte[1])").WithArguments("R.F(System.Span<byte>)", "s").WithLocation(5, 40),
-                // (5,42): error CS8353: A result of a stackalloc expression of type 'Span<byte>' cannot be used in this context because it may be exposed outside of the containing method
-                //     public ref readonly byte _f2 = ref F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc byte[1]").WithArguments("System.Span<byte>").WithLocation(5, 42));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref F(stackalloc byte[1])").WithArguments("_f2", "F(stackalloc byte[1])").WithLocation(5, 36)
+                );
         }
 
         // Similar to above but with scoped parameter.
@@ -27940,21 +27935,16 @@ ref struct R
                 // (4,18): error CS8172: Cannot initialize a by-reference variable with a value
                 //     ref byte _f1 = F(stackalloc byte[1]);
                 Diagnostic(ErrorCode.ERR_InitializeByReferenceVariableWithValue, "= F(stackalloc byte[1])").WithLocation(4, 18),
-                // (4,20): error CS8347: Cannot use a result of 'R.F<byte>(Span<byte>)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
+                // (4,20): error CS8374: Cannot ref-assign 'F(stackalloc byte[1])' to '_f1' because 'F(stackalloc byte[1])' has a narrower escape scope than '_f1'.
                 //     ref byte _f1 = F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F(stackalloc byte[1])").WithArguments("R.F<byte>(System.Span<byte>)", "s").WithLocation(4, 20),
-                // (4,22): error CS8353: A result of a stackalloc expression of type 'Span<byte>' cannot be used in this context because it may be exposed outside of the containing method
-                //     ref byte _f1 = F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc byte[1]").WithArguments("System.Span<byte>").WithLocation(4, 22),
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "F(stackalloc byte[1])").WithArguments("_f1", "F(stackalloc byte[1])").WithLocation(4, 20),
                 // (5,27): error CS8172: Cannot initialize a by-reference variable with a value
                 //     ref readonly byte _f2 = F(stackalloc byte[1]);
                 Diagnostic(ErrorCode.ERR_InitializeByReferenceVariableWithValue, "= F(stackalloc byte[1])").WithLocation(5, 27),
-                // (5,29): error CS8347: Cannot use a result of 'R.F<byte>(Span<byte>)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
+                // (5,29): error CS8374: Cannot ref-assign 'F(stackalloc byte[1])' to '_f2' because 'F(stackalloc byte[1])' has a narrower escape scope than '_f2'.
                 //     ref readonly byte _f2 = F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F(stackalloc byte[1])").WithArguments("R.F<byte>(System.Span<byte>)", "s").WithLocation(5, 29),
-                // (5,31): error CS8353: A result of a stackalloc expression of type 'Span<byte>' cannot be used in this context because it may be exposed outside of the containing method
-                //     ref readonly byte _f2 = F(stackalloc byte[1]);
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc byte[1]").WithArguments("System.Span<byte>").WithLocation(5, 31));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "F(stackalloc byte[1])").WithArguments("_f2", "F(stackalloc byte[1])").WithLocation(5, 29)
+                );
         }
 
         [WorkItem(64725, "https://github.com/dotnet/roslyn/issues/64725")]
@@ -27974,12 +27964,10 @@ ref struct R
                 // (4,5): error CS9050: A ref field cannot refer to a ref struct.
                 //     ref readonly Span<int> _s = ref F(stackalloc int[1]);
                 Diagnostic(ErrorCode.ERR_RefFieldCannotReferToRefStruct, "ref readonly Span<int>").WithLocation(4, 5),
-                // (4,37): error CS8347: Cannot use a result of 'R.F<int>(in Span<int>)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
+                // (4,33): error CS8374: Cannot ref-assign 'F(stackalloc int[1])' to '_s' because 'F(stackalloc int[1])' has a narrower escape scope than '_s'.
                 //     ref readonly Span<int> _s = ref F(stackalloc int[1]);
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F(stackalloc int[1])").WithArguments("R.F<int>(in System.Span<int>)", "s").WithLocation(4, 37),
-                // (4,39): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                //     ref readonly Span<int> _s = ref F(stackalloc int[1]);
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "stackalloc int[1]").WithLocation(4, 39));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref F(stackalloc int[1])").WithArguments("_s", "F(stackalloc int[1])").WithLocation(4, 33)
+                );
         }
 
         [WorkItem(64720, "https://github.com/dotnet/roslyn/issues/64720")]
@@ -28021,18 +28009,13 @@ ref struct R
 }";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // (4,24): error CS8347: Cannot use a result of 'R.F<byte>(out byte)' in this context because it may expose variables referenced by parameter 't' outside of their declaration scope
+                // (4,20): error CS8374: Cannot ref-assign 'F<byte>(out var b1)' to '_f1' because 'F<byte>(out var b1)' has a narrower escape scope than '_f1'.
                 //     ref byte _f1 = ref F<byte>(out var b1); // 1
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F<byte>(out var b1)").WithArguments("R.F<byte>(out byte)", "t").WithLocation(4, 24),
-                // (4,36): error CS8168: Cannot return local 'b1' by reference because it is not a ref local
-                //     ref byte _f1 = ref F<byte>(out var b1); // 1
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "var b1").WithArguments("b1").WithLocation(4, 36),
-                // (5,33): error CS8347: Cannot use a result of 'R.F<byte>(out byte)' in this context because it may expose variables referenced by parameter 't' outside of their declaration scope
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref F<byte>(out var b1)").WithArguments("_f1", "F<byte>(out var b1)").WithLocation(4, 20),
+                // (5,29): error CS8374: Cannot ref-assign 'F<byte>(out var b2)' to '_f2' because 'F<byte>(out var b2)' has a narrower escape scope than '_f2'.
                 //     ref readonly byte _f2 = ref F<byte>(out var b2); // 2
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F<byte>(out var b2)").WithArguments("R.F<byte>(out byte)", "t").WithLocation(5, 33),
-                // (5,45): error CS8168: Cannot return local 'b2' by reference because it is not a ref local
-                //     ref readonly byte _f2 = ref F<byte>(out var b2); // 2
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "var b2").WithArguments("b2").WithLocation(5, 45));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "ref F<byte>(out var b2)").WithArguments("_f2", "F<byte>(out var b2)").WithLocation(5, 29)
+                );
         }
 
         [WorkItem(64720, "https://github.com/dotnet/roslyn/issues/64720")]


### PR DESCRIPTION
Fixes #67371.