### PR TITLE
Allow parsing `ref readonly` parameters in `cref`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -935,7 +935,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 RefKind refKind = parameter.RefKindKeyword.Kind().GetRefKind();
                 if (refKind == RefKind.Ref && parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword))
                 {
-                    CheckFeatureAvailability(parameter.ReadOnlyKeyword, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
+                    CheckFeatureAvailability(parameter.ReadOnlyKeyword, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics, forceWarning: true);
                     refKind = RefKind.RefReadOnlyParameter;
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -933,6 +933,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (CrefParameterSyntax parameter in parameterListSyntax.Parameters)
             {
                 RefKind refKind = parameter.RefKindKeyword.Kind().GetRefKind();
+                Debug.Assert(parameter.ReadOnlyKeyword.IsKind(SyntaxKind.None) ||
+                    (parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword) && refKind == RefKind.Ref));
+                if (refKind == RefKind.Ref && parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword))
+                {
+                    refKind = RefKind.RefReadOnlyParameter;
+                }
 
                 Debug.Assert(parameterListSyntax.Parent is object);
                 TypeSymbol type = BindCrefParameterOrReturnType(parameter.Type, (MemberCrefSyntax)parameterListSyntax.Parent, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -935,6 +935,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 RefKind refKind = parameter.RefKindKeyword.Kind().GetRefKind();
                 if (refKind == RefKind.Ref && parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword))
                 {
+                    CheckFeatureAvailability(parameter.ReadOnlyKeyword, MessageID.IDS_FeatureRefReadonlyParameters, diagnostics);
                     refKind = RefKind.RefReadOnlyParameter;
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -933,8 +933,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (CrefParameterSyntax parameter in parameterListSyntax.Parameters)
             {
                 RefKind refKind = parameter.RefKindKeyword.Kind().GetRefKind();
-                Debug.Assert(parameter.ReadOnlyKeyword.IsKind(SyntaxKind.None) ||
-                    (parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword) && refKind == RefKind.Ref));
                 if (refKind == RefKind.Ref && parameter.ReadOnlyKeyword.IsKind(SyntaxKind.ReadOnlyKeyword))
                 {
                     refKind = RefKind.RefReadOnlyParameter;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -2696,8 +2696,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool CheckFeatureAvailability(SyntaxNode syntax, MessageID feature, BindingDiagnosticBag diagnostics, Location? location = null)
             => CheckFeatureAvailability(syntax, feature, diagnostics.DiagnosticBag, location);
 
-        internal static bool CheckFeatureAvailability(SyntaxToken syntax, MessageID feature, BindingDiagnosticBag diagnostics, Location? location = null)
-            => CheckFeatureAvailability(syntax, feature, diagnostics.DiagnosticBag, location);
+        internal static bool CheckFeatureAvailability(SyntaxToken syntax, MessageID feature, BindingDiagnosticBag diagnostics, Location? location = null, bool forceWarning = false)
+            => CheckFeatureAvailability(syntax, feature, diagnostics.DiagnosticBag, location, forceWarning: forceWarning);
 
         internal static bool CheckFeatureAvailability(SyntaxNodeOrToken syntax, MessageID feature, BindingDiagnosticBag diagnostics, Location? location = null)
             => CheckFeatureAvailability(syntax, feature, diagnostics.DiagnosticBag, location);
@@ -2708,8 +2708,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static bool CheckFeatureAvailability(SyntaxNode syntax, MessageID feature, DiagnosticBag? diagnostics, Location? location = null)
             => CheckFeatureAvailability(syntax.SyntaxTree, feature, diagnostics, (location, syntax), static tuple => tuple.location ?? tuple.syntax.GetLocation());
 
-        private static bool CheckFeatureAvailability(SyntaxToken syntax, MessageID feature, DiagnosticBag? diagnostics, Location? location = null)
-            => CheckFeatureAvailability(syntax.SyntaxTree!, feature, diagnostics, (location, syntax), static tuple => tuple.location ?? tuple.syntax.GetLocation());
+        private static bool CheckFeatureAvailability(SyntaxToken syntax, MessageID feature, DiagnosticBag? diagnostics, Location? location = null, bool forceWarning = false)
+            => CheckFeatureAvailability(syntax.SyntaxTree!, feature, diagnostics, (location, syntax), static tuple => tuple.location ?? tuple.syntax.GetLocation(), forceWarning: forceWarning);
 
         private static bool CheckFeatureAvailability(SyntaxNodeOrToken syntax, MessageID feature, DiagnosticBag? diagnostics, Location? location = null)
             => CheckFeatureAvailability(syntax.SyntaxTree!, feature, diagnostics, (location, syntax), static tuple => tuple.location ?? tuple.syntax.GetLocation()!);
@@ -2720,11 +2720,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="getLocation">Callback function that computes the location to report the diagnostics at
         /// <em>if</em> a diagnostic should be reported.  Should always be passed a static/cached callback to prevent
         /// allocations of the delegate.</param>
-        private static bool CheckFeatureAvailability<TData>(SyntaxTree tree, MessageID feature, DiagnosticBag? diagnostics, TData data, Func<TData, Location> getLocation)
+        private static bool CheckFeatureAvailability<TData>(SyntaxTree tree, MessageID feature, DiagnosticBag? diagnostics, TData data, Func<TData, Location> getLocation, bool forceWarning = false)
         {
             if (feature.GetFeatureAvailabilityDiagnosticInfo((CSharpParseOptions)tree.Options) is { } diagInfo)
             {
-                diagnostics?.Add(diagInfo, getLocation(data));
+                if (forceWarning)
+                {
+                    diagnostics?.Add(ErrorCode.WRN_ErrorOverride, getLocation(data), diagInfo, (int)diagInfo.Code);
+                }
+                else
+                {
+                    diagnostics?.Add(diagInfo, getLocation(data));
+                }
+
                 return false;
             }
             return true;

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -1166,9 +1166,9 @@ cref_parameter_list
   ;
 
 cref_parameter
-  : 'in'? type
-  | 'out'? type
-  | 'ref'? type
+  : 'in'? 'readonly'? type
+  | 'out'? 'readonly'? type
+  | 'ref'? 'readonly'? type
   ;
 
 indexer_member_cref

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -30195,62 +30195,81 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     /// <summary>
     /// An element of a BaseCrefParameterListSyntax.
-    /// Unlike a regular parameter, a cref parameter has only an optional ref or out keyword and a type -
+    /// Unlike a regular parameter, a cref parameter has only an optional ref, in, out keyword,
+    /// an optional readonly keyword, and a type -
     /// there is no name and there are no attributes or other modifiers.
     /// </summary>
     internal sealed partial class CrefParameterSyntax : CSharpSyntaxNode
     {
         internal readonly SyntaxToken? refKindKeyword;
+        internal readonly SyntaxToken? readOnlyKeyword;
         internal readonly TypeSyntax type;
 
-        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, TypeSyntax type, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, SyntaxToken? readOnlyKeyword, TypeSyntax type, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
-            this.SlotCount = 2;
+            this.SlotCount = 3;
             if (refKindKeyword != null)
             {
                 this.AdjustFlagsAndWidth(refKindKeyword);
                 this.refKindKeyword = refKindKeyword;
             }
+            if (readOnlyKeyword != null)
+            {
+                this.AdjustFlagsAndWidth(readOnlyKeyword);
+                this.readOnlyKeyword = readOnlyKeyword;
+            }
             this.AdjustFlagsAndWidth(type);
             this.type = type;
         }
 
-        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, TypeSyntax type, SyntaxFactoryContext context)
+        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, SyntaxToken? readOnlyKeyword, TypeSyntax type, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
-            this.SlotCount = 2;
+            this.SlotCount = 3;
             if (refKindKeyword != null)
             {
                 this.AdjustFlagsAndWidth(refKindKeyword);
                 this.refKindKeyword = refKindKeyword;
             }
+            if (readOnlyKeyword != null)
+            {
+                this.AdjustFlagsAndWidth(readOnlyKeyword);
+                this.readOnlyKeyword = readOnlyKeyword;
+            }
             this.AdjustFlagsAndWidth(type);
             this.type = type;
         }
 
-        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, TypeSyntax type)
+        internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken? refKindKeyword, SyntaxToken? readOnlyKeyword, TypeSyntax type)
           : base(kind)
         {
-            this.SlotCount = 2;
+            this.SlotCount = 3;
             if (refKindKeyword != null)
             {
                 this.AdjustFlagsAndWidth(refKindKeyword);
                 this.refKindKeyword = refKindKeyword;
+            }
+            if (readOnlyKeyword != null)
+            {
+                this.AdjustFlagsAndWidth(readOnlyKeyword);
+                this.readOnlyKeyword = readOnlyKeyword;
             }
             this.AdjustFlagsAndWidth(type);
             this.type = type;
         }
 
         public SyntaxToken? RefKindKeyword => this.refKindKeyword;
