### PR TITLE
Avoid array enumerator allocations in SimpleDiagnostic.Equals

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/ArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ArrayExtensions.cs
@@ -153,6 +153,29 @@ namespace Roslyn.Utilities
             return ~low;
         }
 
+        public static bool SequenceEqual<T>(this T[]? first, T[]? second, Func<T, T, bool> comparer)
+        {
+            RoslynDebug.Assert(comparer != null);
+
+            if (first == second)
+            {
+                return true;
+            }
+
+            if (first == null || second == null || first.Length != second.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < first.Length; i++)
+            {
+                if (!comparer(first[i], second[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Search a sorted integer array for the target value in O(log N) time.
         /// </summary>


### PR DESCRIPTION
Fixes 88GB allocations observed in an 80 second performance trace for the VS testing team. The allocations originated from this line:
https://github.com/dotnet/roslyn/blob/d0c8767ee096a3f8da001d9b12919b3078e38914/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs#L165