### PR TITLE
Remove unnecessary calls to `Contains` for sets

### DIFF
--- a/eng/config/globalconfigs/Common.globalconfig
+++ b/eng/config/globalconfigs/Common.globalconfig
@@ -4,6 +4,7 @@ dotnet_diagnostic.CA1067.severity = warning
 dotnet_diagnostic.CA1068.severity = warning
 dotnet_diagnostic.CA1200.severity = warning
 dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1865.severity = warning
 dotnet_diagnostic.CA2009.severity = warning
 
 # CA2012: Use ValueTasks correctly

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
@@ -592,8 +592,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         {
             ISet<T> set = GenericISetFactory(setLength);
             T value = CreateT(532);
-            if (!set.Contains(value))
-                set.Add(value);
+            set.Add(value);
             set.Remove(value);
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
             Debug.Assert(enumerable != null);

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -2070,10 +2070,8 @@ tryAgain:
                         TypeDefinitionHandle typeDef = typeDefsToSearch.Dequeue();
                         Debug.Assert(!typeDef.IsNil);
 
-                        if (!visitedTypeDefTokens.Contains(typeDef))
+                        if (visitedTypeDefTokens.Add(typeDef))
                         {
-                            visitedTypeDefTokens.Add(typeDef);
-
                             foreach (MethodDefinitionHandle methodDef in Module.GetMethodsOfTypeOrThrow(typeDef))
                             {
                                 if (methodDef == targetMethodDef)
@@ -2091,12 +2089,9 @@ tryAgain:
                         TypeSymbol typeSymbol = typeSymbolsToSearch.Dequeue();
                         Debug.Assert(typeSymbol != null);
 
-                        if (!visitedTypeSymbols.Contains(typeSymbol))
+                        if (visitedTypeSymbols.Add(typeSymbol))
                         {
-                            visitedTypeSymbols.Add(typeSymbol);
-
                             //we're looking for a method def but we're currently on a type *ref*, so just enqueue supertypes
-
                             EnqueueTypeSymbolInterfacesAndBaseTypes(typeDefsToSearch, typeSymbolsToSearch, typeSymbol);
                         }
                     }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -1802,9 +1802,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             Dim candidateLocation As Location = candidate.NonMergedLocation
                             Debug.Assert(candidateLocation IsNot Nothing)
 
-                            If partialMethods.Contains(candidate) Then
-                                '  partial-partial conflict
-                                partialMethods.Remove(candidate)
+                            '  partial-partial conflict
+                            If partialMethods.Remove(candidate) Then
 
                                 '  the 'best' partial method is the one with the 'smallest' 
                                 ' location, we should report errors on the other

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -1802,8 +1802,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             Dim candidateLocation As Location = candidate.NonMergedLocation
                             Debug.Assert(candidateLocation IsNot Nothing)
 
-                            '  partial-partial conflict
                             If partialMethods.Remove(candidate) Then
+                                '  partial-partial conflict
 
                                 '  the 'best' partial method is the one with the 'smallest' 
                                 ' location, we should report errors on the other

--- a/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
+++ b/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
@@ -77,9 +77,8 @@ namespace Microsoft.CodeAnalysis.CodeDefinitionWindow
             if (reason == ConnectionReason.TextViewLifetime ||
                 !textView.BufferGraph.GetTextBuffers(b => b.ContentType.IsOfType(ContentTypeNames.RoslynContentType)).Any())
             {
-                if (_subscribedViews.Contains(textView))
+                if (_subscribedViews.Remove(textView))
                 {
-                    _subscribedViews.Remove(textView);
                     textView.Caret.PositionChanged -= OnTextViewCaretPositionChanged;
                 }
             }

--- a/src/VisualStudio/Core/Def/ChangeSignature/ChangeSignatureDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/ChangeSignature/ChangeSignatureDialogViewModel.cs
@@ -241,11 +241,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             {
                 var parameterToRemove = AllParameters[_selectedIndex!.Value];
 
-                if (_parametersWithoutDefaultValues.Contains(parameterToRemove))
-                {
-                    _parametersWithoutDefaultValues.Remove(parameterToRemove);
-                }
-                else
+                if (!_parametersWithoutDefaultValues.Remove(parameterToRemove))
                 {
                     _parametersWithDefaultValues.Remove(parameterToRemove);
                 }

--- a/src/VisualStudio/Core/Def/Interop/CleanableWeakComHandleTable.cs
+++ b/src/VisualStudio/Core/Def/Interop/CleanableWeakComHandleTable.cs
@@ -170,10 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
         {
             this.AssertIsForeground();
 
-            if (_deadKeySet.Contains(key))
-            {
-                _deadKeySet.Remove(key);
-            }
+            _deadKeySet.Remove(key);
 
             if (_table.TryGetValue(key, out var handle))
             {

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -338,9 +338,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                     ' To keep things simple, we'll just remove everything and add everything back in
                     For Each oldRuntimeLibrary In oldRuntimeLibraries
                         ' If this one was added explicitly in addition to our computation, we don't have to remove it 
-                        If _explicitlyAddedRuntimeLibraries.Contains(oldRuntimeLibrary) Then
-                            _explicitlyAddedRuntimeLibraries.Remove(oldRuntimeLibrary)
-                        Else
+                        If Not _explicitlyAddedRuntimeLibraries.Remove(oldRuntimeLibrary) Then
                             ProjectSystemProject.RemoveMetadataReference(oldRuntimeLibrary, MetadataReferenceProperties.Assembly)
                         End If
                     Next


### PR DESCRIPTION
This commit removes calls to `Contains` if they are immediately followed by either `Add` or `Remove`.
These calls were found during testing of a new analyzer (CA1865), see https://github.com/dotnet/roslyn-analyzers/pull/6767 and https://github.com/dotnet/runtime/issues/85490.