+        public SyntaxToken? ReadOnlyKeyword => this.readOnlyKeyword;
         public TypeSyntax Type => this.type;
 
         internal override GreenNode? GetSlot(int index)
             => index switch
             {
                 0 => this.refKindKeyword,
-                1 => this.type,
+                1 => this.readOnlyKeyword,
+                2 => this.type,
                 _ => null,
             };
 
@@ -30259,11 +30278,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitCrefParameter(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitCrefParameter(this);
 
-        public CrefParameterSyntax Update(SyntaxToken refKindKeyword, TypeSyntax type)
+        public CrefParameterSyntax Update(SyntaxToken refKindKeyword, SyntaxToken readOnlyKeyword, TypeSyntax type)
         {
-            if (refKindKeyword != this.RefKindKeyword || type != this.Type)
+            if (refKindKeyword != this.RefKindKeyword || readOnlyKeyword != this.ReadOnlyKeyword || type != this.Type)
             {
-                var newNode = SyntaxFactory.CrefParameter(refKindKeyword, type);
+                var newNode = SyntaxFactory.CrefParameter(refKindKeyword, readOnlyKeyword, type);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -30277,20 +30296,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.type, diagnostics, GetAnnotations());
+            => new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.readOnlyKeyword, this.type, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.type, GetDiagnostics(), annotations);
+            => new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.readOnlyKeyword, this.type, GetDiagnostics(), annotations);
 
         internal CrefParameterSyntax(ObjectReader reader)
           : base(reader)
         {
-            this.SlotCount = 2;
+            this.SlotCount = 3;
             var refKindKeyword = (SyntaxToken?)reader.ReadValue();
             if (refKindKeyword != null)
             {
                 AdjustFlagsAndWidth(refKindKeyword);
                 this.refKindKeyword = refKindKeyword;
+            }
+            var readOnlyKeyword = (SyntaxToken?)reader.ReadValue();
+            if (readOnlyKeyword != null)
+            {
+                AdjustFlagsAndWidth(readOnlyKeyword);
+                this.readOnlyKeyword = readOnlyKeyword;
             }
             var type = (TypeSyntax)reader.ReadValue();
             AdjustFlagsAndWidth(type);
@@ -30301,6 +30326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             base.WriteTo(writer);
             writer.WriteValue(this.refKindKeyword);
+            writer.WriteValue(this.readOnlyKeyword);
             writer.WriteValue(this.type);
         }
 
