### PR TITLE
Preserve formatting when converting array-expressions to collection-expressions.

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -150,7 +150,9 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider : Sy
 
                     return shouldReplaceExpressionEntirely
                         ? collectionExpression.WithTriviaFrom(currentArrayCreation)
-                        : collectionExpression.WithPrependedLeadingTrivia(currentArrayCreation.Type.GetTrailingTrivia());
+                        : collectionExpression
+                            .WithPrependedLeadingTrivia(currentArrayCreation.Type.GetTrailingTrivia())
+                            .WithPrependedLeadingTrivia(ElasticMarker);
                 });
         }
 
@@ -172,7 +174,9 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider : Sy
 
                     return shouldReplaceExpressionEntirely
                         ? collectionExpression.WithTriviaFrom(currentArrayCreation)
-                        : collectionExpression.WithPrependedLeadingTrivia(currentArrayCreation.CloseBracketToken.TrailingTrivia);
+                        : collectionExpression
+                            .WithPrependedLeadingTrivia(currentArrayCreation.CloseBracketToken.TrailingTrivia)
+                            .WithPrependedLeadingTrivia(ElasticMarker);
                 });
         }
     }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -243,7 +243,8 @@ public class UseCollectionExpressionForArray
             FixedCode = """
                 class C
                 {
-                    object[] i = [
+                    object[] i =
+                    [
                         ""
                     ];
                 }
@@ -347,7 +348,8 @@ public class UseCollectionExpressionForArray
             FixedCode = """
                 class C
                 {
-                    string[] i = [
+                    string[] i =
+                    [
                         ""
                     ];
                 }
@@ -1420,7 +1422,7 @@ public class UseCollectionExpressionForArray
             FixedCode = """
                 class C
                 {
-                    int[] i = 
+                    int[] i =
                     [
                         1, 2, 3
                     ];
@@ -1681,7 +1683,7 @@ public class UseCollectionExpressionForArray
             FixedCode = """
                 class C
                 {
-                    int[] i = 
+                    int[] i =
                     [
                         1, 2, 3
                     ];

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -1133,4 +1133,726 @@ public class UseCollectionExpressionForArray
             LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestInitializerFormatting1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|{|]
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                        [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting1_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = 
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|] int[]|]
+                        {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|] int[]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting9_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting10_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                    [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting1_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = 
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|][]|]
+                        {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|][]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting9_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting10_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                    [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
This is work so that the collection-expression we produce is as close as possible to the user's original code as possible.  Importantly, a major tenet of this is that we want the `[ ]` braces of the collection expression to correspond to where the `{ }` braces were in the original expression if present.

This PR is just for array expressions: `{ ... }`, `new T[] { ... }`, `new[] { ... }`.

This will also apply in future PRs that deal with converting collection initializers `new X() { ... }` to collection expressions.  