### PR TITLE
Downgrade to non-scouting queue to unblock integration tests

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -56,7 +56,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022preview.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
Looks like the integration test queue updated yesterday causing failures in the tests.  Until the failures can be figured out, we should unblock CI by downgrading to the normal queue (which has the prior working version)