### PR TITLE
Reuse the workspace to better take advantage of caches when indexing

### DIFF
--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -94,6 +94,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 _ => throw new NotImplementedException()
             };
 
+            var totalExecutionTime = Stopwatch.StartNew();
+
             try
             {
                 // Exactly one of "solution", or "project" or "compilerInvocation" should be specified
@@ -141,7 +143,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             }
 
             (lsifWriter as IDisposable)?.Dispose();
-            await logFile.WriteLineAsync("Generation complete.");
+            await logFile.WriteLineAsync($"Generation complete. Total execution time: {totalExecutionTime.Elapsed.ToDisplayString()}");
         }
 
         private static async Task LocateAndRegisterMSBuild(TextWriter logFile, DirectoryInfo? sourceDirectory)

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 outputWriter = outputFile;
             }
 
-            using var logFile = log != null ? new StreamWriter(log) : TextWriter.Null;
+            using var logFile = log != null ? new StreamWriter(log) { AutoFlush = true } : TextWriter.Null;
             ILsifJsonWriter lsifWriter = outputFormat switch
             {
                 LsifFormat.Json => new JsonModeLsifJsonWriter(outputWriter),


### PR DESCRIPTION
When we were processing a binlog, we would create a workspace per project. This was't ideal, as it turns out this meant we wouldn't reuse caches for metadata references and documentation comments from one indexing job to the next.

Fixes https://github.com/dotnet/roslyn/issues/68750