### PR TITLE
Method group natural type: only use methods that can be fully substituted and pass constraint checks

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9848,7 +9848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     method = candidate;
                     return true;
                 }
-                if (MemberSignatureComparer.MethodGroupSignatureComparer.Equals(method, candidate))
+                if (MemberSignatureComparer.CSharp10MethodGroupSignatureComparer.Equals(method, candidate))
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9873,30 +9873,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             var typeArguments = node.TypeArgumentsOpt;
             if (node.ResultKind == LookupResultKind.Viable)
             {
-                foreach (var instanceMethod in node.Methods)
+                foreach (var memberMethod in node.Methods)
                 {
                     switch (node.ReceiverOpt)
                     {
                         case BoundTypeExpression:
                         case null: // if `using static Class` is in effect, the receiver is missing
-                            if (!instanceMethod.IsStatic) continue;
+                            if (!memberMethod.IsStatic) continue;
                             break;
                         case BoundThisReference { WasCompilerGenerated: true }:
                             break;
                         default:
-                            if (instanceMethod.IsStatic) continue;
+                            if (memberMethod.IsStatic) continue;
                             break;
                     }
 
                     int arity = typeArguments.IsDefaultOrEmpty ? 0 : typeArguments.Length;
-                    if (instanceMethod.Arity != arity)
+                    if (memberMethod.Arity != arity)
                     {
                         // We have no way of inferring type arguments, so if the given type arguments
                         // don't match the method's arity, the method is not a candidate
                         continue;
                     }
 
-                    var substituted = typeArguments.IsDefaultOrEmpty ? instanceMethod : instanceMethod.Construct(typeArguments);
+                    var substituted = typeArguments.IsDefaultOrEmpty ? memberMethod : memberMethod.Construct(typeArguments);
                     if (!satisfiesConstraintChecks(substituted))
                     {
                         continue;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9869,98 +9869,135 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return GetUniqueSignatureFromMethodGroup_CSharp10(node);
             }
 
-            MethodSymbol? method = selectMethodForSignature(node);
-
-            if (method is null)
+            MethodSymbol? foundMethod = null;
+            var typeArguments = node.TypeArgumentsOpt;
+            if (node.ResultKind == LookupResultKind.Viable)
             {
-                return null;
-            }
-
-            int arity = node.TypeArgumentsOpt.IsDefaultOrEmpty ? 0 : node.TypeArgumentsOpt.Length;
-            if (method.Arity != arity)
-            {
-                return null;
-            }
-            else if (arity > 0)
-            {
-                return method.ConstructedFrom.Construct(node.TypeArgumentsOpt);
-            }
-
-            return method;
-
-            static bool isCandidateUnique(ref MethodSymbol? method, MethodSymbol candidate)
-            {
-                if (method is null)
+                foreach (var instanceMethod in node.Methods)
                 {
-                    method = candidate;
-                    return true;
-                }
-                if (MemberSignatureComparer.MethodGroupSignatureComparer.Equals(method, candidate))
-                {
-                    return true;
-                }
-                method = null;
-                return false;
-            }
-
-            MethodSymbol? selectMethodForSignature(BoundMethodGroup node)
-            {
-                MethodSymbol? method = null;
-                if (node.ResultKind == LookupResultKind.Viable)
-                {
-                    foreach (var m in node.Methods)
+                    switch (node.ReceiverOpt)
                     {
-                        switch (node.ReceiverOpt)
+                        case BoundTypeExpression:
+                        case null: // if `using static Class` is in effect, the receiver is missing
+                            if (!instanceMethod.IsStatic) continue;
+                            break;
+                        case BoundThisReference { WasCompilerGenerated: true }:
+                            break;
+                        default:
+                            if (instanceMethod.IsStatic) continue;
+                            break;
+                    }
+
+                    int arity = typeArguments.IsDefaultOrEmpty ? 0 : typeArguments.Length;
+                    if (instanceMethod.Arity != arity)
+                    {
+                        // We have no way of inferring type arguments, so if the given type arguments
+                        // don't match the method's arity, the method is not a candidate
+                        continue;
+                    }
+
+                    var substituted = typeArguments.IsDefaultOrEmpty ? instanceMethod : instanceMethod.Construct(typeArguments);
+                    if (!satisfiesConstraintChecks(substituted))
+                    {
+                        continue;
+                    }
+
+                    if (!isCandidateUnique(ref foundMethod, substituted))
+                    {
+                        return null;
+                    }
+                }
+
+                if (foundMethod is not null)
+                {
+                    return foundMethod;
+                }
+            }
+
+            if (node.SearchExtensionMethods)
+            {
+                var receiver = node.ReceiverOpt!;
+                var methodGroup = MethodGroup.GetInstance();
+                foreach (var scope in new ExtensionMethodScopes(this))
+                {
+                    methodGroup.Clear();
+                    PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, node.Syntax, receiver, node.Name, typeArguments, BindingDiagnosticBag.Discarded);
+                    foreach (var extensionMethod in methodGroup.Methods)
+                    {
+                        var substituted = typeArguments.IsDefaultOrEmpty ? extensionMethod : extensionMethod.Construct(typeArguments);
+
+                        var reduced = substituted.ReduceExtensionMethod(receiver.Type, Compilation, out bool wasFullyInferred);
+                        if (reduced is null)
                         {
-                            case BoundTypeExpression:
-                            case null: // if `using static Class` is in effect, the receiver is missing
-                                if (!m.IsStatic) continue;
-                                break;
-                            case BoundThisReference { WasCompilerGenerated: true }:
-                                break;
-                            default:
-                                if (m.IsStatic) continue;
-                                break;
+                            // Extension method was not applicable
+                            continue;
                         }
 
-                        if (!isCandidateUnique(ref method, m))
+                        if (!wasFullyInferred)
                         {
+                            continue;
+                        }
+
+                        if (!satisfiesConstraintChecks(reduced))
+                        {
+                            continue;
+                        }
+
+                        var wasUnique = isCandidateUnique(ref foundMethod, reduced);
+                        if (!wasUnique)
+                        {
+                            methodGroup.Free();
                             return null;
                         }
                     }
 
-                    if (method is not null)
+                    if (foundMethod is not null)
                     {
-                        return method;
-                    }
-                }
-
-                if (node.SearchExtensionMethods)
-                {
-                    var receiver = node.ReceiverOpt!;
-                    foreach (var scope in new ExtensionMethodScopes(this))
-                    {
-                        var methodGroup = MethodGroup.GetInstance();
-                        PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, node.Syntax, receiver, node.Name, node.TypeArgumentsOpt, BindingDiagnosticBag.Discarded);
-                        foreach (var m in methodGroup.Methods)
-                        {
-                            if (m.ReduceExtensionMethod(receiver.Type, Compilation) is { } reduced &&
-                                !isCandidateUnique(ref method, reduced))
-                            {
-                                methodGroup.Free();
-                                return null;
-                            }
-                        }
                         methodGroup.Free();
-
-                        if (method is not null)
-                        {
-                            return method;
-                        }
+                        return foundMethod;
                     }
                 }
+                methodGroup.Free();
+            }
 
