### PR TITLE
Fix constraint cycle through nested type of base type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -571,6 +571,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
+        /// <returns>
+        /// - 'true' if constraints disallow nullable reference types
+        /// - 'false' if constraints (or lack of constraints) permit nullable reference types
+        /// - 'null' if constrained to oblivious type
+        /// </returns>
         internal abstract bool? IsNotNullable { get; }
 
         public sealed override bool IsValueType

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected bool? CalculateIsNotNullableFromNonTypeConstraints()
+        internal bool? CalculateIsNotNullableFromNonTypeConstraints()
         {
             if (this.HasNotNullConstraint || this.HasValueTypeConstraint)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -948,7 +948,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private readonly TypeParameterSymbol _typeParameter;
             private int _resolved;
 
-
             public LazySubstitutedType(ImmutableArray<CustomModifier> customModifiers, TypeParameterSymbol typeParameter)
             {
                 Debug.Assert(!customModifiers.IsDefault);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -1005,12 +1005,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override TypeWithAnnotations AsNullableReferenceType(TypeWithAnnotations type)
             {
-                return type.AsNullableReferenceType();
+                return CreateNonLazyType(type.DefaultType, NullableAnnotation.Annotated, _customModifiers);
             }
 
             internal override TypeWithAnnotations AsNotNullableReferenceType(TypeWithAnnotations type)
             {
-                return type.AsNotNullableReferenceType();
+                var defaultType = type.DefaultType;
+                return CreateNonLazyType(defaultType, defaultType.IsNullableType() ? type.NullableAnnotation : NullableAnnotation.NotAnnotated, _customModifiers);
             }
 
             internal override void ReportDiagnosticsIfObsolete(TypeWithAnnotations type, Binder binder, SyntaxNode syntax, BindingDiagnosticBag diagnostics)


### PR DESCRIPTION
Closes #68223

The "unusual" logic we are trying to preserve is quite reasonable, although reading the original code might give one an incorrect impression that C# 8 compat was the motivation for the behavior.

Here's a relevant scenario ([SharpLab](https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQGED2AbbEDGMAlpgHYAyRMECU2yANDCEdgwCYgDUAPgMSk4uKMDwACCKRF4AsACgA9ArEAhKMghiYATwAOm3VFoBbCNQRjsUfAGtkYqGIACAJjH4yyGLSKkYAOjEAUSoACxoxQWFRTUwLUjJUKKsYrT1NIwBzOFM/ew8hdjFgTTgNdn95JTEAFXCkMDjNZDhgLyo4YlJMh1IxTFEiADcSMrT9BwRs3JgxJBbsGHtfXv7BkcwxnX1KuScAZjFfczBrTQBJPxpT/AgARgAeGoA+eQBveTEv50OasQAFBCYXRiN5iTJmADcYg0MGhAF9Pt95AIhClxOwiMhpBAkV8Ds47gA2ZwAFjEAFkXAAKS4nM6PdDPMTsGjDCDsACUeNB8hRyRxEikMR53xZbKGHP8gOBYgAvJE0ZCeYi5Kr+WjBZIcVVlGoNOMDEYoKZzEd8p5vFBfBytJhIokBaltpoAOToV27ap1GgQRpIGGtdrwLo9KB9AbYYajewuybTSSzeZCJZHPqOBKkJKa53pL3KACCYDNdDYWnC/QQREyvjo4rAvioJD6WK0EFwvh6WwrcYA7mRXbMwHBSIRm2JdED9AhsNojmAHIrouI+76J0CRqyKvICcdrmcxHT97cXE9mb36po/iAxOh3jyCX8ZSCwRC4TCoWJVWKNcvNJjsRFOQxQJJxiTJSkaSPBAbggU8mXFKtJS5HkPjkX90U0bUgLFMVWSQqVn3lJdsGhapeyMUhO1vABlAAOIkXAAVhvdBwwSWYPFISUEFmZJLCoGg6xge1M2zP85j9X1R00F1djFVV1TkVEJOw2Q9kOVxb1BL95CAA)):
```cs
#nullable enable
// Base type parameter lacks a class constraint. Either nullable or non-nullable type arguments could be used.
// Therefore substituting an oblivious type argument results in an oblivious type.
public interface Interface1<T>
{
    public T Prop { get; set; }
    
#nullable disable
    public static void M2(Interface1<C> derived)
    {

#nullable enable
        derived.Prop = null;
    }
}

#nullable enable
// Base type parameter is constrained to non-nullable type 'C'.
// Therefore substituting an oblivious type argument results in a non-nullable type.
// After all, the original definition is telling us the type won't function properly if a nullable type were provided.
public interface Interface2<T> where T : C
{
    public T Prop { get; set; }
    
#nullable disable
    public static void M2(Interface2<C> derived)
    {

#nullable enable
        derived.Prop = null; // warning CS8625: Cannot convert null literal to non-nullable reference type.
    }
}

#nullable enable
public class C { }
```

The trouble is, that this means that the nullable annotation of a type argument depends on the type constraints of the type parameter. As shown in the linked issue, when the type parameter is used as a type argument in one of its own constraints, you can get a cycle.

We break the cycle by identifying when a type argument's nullable annotation can't be determined until after binding type constraints, and making the nullable annotation lazy in that case.
