### PR TITLE
Enable building with a dotnet not on PATH

### DIFF
--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -41,23 +40,7 @@ internal static class TaskTestUtil
 
             var message = engine.BuildMessages.OfType<TaskCommandLineEventArgs>().Single();
             var commandLine = message.CommandLine.Replace("  ", " ").Trim();
-
-            var dotnetPath = RuntimeHostInfo.GetDotNetPathOrDefault();
-            var expectedCommandLine = $@"{dotnetPath} exec ""{task.PathToManagedTool}"" {line}";
-
-            bool isOnlyFileName = Path.GetFileName(dotnetPath).Length == dotnetPath.Length;
-            if (isOnlyFileName)
-            {
-                // When ToolTask.GenerateFullPathToTool() returns only a file name (not a path to a file), MSBuild's ToolTask
-                // will search the %PATH% (see https://github.com/dotnet/msbuild/blob/5410bf323451e04e99e79bcffd158e6d8d378149/src/Utilities/ToolTask.cs#L494-L513)
-                // and log the full path to the exe. In this case, only assert that the commandLine ends with the expected
-                // command line, and ignore the full path at the beginning.
-                Assert.EndsWith(expectedCommandLine, commandLine);
-            }
-            else
-            {
-                Assert.Equal(expectedCommandLine, commandLine);
-            }
+            Assert.Equal($@"{RuntimeHostInfo.GetDotNetPathOrDefault()} exec ""{task.PathToManagedTool}"" {line}", commandLine);
 
             compilerTask.NoConfig = true;
             Assert.Equal("/noconfig", compilerTask.GenerateToolArguments());

--- a/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TestUtilities/TaskTestUtil.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -40,7 +41,23 @@ internal static class TaskTestUtil
 
             var message = engine.BuildMessages.OfType<TaskCommandLineEventArgs>().Single();
             var commandLine = message.CommandLine.Replace("  ", " ").Trim();
-            Assert.Equal($@"{RuntimeHostInfo.GetDotNetPathOrDefault()} exec ""{task.PathToManagedTool}"" {line}", commandLine);
+
+            var dotnetPath = RuntimeHostInfo.GetDotNetPathOrDefault();
+            var expectedCommandLine = $@"{dotnetPath} exec ""{task.PathToManagedTool}"" {line}";
+
+            bool isOnlyFileName = Path.GetFileName(dotnetPath).Length == dotnetPath.Length;
+            if (isOnlyFileName)
+            {
+                // When ToolTask.GenerateFullPathToTool() returns only a file name (not a path to a file), MSBuild's ToolTask
+                // will search the %PATH% (see https://github.com/dotnet/msbuild/blob/5410bf323451e04e99e79bcffd158e6d8d378149/src/Utilities/ToolTask.cs#L494-L513)
+                // and log the full path to the exe. In this case, only assert that the commandLine ends with the expected
+                // command line, and ignore the full path at the beginning.
+                Assert.EndsWith(expectedCommandLine, commandLine);
+            }
+            else
+            {
+                Assert.Equal(expectedCommandLine, commandLine);
+            }
 
             compilerTask.NoConfig = true;
             Assert.Equal("/noconfig", compilerTask.GenerateToolArguments());

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -49,40 +49,15 @@ namespace Microsoft.CodeAnalysis
 
         internal static bool IsCoreClrRuntime => true;
 
+        private const string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";
+
         /// <summary>
-        /// Get the path to the dotnet executable. In the case the host did not provide this information
+        /// Get the path to the dotnet executable. In the case the .NET SDK did not provide this information
         /// in the environment this will return simply "dotnet".
         /// </summary>
-        /// <remarks>
-        /// See the following issue for rationale why only %PATH% is considered
-        /// https://github.com/dotnet/runtime/issues/88754
-        /// </remarks>
-        internal static string GetDotNetPathOrDefault()
-        {
-            var (fileName, sep) = PlatformInformation.IsWindows
-                ? ("dotnet.exe", ';')
-                : ("dotnet", ':');
-
-            var path = Environment.GetEnvironmentVariable("PATH") ?? "";
-            foreach (var item in path.Split(sep, StringSplitOptions.RemoveEmptyEntries))
-            {
-                try
-                {
-                    var filePath = Path.Combine(item, fileName);
-                    if (File.Exists(filePath))
-                    {
-                        return filePath;
-                    }
-                }
-                catch
-                {
-                    // If we can't read a directory for any reason just skip it
-                }
-            }
-
-            return fileName;
-        }
-
+        internal static string GetDotNetPathOrDefault() =>
+            Environment.GetEnvironmentVariable(DotNetHostPathEnvironmentName) ??
+                (PlatformInformation.IsWindows ? "dotnet.exe" : "dotnet");
 #else
 
         internal static bool IsCoreClrRuntime => false;


### PR DESCRIPTION
In #68918 we removed inspecting DOTNET_HOST_PATH environment variable. This broke the scenario where a specific dotnet "hive" was installed to a location not on the PATH.

When the .NET SDK commands invoke a sub-process (for example MSBuild), it sets the DOTNET_HOST_PATH environment variable to tell the sub-process "this is where the dotnet.exe that invoked this command is located". See https://github.com/dotnet/roslyn/pull/21237 and https://github.com/dotnet/cli/pull/7311 for more info.

This change reverts the behavior back to respect DOTNET_HOST_PATH, and if it isn't set it will just use "dotnet" and let the OS take care of finding the executable on the PATH.

Fix #69150

cc @jaredpar @333fred @ericstj @vitek-karas @dsplaisted 