-                return null;
+            return null;
+
+            static bool isCandidateUnique(ref MethodSymbol? foundMethod, MethodSymbol candidate)
+            {
+                if (foundMethod is null)
+                {
+                    foundMethod = candidate;
+                    return true;
+                }
+                if (MemberSignatureComparer.MethodGroupSignatureComparer.Equals(foundMethod, candidate))
+                {
+                    return true;
+                }
+                foundMethod = null;
+                return false;
+            }
+
+            bool satisfiesConstraintChecks(MethodSymbol method)
+            {
+                if (method.Arity == 0)
+                {
+                    return true;
+                }
+
+                var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
+                ArrayBuilder<TypeParameterDiagnosticInfo>? useSiteDiagnosticsBuilder = null;
+
+                bool constraintsSatisfied = ConstraintsHelper.CheckMethodConstraints(
+                    method,
+                    new ConstraintsHelper.CheckConstraintsArgs(this.Compilation, this.Conversions, includeNullability: false, location: NoLocation.Singleton, diagnostics: null),
+                    diagnosticsBuilder,
+                    nullabilityDiagnosticsBuilderOpt: null,
+                    ref useSiteDiagnosticsBuilder);
+
+                diagnosticsBuilder.Free();
+                useSiteDiagnosticsBuilder?.Free();
+
+                return constraintsSatisfied;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we need to take special care to intercept with the extension method as though it is being called in reduced form.
             Debug.Assert(receiverOpt is not BoundTypeExpression || method.IsStatic);
             var needToReduce = receiverOpt is not (null or BoundTypeExpression) && interceptor.IsExtensionMethod;
-            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation) : interceptor;
+            var symbolForCompare = needToReduce ? ReducedExtensionMethodSymbol.Create(interceptor, receiverOpt!.Type, _compilation, out _) : interceptor;
 
             if (!MemberSignatureComparer.InterceptorsComparer.Equals(method, symbolForCompare))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -329,6 +329,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             typeComparison: TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
+        /// Compare signatures of methods from a method group (only used in logic for older language version).
+        /// </summary>
+        internal static readonly MemberSignatureComparer CSharp10MethodGroupSignatureComparer = new MemberSignatureComparer(
+            considerName: false,
+            considerExplicitlyImplementedInterfaces: false,
+            considerReturnType: true,
+            considerTypeConstraints: false,
+            refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
+            considerCallingConvention: false,
+            considerArity: true,
+            typeComparison: TypeCompareKind.AllIgnoreOptions);
+
+        /// <summary>
         /// Compare signatures of methods from a method group.
         /// </summary>
         internal static readonly MemberSignatureComparer MethodGroupSignatureComparer = new MemberSignatureComparer(

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -338,6 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false,
             refKindCompareMode: RefKindCompareMode.ConsiderDifferences,
             considerCallingConvention: false,
+            considerArity: false,
             typeComparison: TypeCompareKind.AllIgnoreOptions);
 
         // Compare the "unqualified" part of the member name (no explicit part)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -733,6 +733,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitMethod(this);
         }
 