@@ -35985,7 +36011,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((SyntaxToken)Visit(node.OpenBracketToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.CloseBracketToken));
 
         public override CSharpSyntaxNode VisitCrefParameter(CrefParameterSyntax node)
-            => node.Update((SyntaxToken)Visit(node.RefKindKeyword), (TypeSyntax)Visit(node.Type));
+            => node.Update((SyntaxToken)Visit(node.RefKindKeyword), (SyntaxToken)Visit(node.ReadOnlyKeyword), (TypeSyntax)Visit(node.Type));
 
         public override CSharpSyntaxNode VisitXmlElement(XmlElementSyntax node)
             => node.Update((XmlElementStartTagSyntax)Visit(node.StartTag), VisitList(node.Content), (XmlElementEndTagSyntax)Visit(node.EndTag));
@@ -40645,7 +40671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public CrefParameterSyntax CrefParameter(SyntaxToken? refKindKeyword, TypeSyntax type)
+        public CrefParameterSyntax CrefParameter(SyntaxToken? refKindKeyword, SyntaxToken? readOnlyKeyword, TypeSyntax type)
         {
 #if DEBUG
             if (refKindKeyword != null)
@@ -40659,14 +40685,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     default: throw new ArgumentException(nameof(refKindKeyword));
                 }
             }
+            if (readOnlyKeyword != null)
+            {
+                switch (readOnlyKeyword.Kind)
+                {
+                    case SyntaxKind.ReadOnlyKeyword:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(readOnlyKeyword));
+                }
+            }
             if (type == null) throw new ArgumentNullException(nameof(type));
 #endif
 
             int hash;
-            var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, type, this.context, out hash);
+            var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, readOnlyKeyword, type, this.context, out hash);
             if (cached != null) return (CrefParameterSyntax)cached;
 
-            var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, type, this.context);
+            var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, readOnlyKeyword, type, this.context);
             if (hash >= 0)
             {
                 SyntaxNodeCache.AddNode(result, hash);
@@ -45852,7 +45887,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public static CrefParameterSyntax CrefParameter(SyntaxToken? refKindKeyword, TypeSyntax type)
+        public static CrefParameterSyntax CrefParameter(SyntaxToken? refKindKeyword, SyntaxToken? readOnlyKeyword, TypeSyntax type)
         {
 #if DEBUG
             if (refKindKeyword != null)
@@ -45866,14 +45901,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     default: throw new ArgumentException(nameof(refKindKeyword));
                 }
             }
+            if (readOnlyKeyword != null)
+            {
+                switch (readOnlyKeyword.Kind)
+                {
+                    case SyntaxKind.ReadOnlyKeyword:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(readOnlyKeyword));
+                }
+            }
             if (type == null) throw new ArgumentNullException(nameof(type));
 #endif
 
             int hash;
-            var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, type, out hash);
+            var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, readOnlyKeyword, type, out hash);
             if (cached != null) return (CrefParameterSyntax)cached;
 
