### PR TITLE
LSP: add empty commands array to ServerCapabilites.ExecuteCommandProvider

### DIFF
--- a/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             };
 
             capabilities.FoldingRangeProvider = true;
-            capabilities.ExecuteCommandProvider = new ExecuteCommandOptions();
+            capabilities.ExecuteCommandProvider = new ExecuteCommandOptions() { Commands = Array.Empty<string>() };
             capabilities.TextDocumentSync = new TextDocumentSyncOptions
             {
                 Change = TextDocumentSyncKind.Incremental,


### PR DESCRIPTION
fixes #68849