### PR TITLE
Don't create a .exe when building platform neutral language server bits

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
+        <UseAppHost Condition="'$(RuntimeIdentifier)' == ''">false</UseAppHost>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -1,6 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
+        <!--
+            By default since this is an Exe project and we build on windows, we'll get a .exe as output from a platform neutral build.
+            However, we really only want an executable if we're building for a specific platform (aka have a runtime identifier).
+
+            So if we don't have a platform, tell the build not to output a .exe file because we're building platform neutral bits.
+        -->
         <UseAppHost Condition="'$(RuntimeIdentifier)' == ''">false</UseAppHost>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
To fully work, this needs changes on the client to automatically detect no executable is present (working on it now).  However the neutral version is broken anyway (it can't find the appropriate executable on linux)

Property docs - https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#useapphost

![image](https://github.com/dotnet/roslyn/assets/5749229/19dcc5f1-f368-4489-b70b-11e099c6e2d3)
