### PR TITLE
Disable local deploy of the arm64 ServiceHub project

### DIFF
--- a/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
+++ b/src/VisualStudio/Setup.ServiceHub/arm64/Roslyn.VisualStudio.ServiceHub.Setup.arm64.csproj
@@ -5,6 +5,11 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net472</TargetFramework>
     <SetupProductArch>arm64</SetupProductArch>
+    <!-- If the user is building the entire repository locally, don't deploy this project. We will deploy the x64 flavor,
+         which for purposes of local deploy is actually the same thing; the only difference of this project and the x64 flavor
+         is for crossgen, which we don't run during F5. Since either project will work equally well (even if you were developing on
+         an arm64 machine), we'll just disable this one. -->
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Workspaces\Remote\ServiceHub.CoreComponents\arm64\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.arm64.csproj">

--- a/src/VisualStudio/Setup.ServiceHub/arm64/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.ServiceHub/arm64/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="35B9F49B-CC6A-4102-923E-2A41C179BF1F" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Roslyn Services for .NET ServiceHub Host</DisplayName>
+    <DisplayName>Roslyn Services for .NET ServiceHub Host (arm64)</DisplayName>
     <Description xml:space="preserve">Roslyn Services for .NET ServiceHub Host</Description>
     <PackageId>Microsoft.CodeAnalysis.VisualStudio.ServiceHub.Setup.arm64</PackageId>
     <License>EULA.rtf</License>


### PR DESCRIPTION
This should address some reports where local F5 debugging fails when we try to deploy two different projects to the same place at once. I also rename the one ServiceHub package, so if by accident something were to get deployed twice it'll be clearer what is going on.