-            var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, type);
+            var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, readOnlyKeyword, type);
             if (hash >= 0)
             {
                 SyntaxNodeCache.AddNode(result, hash);

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -2089,7 +2089,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update(VisitToken(node.OpenBracketToken), VisitList(node.Parameters), VisitToken(node.CloseBracketToken));
 
         public override SyntaxNode? VisitCrefParameter(CrefParameterSyntax node)
-            => node.Update(VisitToken(node.RefKindKeyword), (TypeSyntax?)Visit(node.Type) ?? throw new ArgumentNullException("type"));
+            => node.Update(VisitToken(node.RefKindKeyword), VisitToken(node.ReadOnlyKeyword), (TypeSyntax?)Visit(node.Type) ?? throw new ArgumentNullException("type"));
 
         public override SyntaxNode? VisitXmlElement(XmlElementSyntax node)
             => node.Update((XmlElementStartTagSyntax?)Visit(node.StartTag) ?? throw new ArgumentNullException("startTag"), VisitList(node.Content), (XmlElementEndTagSyntax?)Visit(node.EndTag) ?? throw new ArgumentNullException("endTag"));
@@ -5860,7 +5860,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.CrefBracketedParameterList(SyntaxFactory.Token(SyntaxKind.OpenBracketToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         /// <summary>Creates a new CrefParameterSyntax instance.</summary>
-        public static CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, TypeSyntax type)
+        public static CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, SyntaxToken readOnlyKeyword, TypeSyntax type)
         {
             switch (refKindKeyword.Kind())
             {
@@ -5870,13 +5870,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.None: break;
                 default: throw new ArgumentException(nameof(refKindKeyword));
             }
+            switch (readOnlyKeyword.Kind())
+            {
+                case SyntaxKind.ReadOnlyKeyword:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(readOnlyKeyword));
+            }
             if (type == null) throw new ArgumentNullException(nameof(type));
-            return (CrefParameterSyntax)Syntax.InternalSyntax.SyntaxFactory.CrefParameter((Syntax.InternalSyntax.SyntaxToken?)refKindKeyword.Node, (Syntax.InternalSyntax.TypeSyntax)type.Green).CreateRed();
+            return (CrefParameterSyntax)Syntax.InternalSyntax.SyntaxFactory.CrefParameter((Syntax.InternalSyntax.SyntaxToken?)refKindKeyword.Node, (Syntax.InternalSyntax.SyntaxToken?)readOnlyKeyword.Node, (Syntax.InternalSyntax.TypeSyntax)type.Green).CreateRed();
         }
 
         /// <summary>Creates a new CrefParameterSyntax instance.</summary>
+        public static CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, TypeSyntax type)
+            => SyntaxFactory.CrefParameter(refKindKeyword, default, type);
+
+        /// <summary>Creates a new CrefParameterSyntax instance.</summary>
         public static CrefParameterSyntax CrefParameter(TypeSyntax type)
-            => SyntaxFactory.CrefParameter(default, type);
+            => SyntaxFactory.CrefParameter(default, default, type);
 
         /// <summary>Creates a new XmlElementSyntax instance.</summary>
         public static XmlElementSyntax XmlElement(XmlElementStartTagSyntax startTag, SyntaxList<XmlNodeSyntax> content, XmlElementEndTagSyntax endTag)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -14332,7 +14332,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
     /// <summary>
     /// An element of a BaseCrefParameterListSyntax.
-    /// Unlike a regular parameter, a cref parameter has only an optional ref or out keyword and a type -
+    /// Unlike a regular parameter, a cref parameter has only an optional ref, in, out keyword,
+    /// an optional readonly keyword, and a type -
     /// there is no name and there are no attributes or other modifiers.
     /// </summary>
     /// <remarks>
@@ -14359,20 +14360,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
         }
 
-        public TypeSyntax Type => GetRed(ref this.type, 1)!;
+        public SyntaxToken ReadOnlyKeyword
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.CrefParameterSyntax)this.Green).readOnlyKeyword;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(1), GetChildIndex(1)) : default;
+            }
+        }
 
-        internal override SyntaxNode? GetNodeSlot(int index) => index == 1 ? GetRed(ref this.type, 1)! : null;
+        public TypeSyntax Type => GetRed(ref this.type, 2)!;
 
-        internal override SyntaxNode? GetCachedSlot(int index) => index == 1 ? this.type : null;
+        internal override SyntaxNode? GetNodeSlot(int index) => index == 2 ? GetRed(ref this.type, 2)! : null;
+
+        internal override SyntaxNode? GetCachedSlot(int index) => index == 2 ? this.type : null;
 
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitCrefParameter(this);
         public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitCrefParameter(this);
 
-        public CrefParameterSyntax Update(SyntaxToken refKindKeyword, TypeSyntax type)
+        public CrefParameterSyntax Update(SyntaxToken refKindKeyword, SyntaxToken readOnlyKeyword, TypeSyntax type)
         {
-            if (refKindKeyword != this.RefKindKeyword || type != this.Type)
+            if (refKindKeyword != this.RefKindKeyword || readOnlyKeyword != this.ReadOnlyKeyword || type != this.Type)
             {
-                var newNode = SyntaxFactory.CrefParameter(refKindKeyword, type);
+                var newNode = SyntaxFactory.CrefParameter(refKindKeyword, readOnlyKeyword, type);
                 var annotations = GetAnnotations();
                 return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
             }
@@ -14380,8 +14390,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return this;
         }
 
-        public CrefParameterSyntax WithRefKindKeyword(SyntaxToken refKindKeyword) => Update(refKindKeyword, this.Type);
-        public CrefParameterSyntax WithType(TypeSyntax type) => Update(this.RefKindKeyword, type);
+        public CrefParameterSyntax WithRefKindKeyword(SyntaxToken refKindKeyword) => Update(refKindKeyword, this.ReadOnlyKeyword, this.Type);
+        public CrefParameterSyntax WithReadOnlyKeyword(SyntaxToken readOnlyKeyword) => Update(this.RefKindKeyword, readOnlyKeyword, this.Type);
+        public CrefParameterSyntax WithType(TypeSyntax type) => Update(this.RefKindKeyword, this.ReadOnlyKeyword, type);
     }
 
     public abstract partial class XmlNodeSyntax : CSharpSyntaxNode

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -1248,7 +1248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// Parse an element of a cref parameter list.
         /// </summary>
         /// <remarks>
