### PR TITLE
Only Left and returnValue gets checked for dynamic in signature

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -4127,7 +4127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Dynamic built-in operators allow virtually all operations with all types.  So we do no further checking here.
                 if (csharpReturnType.TypeKind is TypeKind.Dynamic ||
                     csharpLeftType.TypeKind is TypeKind.Dynamic ||
-                    csharpReturnType.TypeKind is TypeKind.Dynamic)
+                    csharpRightType.TypeKind is TypeKind.Dynamic)
                 {
                     return;
                 }


### PR DESCRIPTION
In CSharpcompilation there was a signature check for dynamic Types but only left and return were checked. I was running my roslyn analyser to check for identical subexpressions over this repository to get some edgecases that I forgot about. This came out as response