### PR TITLE
Also downgrade corehost to normal queue to avoid issues in new VS version

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -59,7 +59,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.scout.amd64.open
+  default: windows.vs2022preview.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
same as https://github.com/dotnet/roslyn/pull/69262 but for the corehost leg as well