-        /// "ref" and "out" work, but "params", "this", and "__arglist" don't.
+        /// "ref", "ref readonly", "in", "out" work, but "params", "this", and "__arglist" don't.
         /// </remarks>
         private CrefParameterSyntax ParseCrefParameter()
         {
@@ -1262,8 +1262,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     break;
             }
 
+            SyntaxToken readOnlyOpt = null;
+            if (CurrentToken.Kind == SyntaxKind.ReadOnlyKeyword && refKindOpt is { Kind: SyntaxKind.RefKeyword })
+            {
+                readOnlyOpt = EatToken();
+            }
+
             TypeSyntax type = ParseCrefType(typeArgumentsMustBeIdentifiers: false);
-            return SyntaxFactory.CrefParameter(refKindOpt, type);
+            return SyntaxFactory.CrefParameter(refKindKeyword: refKindOpt, readOnlyKeyword: readOnlyOpt, type);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -1268,7 +1268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (refKindOpt.Kind != SyntaxKind.RefKeyword)
                 {
                     // if we encounter `readonly` after `in` or `out`, we place the `readonly` as skipped trivia on the previous keyword
-                    var misplacedToken = AddError(EatToken(), ErrorCode.ERR_RefReadOnlyWrongOrdering);
+                    var misplacedToken = AddErrorAsWarning(EatToken(), ErrorCode.ERR_RefReadOnlyWrongOrdering);
                     refKindOpt = AddTrailingSkippedSyntax(refKindOpt, misplacedToken);
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -725,6 +725,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return AddError(node, code, Array.Empty<object>());
         }
 
