### PR TITLE
Add support for generating the `.. x ? [y] : []` pattern in a collection-expression

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -83,6 +83,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\CSharpUseCollectionInitializerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\Utilities.cs" />

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -21,6 +21,9 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         VariableDeclaratorSyntax,
         CSharpUseCollectionInitializerAnalyzer>
 {
+    protected override bool IsComplexElementInitializer(SyntaxNode expression)
+        => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);
+
     protected override void GetPartsOfForeachStatement(
         ForEachStatementSyntax statement,
         out SyntaxToken identifier,
@@ -36,11 +39,11 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         IfStatementSyntax statement,
         out ExpressionSyntax condition,
         out IEnumerable<StatementSyntax> whenTrueStatements,
-        out IEnumerable<StatementSyntax> whenFalseStatements)
+        out IEnumerable<StatementSyntax>? whenFalseStatements)
     {
         condition = statement.Condition;
         whenTrueStatements = ExtractEmbeddedStatements(statement.Statement);
-        whenFalseStatements = statement.Else != null ? ExtractEmbeddedStatements(statement.Else.Statement) : SpecializedCollections.EmptyEnumerable<StatementSyntax>();
+        whenFalseStatements = statement.Else != null ? ExtractEmbeddedStatements(statement.Else.Statement) : null;
     }
 
     private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -11,15 +11,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 
 internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollectionInitializerAnalyzer<
     ExpressionSyntax,
-        StatementSyntax,
-        BaseObjectCreationExpressionSyntax,
-        MemberAccessExpressionSyntax,
-        InvocationExpressionSyntax,
-        ExpressionStatementSyntax,
-        ForEachStatementSyntax,
-        IfStatementSyntax,
-        VariableDeclaratorSyntax,
-        CSharpUseCollectionInitializerAnalyzer>
+    StatementSyntax,
+    BaseObjectCreationExpressionSyntax,
+    MemberAccessExpressionSyntax,
+    InvocationExpressionSyntax,
+    ExpressionStatementSyntax,
+    ForEachStatementSyntax,
+    IfStatementSyntax,
+    VariableDeclaratorSyntax,
+    CSharpUseCollectionInitializerAnalyzer>
 {
     protected override bool IsComplexElementInitializer(SyntaxNode expression)
         => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.UseCollectionInitializer;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
+
+internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollectionInitializerAnalyzer<
+    ExpressionSyntax,
+        StatementSyntax,
+        BaseObjectCreationExpressionSyntax,
+        MemberAccessExpressionSyntax,
+        InvocationExpressionSyntax,
+        ExpressionStatementSyntax,
+        ForEachStatementSyntax,
+        IfStatementSyntax,
+        VariableDeclaratorSyntax,
+        CSharpUseCollectionInitializerAnalyzer>
+{
+    protected override void GetPartsOfForeachStatement(
+        ForEachStatementSyntax statement,
+        out SyntaxToken identifier,
+        out ExpressionSyntax expression,
+        out IEnumerable<StatementSyntax> statements)
+    {
+        identifier = statement.Identifier;
+        expression = statement.Expression;
+        statements = ExtractEmbeddedStatements(statement.Statement);
+    }
+
+    protected override void GetPartsOfIfStatement(
+        IfStatementSyntax statement,
+        out ExpressionSyntax condition,
+        out IEnumerable<StatementSyntax> whenTrueStatements,
+        out IEnumerable<StatementSyntax> whenFalseStatements)
+    {
+        condition = statement.Condition;
+        whenTrueStatements = ExtractEmbeddedStatements(statement.Statement);
+        whenFalseStatements = statement.Else != null ? ExtractEmbeddedStatements(statement.Else.Statement) : SpecializedCollections.EmptyEnumerable<StatementSyntax>();
+    }
+
+    private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)
+        => embeddedStatement is BlockSyntax block ? block.Statements : SpecializedCollections.SingletonEnumerable(embeddedStatement);
+}

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -44,5 +44,5 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
         => CSharpSyntaxFacts.Instance;
 
     protected override bool CanUseCollectionExpression(SemanticModel semanticModel, BaseObjectCreationExpressionSyntax objectCreationExpression, CancellationToken cancellationToken)
-        => UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(semanticModel, objectCreationExpression, skipVerificationForReplacedNode: false, cancellationToken);
+        => UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(semanticModel, objectCreationExpression, skipVerificationForReplacedNode: true, cancellationToken);
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.UseCollectionExpression;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -11,11 +12,12 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal class CSharpUseCollectionInitializerDiagnosticAnalyzer :
+internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
     AbstractUseCollectionInitializerDiagnosticAnalyzer<
         SyntaxKind,
         ExpressionSyntax,
@@ -25,8 +27,13 @@ internal class CSharpUseCollectionInitializerDiagnosticAnalyzer :
         InvocationExpressionSyntax,
         ExpressionStatementSyntax,
         ForEachStatementSyntax,
