### PR TITLE
Remove positive Unary expressions to avoid confusion in addition

### DIFF
--- a/src/Compilers/Test/Core/Metadata/ILValidation.cs
+++ b/src/Compilers/Test/Core/Metadata/ILValidation.cs
@@ -182,10 +182,10 @@ namespace Roslyn.Test.Utilities
                 + sizeof(int)                                  // Checksum
                 + sizeof(short)                                // Subsystem
                 + sizeof(short)                                // DllCharacteristics
-                + 4 * (is32bit ? sizeof(int) : sizeof(long)) + // SizeOfStackReserve, SizeOfStackCommit, SizeOfHeapReserve, SizeOfHeapCommit
-                +sizeof(int) +                                // LoaderFlags
-                +sizeof(int) +                                // NumberOfRvaAndSizes
-                +4 * sizeof(long);                            // directory entries before Authenticode
+                + 4 * (is32bit ? sizeof(int) : sizeof(long))   // SizeOfStackReserve, SizeOfStackCommit, SizeOfHeapReserve, SizeOfHeapCommit
+                + sizeof(int)                                  // LoaderFlags
+                + sizeof(int)                                  // NumberOfRvaAndSizes
+                + 4 * sizeof(long);                            // directory entries before Authenticode
         }
 
         private static MethodInfo s_peheaderSizeMethod;


### PR DESCRIPTION
A small cleanup to avoid having problems when updating this code. I think adding an analyzer to detect positive unary expressions in an addition expression would be helpful for others too.