### PR TITLE
Check both csc.exe and vbc.exe as filename to exclude

### DIFF
--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -107,7 +107,6 @@ namespace BuildBoss
                     PathComparer.Equals(relativeFileName, "Icon.png") ||
                     PathComparer.Equals(relativeFileName, "Init.cmd") ||
                     PathComparer.Equals(relativeFileName, "VS.Tools.Roslyn.nuspec") ||
-                    PathComparer.Equals(relativeFileName, "csc.exe") ||
                     relativeFileName.EndsWith(".resources.dll", PathComparison) ||
                     relativeFileName.EndsWith(".rels", PathComparison) ||
                     relativeFileName.EndsWith(".psmdcp", PathComparison),

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -107,6 +107,7 @@ namespace BuildBoss
                     PathComparer.Equals(relativeFileName, "Icon.png") ||
                     PathComparer.Equals(relativeFileName, "Init.cmd") ||
                     PathComparer.Equals(relativeFileName, "VS.Tools.Roslyn.nuspec") ||
+                    PathComparer.Equals(relativeFileName, "vbc.exe") ||
                     relativeFileName.EndsWith(".resources.dll", PathComparison) ||
                     relativeFileName.EndsWith(".rels", PathComparison) ||
                     relativeFileName.EndsWith(".psmdcp", PathComparison),


### PR DESCRIPTION
I used my identical subexpression analyzer to see if I missed certain exceptions. 
This was one diagnostic found that wasn't wrong. 

```
PathComparer.Equals(relativeFileName, "csc.exe") 
```
was checked twice.