-        VariableDeclaratorSyntax>
+        IfStatementSyntax,
+        VariableDeclaratorSyntax,
+        CSharpUseCollectionInitializerAnalyzer>
 {
+    protected override CSharpUseCollectionInitializerAnalyzer GetAnalyzer()
+        => CSharpUseCollectionInitializerAnalyzer.Allocate();
+
     protected override bool AreCollectionInitializersSupported(Compilation compilation)
         => compilation.LanguageVersion() >= LanguageVersion.CSharp3;
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
@@ -33,13 +33,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
             InvocationExpressionSyntax,
             ExpressionStatementSyntax,
             ForEachStatementSyntax,
-            VariableDeclaratorSyntax>
+            IfStatementSyntax,
+            VariableDeclaratorSyntax,
+            CSharpUseCollectionInitializerAnalyzer>
     {
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpUseCollectionInitializerCodeFixProvider()
         {
         }
+
+        protected override CSharpUseCollectionInitializerAnalyzer GetAnalyzer()
+            => CSharpUseCollectionInitializerAnalyzer.Allocate();
 
         protected override StatementSyntax GetNewStatement(
             SourceText sourceText,

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -67,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
             ImmutableArray<Match<StatementSyntax>> matches)
         {
             return useCollectionExpression
-                ? CreateCollectionExpression(objectCreation, matches, MakeMultiLine(sourceText, objectCreation, matches, wrappingLength))
+                ? CreateCollectionExpression(sourceText, objectCreation, wrappingLength, matches)
                 : CreateObjectInitializerExpression(objectCreation, matches);
         }
 
@@ -81,15 +83,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
         }
 
         private static CollectionExpressionSyntax CreateCollectionExpression(
+            SourceText sourceText,
             BaseObjectCreationExpressionSyntax objectCreation,
-            ImmutableArray<Match<StatementSyntax>> matches,
-            bool makeMultiLine)
+            int wrappingLength,
+            ImmutableArray<Match<StatementSyntax>> matches)
         {
             var elements = CreateElements<CollectionElementSyntax>(
                 objectCreation, matches,
                 static (match, expression) => match?.UseSpread is true ? SpreadElement(expression) : ExpressionElement(expression));
 
-            if (makeMultiLine)
+            if (MakeMultiLine(sourceText, objectCreation, matches, wrappingLength))
                 elements = AddLineBreaks(elements, includeFinalLineBreak: false);
 
             return CollectionExpression(elements).WithTriviaFrom(objectCreation);
@@ -145,41 +148,47 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
             if (!sourceText.AreOnSameLine(objectCreation.GetFirstToken(), objectCreation.GetLastToken()))
                 return true;
 
-            foreach (var match in matches)
-            {
-                var expression = GetExpression(match);
-
-                // If we have anything like: `new Dictionary<X,Y> { { A, B }, { C, D } }` then always make multiline.
-                // Similarly, if we have `new Dictionary<X,Y> { [A] = B }`.
-                if (expression is InitializerExpressionSyntax or AssignmentExpressionSyntax)
-                    return true;
-
-                // if any of the expressions we're adding are multiline, then make things multiline.
-                if (!sourceText.AreOnSameLine(expression.GetFirstToken(), expression.GetLastToken()))
-                    return true;
-            }
-
             var totalLength = "{}".Length;
             foreach (var match in matches)
             {
-                var expression = GetExpression(match);
-                totalLength += expression.Span.Length;
-                totalLength += ", ".Length;
+                foreach (var component in GetElementComponents(match.Statement))
+                {
+                    // if any of the expressions we're adding are multiline, then make things multiline.
+                    if (!sourceText.AreOnSameLine(component.GetFirstToken(), component.GetLastToken()))
+                        return true;
 
-                if (totalLength > wrappingLength)
-                    return true;
+                    totalLength += component.Span.Length;
+                    totalLength += ", ".Length;
+
+                    if (totalLength > wrappingLength)
+                        return true;
+                }
             }
 
             return false;
 
-            static ExpressionSyntax GetExpression(Match<StatementSyntax> match)
-                => match.Statement switch
+            static IEnumerable<SyntaxNode> GetElementComponents(StatementSyntax statement)
+            {
+                if (statement is ExpressionStatementSyntax expressionStatement)
                 {
-                    ExpressionStatementSyntax expressionStatement => expressionStatement.Expression,
-                    ForEachStatementSyntax foreachStatement => foreachStatement.Expression,
-                    _ => throw ExceptionUtilities.Unreachable(),
-                };
+                    yield return expressionStatement.Expression;
+                }
+                else if (statement is ForEachStatementSyntax foreachStatement)
+                {
+                    yield return foreachStatement.Expression;
+                }
+                else if (statement is IfStatementSyntax ifStatement)
+                {
+                    yield return ifStatement.Condition;
+                    yield return UnwrapEmbeddedStatement(ifStatement.Statement);
+                    if (ifStatement.Else != null)
+                        yield return UnwrapEmbeddedStatement(ifStatement.Else.Statement);
+                }
+            }
         }
