### PR TITLE
Avoid doing expensive work in Release when only used by Debug.Assert

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7682,9 +7682,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(lookupResult.Symbols.Any());
                 var members = ArrayBuilder<Symbol>.GetInstance();
-                bool wasError;
-                Symbol symbol = GetSymbolOrMethodOrPropertyGroup(lookupResult, node, rightName, arity, members, diagnostics, out wasError, qualifierOpt: null);
+
+#if DEBUG
+                Symbol symbol = GetSymbolOrMethodOrPropertyGroup(lookupResult, node, rightName, arity, members, diagnostics, out _, qualifierOpt: null);
                 Debug.Assert((object)symbol == null);
+#endif
                 Debug.Assert(members.Count > 0);
                 methodGroup.PopulateWithExtensionMethods(left, members, typeArgumentsWithAnnotations, lookupResult.Kind);
                 members.Free();


### PR DESCRIPTION
This method isn't super expensive regarding CPU time, but it shows 2.6% allocations in the IntelliSense scenario I'm profiling.

![image](https://github.com/dotnet/roslyn/assets/31348972/07dcc802-40f1-43e0-87cf-7acf20a4847e)
