### PR TITLE
Do not offer 'use collection initializer' in a specific VB case

### DIFF
--- a/src/Analyzers/VisualBasic/Tests/UseCollectionInitializer/UseCollectionInitializerTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/UseCollectionInitializer/UseCollectionInitializerTests.vb
@@ -336,5 +336,17 @@ Class C
     End Sub
 End Class")
         End Function
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69106")>
+        Public Async Function TestNotWithCollectionInitializerArgument() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Imports System.Collections.Generic
+Class C
+    Sub M()
+        Dim Data As [||]New List(Of IEnumerable(Of String))
+        Data.Add({""Goo"", ""Bar"", ""Baz"", ""Buzz""})
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
         public int ArrayCreationExpression => (int)SyntaxKind.ArrayCreationExpression;
         public int AwaitExpression => (int)SyntaxKind.AwaitExpression;
         public int BaseExpression => (int)SyntaxKind.BaseExpression;
+        public int CollectionInitializerExpression => (int)SyntaxKind.CollectionInitializerExpression;
         public int ConditionalAccessExpression => (int)SyntaxKind.ConditionalAccessExpression;
         public int ConditionalExpression => (int)SyntaxKind.ConditionalExpression;
         public int? ImplicitArrayCreationExpression => (int)SyntaxKind.ImplicitArrayCreationExpression;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         int ArrayCreationExpression { get; }
         int AwaitExpression { get; }
         int BaseExpression { get; }
+        int CollectionInitializerExpression { get; }
         int ConditionalAccessExpression { get; }
         int ConditionalExpression { get; }
         int? ImplicitArrayCreationExpression { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
@@ -91,6 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
         Public ReadOnly Property ArrayCreationExpression As Integer = SyntaxKind.ArrayCreationExpression Implements ISyntaxKinds.ArrayCreationExpression
         Public ReadOnly Property AwaitExpression As Integer = SyntaxKind.AwaitExpression Implements ISyntaxKinds.AwaitExpression
         Public ReadOnly Property BaseExpression As Integer = SyntaxKind.MyBaseExpression Implements ISyntaxKinds.BaseExpression
+        Public ReadOnly Property CollectionInitializerExpression As Integer = SyntaxKind.CollectionInitializer Implements ISyntaxKinds.CollectionInitializerExpression
         Public ReadOnly Property ConditionalAccessExpression As Integer = SyntaxKind.ConditionalAccessExpression Implements ISyntaxKinds.ConditionalAccessExpression
         Public ReadOnly Property ConditionalExpression As Integer = SyntaxKind.TernaryConditionalExpression Implements ISyntaxKinds.ConditionalExpression
         Public ReadOnly Property ImplicitArrayCreationExpression As Integer? Implements ISyntaxKinds.ImplicitArrayCreationExpression


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69106