### PR TITLE
Check  fo both csharp and visualbasic in IsCSharpOrVisualBasicSuperSet

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EditorConfig/Parsing/Sections/SectionMatcher.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EditorConfig/Parsing/Sections/SectionMatcher.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.EditorConfig.Parsing
                !pattern.Contains(DefaultVisualBasicExtensionWithoutDot);
 
         private static bool IsCSharpOrVisualBasicSuperSet(Language language, string pattern)
-            => language.HasFlag(Language.VisualBasic) && language.HasFlag(Language.VisualBasic) &&
+            => language.HasFlag(Language.VisualBasic) && language.HasFlag(Language.CSharp) &&
                !(pattern.Contains(DefaultCSharpExtensionWithoutDot) && pattern.Contains(DefaultVisualBasicExtensionWithoutDot));
 
         private bool IsPathMatch(string s)


### PR DESCRIPTION
It probably should check both visual basic and csharp in this method instead of checking visual basic twice.