### PR TITLE
Disallow declaring readonly, volatile, or fixed size buffer fields as element fields of an inline array type.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7679,7 +7679,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_PrimaryConstructorParameterIsShadowedAndNotPassedToBase_Title" xml:space="preserve">
     <value>Primary constructor parameter is shadowed by a member from base</value>
   </data>
-  <data name="ERR_InlineArrayRequiredElementField" xml:space="preserve">
-    <value>Inline array element field cannot be declared required.</value>
+  <data name="ERR_InlineArrayUnsupportedElementFieldModifier" xml:space="preserve">
+    <value>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2242,7 +2242,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         WRN_PrimaryConstructorParameterIsShadowedAndNotPassedToBase = 9179,
 
-        ERR_InlineArrayRequiredElementField = 9180,
+        ERR_InlineArrayUnsupportedElementFieldModifier = 9180,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2362,7 +2362,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_ExpressionTreeContainsCollectionLiteral:
                 case ErrorCode.ERR_CollectionLiteralNoTargetType:
                 case ErrorCode.WRN_PrimaryConstructorParameterIsShadowedAndNotPassedToBase:
-                case ErrorCode.ERR_InlineArrayRequiredElementField:
+                case ErrorCode.ERR_InlineArrayUnsupportedElementFieldModifier:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1754,9 +1754,9 @@ next:;
 
                 if (TryGetPossiblyUnsupportedByLanguageInlineArrayElementField() is FieldSymbol elementField)
                 {
-                    if (elementField.IsRequired)
+                    if (elementField.IsRequired || elementField.IsReadOnly || elementField.IsVolatile || elementField.IsFixedSizeBuffer)
                     {
-                        diagnostics.Add(ErrorCode.ERR_InlineArrayRequiredElementField, elementField.TryGetFirstLocation() ?? GetFirstLocation());
+                        diagnostics.Add(ErrorCode.ERR_InlineArrayUnsupportedElementFieldModifier, elementField.TryGetFirstLocation() ?? GetFirstLocation());
                     }
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -2504,7 +2504,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal FieldSymbol? TryGetInlineArrayElementField()
         {
-            return TryGetPossiblyUnsupportedByLanguageInlineArrayElementField() is { RefKind: RefKind.None } field ? field : null;
+            return TryGetPossiblyUnsupportedByLanguageInlineArrayElementField() is { RefKind: RefKind.None, IsFixedSizeBuffer: false } field ? field : null;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -887,9 +887,9 @@
         <target state="translated">Index je mimo hranice vloženého pole.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -887,9 +887,9 @@
         <target state="translated">Der Index liegt außerhalb des gültigen Bereichs des Inlinearrays.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -887,9 +887,9 @@
         <target state="translated">El índice está fuera de los límites de la matriz insertada.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -887,9 +887,9 @@
         <target state="translated">L'index est en dehors des limites du tableau en ligne</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -887,9 +887,9 @@
         <target state="translated">L'indice non è compreso nei limiti della matrice inline</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -887,9 +887,9 @@
         <target state="translated">インデックスがインライン配列の範囲外です</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -887,9 +887,9 @@
         <target state="translated">인덱스가 인라인 배열의 범위 밖에 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -887,9 +887,9 @@
         <target state="translated">Indeks znajduje się poza granicami tablicy śródwierszowej.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -887,9 +887,9 @@
         <target state="translated">O índice está fora dos limites do texto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -887,9 +887,9 @@
         <target state="translated">Индекс находится за пределами встроенного массива</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -887,9 +887,9 @@
         <target state="translated">Dizin satır içi dizinin sınırları dışında</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -887,9 +887,9 @@
         <target state="translated">索引超出了内联数组的界限</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -887,9 +887,9 @@
         <target state="translated">索引超出內嵌陣列的界限。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_InlineArrayRequiredElementField">
-        <source>Inline array element field cannot be declared required.</source>
-        <target state="new">Inline array element field cannot be declared required.</target>
+      <trans-unit id="ERR_InlineArrayUnsupportedElementFieldModifier">
+        <source>Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</source>
+        <target state="new">Inline array element field cannot be declared as required, readonly, volatile, or as a fixed size buffer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InstancePropertyInitializerInInterface">


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/67826