### PR TITLE
Exclude LSP projects from source build

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -44,6 +44,7 @@
         <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;alpine-x64;alpine-arm64;osx-x64;osx-arm64</RuntimeIdentifiers> 
         <!-- Publish ready to run executables when we're publishing platform specific executables. -->
         <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' Or '$(RestoreWithR2R)' == 'true'">true</PublishReadyToRun>
+        <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     </PropertyGroup>
 
     <ItemGroup Label="Project References">

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.Example/Microsoft.CommonLanguageServerProtocol.Framework.Example.csproj
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.Example/Microsoft.CommonLanguageServerProtocol.Framework.Example.csproj
@@ -7,6 +7,7 @@
     <IsShipping>false</IsShipping>
     <IsPackable>false</IsPackable>
     <PackageDescription>An example implementation of the Common Language Server Protocol Framework.</PackageDescription>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/Microsoft.CommonLanguageServerProtocol.Framework.csproj
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/Microsoft.CommonLanguageServerProtocol.Framework.csproj
@@ -8,6 +8,7 @@
     <PackageDescription>
       A framework for building Language Server Protocol implementations in C#.
     </PackageDescription>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="Utilities\IsExternalInit.cs" />

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -9,6 +9,7 @@
     <PackageDescription>
       .NET Compiler Platform ("Roslyn") support for Language Server Protocol.
     </PackageDescription>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Exclude LSP based projects from the source build to make sure that licensing for source build is correct. 

I'm updated the projects in LanguageServer. Let me know if there are other places I should look as well! 