### PR TITLE
Fix dotnet test SDK resolution when server starts as dll

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/DotnetCliHelper.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/DotnetCliHelper.cs
@@ -145,6 +145,7 @@ internal sealed class DotnetCliHelper
             }
         }
 
+        _logger.LogInformation("Could not find dotnet executable from PATH");
         return fileName;
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -52,8 +52,8 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             TraceLevel = GetTraceLevel(serverConfiguration),
             EnvironmentVariables = new()
             {
-                // Reset dotnet root to the user's original configuration so that vs test console can find the right runtimes.
-                { DotnetCliHelper.DotnetRootEnvVar, DotnetCliHelper.GetUserDotnetRoot() },
+                // Reset dotnet root so that vs test console can find the right runtimes.
+                { DotnetCliHelper.DotnetRootEnvVar, string.Empty },
             }
         });
 


### PR DESCRIPTION
Updates the dotnet cli retrieved to run the tests to look at the ones explicitly on the path and ignores the dotnet_root value.  Based on information from https://github.com/dotnet/runtime/issues/88754

This also fixes dotnet test execution when running via `dotnet exec <language server dll>` instead of via an .exe.  When starting the language server as a dll, shelling out to the dotnet CLI via `dotnet` in a child process will be unable to find any SDKs installed on the path.  It will only resolve the dotnet runtime the server is executing on.  

To fix this, we explicitly pass the dotnet executable from the path to shell out to the CLI and avoid this resolution problem.