### PR TITLE
Update Concord dependency versions and fix nullability warnings

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -146,8 +146,8 @@
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.6.0-beta.23252.1</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
     <MicrosoftVisualStudioDebuggerContractsVersion>17.6.0-beta.23252.1</MicrosoftVisualStudioDebuggerContractsVersion>
-    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
-    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
+    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>17.8.1072001-preview</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
+    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>17.8.1072001-preview</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsMeasurementVersion>17.0.0-preview-1-30928-1112</MicrosoftVisualStudioDiagnosticsMeasurementVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -229,8 +229,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
 
             Debug.Assert(compResult.Assembly != null);
-            Debug.Assert(compResult.TypeName != null);
-            Debug.Assert(compResult.MethodName != null);
 
             ReadOnlyCollection<byte>? customTypeInfo;
             Guid customTypeInfoId = compResult.GetCustomTypeInfo(out customTypeInfo);

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
         }
 
-        private static ImmutableArray<Alias> GetAliases(DkmClrRuntimeInstance runtimeInstance, DkmInspectionContext inspectionContext)
+        private static ImmutableArray<Alias> GetAliases(DkmClrRuntimeInstance runtimeInstance, DkmInspectionContext? inspectionContext)
         {
             var dkmAliases = runtimeInstance.GetAliases(inspectionContext);
             if (dkmAliases == null)
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         void IDkmClrExpressionCompiler.CompileExpression(
             DkmLanguageExpression expression,
             DkmClrInstructionAddress instructionAddress,
-            DkmInspectionContext inspectionContext,
+            DkmInspectionContext? inspectionContext,
             out string? error,
             out DkmCompiledClrInspectionQuery? result)
         {
@@ -158,6 +158,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     (blocks, useReferencedModulesOnly) => CreateMethodContext(instructionAddress, blocks, useReferencedModulesOnly),
                     (context, diagnostics) =>
                     {
+                        // Concord marks this as nullable but it should always have a value in our scenario.
+                        RoslynDebug.AssertNotNull(lValue.FullName);
+
                         var compileResult = context.CompileAssignment(
                             lValue.FullName,
                             expression.Text,

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/FrameDecoder.cs
@@ -92,6 +92,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // NOTE: We could always call GetClrGenericParameters, pass them to GetMethod and have that
             // return a constructed method symbol, but it seems unwise to call GetClrGenericParameters
             // for all frames (as this call requires a round-trip to the debuggee process).
+
+            // [nullability] We do not expect frames without instruction addresses in this path. Additionally, there is no good 
+            // way to return if we receive a frame with no address, as executing the onFailure callback would just hide a deeper issue.
+            RoslynDebug.AssertNotNull(frame.InstructionAddress);
             var instructionAddress = (DkmClrInstructionAddress)frame.InstructionAddress;
             var compilation = _instructionDecoder.GetCompilation(instructionAddress.ModuleInstance);
             var method = _instructionDecoder.GetMethod(compilation, instructionAddress);


### PR DESCRIPTION
- Update Concord dependency versions to pull in their latest APIs which are required for future changes.
- Concord has increased its surface area of nullable reference types, resolve the warnings created by the new nullable references types in Concord APIs