### PR TITLE
Update rule ID for 'Unnecessary call to Set.Contains'

### DIFF
--- a/eng/config/globalconfigs/Common.globalconfig
+++ b/eng/config/globalconfigs/Common.globalconfig
@@ -4,7 +4,7 @@ dotnet_diagnostic.CA1067.severity = warning
 dotnet_diagnostic.CA1068.severity = warning
 dotnet_diagnostic.CA1200.severity = warning
 dotnet_diagnostic.CA1821.severity = warning
-dotnet_diagnostic.CA1865.severity = warning
+dotnet_diagnostic.CA1868.severity = warning
 dotnet_diagnostic.CA2009.severity = warning
 
 # CA2012: Use ValueTasks correctly

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -330,13 +330,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     var attr = this.ParseXmlAttribute(elementName);
                     string attrName = attr.Name.ToString();
-                    if (_attributesSeen.Contains(attrName))
+                    if (!_attributesSeen.Add(attrName))
                     {
                         attr = this.WithXmlParseError(attr, XmlParseErrorCode.XML_DuplicateAttribute, attrName);
-                    }
-                    else
-                    {
-                        _attributesSeen.Add(attrName);
                     }
 
                     attrs.Add(attr);


### PR DESCRIPTION
Follow-up to #69179.

Another analyzer used CA1865, so this rule now uses CA1868.
Also fixed a diagnostic found during final testing of the PR for the analyzer.