### PR TITLE
Fix issue where we were trimming the semicolon errantly from a class when doing override completion

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3442,6 +3442,39 @@ class D : C
             End Using
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/69153")>
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestOverrideWithClassWithTrailingSemicolon(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[class Class1
+{
+    override tostring$$
+};
+
+class Class2
+{
+
+};]]></Document>,
+                showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendInvokeCompletionList()
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                Assert.Equal("class Class1
+{
+    public override string ToString()
+    {
+        return base.ToString();
+    }
+};
+
+class Class2
+{
+
+};", state.SubjectBuffer.CurrentSnapshot.GetText())
+            End Using
+        End Function
+
         <WpfTheory, CombinatorialData>
         Public Async Function TestOverrideDefaultParameter(showCompletionInArgumentLists As Boolean) As Task
             Using state = TestStateFactory.CreateCSharpTestState(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
@@ -112,10 +112,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var openBrace = EnsureToken(typeDeclaration.OpenBraceToken, SyntaxKind.OpenBraceToken);
             var closeBrace = EnsureToken(typeDeclaration.CloseBraceToken, SyntaxKind.CloseBraceToken, appendNewLineIfMissing: true);
 
+            // Don't make any changes if the type already has both braces.
+            if (openBrace == typeDeclaration.OpenBraceToken && closeBrace == typeDeclaration.CloseBraceToken)
+                return typeDeclaration;
+
+            // If we are adding braces, then remove any semicolon to we cconvert something like `record class X();` to
+            // `record class X { }`
             if (typeDeclaration.SemicolonToken.IsKind(SyntaxKind.SemicolonToken))
-            {
                 typeDeclaration = typeDeclaration.WithSemicolonToken(default).WithTrailingTrivia(typeDeclaration.SemicolonToken.TrailingTrivia);
-            }
 
             if (!hasMembers)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/TypeDeclarationSyntaxExtensions.cs
@@ -112,13 +112,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var openBrace = EnsureToken(typeDeclaration.OpenBraceToken, SyntaxKind.OpenBraceToken);
             var closeBrace = EnsureToken(typeDeclaration.CloseBraceToken, SyntaxKind.CloseBraceToken, appendNewLineIfMissing: true);
 
-            // Don't make any changes if the type already has both braces.
-            if (openBrace == typeDeclaration.OpenBraceToken && closeBrace == typeDeclaration.CloseBraceToken)
-                return typeDeclaration;
-
-            // If we are adding braces, then remove any semicolon to we cconvert something like `record class X();` to
+            // If we are adding braces, then remove any semicolon to we convert something like `record class X();` to
             // `record class X { }`
-            if (typeDeclaration.SemicolonToken.IsKind(SyntaxKind.SemicolonToken))
+            var addedBraces = openBrace != typeDeclaration.OpenBraceToken || closeBrace != typeDeclaration.CloseBraceToken;
+            if (addedBraces && typeDeclaration.SemicolonToken.IsKind(SyntaxKind.SemicolonToken))
                 typeDeclaration = typeDeclaration.WithSemicolonToken(default).WithTrailingTrivia(typeDeclaration.SemicolonToken.TrailingTrivia);
 
             if (!hasMembers)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69153