### PR TITLE
Switch way from IVsService in option persister creation

### DIFF
--- a/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
+++ b/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
@@ -72,6 +72,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
 
                     Return _settingsManager
 
+                Case GetType(SVsFeatureFlags)
+                    ' The only places that we consume this treat it as optional, so we can skip it here, and remove this in 
+                    ' https://github.com/dotnet/roslyn/pull/69160.
+                    Return Nothing
+
                 Case Else
                     Throw New Exception($"{NameOf(MockServiceProvider)} does not implement {serviceType.FullName}.")
             End Select


### PR DESCRIPTION
We expect that option persisters are creatable off the UI thread; the underying VS services we fetch to create it are fully free- threaded services which can be fetched off the UI thread just fine. Unfortunately, we recently switched the fetching the services to use IVsService<>, which calls into a helper which always does a switch to to the main thread to cast the interface. Generally, this is necessary, but since the services we're fetching don't need it, it can result in deadlocks since it breaks assumptions in other parts of the system.

I've started a conversation with @ryanmolden about updating the helpers IVsService call to not transition to the UI thread if it's a managed object or free-threaded service, but for 17.7 we'll just revert this back to the old code to limit risk.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1851874