+        protected TNode AddErrorAsWarning<TNode>(TNode node, ErrorCode code, params object[] args) where TNode : GreenNode
+        {
+            return AddError(node, ErrorCode.WRN_ErrorOverride, MakeError(node, code, args), (int)code);
+        }
+
         protected TNode AddError<TNode>(TNode node, ErrorCode code, params object[] args) where TNode : GreenNode
         {
             if (!node.IsMissing)

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -727,6 +727,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         protected TNode AddErrorAsWarning<TNode>(TNode node, ErrorCode code, params object[] args) where TNode : GreenNode
         {
+            Debug.Assert(!node.IsMissing);
             return AddError(node, ErrorCode.WRN_ErrorOverride, MakeError(node, code, args), (int)code);
         }
 

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax.WithElements(Mic
 Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax.WithOpenBracketToken(Microsoft.CodeAnalysis.SyntaxToken openBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
-*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax! type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax! type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -10,6 +10,10 @@ Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax.WithCloseBracket
 Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax.WithElements(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax!> elements) -> Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax.WithOpenBracketToken(Microsoft.CodeAnalysis.SyntaxToken openBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax! type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax! type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax.Expression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax!
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax!
@@ -31,6 +35,7 @@ override Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax.Accept(Microso
 override Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>! visitor) -> TResult?
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CollectionExpression(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax!> elements = default(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax!>)) -> Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax!
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CollectionExpression(Microsoft.CodeAnalysis.SyntaxToken openBracketToken, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.CollectionElementSyntax!> elements, Microsoft.CodeAnalysis.SyntaxToken closeBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.CollectionExpressionSyntax!
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CrefParameter(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax! type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax!
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ExpressionElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionElementSyntax!
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SpreadElement(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax!
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SpreadElement(Microsoft.CodeAnalysis.SyntaxToken operatorToken, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax! expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.SpreadElementSyntax!

--- a/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
@@ -15,12 +15,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public SyntaxToken RefOrOutKeyword => this.RefKindKeyword;
 
         /// <summary>
-        /// Pre C# 7.2 back-compat overload, which simply calls the replacement method <see cref="Update"/>.
+        /// Pre C# 7.2 back-compat overload, which simply calls the replacement method <see cref="Update(SyntaxToken, TypeSyntax)"/>.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CrefParameterSyntax WithRefOrOutKeyword(SyntaxToken refOrOutKeyword)
         {
-            return this.Update(refKindKeyword: refOrOutKeyword, readOnlyKeyword: default, this.Type);
+            return this.Update(refOrOutKeyword, this.Type);
+        }
+
+        public CrefParameterSyntax Update(SyntaxToken refKindKeyword, TypeSyntax type)
+        {
+            return this.Update(refKindKeyword: refKindKeyword, readOnlyKeyword: this.ReadOnlyKeyword, type: type);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CrefParameterSyntax WithRefOrOutKeyword(SyntaxToken refOrOutKeyword)
         {
-            return this.Update(refOrOutKeyword, this.Type);
+            return this.Update(refKindKeyword: refOrOutKeyword, readOnlyKeyword: default, this.Type);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -4519,7 +4519,8 @@
     <TypeComment>
       <summary>
         An element of a BaseCrefParameterListSyntax.
-        Unlike a regular parameter, a cref parameter has only an optional ref or out keyword and a type -
+        Unlike a regular parameter, a cref parameter has only an optional ref, in, out keyword,
+        an optional readonly keyword, and a type -
         there is no name and there are no attributes or other modifiers.
       </summary>
     </TypeComment>
@@ -4528,6 +4529,9 @@
       <Kind Name="RefKeyword"/>
       <Kind Name="OutKeyword"/>
       <Kind Name="InKeyword"/>
+    </Field>
+    <Field Name="ReadOnlyKeyword" Type="SyntaxToken" Optional="true">
+      <Kind Name="ReadOnlyKeyword"/>
     </Field>
     <Field Name="Type" Type="TypeSyntax"/>
   </Node>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/RefReadonlyParameterTests.cs
@@ -4693,7 +4693,7 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         Assert.Same(methodFromCref, methodFromClass.GetPublicSymbol());
     }
 
-    [Theory(Skip = "PROTOTYPE: cref parsing of ref readonly doesn't work"), CombinatorialData]
+    [Theory, CombinatorialData]
     public void CrefComparer_RefReadonly([CombinatorialValues("ref", "in")] string modifier)
     {
         var source = $$"""
@@ -4716,8 +4716,8 @@ public partial class RefReadonlyParameterTests : CSharpTestBase
         var cref = docComment.DescendantNodes().OfType<XmlCrefAttributeSyntax>().Select(attr => attr.Cref).Single();
         var info = model.GetSymbolInfo(cref);
         var methodFromCref = info.Symbol as IMethodSymbol;
-        Assert.Equal(RefKind.RefReadOnly, methodFromCref!.Parameters.Single().RefKind);
-        var methodFromClass = comp.GetMembers("C.M").Cast<MethodSymbol>().Single(m => m.Parameters.Single().RefKind == RefKind.RefReadOnly);
+        Assert.Equal(RefKind.RefReadOnlyParameter, methodFromCref!.Parameters.Single().RefKind);
+        var methodFromClass = comp.GetMembers("C.M").Cast<MethodSymbol>().Single(m => m.Parameters.Single().RefKind == RefKind.RefReadOnlyParameter);
         Assert.Same(methodFromCref, methodFromClass.GetPublicSymbol());
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -6751,6 +6751,145 @@ class Test
         }
 
         [Fact]
+        public void CRef_RefReadonlyParameter_ReadonlyRef()
+        {
+            var source = """
+                class Test
+                {
+                    void M(ref readonly int x)
+                    {
+                    }
+
+                    /// <summary>
+                    /// <see cref="M(readonly ref int)"/>
+                    /// </summary>
+                    void S()
+                    {
+                    }
+                }
+                """;
+
+            verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(
+                // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     void M(ref readonly int x)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (8,20): warning CS1584: XML comment has syntactically incorrect cref attribute 'M(readonly ref int)'
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "M(").WithArguments("M(readonly ref int)").WithLocation(8, 20),
+                // (8,22): warning CS1658: ) expected. See also error CS1026.
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(8, 22)));
+
+            var expectedDiagnostics = new[]
+            {
+                // (8,20): warning CS1584: XML comment has syntactically incorrect cref attribute 'M(readonly ref int)'
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "M(").WithArguments("M(readonly ref int)").WithLocation(8, 20),
+                // (8,22): warning CS1658: ) expected. See also error CS1026.
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(8, 22)
+            };
+
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+
+            static void verify(CSharpCompilation compilation)
+            {
+                var cref = (NameMemberCrefSyntax)GetCrefSyntaxes(compilation).Single();
+                Assert.Empty(cref.Parameters.Parameters);
+            }
+        }
+
+        [Fact]
+        public void CRef_ReadonlyRefParameter()
+        {
+            var source = """
+                class Test
+                {
+                    void M(readonly ref int x)
+                    {
+                    }
+
+                    /// <summary>
+                    /// <see cref="M(readonly ref int)"/>
+                    /// </summary>
+                    void S()
+                    {
+                    }
+                }
+                """;
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly ref int x)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (8,20): warning CS1584: XML comment has syntactically incorrect cref attribute 'M(readonly ref int)'
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "M(").WithArguments("M(readonly ref int)").WithLocation(8, 20),
+                // (8,22): warning CS1658: ) expected. See also error CS1026.
+                //     /// <see cref="M(readonly ref int)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(8, 22)
+            };
+
+            verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+
+            static void verify(CSharpCompilation compilation)
+            {
+                var cref = (NameMemberCrefSyntax)GetCrefSyntaxes(compilation).Single();
+                Assert.Empty(cref.Parameters.Parameters);
+            }
+        }
+
+        [Fact]
+        public void CRef_ReadonlyRefParameter_RefReadonly()
+        {
+            var source = """
+                class Test
+                {
+                    void M(readonly ref int x)
+                    {
+                    }
+
+                    /// <summary>
+                    /// <see cref="M(ref readonly int)"/>
+                    /// </summary>
+                    void S()
+                    {
+                    }
+                }
+                """;
+
+            var expectedDiagnostics = new[]
+            {
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly ref int x)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (8,20): warning CS1574: XML comment has cref attribute 'M(ref readonly int)' that could not be resolved
+                //     /// <see cref="M(ref readonly int)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "M(ref readonly int)").WithArguments("M(ref readonly int)").WithLocation(8, 20)
+            };
+
+            verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+            verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
+
+            static void verify(CSharpCompilation compilation)
+            {
+                var model = compilation.GetSemanticModel(compilation.SyntaxTrees.Single());
+                var cref = (NameMemberCrefSyntax)GetCrefSyntaxes(compilation).Single();
+
+                var parameter = cref.Parameters.Parameters.Single();
+                Assert.Equal(SyntaxKind.RefKeyword, parameter.RefKindKeyword.Kind());
+                Assert.Equal(SyntaxKind.ReadOnlyKeyword, parameter.ReadOnlyKeyword.Kind());
+
+                Assert.True(model.GetSymbolInfo(cref).IsEmpty);
+            }
+        }
+
+        [Fact]
         public void Cref_TupleType()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -6732,9 +6732,9 @@ class Test
                 // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     void M(ref readonly int x)
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
-                // (8,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,26): warning CS1658: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.. See also error CS8652.
                 //     /// <see cref="M(ref readonly int)"/>
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(8, 26)));
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments("The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.", "8652").WithLocation(8, 26)));
 
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics());
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics());
@@ -6872,9 +6872,9 @@ class Test
                 // (8,20): warning CS1574: XML comment has cref attribute 'M(ref readonly int)' that could not be resolved
                 //     /// <see cref="M(ref readonly int)"/>
                 Diagnostic(ErrorCode.WRN_BadXMLRef, "M(ref readonly int)").WithArguments("M(ref readonly int)").WithLocation(8, 20),
-                // (8,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // (8,26): warning CS1658: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.. See also error CS8652.
                 //     /// <see cref="M(ref readonly int)"/>
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(8, 26)));
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments("The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.", "8652").WithLocation(8, 26)));
 
             var expectedDiagnostics = new[]
             {

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -6731,7 +6731,10 @@ class Test
             verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(
                 // (3,16): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     void M(ref readonly int x)
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16)));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(3, 16),
+                // (8,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     /// <see cref="M(ref readonly int)"/>
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(8, 26)));
 
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics());
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics());
@@ -6862,6 +6865,17 @@ class Test
                 }
                 """;
 
+            verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(
+                // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                //     void M(readonly ref int x)
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(3, 12),
+                // (8,20): warning CS1574: XML comment has cref attribute 'M(ref readonly int)' that could not be resolved
+                //     /// <see cref="M(ref readonly int)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "M(ref readonly int)").WithArguments("M(ref readonly int)").WithLocation(8, 20),
+                // (8,26): error CS8652: The feature 'ref readonly parameters' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     /// <see cref="M(ref readonly int)"/>
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "readonly").WithArguments("ref readonly parameters").WithLocation(8, 26)));
+
             var expectedDiagnostics = new[]
             {
                 // (3,12): error CS9501: 'readonly' modifier must be specified after 'ref'.
@@ -6872,7 +6886,6 @@ class Test
                 Diagnostic(ErrorCode.WRN_BadXMLRef, "M(ref readonly int)").WithArguments("M(ref readonly int)").WithLocation(8, 20)
             };
 
-            verify(CreateCompilation(source, parseOptions: TestOptions.Regular11.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularNext.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
             verify(CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose)).VerifyDiagnostics(expectedDiagnostics));
 

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -632,7 +632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.CrefBracketedParameterList(InternalSyntaxFactory.Token(SyntaxKind.OpenBracketToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.CrefParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         private static Syntax.InternalSyntax.CrefParameterSyntax GenerateCrefParameter()
-            => InternalSyntaxFactory.CrefParameter(null, GenerateIdentifierName());
+            => InternalSyntaxFactory.CrefParameter(null, null, GenerateIdentifierName());
 
         private static Syntax.InternalSyntax.XmlElementSyntax GenerateXmlElement()
             => InternalSyntaxFactory.XmlElement(GenerateXmlElementStartTag(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.XmlNodeSyntax>(), GenerateXmlElementEndTag());
@@ -3379,6 +3379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameter();
 
             Assert.Null(node.RefKindKeyword);
+            Assert.Null(node.ReadOnlyKeyword);
             Assert.NotNull(node.Type);
 
             AttachAndCheckDiagnostics(node);
@@ -10728,7 +10729,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.CrefBracketedParameterList(SyntaxFactory.Token(SyntaxKind.OpenBracketToken), new SeparatedSyntaxList<CrefParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         private static CrefParameterSyntax GenerateCrefParameter()
-            => SyntaxFactory.CrefParameter(default(SyntaxToken), GenerateIdentifierName());
+            => SyntaxFactory.CrefParameter(default(SyntaxToken), default(SyntaxToken), GenerateIdentifierName());
 
         private static XmlElementSyntax GenerateXmlElement()
             => SyntaxFactory.XmlElement(GenerateXmlElementStartTag(), new SyntaxList<XmlNodeSyntax>(), GenerateXmlElementEndTag());
@@ -13475,8 +13476,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameter();
 
             Assert.Equal(SyntaxKind.None, node.RefKindKeyword.Kind());
+            Assert.Equal(SyntaxKind.None, node.ReadOnlyKeyword.Kind());
             Assert.NotNull(node.Type);
-            var newNode = node.WithRefKindKeyword(node.RefKindKeyword).WithType(node.Type);
+            var newNode = node.WithRefKindKeyword(node.RefKindKeyword).WithReadOnlyKeyword(node.ReadOnlyKeyword).WithType(node.Type);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
@@ -1524,9 +1524,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(in readonly B)'
                 // /// <see cref="A(in readonly B)"/>
                 Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(in readonly B)").WithArguments("A(in readonly B)").WithLocation(1, 16),
-                // (1,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                // (1,21): warning CS1658: 'readonly' modifier must be specified after 'ref'.. See also error CS9501.
                 // /// <see cref="A(in readonly B)"/>
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(1, 21));
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments("'readonly' modifier must be specified after 'ref'.", "9501").WithLocation(1, 21));
 
             N(SyntaxKind.NameMemberCref);
             {
@@ -1559,9 +1559,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(out readonly B)'
                 // /// <see cref="A(out readonly B)"/>
                 Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(out readonly B)").WithArguments("A(out readonly B)").WithLocation(1, 16),
-                // (1,22): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                // (1,22): warning CS1658: 'readonly' modifier must be specified after 'ref'.. See also error CS9501.
                 // /// <see cref="A(out readonly B)"/>
-                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(1, 22));
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments("'readonly' modifier must be specified after 'ref'.", "9501").WithLocation(1, 22));
 
             N(SyntaxKind.NameMemberCref);
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
@@ -1326,6 +1326,170 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void ParameterRefReadonly_01()
+        {
+            UsingNode("A(ref readonly B)");
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.ReadOnlyKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParameterRefReadonly_02()
+        {
+            UsingNode("A(ref readonly B, C)");
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.ReadOnlyKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParameterRefReadonly_03()
+        {
+            UsingNode("A(B, ref readonly C)");
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.ReadOnlyKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+        }
+
+        [Fact]
+        public void ParameterRefReadonly_04()
+        {
+            UsingNode("A(out B, ref readonly C)");
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.OutKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.ReadOnlyKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+        }
+
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_05(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(readonly ref B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(readonly ref B)'
+                // /// <see cref="A(readonly ref B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(").WithArguments("A(readonly ref B)").WithLocation(1, 16),
+                // (1,18): warning CS1658: ) expected. See also error CS1026.
+                // /// <see cref="A(readonly ref B)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(1, 18));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
         public void ParameterNullableType()
         {
             UsingNode("A(B?)");

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
@@ -1489,6 +1489,169 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_06(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(readonly B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(readonly B)'
+                // /// <see cref="A(readonly B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(").WithArguments("A(readonly B)").WithLocation(1, 16),
+                // (1,18): warning CS1658: ) expected. See also error CS1026.
+                // /// <see cref="A(readonly B)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(1, 18));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_07(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(in readonly B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(in readonly B)'
+                // /// <see cref="A(in readonly B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(in readonly B)").WithArguments("A(in readonly B)").WithLocation(1, 16),
+                // (1,21): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                // /// <see cref="A(in readonly B)"/>
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(1, 21));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.InKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "B");
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_08(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(out readonly B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(out readonly B)'
+                // /// <see cref="A(out readonly B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(out readonly B)").WithArguments("A(out readonly B)").WithLocation(1, 16),
+                // (1,22): error CS9501: 'readonly' modifier must be specified after 'ref'.
+                // /// <see cref="A(out readonly B)"/>
+                Diagnostic(ErrorCode.ERR_RefReadOnlyWrongOrdering, "readonly").WithLocation(1, 22));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.OutKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "B");
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_09(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(ref readonly readonly B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(ref readonly readonly B)'
+                // /// <see cref="A(ref readonly readonly B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(ref readonly").WithArguments("A(ref readonly readonly B)").WithLocation(1, 16),
+                // (1,31): warning CS1658: Identifier expected; 'readonly' is a keyword. See also error CS1041.
+                // /// <see cref="A(ref readonly readonly B)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments("Identifier expected; 'readonly' is a keyword", "1041").WithLocation(1, 31),
+                // (1,31): warning CS1658: ) expected. See also error CS1026.
+                // /// <see cref="A(ref readonly readonly B)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(1, 31));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CrefParameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.ReadOnlyKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
+        [Theory, CombinatorialData]
+        public void ParameterRefReadonly_10(
+            [CombinatorialValues(LanguageVersion.CSharp11, LanguageVersionFacts.CSharpNext, LanguageVersion.Preview)] LanguageVersion languageVersion)
+        {
+            UsingNode("A(readonly ref B)", TestOptions.Regular.WithLanguageVersion(languageVersion).WithDocumentationMode(DocumentationMode.Diagnose),
+                // (1,16): warning CS1584: XML comment has syntactically incorrect cref attribute 'A(readonly ref B)'
+                // /// <see cref="A(readonly ref B)"/>
+                Diagnostic(ErrorCode.WRN_BadXMLRefSyntax, "A(").WithArguments("A(readonly ref B)").WithLocation(1, 16),
+                // (1,18): warning CS1658: ) expected. See also error CS1026.
+                // /// <see cref="A(readonly ref B)"/>
+                Diagnostic(ErrorCode.WRN_ErrorOverride, "readonly").WithArguments(") expected", "1026").WithLocation(1, 18));
+
+            N(SyntaxKind.NameMemberCref);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.CrefParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
         [Fact]
         public void ParameterNullableType()
         {


### PR DESCRIPTION
Test plan: #68056