+        public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType, CSharpCompilation compilation)
+        {
+            return ReduceExtensionMethod(receiverType, compilation, wasFullyInferred: out _);
+        }
+
         /// <summary>
         /// If this is an extension method that can be applied to a receiver of the given type,
         /// returns a reduced extension method symbol thus formed. Otherwise, returns null.
@@ -740,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="compilation">The compilation in which constraints should be checked.
         /// Should not be null, but if it is null we treat constraints as we would in the latest
         /// language version.</param>
-        public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType, CSharpCompilation compilation)
+        public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType, CSharpCompilation compilation, out bool wasFullyInferred)
         {
             if ((object)receiverType == null)
             {
@@ -749,10 +754,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!this.IsExtensionMethod || this.MethodKind == MethodKind.ReducedExtension || receiverType.IsVoidType())
             {
+                wasFullyInferred = false;
                 return null;
             }
 
-            return ReducedExtensionMethodSymbol.Create(this, receiverType, compilation);
+            return ReducedExtensionMethodSymbol.Create(this, receiverType, compilation, out wasFullyInferred);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // For the purpose of construction we use original type parameters in place of type arguments that we couldn't infer from the first argument.
             ImmutableArray<TypeWithAnnotations> typeArgsForConstruct = typeArgs;
-            wasFullyInferred = !typeArgs.Any(static t => !t.HasType);
+            wasFullyInferred = typeArgs.All(static t => t.HasType);
             if (!wasFullyInferred)
             {
                 typeArgsForConstruct = typeArgs.ZipAsArray(

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         /// <param name="compilation">Compilation used to check constraints.
         /// The latest language version is assumed if this is null.</param>
-        public static MethodSymbol Create(MethodSymbol method, TypeSymbol receiverType, CSharpCompilation compilation)
+        public static MethodSymbol Create(MethodSymbol method, TypeSymbol receiverType, CSharpCompilation compilation, out bool wasFullyInferred)
         {
             Debug.Assert(method.IsExtensionMethod && method.MethodKind != MethodKind.ReducedExtension);
             Debug.Assert(method.ParameterCount > 0);
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var useSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependencies;
 
-            method = InferExtensionMethodTypeArguments(method, receiverType, compilation, ref useSiteInfo);
+            method = InferExtensionMethodTypeArguments(method, receiverType, compilation, ref useSiteInfo, out wasFullyInferred);
             if ((object)method == null)
             {
                 return null;
@@ -109,19 +109,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// are not satisfied, the return value is null.
         /// </summary>
         /// <param name="compilation">Compilation used to check constraints.  The latest language version is assumed if this is null.</param>
-        private static MethodSymbol InferExtensionMethodTypeArguments(MethodSymbol method, TypeSymbol thisType, CSharpCompilation compilation, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private static MethodSymbol InferExtensionMethodTypeArguments(MethodSymbol method, TypeSymbol thisType, CSharpCompilation compilation,
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, out bool wasFullyInferred)
         {
             Debug.Assert(method.IsExtensionMethod);
             Debug.Assert((object)thisType != null);
 
             if (!method.IsGenericMethod || method != method.ConstructedFrom)
             {
+                wasFullyInferred = true;
                 return method;
             }
 
             // We never resolve extension methods on a dynamic receiver.
             if (thisType.IsDynamic())
             {
+                wasFullyInferred = false;
                 return null;
             }
 
@@ -158,6 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (typeArgs.IsDefault)
             {
+                wasFullyInferred = false;
                 return null;
             }
 
@@ -215,12 +219,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!success)
             {
+                wasFullyInferred = false;
                 return null;
             }
 
             // For the purpose of construction we use original type parameters in place of type arguments that we couldn't infer from the first argument.
             ImmutableArray<TypeWithAnnotations> typeArgsForConstruct = typeArgs;
-            if (typeArgs.Any(static t => !t.HasType))
+            wasFullyInferred = !typeArgs.Any(static t => !t.HasType);
+            if (!wasFullyInferred)
             {
                 typeArgsForConstruct = typeArgs.ZipAsArray(
                     method.TypeParameters,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -1989,7 +1989,8 @@ namespace N
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: "RAN N.B.F: System.Action");
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            var verifier = CompileAndVerify(comp, expectedOutput: "RAN N.B.F: System.Action", verify: Verification.FailsILVerify);
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2506,7 +2507,8 @@ public static class E
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: "E.M");
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            var verifier = CompileAndVerify(comp, expectedOutput: "E.M", verify: Verification.FailsILVerify);
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2554,7 +2556,8 @@ namespace N
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: "E2.M E2.M");
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            var verifier = CompileAndVerify(comp, expectedOutput: "E2.M E2.M", verify: Verification.FailsILVerify);
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
@@ -2602,7 +2605,8 @@ namespace N
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: "E1.M E1.M");
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            var verifier = CompileAndVerify(comp, expectedOutput: "E1.M E1.M", verify: Verification.FailsILVerify);
             verifier.VerifyDiagnostics(
                 // (1,1): hidden CS8019: Unnecessary using directive.
                 // using N;
@@ -3075,7 +3079,8 @@ static class A
                 Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new object().F").WithLocation(1, 9));
 
             var comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            var verifier = CompileAndVerify(comp, expectedOutput: "A.F");
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            var verifier = CompileAndVerify(comp, expectedOutput: "A.F", verify: Verification.FailsILVerify);
             verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -1141,9 +1141,7 @@ internal new void F(object? x) { }
     @"#nullable enable
 internal object? F() => throw null!;
 #nullable disable", "internal new object F() => throw null;", "F", "F", null, "System.Func<System.Object>"); // different nullability
-            yield return getData("internal void F() { }", "internal void F<T>() { }", "F", "F"); // different arity
             yield return getData("internal void F() { }", "internal void F<T>() { }", "F<int>", "F<int>", null, "System.Action"); // different arity
-            yield return getData("internal void F<T>() { }", "internal void F() { }", "F", "F"); // different arity
             yield return getData("internal void F<T>() { }", "internal void F() { }", "F<int>", "F<int>", null, "System.Action"); // different arity
             yield return getData("internal void F<T>() { }", "internal void F<T, U>() { }", "F<int>", "F<int>", null, "System.Action"); // different arity
             yield return getData("internal void F<T>() { }", "internal void F<T, U>() { }", "F<int, object>", "F<int, object>", null, "System.Action"); // different arity
@@ -1222,6 +1220,41 @@ partial class B : A
             Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
         }
 
+        [Fact]
+        public void MethodGroup_BaseAndDerivedTypes_1()
+        {
+            var source = """
+new B().M();
+
+partial class B
+{
+    public void M()
+    {
+        System.Delegate d = F;
+        System.Console.Write(d.GetDelegateTypeName());
+    }
+}
+abstract class A
+{
+    internal void F() { }
+}
+partial class B : A
+{
+    internal void F<T>() { }
+}
+""";
+            var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "System.Action");
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single().Initializer!.Value;
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
+        }
+
         public static IEnumerable<object?[]> GetExtensionMethodsSameScopeData()
         {
             yield return getData("internal static void F(this object x) { }", "internal static void F(this string x) { }", "string.Empty.F", "F", null, "B.F", "System.Action"); // different parameter type
@@ -1231,9 +1264,7 @@ partial class B : A
             yield return getData("internal static void F(this object x, ref object y) { }", "internal static void F(this object x, object y) { }", "this.F", "F"); // different parameter ref kind
             yield return getData("internal static object F(this object x) => throw null;", "internal static ref object F(this object x) => throw null;", "this.F", "F"); // different return ref kind
             yield return getData("internal static ref object F(this object x) => throw null;", "internal static object F(this object x) => throw null;", "this.F", "F"); // different return ref kind
-            yield return getData("internal static void F(this object x, object y) { }", "internal static void F<T>(this object x, T y) { }", "this.F", "F"); // different arity
             yield return getData("internal static void F(this object x, object y) { }", "internal static void F<T>(this object x, T y) { }", "this.F<int>", "F<int>", null, "B.F", "System.Action<System.Int32>"); // different arity
-            yield return getData("internal static void F<T>(this object x) { }", "internal static void F(this object x) { }", "this.F", "F"); // different arity
             yield return getData("internal static void F<T>(this object x) { }", "internal static void F(this object x) { }", "this.F<int>", "F<int>", null, "A.F", "System.Action"); // different arity
             yield return getData("internal static void F<T>(this T t) where T : class { }", "internal static void F<T>(this T t) { }", "this.F<object>", "F<object>",
                 new[]
@@ -1249,13 +1280,6 @@ partial class B : A
                     //         System.Delegate d = this.F<object>;
                     Diagnostic(ErrorCode.ERR_AmbigCall, "this.F<object>").WithArguments("A.F<T>(T)", "B.F<T>(T)").WithLocation(5, 29)
                 }); // different type parameter constraints
-            yield return getData("internal static void F<T>(this T t) where T : class { }", "internal static void F<T>(this T t) where T : struct { }", "this.F<int>", "F<int>",
-                new[]
-                {
-                    // (5,34): error CS0123: No overload for 'F' matches delegate 'Action'
-                    //         System.Delegate d = this.F<int>;
-                    Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "F<int>").WithArguments("F", "System.Action").WithLocation(5, 34)
-                 }); // different type parameter constraints
 
             static object?[] getData(string methodA, string methodB, string methodGroupExpression, string methodGroupOnly, DiagnosticDescription[]? expectedDiagnostics = null, string? expectedMethod = null, string? expectedType = null)
             {
@@ -1319,6 +1343,135 @@ static class B
             var symbolInfo = model.GetSymbolInfo(expr);
             // https://github.com/dotnet/roslyn/issues/52870: GetSymbolInfo() should return resolved method from method group.
             Assert.Null(symbolInfo.Symbol);
+        }
+
+        [Fact]
+        public void MethodGroup_ExtensionMethodsSameScope_1()
+        {
+            var source = """
+new Program().M();
+
+partial class Program
+{
+    public void M()
+    {
+        System.Delegate d = this.F;
+        System.Console.Write("{0}: {1}", d.GetDelegateMethodName(), d.GetDelegateTypeName());
+    }
+}
+static class A
+{
+    internal static void F(this object x, object y) { }
+}
+static class B
+{
+    internal static void F<T>(this object x, T y) { }
+}
+""";
+            var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "A.F: System.Action<System.Object>", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single().Initializer!.Value;
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
+
+            var symbolInfo = model.GetSymbolInfo(expr);
+            // https://github.com/dotnet/roslyn/issues/52870: GetSymbolInfo() should return resolved method from method group.
+            Assert.Null(symbolInfo.Symbol);
+
+            Assert.Equal(new[] { "void System.Object.F(System.Object y)", "void System.Object.F<T>(T y)" },
+                model.GetMemberGroup(expr).ToTestDisplayStrings());
+        }
+
+        [Fact]
+        public void MethodGroup_ExtensionMethodsSameScope_2()
+        {
+            var source = """
+new Program().M();
+
+partial class Program
+{
+    public void M()
+    {
+        System.Delegate d = this.F;
+        System.Console.Write("{0}: {1}", d.GetDelegateMethodName(), d.GetDelegateTypeName());
+    }
+}
+static class A
+{
+    internal static void F<T>(this object x) { }
+}
+static class B
+{
+    internal static void F(this object x) { }
+}
+""";
+            var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "B.F: System.Action", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single().Initializer!.Value;
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
+
+            var symbolInfo = model.GetSymbolInfo(expr);
+            // https://github.com/dotnet/roslyn/issues/52870: GetSymbolInfo() should return resolved method from method group.
+            Assert.Null(symbolInfo.Symbol);
+
+            Assert.Equal(new[] { "void System.Object.F<T>()", "void System.Object.F()" },
+                model.GetMemberGroup(expr).ToTestDisplayStrings());
+        }
+
+        [Fact]
+        public void MethodGroup_ExtensionMethodsSameScope_3()
+        {
+            var source = """
+new Program().M();
+
+partial class Program
+{
+    public void M()
+    {
+        System.Delegate d = this.F<int>;
+        System.Console.Write("{0}: {1}", d.GetDelegateMethodName(), d.GetDelegateTypeName());
+    }
+}
+static class A
+{
+    internal static void F<T>(this T t) where T : class { }
+}
+static class B
+{
+    internal static void F<T>(this T t) where T : struct { }
+}
+""";
+            var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics(
+                // 0.cs(7,34): error CS8917: The delegate type could not be inferred.
+                //         System.Delegate d = this.F<int>;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "F<int>").WithLocation(7, 34)
+                );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single().Initializer!.Value;
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
+
+            var symbolInfo = model.GetSymbolInfo(expr);
+            // https://github.com/dotnet/roslyn/issues/52870: GetSymbolInfo() should return resolved method from method group.
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Empty(model.GetMemberGroup(expr));
         }
 
         public static IEnumerable<object?[]> GetExtensionMethodsDifferentScopeData_CSharp10()
@@ -1428,13 +1581,6 @@ namespace N
             yield return getData("internal static void F<T>(this object x) { }", "internal static void F(this object x) { }", "this.F<int>", "F<int>", null, "A.F", "System.Action"); // different arity
             yield return getData("internal static void F<T>(this T t) where T : class { }", "internal static void F<T>(this T t) { }", "this.F<object>", "F<object>", null, "A.F", "System.Action"); // different type parameter constraints
             yield return getData("internal static void F<T>(this T t) { }", "internal static void F<T>(this T t) where T : class { }", "this.F<object>", "F<object>", null, "A.F", "System.Action"); // different type parameter constraints
-            yield return getData("internal static void F<T>(this T t) where T : class { }", "internal static void F<T>(this T t) where T : struct { }", "this.F<int>", "F<int>",
-                new[]
-                {
-                    // (6,34): error CS0123: No overload for 'F' matches delegate 'Action'
-                    //         System.Delegate d = this.F<int>;
-                    Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "F<int>").WithArguments("F", "System.Action").WithLocation(6, 34)
-                 }); // different type parameter constraints
 
             static object?[] getData(string methodA, string methodB, string methodGroupExpression, string methodGroupOnly, DiagnosticDescription[]? expectedDiagnostics = null, string? expectedMethod = null, string? expectedType = null)
             {
@@ -1840,13 +1986,54 @@ namespace N
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var expr = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single().Initializer!.Value;
+            var typeInfo = model.GetTypeInfo(expr);
+            Assert.Null(typeInfo.Type);
+            Assert.Equal(SpecialType.System_Delegate, typeInfo.ConvertedType!.SpecialType);
+
+            var symbolInfo = model.GetSymbolInfo(expr);
+            // https://github.com/dotnet/roslyn/issues/52870: GetSymbolInfo() should return resolved method from method group.
+            Assert.Null(symbolInfo.Symbol);
+        }
+
+        [Theory, CombinatorialData]
+        public void MethodGroup_ExtensionMethodsDifferentScope_CSharp13_9(bool useCSharp13)
+        {
+            var source = """
+using N;
+
+new Program().M();
+
+partial class Program
+{
+    public void M()
+    {
+        System.Delegate d = this.F<int>;
+        System.Console.Write("{0}: {1}", d.GetDelegateMethodName(), d.GetDelegateTypeName());
+    }
+}
+
+static class A
+{
+    internal static void F<T>(this T t) where T : class { }
+}
+namespace N
+{
+    static class B
+    {
+        internal static void F<T>(this T t) where T : struct { }
+    }
+}
+""";
+            var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
-                // 0.cs(1,1): hidden CS8019: Unnecessary using directive.
-                // using N;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1),
                 // 0.cs(9,34): error CS8917: The delegate type could not be inferred.
-                //         System.Delegate d = this.F;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "F").WithLocation(9, 34)
+                //         System.Delegate d = this.F<int>;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "F<int>").WithLocation(9, 34)
                 );
 
             var tree = comp.SyntaxTrees[0];
@@ -2291,9 +2478,6 @@ public static class E
         public void MethodGroup_ScopeByScope_NoTypeArguments_ExtensionMethodHasZeroArity(bool useCSharp13)
         {
             var source = """
-System.Action x = new C().M;
-x();
-
 var z = new C().M;
 z();
 
@@ -2306,31 +2490,27 @@ public static class E
 {
     public static void M(this C c)
     {
-        System.Console.Write("E.M ");
+        System.Console.Write("E.M");
     }
 }
 """;
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular12);
             comp.VerifyDiagnostics(
-                // (4,9): error CS8917: The delegate type could not be inferred.
+                // (1,9): error CS8917: The delegate type could not be inferred.
                 // var z = new C().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(4, 9)
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(1, 9)
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            comp.VerifyDiagnostics(
-                // (4,9): error CS8917: The delegate type could not be inferred.
-                // var z = new C().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(4, 9)
-                );
+            comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "new C().M").Last();
             var typeInfo = model.GetTypeInfo(memberAccess);
             Assert.Null(typeInfo.Type);
-            Assert.True(typeInfo.ConvertedType!.IsErrorType());
-            Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+            Assert.Equal("System.Action", typeInfo.ConvertedType!.ToTestDisplayString());
+            Assert.Equal("void C.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
             Assert.Equal(["void C.M<T>()", "void C.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
@@ -2369,19 +2549,15 @@ namespace N
                 );
 
             comp = CreateCompilation(source, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            comp.VerifyDiagnostics(
-                // (6,9): error CS8917: The delegate type could not be inferred.
-                // var z = new C().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(6, 9)
-                );
+            comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "new C().M").Last();
             var typeInfo = model.GetTypeInfo(memberAccess);
             Assert.Null(typeInfo.Type);
-            Assert.True(typeInfo.ConvertedType!.IsErrorType());
-            Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+            Assert.Equal("System.Action", typeInfo.ConvertedType!.ToTestDisplayString());
+            Assert.Equal("void C.M()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
             Assert.Equal(["void C.M<T>()", "void C.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
@@ -2423,10 +2599,7 @@ namespace N
             comp.VerifyDiagnostics(
                 // (1,1): hidden CS8019: Unnecessary using directive.
                 // using N;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1),
-                // (6,9): error CS8917: The delegate type could not be inferred.
-                // var z = new C().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(6, 9)
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N;").WithLocation(1, 1)
                 );
 
             var tree = comp.SyntaxTrees[0];
@@ -2434,8 +2607,8 @@ namespace N
             var memberAccess = GetSyntaxes<MemberAccessExpressionSyntax>(tree, "new C().M").Last();
             var typeInfo = model.GetTypeInfo(memberAccess);
             Assert.Null(typeInfo.Type);
-            Assert.True(typeInfo.ConvertedType!.IsErrorType());
-            Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+            Assert.Equal("System.Action", typeInfo.ConvertedType!.ToTestDisplayString());
+            Assert.Equal("void C.M<C>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
             Assert.Equal(["void C.M<C>()", "void C.M()"], model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
@@ -2643,11 +2816,15 @@ static class E
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (1,9): error CS8917: The delegate type could not be inferred.
-                // var d = new object().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new object().M").WithLocation(1, 9)
-                );
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+            Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+            Assert.Equal(new[] { "void System.Object.M<System.Object>()" }, model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
@@ -2668,11 +2845,46 @@ static class E
 }
 """;
             var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C<int, long>().M");
+            Assert.Equal("void C<System.Int32, System.Int64>.M<System.Int32, System.Int64>()",
+                model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+
+            Assert.Equal(new[] { "void C<System.Int32, System.Int64>.M<System.Int32, System.Int64>()" },
+                 model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
+        public void MethodGroup_GenericExtensionMethod_UnsubstitutedTypeParameter()
+        {
+            var source = """
+var d = new C().M;
+d();
+
+class C { }
+
+static class E
+{
+    public static void M<T>(this C c) { }
+}
+""";
+            var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (1,9): error CS8917: The delegate type could not be inferred.
-                // var d = new C<int, long>().M;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C<int, long>().M").WithLocation(1, 9)
+                // var d = new C().M;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M").WithLocation(1, 9)
                 );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M");
+            Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+            Assert.Equal(new[] { "void C.M<T>()" }, model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
@@ -2680,19 +2892,268 @@ static class E
         {
             var source = """
 var x = new C().M<int>;
+x();
+
+public class C
+{
+    public void M<T>()
+    {
+        System.Console.Write("ran");
+    }
+
+    public void M<T>(object o) where T : class { }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "ran");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<int>");
+            Assert.Equal("void C.M<System.Int32>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+
+            Assert.Equal(new[] { "void C.M<System.Int32>()", "void C.M<System.Int32>(System.Object o)" },
+                model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
+        public void MethodGroup_GenericInstanceMethod_Constraint_Nullability_Ambiguity()
+        {
+            var source = """
+#nullable enable
+var x = new C().M<object?>;
+x();
 
 public class C
 {
     public void M<T>() { }
+
     public void M<T>(object o) where T : class { }
 }
 """;
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (1,9): error CS8917: The delegate type could not be inferred.
-                // var x = new C().M<int>;
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M<int>").WithLocation(1, 9)
+                // (2,9): error CS8917: The delegate type could not be inferred.
+                // var x = new C().M<object?>;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().M<object?>").WithLocation(2, 9)
                 );
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<object?>");
+            Assert.Null(model.GetSymbolInfo(memberAccess).Symbol);
+
+            Assert.Equal(new[] { "void C.M<System.Object?>()", "void C.M<System.Object?>(System.Object o)" },
+                model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
+        public void MethodGroup_GenericInstanceMethod_Constraint_Nullability_Warn()
+        {
+            var source = """
+#nullable enable
+var x = new C().M<object?>;
+x();
+
+public class C
+{
+    public void M<T>() where T : class
+    {
+        System.Console.Write("ran");
+    }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C.M<T>()'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                // var x = new C().M<object?>;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "new C().M<object?>").WithArguments("C.M<T>()", "T", "object?").WithLocation(2, 9)
+                );
+            CompileAndVerify(comp, expectedOutput: "ran");
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new C().M<object?>");
+            Assert.Equal("void C.M<System.Object?>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+            Assert.Equal(new[] { "void C.M<System.Object?>()" }, model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
+        public void MethodGroup_GenericExtensionMethod_Constraint_ImplicitTypeArguments()
+        {
+            var source = """
+var x = new object().M;
+x();
+
+static class E1
+{
+    public static void M<T>(this T t)
+    {
+        System.Console.Write("ran");
+    }
+}
+
+static class E2
+{
+    public static void M<T>(this T t, object ignored) where T : struct { }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M");
+            Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+            Assert.Equal(new[] { "void System.Object.M<System.Object>()" }, model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69222")]
+        public void MethodGroup_GenericExtensionMethod_Constraint_ExplicitTypeArguments()
+        {
+            var source = """
+var x = new object().M<object>;
+x();
+
+static class E1
+{
+    public static void M<T>(this T t)
+    {
+        System.Console.Write("ran");
+    }
+}
+
+static class E2
+{
+    public static void M<T>(this T t, object ignored) where T : struct { }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            // ILVerify: Unrecognized arguments for delegate .ctor.
+            CompileAndVerify(comp, expectedOutput: "ran", verify: Verification.FailsILVerify);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = GetSyntax<MemberAccessExpressionSyntax>(tree, "new object().M<object>");
+            Assert.Equal("void System.Object.M<System.Object>()", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+
+            Assert.Equal(new[] { "void System.Object.M<System.Object>()", "void System.Object.M<System.Object>(System.Object ignored)" },
+                model.GetMemberGroup(memberAccess).ToTestDisplayStrings());
+        }
+
+        [Fact]
+        public void GenericExtensionMethod_ArityCountsInSignature()
+        {
+            // Arity counts as part of "signature" so we have two different signatures even after reducing extension methods
+            var source = """
+var x = new object().F;
+
+static class B
+{
+    internal static void F<T>(this T x) { }
+}
+
+static class A
+{
+    internal static void F(this object x) { }
+}
+""";
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,9): error CS8917: The delegate type could not be inferred.
+                // var x = new object().F;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new object().F").WithLocation(1, 9));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
+                // (1,9): error CS8917: The delegate type could not be inferred.
+                // var x = new object().F;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new object().F").WithLocation(1, 9));
+        }
+
+        [Fact]
+        public void GenericExtensionMethod_Constraint()
+        {
+            // In C# 12, a method group that cannot be successfully substituted (ie. respecting constraints)
+            // does not contribute to the natural type determination
+            var source = """
+var x = new C().F<object>;
+
+class C { }
+
+static class E
+{
+    public static void F<T>(this C c) where T : struct { }
+}
+""";
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,9): error CS0453: The type 'object' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'E.F<T>(C)'
+                // var x = new C().F<object>;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "new C().F<object>").WithArguments("E.F<T>(C)", "T", "object").WithLocation(1, 9));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
+                // (1,9): error CS8917: The delegate type could not be inferred.
+                // var x = new C().F<object>;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().F<object>").WithLocation(1, 9));
+        }
+
+        [Fact]
+        public void GenericInstanceMethod_Constraint()
+        {
+            // In C# 12, a method that cannot be successfully substituted (ie. respecting constraints)
+            // does not contribute to the natural type determination
+            var source = """
+var x = new C().F<object>;
+
+class C
+{
+    public void F<T>() where T : struct { }
+}
+""";
+            CreateCompilation(source, parseOptions: TestOptions.Regular11).VerifyDiagnostics(
+                // (1,9): error CS0453: The type 'object' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.F<T>()'
+                // var x = new C().F<object>;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "new C().F<object>").WithArguments("C.F<T>()", "T", "object").WithLocation(1, 9));
+
+            CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
+                // (1,9): error CS8917: The delegate type could not be inferred.
+                // var x = new C().F<object>;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "new C().F<object>").WithLocation(1, 9));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/csharplang/discussions/129")]
+        public void BoundInferenceFromMethodGroup()
+        {
+            var source = """
+int result1 = Test(IsEven); // 1
+bool result2 = Test2(IsEven);
+int result3 = Test3(IsEven); // 2
+bool result4 = Test4(IsEven);
+System.Func<int, bool> result5 = Test5(IsEven);
+
+delegate bool Predicate<T>(T t);
+delegate T Predicate2<T>(int i);
+
+partial class Program
+{
+    public static bool IsEven(int x) => x % 2 == 0;
+
+    public static T Test<T>(System.Func<T, bool> predicate) => throw null;
+    public static T Test2<T>(System.Func<int, T> predicate) => throw null;
+    public static T Test3<T>(Predicate<T> predicate) => throw null;
+    public static T Test4<T>(Predicate2<T> predicate) => throw null;
+    public static T Test5<T>(T predicate) => throw null;
+}
+""";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (1,15): error CS0411: The type arguments for method 'Program.Test<T>(Func<T, bool>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // int result1 = Test(IsEven); // 1
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test").WithArguments("Program.Test<T>(System.Func<T, bool>)").WithLocation(1, 15),
+                // (3,15): error CS0411: The type arguments for method 'Program.Test3<T>(Predicate<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // int result3 = Test3(IsEven); // 2
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test3").WithArguments("Program.Test3<T>(Predicate<T>)").WithLocation(3, 15));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -1971,24 +1971,26 @@ partial class Program
     public void M()
     {
         System.Delegate d = this.F;
+        d.DynamicInvoke();
         System.Console.Write("{0}: {1}", d.GetDelegateMethodName(), d.GetDelegateTypeName());
     }
 }
 
 static class A
 {
-    internal static void F<T>(this object x) { }
+    internal static void F<T>(this object x) => throw null;
 }
 namespace N
 {
     static class B
     {
-        internal static void F(this object x) { }
+        internal static void F(this object x) { System.Console.Write("RAN "); }
     }
 }
 """;
             var comp = CreateCompilation(new[] { source, s_utils }, parseOptions: useCSharp13 ? TestOptions.RegularNext : TestOptions.RegularPreview);
-            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "RAN N.B.F: System.Action");
+            verifier.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);


### PR DESCRIPTION
Speclet: https://github.com/dotnet/csharplang/blob/main/proposals/method-group-natural-type-improvements.md

There's three parts to this change:
1. we check whether generic extension methods can be fully substituted instead of checking for arity
2. we check for type constraints
3. both of those checks occur early (which allows pruning candidates within a given scope)

Relates to test plan https://github.com/dotnet/roslyn/issues/69432