### PR TITLE
Enable bootstrapped builds in VS test insertion YAML

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -189,7 +189,6 @@ stages:
                    -pack
                    -sign
                    -publish
-                   -bootstrap
                    -binaryLog
                    -configuration $(BuildConfiguration)
                    -officialBuildId $(Build.BuildNumber)

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -189,6 +189,7 @@ stages:
                    -pack
                    -sign
                    -publish
+                   -bootstrap
                    -binaryLog
                    -configuration $(BuildConfiguration)
                    -officialBuildId $(Build.BuildNumber)

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -124,6 +124,7 @@ stages:
                    -pack
                    -sign
                    -publish
+                   -bootstrap
                    -binaryLog
                    -configuration $(BuildConfiguration)
                    -officialBuildId $(Build.BuildNumber)


### PR DESCRIPTION
In order to get speedometer results on an experimental [compiler codegen change](https://github.com/dotnet/roslyn/pull/67487), we need to temporarily enable bootstrapping.