+
+        private static StatementSyntax UnwrapEmbeddedStatement(StatementSyntax statement)
+            => statement is BlockSyntax { Statements: [var innerStatement] } ? innerStatement : statement;
 
         public static SeparatedSyntaxList<TNode> AddLineBreaks<TNode>(
             SeparatedSyntaxList<TNode> nodes, bool includeFinalLineBreak)
@@ -212,7 +221,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
         {
             using var _ = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(out var nodesAndTokens);
 
-            UseInitializerHelpers.AddExistingItems(objectCreation, nodesAndTokens, createElement);
+            UseInitializerHelpers.AddExistingItems(
+                objectCreation, nodesAndTokens, addTrailingComma: matches.Length > 0, createElement);
 
             for (var i = 0; i < matches.Length; i++)
             {
@@ -243,6 +253,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
                 else if (statement is ForEachStatementSyntax foreachStatement)
                 {
                     nodesAndTokens.Add(createElement(match, foreachStatement.Expression.WithoutTrivia()));
+                    if (i < matches.Length - 1)
+                        nodesAndTokens.Add(Token(SyntaxKind.CommaToken));
+                }
+                else if (statement is IfStatementSyntax ifStatement)
+                {
+                    var trueStatement = (ExpressionStatementSyntax)UnwrapEmbeddedStatement(ifStatement.Statement);
+
+                    if (ifStatement.Else is null)
+                    {
+                        // Create: x ? [y] : []
+                        var expression = ConditionalExpression(
+                            ifStatement.Condition.Parenthesize(),
+                            CollectionExpression(SingletonSeparatedList<CollectionElementSyntax>(ExpressionElement(ConvertExpression(trueStatement.Expression)))),
+                            CollectionExpression());
+                        nodesAndTokens.Add(createElement(match, expression));
+                    }
+                    else
+                    {
+                        // Create: x ? y : z
+                        var falseStatement = (ExpressionStatementSyntax)UnwrapEmbeddedStatement(ifStatement.Else.Statement);
+                        var expression = ConditionalExpression(ifStatement.Condition.Parenthesize(), ConvertExpression(trueStatement.Expression), ConvertExpression(falseStatement.Expression));
+                        nodesAndTokens.Add(createElement(match, expression));
+                    }
+
                     if (i < matches.Length - 1)
                         nodesAndTokens.Add(Token(SyntaxKind.CommaToken));
                 }

--- a/src/Analyzers/CSharp/CodeFixes/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
             using var _ = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(out var nodesAndTokens);
 
             UseInitializerHelpers.AddExistingItems<ObjectInitializerMatch, ExpressionSyntax>(
-                objectCreation, nodesAndTokens, static (_, e) => e);
+                objectCreation, nodesAndTokens, addTrailingComma: true, static (_, e) => e);
 
             for (var i = 0; i < matches.Length; i++)
             {

--- a/src/Analyzers/CSharp/CodeFixes/UseObjectInitializer/UseInitializerHelpers.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseObjectInitializer/UseInitializerHelpers.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
         public static void AddExistingItems<TMatch, TElementSyntax>(
             BaseObjectCreationExpressionSyntax objectCreation,
             ArrayBuilder<SyntaxNodeOrToken> nodesAndTokens,
+            bool addTrailingComma,
             Func<TMatch?, ExpressionSyntax, TElementSyntax> createElement)
             where TMatch : struct
             where TElementSyntax : SyntaxNode
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
 
             // If we have an odd number of elements already, add a comma at the end so that we can add the rest of the
             // items afterwards without a syntax issue.
-            if (nodesAndTokens.Count % 2 == 1)
+            if (addTrailingComma && nodesAndTokens.Count % 2 == 1)
             {
                 var last = nodesAndTokens.Last();
                 nodesAndTokens.RemoveLast();

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -155,6 +155,122 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCollectionInitialize
         }
 
         [Fact]
+        public async Task TestOnVariableDeclarator_If1()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = [|new|] List<int>();
+                        [|c.Add(|]1);
+                        if (b)
+                            c.Add(2);
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = new List<int>
+                        {
+                            1
+                        };
+                        if (b)
+                            c.Add(2);
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestOnVariableDeclarator_If2()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = [|new|] List<int>();
+                        [|c.Add(|]1);
+                        if (b)
+                            c.Add(2);
+                        else
+                            c.Add(3);
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = new List<int>
+                        {
+                            1
+                        };
+                        if (b)
+                            c.Add(2);
+                        else
+                            c.Add(3);
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestOnVariableDeclarator_If3()
+        {
+            await TestInRegularAndScriptAsync(
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = [|new|] List<int>();
+                        [|c.Add(|]1);
+                        if (b)
+                        {
+                            c.Add(2);
+                        }
+                    }
+                }
+                """,
+                """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    void M(bool b)
+                    {
+                        var c = new List<int>
+                        {
+                            1
+                        };
+                        if (b)
+                        {
+                            c.Add(2);
+                        }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
         public async Task TestIndexAccess1()
         {
             await TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -97,7 +97,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             """);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69277")]
     public async Task TestOnVariableDeclarator_If1()
     {
         await TestInRegularAndScriptAsync(
@@ -108,7 +108,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(bool b)
                 {
-                    var c = [|new|] List<int>();
+                    List<int> c = [|new|] List<int>();
                     [|c.Add(|]1);
                     if (b)
                         c.Add(2);
@@ -120,14 +120,9 @@ public partial class UseCollectionInitializerTests_CollectionExpression
 
             class C
             {
-                void M()
+                void M(bool b)
                 {
-                    List<int> c = new List<int>
-                    {
-                        1
-                    };
-                    if (b)
-                        c.Add(2);
+                    List<int> c = [1, .. {|CS0173:b ? [2] : []|}];
                 }
             }
             """);
@@ -144,7 +139,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(bool b)
                 {
-                    var c = [|new|] List<int>();
+                    List<int> c = [|new|] List<int>();
                     [|c.Add(|]1);
                     if (b)
                         c.Add(2);
@@ -158,22 +153,15 @@ public partial class UseCollectionInitializerTests_CollectionExpression
 
             class C
             {
-                void M()
+                void M(bool b)
                 {
-                    List<int> c = new List<int>
-                    {
-                        1
-                    };
-                    if (b)
-                        c.Add(2);
-                    else
-                        c.Add(3);
+                    List<int> c = [1, b ? 2 : 3];
                 }
             }
             """);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69277")]
     public async Task TestOnVariableDeclarator_If3()
     {
         await TestInRegularAndScriptAsync(
@@ -198,16 +186,9 @@ public partial class UseCollectionInitializerTests_CollectionExpression
 
             class C
             {
-                void M()
+                void M(bool b)
                 {
-                    List<int> c = new List<int>
-                    {
-                        1
-                    };
-                    if (b)
-                    {
-                        c.Add(2);
-                    }
+                    List<int> c = [1, .. {|CS0173:b ? [2] : []|}];
                 }
             }
             """);
@@ -242,12 +223,66 @@ public partial class UseCollectionInitializerTests_CollectionExpression
 
             class C
             {
-                void M()
+                void M(bool b)
                 {
-                    List<int> c = new List<int>
+                    List<int> c = [1, b ? 2 : 3];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If5()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
                     {
-                        1
-                    };
+                        c.Add(2);
+                        c.Add(3);
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [1];
+                    if (b)
+                    {
+                        c.Add(2);
+                        c.Add(3);
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If6()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
                     if (b)
                     {
                         c.Add(2);
@@ -255,6 +290,105 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                     else
                     {
                         c.Add(3);
+                        c.Add(4);
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [1];
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                    else
+                    {
+                        c.Add(3);
+                        c.Add(4);
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If7()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                    {
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [1];
+                    if (b)
+                    {
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If8()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                    else
+                    {
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [1];
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                    else
+                    {
                     }
                 }
             }
@@ -1053,9 +1187,9 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     }
 
     [Fact]
-    public async Task TestNotOnNamedArg()
+    public async Task TestOnNamedArg()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -1063,7 +1197,19 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = new List<int>();
+                    List<int> c = [|new|] List<int>();
+                    c.Add(item: 1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [];
                     c.Add(item: 1);
                 }
             }
@@ -1516,9 +1662,9 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     }
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17823")]
-    public async Task TestMissingWhenReferencedInInitializer()
+    public async Task TestWhenReferencedInInitializer()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -1526,7 +1672,19 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 static void M()
                 {
-                    List<object> items = new List<object>();
+                    List<object> items = [|new|] List<object>();
+                    items[0] = items[0];
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                static void M()
+                {
+                    List<object> items = [];
                     items[0] = items[0];
                 }
             }
@@ -1645,7 +1803,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/18260")]
     public async Task TestFieldReference()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -1654,7 +1812,20 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 private List<int> myField;
                 void M()
                 {
-                    myField = new List<int>();
+                    myField = [|new|] List<int>();
+                    myField.Add(this.myField.Count);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                private List<int> myField;
+                void M()
+                {
+                    myField = [];
                     myField.Add(this.myField.Count);
                 }
             }
@@ -1965,5 +2136,165 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             List<int> list = [1];
 
             """, OutputKind.ConsoleApplication);
+    }
+
+    [Fact]
+    public async Task TestUpdateExistingCollectionInitializerToExpression1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>();
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestUpdateExistingCollectionInitializerToExpression2()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>()
+                    {
+                        1
+                    };
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [1
+            ];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestUpdateExistingCollectionInitializerToExpression3()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>()
+                    {
+                        1,
+                    };
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [1,
+                    ];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestUpdateExistingCollectionInitializerToExpression4()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>()
+                    {
+                        1,
+                        2
+                    };
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [1,
+                        2
+            ];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestUpdateExistingCollectionInitializerToExpression5()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>()
+                    {
+                        1,
+                        2,
+                    };
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [1,
+                        2,
+                    ];
+                }
+            }
+            """);
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -98,6 +98,170 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     }
 
     [Fact]
+    public async Task TestOnVariableDeclarator_If1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    var c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                        c.Add(2);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = new List<int>
+                    {
+                        1
+                    };
+                    if (b)
+                        c.Add(2);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If2()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    var c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                        c.Add(2);
+                    else
+                        c.Add(3);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = new List<int>
+                    {
+                        1
+                    };
+                    if (b)
+                        c.Add(2);
+                    else
+                        c.Add(3);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If3()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = new List<int>
+                    {
+                        1
+                    };
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestOnVariableDeclarator_If4()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(bool b)
+                {
+                    List<int> c = [|new|] List<int>();
+                    [|c.Add(|]1);
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                    else
+                    {
+                        c.Add(3);
+                    }
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = new List<int>
+                    {
+                        1
+                    };
+                    if (b)
+                    {
+                        c.Add(2);
+                    }
+                    else
+                    {
+                        c.Add(3);
+                    }
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task TestOnVariableDeclaratorDifferentType()
     {
         await TestInRegularAndScriptAsync(

--- a/src/Analyzers/Core/Analyzers/Analyzers.projitems
+++ b/src/Analyzers/Core/Analyzers/Analyzers.projitems
@@ -82,7 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\AbstractUseCoalesceExpressionForNullableTernaryConditionalCheckDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractObjectCreationExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractUseCollectionInitializerDiagnosticAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\UseCollectionInitializerAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractUseCollectionInitializerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\UseCollectionInitializerHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\UseCompoundAssignmentUtilities.cs" />

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
@@ -38,6 +38,9 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         {
         }
 
+        protected abstract bool ShouldAnalyze();
+        protected abstract void AddMatches(ArrayBuilder<TMatch> matches);
+
         public void Initialize(
             SemanticModel semanticModel,
             ISyntaxFacts syntaxFacts,
@@ -63,9 +66,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             _valuePattern = default;
             _initializedSymbol = null;
         }
-
-        protected abstract bool ShouldAnalyze();
-        protected abstract void AddMatches(ArrayBuilder<TMatch> matches);
 
         protected ImmutableArray<TMatch> AnalyzeWorker()
         {

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractObjectCreationExpressionAnalyzer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         }
 
         protected abstract bool ShouldAnalyze();
-        protected abstract void AddMatches(ArrayBuilder<TMatch> matches);
+        protected abstract bool TryAddMatches(ArrayBuilder<TMatch> matches);
 
         public void Initialize(
             SemanticModel semanticModel,
@@ -83,7 +83,9 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             }
 
             using var _ = ArrayBuilder<TMatch>.GetInstance(out var matches);
-            AddMatches(matches);
+            if (!TryAddMatches(matches))
+                return default;
+
             return matches.ToImmutable();
         }
 

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -13,7 +14,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 {
-    internal sealed class UseCollectionInitializerAnalyzer<
+    internal abstract class AbstractUseCollectionInitializerAnalyzer<
         TExpressionSyntax,
         TStatementSyntax,
         TObjectCreationExpressionSyntax,
@@ -22,12 +23,13 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         TExpressionStatementSyntax,
         TForeachStatementSyntax,
         TIfStatementSyntax,
-        TVariableDeclaratorSyntax> : AbstractObjectCreationExpressionAnalyzer<
+        TVariableDeclaratorSyntax,
+        TAnalyzer> : AbstractObjectCreationExpressionAnalyzer<
             TExpressionSyntax,
             TStatementSyntax,
             TObjectCreationExpressionSyntax,
             TVariableDeclaratorSyntax,
-            Match<TStatementSyntax>>
+            Match<TStatementSyntax>>, IDisposable
         where TExpressionSyntax : SyntaxNode
         where TStatementSyntax : SyntaxNode
         where TObjectCreationExpressionSyntax : TExpressionSyntax
@@ -37,9 +39,21 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         where TForeachStatementSyntax : TStatementSyntax
         where TIfStatementSyntax : TStatementSyntax
         where TVariableDeclaratorSyntax : SyntaxNode
+        where TAnalyzer : AbstractUseCollectionInitializerAnalyzer<
+            TExpressionSyntax,
+            TStatementSyntax,
+            TObjectCreationExpressionSyntax,
+            TMemberAccessExpressionSyntax,
+            TInvocationExpressionSyntax,
+            TExpressionStatementSyntax,
+            TForeachStatementSyntax,
+            TIfStatementSyntax,
+            TVariableDeclaratorSyntax,
+            TAnalyzer>, new()
     {
-        private static readonly ObjectPool<UseCollectionInitializerAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TIfStatementSyntax, TVariableDeclaratorSyntax>> s_pool
-            = SharedPools.Default<UseCollectionInitializerAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TIfStatementSyntax, TVariableDeclaratorSyntax>>();
+        private static readonly ObjectPool<TAnalyzer> s_pool = SharedPools.Default<TAnalyzer>();
+
+        public abstract void Dispose();
 
         public static ImmutableArray<Match<TStatementSyntax>> Analyze(
             SemanticModel semanticModel,

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -17,6 +17,16 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 {
+    /// <summary>
+    /// Represents statements following an object initializer that should be converted into
+    /// collection-initializer/expression elements.
+    /// </summary>
+    /// <param name="Statement">The statement that follows that contains the values to add to the new
+    /// collection-initializer or collection-expression</param>
+    /// <param name="UseSpread">Whether or not a spread (<c>.. x</c>) element should be created for this statement. This
+    /// is needed as the statement could be cases like <c>expr.Add(x)</c> vs. <c>expr.AddRange(x)</c>. This property
+    /// indicates that the latter should become a spread, without the consumer having to reexamine the statement to see
+    /// what form it is.</param>
     internal readonly record struct Match<TStatementSyntax>(
         TStatementSyntax Statement,
         bool UseSpread) where TStatementSyntax : SyntaxNode;
@@ -158,7 +168,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             (ImmutableArray<Match<TStatementSyntax>> matches, bool shouldUseCollectionExpression)? GetCollectionInitializerMatches()
             {
                 var matches = UseCollectionInitializerAnalyzer<
-                    TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
+                    TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TIfStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
                     semanticModel, GetSyntaxFacts(), objectCreationExpression, areCollectionExpressionsSupported: false, cancellationToken);
 
                 // If analysis failed, we can't change this, no matter what.
@@ -181,7 +191,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                     return null;
 
                 var matches = UseCollectionInitializerAnalyzer<
-                    TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
+                    TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TIfStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
                     semanticModel, GetSyntaxFacts(), objectCreationExpression, areCollectionExpressionsSupported: true, cancellationToken);
 
                 // If analysis failed, we can't change this, no matter what.

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             return !_syntaxFacts.IsObjectCollectionInitializer(_syntaxFacts.GetInitializerOfBaseObjectCreationExpression(_objectCreationExpression));
         }
 
-        protected override void AddMatches(ArrayBuilder<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches)
+        protected override bool TryAddMatches(ArrayBuilder<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches)
         {
             // If containing statement is inside a block (e.g. method), than we need to iterate through its child statements.
             // If containing statement is in top-level code, than we need to iterate through child statements of containing compilation unit.
@@ -180,6 +180,8 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 matches.Add(new Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>(
                     statement, leftMemberAccess, rightExpression, typeMember?.Name ?? identifier.ValueText));
             }
+
+            return true;
         }
 
         private static bool IsExplicitlyImplemented(

--- a/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         TInvocationExpressionSyntax,
         TExpressionStatementSyntax,
         TForeachStatementSyntax,
+        TIfStatementSyntax,
         TVariableDeclaratorSyntax>
         : SyntaxEditorBasedCodeFixProvider
         where TSyntaxKind : struct
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         where TInvocationExpressionSyntax : TExpressionSyntax
         where TExpressionStatementSyntax : TStatementSyntax
         where TForeachStatementSyntax : TStatementSyntax
+        where TIfStatementSyntax : TStatementSyntax
         where TVariableDeclaratorSyntax : SyntaxNode
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 var (originalObjectCreation, useCollectionExpression) = originalObjectCreationNodes.Pop();
                 var objectCreation = currentRoot.GetCurrentNodes(originalObjectCreation).Single();
 
-                var matches = UseCollectionInitializerAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
+                var matches = UseCollectionInitializerAnalyzer<TExpressionSyntax, TStatementSyntax, TObjectCreationExpressionSyntax, TMemberAccessExpressionSyntax, TInvocationExpressionSyntax, TExpressionStatementSyntax, TForeachStatementSyntax, TIfStatementSyntax, TVariableDeclaratorSyntax>.Analyze(
                     semanticModel, syntaxFacts, objectCreation, useCollectionExpression, cancellationToken);
 
                 if (matches.IsDefaultOrEmpty)

--- a/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
                 var matches = analyzer.Analyze(semanticModel, syntaxFacts, objectCreation, useCollectionExpression, cancellationToken);
 
-                if (matches.IsDefaultOrEmpty)
+                if (matches.IsDefault)
                     continue;
 
                 var statement = objectCreation.FirstAncestorOrSelf<TStatementSyntax>();

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -28,5 +28,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             ' Only called for collection expressions, which VB does not support
             Throw ExceptionUtilities.Unreachable()
         End Sub
+
+        Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode) As Boolean
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
+        End Function
     End Class
 End Namespace

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -1,0 +1,32 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.UseCollectionInitializer
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
+    Friend NotInheritable Class VisualBasicCollectionInitializerAnalyzer
+        Inherits AbstractUseCollectionInitializerAnalyzer(Of
+            ExpressionSyntax,
+            StatementSyntax,
+            ObjectCreationExpressionSyntax,
+            MemberAccessExpressionSyntax,
+            InvocationExpressionSyntax,
+            ExpressionStatementSyntax,
+            ForEachStatementSyntax,
+            IfStatementSyntax,
+            VariableDeclaratorSyntax,
+            VisualBasicCollectionInitializerAnalyzer)
+
+        Protected Overrides Sub GetPartsOfForeachStatement(statement As ForEachStatementSyntax, ByRef identifier As SyntaxToken, ByRef expression As ExpressionSyntax, ByRef statements As IEnumerable(Of StatementSyntax))
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
+        End Sub
+
+        Protected Overrides Sub GetPartsOfIfStatement(statement As IfStatementSyntax, ByRef condition As ExpressionSyntax, ByRef whenTrueStatements As IEnumerable(Of StatementSyntax), ByRef whenFalseStatements As IEnumerable(Of StatementSyntax))
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
+        End Sub
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-    Friend Class VisualBasicUseCollectionInitializerDiagnosticAnalyzer
+    Friend NotInheritable Class VisualBasicUseCollectionInitializerDiagnosticAnalyzer
         Inherits AbstractUseCollectionInitializerDiagnosticAnalyzer(Of
             SyntaxKind,
             ExpressionSyntax,
@@ -21,7 +21,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             InvocationExpressionSyntax,
             ExpressionStatementSyntax,
             ForEachStatementSyntax,
-            VariableDeclaratorSyntax)
+            IfStatementSyntax,
+            VariableDeclaratorSyntax,
+            VisualBasicCollectionInitializerAnalyzer)
+
+        Protected Overrides Function GetAnalyzer() As VisualBasicCollectionInitializerAnalyzer
+            Return VisualBasicCollectionInitializerAnalyzer.Allocate()
+        End Function
 
         Protected Overrides Function AreCollectionInitializersSupported(compilation As Compilation) As Boolean
             Return True

--- a/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
+++ b/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForIfNullStatementCheckDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForTernaryConditionalCheckDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForNullableTernaryConditionalCheckDiagnosticAnalyzer.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicCollectionInitializerAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\Utilities.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb" />

--- a/src/Analyzers/VisualBasic/CodeFixes/UseCollectionInitializer/VisualBasicUseCollectionInitializerCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseCollectionInitializer/VisualBasicUseCollectionInitializerCodeFixProvider.vb
@@ -24,12 +24,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             InvocationExpressionSyntax,
             ExpressionStatementSyntax,
             ForEachStatementSyntax,
-            VariableDeclaratorSyntax)
+            IfStatementSyntax,
+            VariableDeclaratorSyntax,
+            VisualBasicCollectionInitializerAnalyzer)
 
         <ImportingConstructor>
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New()
         End Sub
+
+        Protected Overrides Function GetAnalyzer() As VisualBasicCollectionInitializerAnalyzer
+            Return VisualBasicCollectionInitializerAnalyzer.Allocate()
+        End Function
 
         Protected Overrides Function GetNewStatement(
                 sourceText As SourceText,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1614,16 +1614,10 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
             whenFalse = conditionalExpression.WhenFalse;
         }
 
-        public void GetPartsOfForeachStatement(SyntaxNode statement, out SyntaxToken identifier, out SyntaxNode expression, out IEnumerable<SyntaxNode> statements)
+        public SyntaxNode GetExpressionOfForeachStatement(SyntaxNode statement)
         {
             var commonForeach = (CommonForEachStatementSyntax)statement;
-            identifier = commonForeach is ForEachStatementSyntax { Identifier: var foreachIdentifier }
-                ? foreachIdentifier
-                : default;
-            expression = commonForeach.Expression;
-            statements = commonForeach.Statement is BlockSyntax block
-                ? block.Statements
-                : SpecializedCollections.SingletonEnumerable(commonForeach.Statement);
+            return commonForeach.Expression;
         }
 
         public void GetPartsOfGenericName(SyntaxNode node, out SyntaxToken identifier, out SeparatedSyntaxList<SyntaxNode> typeArguments)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -198,9 +198,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         bool IsCastExpression([NotNullWhen(true)] SyntaxNode? node);
 
         bool IsExpressionOfForeach([NotNullWhen(true)] SyntaxNode? node);
-        void GetPartsOfForeachStatement(SyntaxNode statement, out SyntaxToken identifier, out SyntaxNode expression, out IEnumerable<SyntaxNode> statements);
-
-        void GetPartsOfIfStatement(SyntaxNode statement, out SyntaxNode condition, out IEnumerable<SyntaxNode> whenTrueStatements, out IEnumerable<SyntaxNode> whenFalseStatements);
+        SyntaxNode GetExpressionOfForeachStatement(SyntaxNode statement);
 
         void GetPartsOfTupleExpression<TArgumentSyntax>(SyntaxNode node,
             out SyntaxToken openParen, out SeparatedSyntaxList<TArgumentSyntax> arguments, out SyntaxToken closeParen) where TArgumentSyntax : SyntaxNode;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -200,6 +200,8 @@ namespace Microsoft.CodeAnalysis.LanguageService
         bool IsExpressionOfForeach([NotNullWhen(true)] SyntaxNode? node);
         void GetPartsOfForeachStatement(SyntaxNode statement, out SyntaxToken identifier, out SyntaxNode expression, out IEnumerable<SyntaxNode> statements);
 
+        void GetPartsOfIfStatement(SyntaxNode statement, out SyntaxNode condition, out IEnumerable<SyntaxNode> whenTrueStatements, out IEnumerable<SyntaxNode> whenFalseStatements);
+
         void GetPartsOfTupleExpression<TArgumentSyntax>(SyntaxNode node,
             out SyntaxToken openParen, out SeparatedSyntaxList<TArgumentSyntax> arguments, out SyntaxToken closeParen) where TArgumentSyntax : SyntaxNode;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
@@ -518,12 +518,6 @@ namespace Microsoft.CodeAnalysis.LanguageService
             return expression;
         }
 
-        public static SyntaxNode GetExpressionOfForeachStatement(this ISyntaxFacts syntaxFacts, SyntaxNode node)
-        {
-            syntaxFacts.GetPartsOfForeachStatement(node, out _, out var expression, out _);
-            return expression;
-        }
-
         public static SyntaxToken GetIdentifierOfGenericName(this ISyntaxFacts syntaxFacts, SyntaxNode node)
         {
             syntaxFacts.GetPartsOfGenericName(node, out var identifier, out _);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1823,6 +1823,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             statements = If(foreachBlock Is Nothing, SpecializedCollections.EmptyEnumerable(Of SyntaxNode), foreachBlock.Statements)
         End Sub
 
+        Public Sub GetPartsOfIfStatement(statement As IfStatementSyntax, ByRef condition As SyntaxNode, ByRef whenTrueStatements As IEnumerable(Of SyntaxNode), ByRef whenFalseStatements As IEnumerable(Of SyntaxNode)) Implements ISyntaxFacts.GetPartsOfIfStatement
+            Dim ifStatement = DirectCast(statement, IfStatementSyntax)
+
+        End Sub
+
         Public Sub GetPartsOfInterpolationExpression(node As SyntaxNode, ByRef stringStartToken As SyntaxToken, ByRef contents As SyntaxList(Of SyntaxNode), ByRef stringEndToken As SyntaxToken) Implements ISyntaxFacts.GetPartsOfInterpolationExpression
             Dim interpolatedStringExpression = DirectCast(node, InterpolatedStringExpressionSyntax)
             stringStartToken = interpolatedStringExpression.DollarSignDoubleQuoteToken

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1813,20 +1813,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
             whenFalse = conditionalExpression.WhenFalse
         End Sub
 
-        Public Sub GetPartsOfForeachStatement(statement As SyntaxNode, ByRef identifier As SyntaxToken, ByRef expression As SyntaxNode, ByRef statements As IEnumerable(Of SyntaxNode)) Implements ISyntaxFacts.GetPartsOfForeachStatement
-            Dim foreachStatement = DirectCast(statement, ForEachStatementSyntax)
-            Dim declarator = TryCast(foreachStatement.ControlVariable, VariableDeclaratorSyntax)
-            identifier = If(declarator Is Nothing, Nothing, declarator.Names(0).Identifier)
-            expression = foreachStatement.Expression
-
-            Dim foreachBlock = TryCast(foreachStatement.Parent, ForEachBlockSyntax)
-            statements = If(foreachBlock Is Nothing, SpecializedCollections.EmptyEnumerable(Of SyntaxNode), foreachBlock.Statements)
-        End Sub
-
-        Public Sub GetPartsOfIfStatement(statement As IfStatementSyntax, ByRef condition As SyntaxNode, ByRef whenTrueStatements As IEnumerable(Of SyntaxNode), ByRef whenFalseStatements As IEnumerable(Of SyntaxNode)) Implements ISyntaxFacts.GetPartsOfIfStatement
-            Dim ifStatement = DirectCast(statement, IfStatementSyntax)
-
-        End Sub
+        Public Function GetExpressionOfForeachStatement(statement As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetExpressionOfForeachStatement
+            Return DirectCast(statement, ForEachStatementSyntax).Expression
+        End Function
 
         Public Sub GetPartsOfInterpolationExpression(node As SyntaxNode, ByRef stringStartToken As SyntaxToken, ByRef contents As SyntaxList(Of SyntaxNode), ByRef stringEndToken As SyntaxToken) Implements ISyntaxFacts.GetPartsOfInterpolationExpression
             Dim interpolatedStringExpression = DirectCast(node, InterpolatedStringExpressionSyntax)


### PR DESCRIPTION
Part of: https://github.com/dotnet/roslyn/issues/69132

This change makes it so that if we see:

```c#
List<int> list = new List<int>();
list.Add(1);
if (x)
    list.Add(2);
```

We now generate: `[1, .. x ? [2] : []]`.  

This is a form which we view as idiomatic for inserting elements conditionally, and will be optimized by the compiler.

As i've been working in this space, i've been pulling out cleanups that i think help the code.  This PR is a collection of them.  

THis also adds a ton more tests validating behavior.

Note: next PR works a lot on improving the formatting of the produced collection-expressions.