### PR TITLE
Only use scoped for ref parameters

### DIFF
--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -4754,6 +4754,7 @@ public readonly struct [|S|]
                     public readonly ref int RORefValue;
 
                     public void M(scoped ref int value) { }
+                    public void N(out int value) { }
                 }
                 """);
 
@@ -4767,6 +4768,10 @@ public readonly struct [|S|]
                     public ref global::System.Int32 RefValue;
                     public readonly ref global::System.Int32 RORefValue;
                     public void M(scoped ref global::System.Int32 value)
+                    {
+                    }
+
+                    public void N(out global::System.Int32 value)
                     {
                     }
 

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 symbol.RefKind,
                 isExtension: symbol is { Ordinal: 0, ContainingSymbol: IMethodSymbol { IsExtensionMethod: true } },
                 symbol.IsParams,
-                symbol.ScopedKind == ScopedKind.ScopedRef);
+                isScoped: symbol is { RefKind: RefKind.Ref, ScopedKind: ScopedKind.ScopedRef});
         }
 
         private protected abstract SyntaxNode TypeParameter(ITypeParameterSymbol typeParameter);


### PR DESCRIPTION
Fixes: #69213 

When I attempted to add `scoped` I didn't realize that `ScopedKind` would be set to `ScopedRef` for `out` parameters.  I'm not certain if that's expected or not, but I found that considering `RefKind` as well would fix this issue.  I'd like feedback from @cston if this is the right way to fix this or not.

cc @CyrusNajmabadi