### PR TITLE
Fix auto-default behavior when value-assigning a ref field

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7778,4 +7778,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_TargetDifferentRefness_Title" xml:space="preserve">
     <value>Reference kind modifier of parameter doesn't match the corresponding parameter in target.</value>
   </data>
+  <data name="WRN_UseDefViolationRefField" xml:space="preserve">
+    <value>'ref' field '{0}' should be ref-assigned before use.</value>
+  </data>
+  <data name="WRN_UseDefViolationRefField_Title" xml:space="preserve">
+    <value>'ref' field should be ref-assigned before use.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7785,9 +7785,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Reference kind modifier of parameter doesn't match the corresponding parameter in target.</value>
   </data>
   <data name="WRN_UseDefViolationRefField" xml:space="preserve">
-    <value>'ref' field '{0}' should be ref-assigned before use.</value>
+    <value>ref field '{0}' should be ref-assigned before use.</value>
   </data>
   <data name="WRN_UseDefViolationRefField_Title" xml:space="preserve">
-    <value>'ref' field should be ref-assigned before use.</value>
+    <value>ref field should be ref-assigned before use.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7785,9 +7785,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Reference kind modifier of parameter doesn't match the corresponding parameter in target.</value>
   </data>
   <data name="WRN_UseDefViolationRefField" xml:space="preserve">
-    <value>ref field '{0}' should be ref-assigned before use.</value>
+    <value>Ref field '{0}' should be ref-assigned before use.</value>
   </data>
   <data name="WRN_UseDefViolationRefField_Title" xml:space="preserve">
-    <value>ref field should be ref-assigned before use.</value>
+    <value>Ref field should be ref-assigned before use.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2265,6 +2265,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_OutAttrOnRefReadonlyParam = 9199,
         WRN_RefReadonlyParameterDefaultValue = 9200,
 
+        WRN_UseDefViolationRefField = 9210,
+
         #endregion
 
         // Note: you will need to do the following after adding warnings:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2265,8 +2265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_TargetDifferentRefness = 9198,
         ERR_OutAttrOnRefReadonlyParam = 9199,
         WRN_RefReadonlyParameterDefaultValue = 9200,
-
-        WRN_UseDefViolationRefField = 9210,
+        WRN_UseDefViolationRefField = 9201,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -549,6 +549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_HidingDifferentRefness:
                 case ErrorCode.WRN_TargetDifferentRefness:
                 case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
+                case ErrorCode.WRN_UseDefViolationRefField:
                     return 1;
                 default:
                     return 0;
@@ -2394,6 +2395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_TargetDifferentRefness:
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
                 case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
+                case ErrorCode.WRN_UseDefViolationRefField:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1324,7 +1324,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // should we handle nested fields here? https://github.com/dotnet/roslyn/issues/59890
                         AddImplicitlyInitializedField((FieldSymbol)fieldIdentifier.Symbol);
 
-                        if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureAutoDefaultStructs))
+                        if (fieldSymbol.RefKind != RefKind.None)
+                        {
+                            // it should be impossible for 'hasAssociatedProperty' to be true but don't want to rule it out in error scenarios.
+                            Diagnostics.Add(
+                                ErrorCode.WRN_UseDefViolationRefField,
+                                node.Location,
+                                symbolName);
+                        }
+                        else if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureAutoDefaultStructs))
                         {
                             Diagnostics.Add(
                                 hasAssociatedProperty ? ErrorCode.WRN_UseDefViolationPropertySupportedVersion : ErrorCode.WRN_UseDefViolationFieldSupportedVersion,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1497,6 +1497,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected void Assign(BoundNode node, BoundExpression value, bool isRef = false, bool read = true)
         {
+            if (!isRef && node is BoundFieldAccess { FieldSymbol.RefKind: not RefKind.None } fieldAccess)
+            {
+                CheckAssigned(fieldAccess, node.Syntax);
+            }
             AssignImpl(node, value, written: true, isRef: isRef, read: read);
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1326,11 +1326,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (fieldSymbol.RefKind != RefKind.None)
                         {
-                            // it should be impossible for 'hasAssociatedProperty' to be true but don't want to rule it out in error scenarios.
-                            Diagnostics.Add(
-                                ErrorCode.WRN_UseDefViolationRefField,
-                                node.Location,
-                                symbolName);
+                            // 'hasAssociatedProperty' is only true here in error scenarios where we don't need to report this as a cascading diagnostic
+                            if (!hasAssociatedProperty)
+                            {
+                                Diagnostics.Add(
+                                    ErrorCode.WRN_UseDefViolationRefField,
+                                    node.Location,
+                                    symbolName);
+                            }
                         }
                         else if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureAutoDefaultStructs))
                         {

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -332,6 +332,7 @@
                 case ErrorCode.WRN_HidingDifferentRefness:
                 case ErrorCode.WRN_TargetDifferentRefness:
                 case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
+                case ErrorCode.WRN_UseDefViolationRefField:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Použily se pravděpodobně nepřiřazené automaticky implementované vlastnosti</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">Objekt this se přečte před přiřazením všech jeho polí, což způsobí, že předchozí implicitní přiřazení default k ne explicitně přiřazeným polím.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Verwenden einer möglicherweise nicht zugewiesenen, automatisch implementierten Eigenschaft</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">Das „this“-Objekt wird gelesen, bevor alle zugehörigen Felder zugewiesen wurden, was zu vorherigen impliziten Zuweisungen von "default" zu nicht explizit zugewiesenen Feldern führt.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Uso de una propiedad implementada automáticamente posiblemente sin asignar</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">El objeto "this" se lee antes de que se hayan asignado todos sus campos, lo que provoca las asignaciones implícitas anteriores de "default" a los campos asignados de forma no explícita.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Utilisation d'une propriété implémentée automatiquement éventuellement non assignée</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">L’objet « this » est lu avant que tous ses champs aient été affectés, ce qui entraîne les affectations implicites précédentes de 'default' aux champs non explicitement attribués.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4982,6 +4982,16 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <target state="translated">Uso della proprietà implementata automaticamente probabilmente non assegnata</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">L'oggetto 'this' viene letto prima che tutti i relativi campi siano stati assegnati, determinando le assegnazioni implicite precedenti di 'default' ai campi non esplicitamente assegnati.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4993,13 +4993,13 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4993,13 +4993,13 @@ target:module               Compila un modulo che può essere aggiunto ad altro
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">割り当てられていない可能性のある自動実装プロパティの使用</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">'this' オブジェクトは、すべてのフィールドが割り当てられる前に読み取られます。これにより、明示的に割り当てられていないフィールドに対する 'default' の暗黙的な割り当てが先行しています。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">할당되지 않은 자동 구현 속성을 사용하고 있는 것 같음</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">'this' 개체는 모든 필드가 할당되기 전에 읽혀서 명시적으로 할당되지 않은 필드에 'default'의 암시적 할당이 선행되도록 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Użycie prawdopodobnie nieprzypisanej automatycznie implementowanej właściwości</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">Obiekt „this” jest odczytywany przed przypisaniem wszystkich jego pól, co powoduje, że wcześniejsze niejawne przypisania wartości „default” są przypisywane do pól nieprzypisanych jawnie.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Uso de propriedade autoimplementada possivelmente não atribuída</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">O objeto 'this' é lido antes que todos os seus campos tenham sido atribuídos, causando atribuições anteriores implícitas de campos 'default' a campos não explicitamente atribuídos.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Использование автоматически реализованного свойства, которому, возможно, не присвоено значение</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">Объект "this" прочитывается до назначения всех его полей, что приводит к неявному назначению "default" полям, которые не назначены явным образом.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">Atanmamış olabilecek otomatik uygulanmış özelliğin kullanımı</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">'this' nesnesi, tüm alanları atanmadan önce okunur ve bu da açıkça atanmamış alanlara yönelik 'default' öğesinin önceki örtük atamaları ile sonuçlanır.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4982,6 +4982,16 @@
         <target state="translated">使用可能未赋值的自动实现的属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">分配“this”对象的所有字段之前读取该对象，从而导致对未显式分配的字段进行前面的隐式分配“default”。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4993,13 +4993,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4993,13 +4993,13 @@ strument:TestCoverage      產生檢測要收集
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>ref field '{0}' should be ref-assigned before use.</source>
-        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
+        <source>Ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">Ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>ref field should be ref-assigned before use.</source>
-        <target state="new">ref field should be ref-assigned before use.</target>
+        <source>Ref field should be ref-assigned before use.</source>
+        <target state="new">Ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4993,13 +4993,13 @@ strument:TestCoverage      產生檢測要收集
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField">
-        <source>'ref' field '{0}' should be ref-assigned before use.</source>
-        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <source>ref field '{0}' should be ref-assigned before use.</source>
+        <target state="new">ref field '{0}' should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationRefField_Title">
-        <source>'ref' field should be ref-assigned before use.</source>
-        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <source>ref field should be ref-assigned before use.</source>
+        <target state="new">ref field should be ref-assigned before use.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4982,6 +4982,16 @@ strument:TestCoverage      產生檢測要收集
         <target state="translated">使用可能未指派的自動實作屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField">
+        <source>'ref' field '{0}' should be ref-assigned before use.</source>
+        <target state="new">'ref' field '{0}' should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UseDefViolationRefField_Title">
+        <source>'ref' field should be ref-assigned before use.</source>
+        <target state="new">'ref' field should be ref-assigned before use.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UseDefViolationThisSupportedVersion">
         <source>The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.</source>
         <target state="translated">在指派 'this' 物件的所有欄位之前，會先讀取該物件，導致先前對未明確指派的欄位進行隱含的 'default' 指派。</target>

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/RegionAnalysisTests.cs
@@ -14096,5 +14096,53 @@ class B
             Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
+
+        [Fact]
+        public void RefField_Assignment()
+        {
+            var comp = CreateCompilation("""
+                ref struct RS
+                {
+                    ref int ri;
+                    public RS() => ri = 0;
+                }
+                """,
+                targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyEmitDiagnostics(
+                // (4,20): warning CS9201: ref field 'ri' should be ref-assigned before use.
+                //     public RS() => ri = 0;
+                Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(4, 20));
+
+            var tree = comp.CommonSyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var assignment = tree.GetRoot().DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+
+            var flowAnalysis = model.AnalyzeDataFlow(assignment);
+            Assert.Equal("this", GetSymbolNamesJoined(flowAnalysis.ReadInside));
+            Assert.Equal("this", GetSymbolNamesJoined(flowAnalysis.WrittenInside));
+        }
+
+        [Fact]
+        public void RefField_RefAssignment()
+        {
+            var comp = CreateCompilation("""
+                ref struct RS
+                {
+                    ref int ri;
+                    public unsafe RS() => ri = ref *default(int*);
+                }
+                """,
+                targetFramework: TargetFramework.NetCoreApp,
+                options: TestOptions.UnsafeDebugDll);
+            comp.VerifyEmitDiagnostics();
+
+            var tree = comp.CommonSyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var assignment = tree.GetRoot().DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+
+            var flowAnalysis = model.AnalyzeDataFlow(assignment);
+            Assert.Null(GetSymbolNamesJoined(flowAnalysis.ReadInside));
+            Assert.Equal("this", GetSymbolNamesJoined(flowAnalysis.WrittenInside));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/RegionAnalysisTests.cs
@@ -14097,7 +14097,7 @@ class B
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_Assignment()
         {
             var comp = CreateCompilation("""
@@ -14109,7 +14109,7 @@ class B
                 """,
                 targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyEmitDiagnostics(
-                // (4,20): warning CS9201: ref field 'ri' should be ref-assigned before use.
+                // (4,20): warning CS9201: Ref field 'ri' should be ref-assigned before use.
                 //     public RS() => ri = 0;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(4, 20));
 
@@ -14122,7 +14122,7 @@ class B
             Assert.Equal("this", GetSymbolNamesJoined(flowAnalysis.WrittenInside));
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_RefAssignment()
         {
             var comp = CreateCompilation("""

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -15489,7 +15489,7 @@ class Program
                 readonly ref struct R
                 {
                     private readonly ref int _i;
-                    public R(ref int i) { _i = i; }
+                    public R(ref int i) { _i = ref i; }
                     public R F([InterpolatedStringHandlerArgument("")] CustomHandler handler)
                         => this;
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -29626,7 +29626,6 @@ Block[B2] - Exit
                 targetFramework: TargetFramework.NetCoreApp,
                 expectedOutput: "1");
 
-            // TODO2: why are we getting an 'unassigned this' as well as 'use def violation' diagnostic
             verifier.VerifyDiagnostics(
                 // (14,13): warning CS0649: Field 'RS.ri' is never assigned to, and will always have its default value 0
                 //     ref int ri;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -29532,5 +29532,21 @@ Block[B2] - Exit
                 // }
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(27, 2));
         }
+
+        [Fact]
+        public void AutoDefault()
+        {
+            var comp = CreateCompilation("""
+                ref struct RS
+                {
+                    ref int ri;
+                    public RS() => ri = 0;
+                }
+                """,
+                options: TestOptions.DebugDll.WithSpecificDiagnosticOptions(ReportStructInitializationWarnings),
+                targetFramework: TargetFramework.NetCoreApp);
+
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -29634,7 +29634,7 @@ Block[B2] - Exit
                 //     public RS()
                 Diagnostic(ErrorCode.WRN_UnassignedThisSupportedVersion, "RS").WithArguments("RS.ri").WithLocation(15, 12),
                 // (17,21): warning CS9201: Ref field 'ri' should be ref-assigned before use.
-                //         int local = ri; // 1
+                //         int local = ri;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(17, 21));
 
             verifier.VerifyIL("RS..ctor", """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -29549,7 +29549,7 @@ Block[B2] - Exit
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(27, 2));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_Assignment_AutoDefault_01()
         {
             var verifier = CompileAndVerify("""
@@ -29576,7 +29576,7 @@ Block[B2] - Exit
                 expectedOutput: "1");
 
             verifier.VerifyDiagnostics(
-                // (15,20): warning CS9201: 'ref' field 'ri' should be ref-assigned before use.
+                // (15,20): warning CS9201: Ref field 'ri' should be ref-assigned before use.
                 //     public RS() => ri = 0;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(15, 20));
 
@@ -29597,7 +29597,7 @@ Block[B2] - Exit
                 """);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_Assignment_AutoDefault_02()
         {
             var verifier = CompileAndVerify("""
@@ -29633,7 +29633,7 @@ Block[B2] - Exit
                 // (15,12): warning CS9022: Control is returned to caller before field 'RS.ri' is explicitly assigned, causing a preceding implicit assignment of 'default'.
                 //     public RS()
                 Diagnostic(ErrorCode.WRN_UnassignedThisSupportedVersion, "RS").WithArguments("RS.ri").WithLocation(15, 12),
-                // (17,21): warning CS9201: 'ref' field 'ri' should be ref-assigned before use.
+                // (17,21): warning CS9201: Ref field 'ri' should be ref-assigned before use.
                 //         int local = ri; // 1
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(17, 21));
 
@@ -29656,7 +29656,7 @@ Block[B2] - Exit
                 """);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_Assignment_AutoDefault_03()
         {
             var verifier = CompileAndVerify("""
@@ -29695,10 +29695,10 @@ Block[B2] - Exit
                 expectedOutput: "12");
 
             verifier.VerifyDiagnostics(
-                // (20,29): warning CS9201: ref field 'ri' should be ref-assigned before use.
+                // (20,29): warning CS9201: Ref field 'ri' should be ref-assigned before use.
                 //         ref int local = ref ri; // 1
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(20, 29),
-                // (25,29): warning CS9201: ref field 'ri' should be ref-assigned before use.
+                // (25,29): warning CS9201: Ref field 'ri' should be ref-assigned before use.
                 //         ref int local = ref ri; // 2
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(25, 29));
 
@@ -29720,7 +29720,7 @@ Block[B2] - Exit
                 """);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
         public void RefField_Assignment_AutoDefault_04()
         {
             var verifier = CompileAndVerify("""
@@ -29755,6 +29755,27 @@ Block[B2] - Exit
                 expectedOutput: "12");
 
             verifier.VerifyDiagnostics();
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem("https://github.com/dotnet/roslyn/issues/69148")]
+        public void RefField_Assignment_AutoDefault_05()
+        {
+            var comp = CreateCompilation("""
+                ref struct RS
+                {
+                    ref readonly int ri;
+                    public RS() => ri = 0;
+                }
+                """,
+                targetFramework: TargetFramework.NetCoreApp);
+
+            comp.VerifyDiagnostics(
+                // (4,20): error CS8331: Cannot assign to field 'ri' or use it as the right hand side of a ref assignment because it is a readonly variable
+                //     public RS() => ri = 0;
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "ri").WithArguments("field", "ri").WithLocation(4, 20),
+                // (4,20): warning CS9201: Ref field 'ri' should be ref-assigned before use.
+                //     public RS() => ri = 0;
+                Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(4, 20));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -5212,7 +5212,7 @@ class Program
 }";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // (4,25): warning CS9210: 'ref' field '_t' should be ref-assigned before use.
+                // (4,25): warning CS9201: 'ref' field '_t' should be ref-assigned before use.
                 //     public R(ref T t) { _t = t; }
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "_t").WithArguments("_t").WithLocation(4, 25));
         }
@@ -5460,7 +5460,7 @@ class Program
 }";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // (6,9): warning CS9210: 'ref' field 'F' should be ref-assigned before use.
+                // (6,9): warning CS9201: 'ref' field 'F' should be ref-assigned before use.
                 //         F = t;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "F").WithArguments("F").WithLocation(6, 9));
         }
@@ -5570,7 +5570,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // 0.cs(7,9): warning CS9210: 'ref' field 'F' should be ref-assigned before use.
+                // 0.cs(7,9): warning CS9201: 'ref' field 'F' should be ref-assigned before use.
                 //         F = tValue;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "F").WithArguments("F").WithLocation(7, 9));
         }
@@ -5608,7 +5608,7 @@ class Program
                 // (7,9): error CS8331: Cannot assign to field 'F' or use it as the right hand side of a ref assignment because it is a readonly variable
                 //         F = tValue; // 1
                 Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "F").WithArguments("field", "F").WithLocation(7, 9),
-                // (7,9): warning CS9210: 'ref' field 'F' should be ref-assigned before use.
+                // (7,9): warning CS9201: 'ref' field 'F' should be ref-assigned before use.
                 //         F = tValue; // 1
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "F").WithArguments("F").WithLocation(7, 9),
                 // (8,9): error CS8331: Cannot assign to field 'F' or use it as the right hand side of a ref assignment because it is a readonly variable
@@ -5661,7 +5661,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
-                // 0.cs(7,9): warning CS9210: 'ref' field 'F' should be ref-assigned before use.
+                // 0.cs(7,9): warning CS9201: 'ref' field 'F' should be ref-assigned before use.
                 //         F = tValue;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "F").WithArguments("F").WithLocation(7, 9));
         }
@@ -5699,7 +5699,7 @@ class Program
                 // (7,9): error CS8331: Cannot assign to field 'F' or use it as the right hand side of a ref assignment because it is a readonly variable
                 //         F = tValue; // 1
                 Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "F").WithArguments("field", "F").WithLocation(7, 9),
-                // (7,9): warning CS9210: 'ref' field 'F' should be ref-assigned before use.
+                // (7,9): warning CS9201: 'ref' field 'F' should be ref-assigned before use.
                 //         F = tValue; // 1
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "F").WithArguments("F").WithLocation(7, 9),
                 // (8,9): error CS8331: Cannot assign to field 'F' or use it as the right hand side of a ref assignment because it is a readonly variable
@@ -29576,7 +29576,7 @@ Block[B2] - Exit
                 expectedOutput: "1");
 
             verifier.VerifyDiagnostics(
-                // (15,20): warning CS9210: 'ref' field 'ri' should be ref-assigned before use.
+                // (15,20): warning CS9201: 'ref' field 'ri' should be ref-assigned before use.
                 //     public RS() => ri = 0;
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(15, 20));
 
@@ -29633,7 +29633,7 @@ Block[B2] - Exit
                 // (15,12): warning CS9022: Control is returned to caller before field 'RS.ri' is explicitly assigned, causing a preceding implicit assignment of 'default'.
                 //     public RS()
                 Diagnostic(ErrorCode.WRN_UnassignedThisSupportedVersion, "RS").WithArguments("RS.ri").WithLocation(15, 12),
-                // (17,21): warning CS9210: 'ref' field 'ri' should be ref-assigned before use.
+                // (17,21): warning CS9201: 'ref' field 'ri' should be ref-assigned before use.
                 //         int local = ri; // 1
                 Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(17, 21));
 
@@ -29665,6 +29665,15 @@ Block[B2] - Exit
                 new RS();
                 Console.Write(1);
 
+                try
+                {
+                    new RS(ignored: true);
+                }
+                catch
+                {
+                    Console.Write(2);
+                }
+
                 ref struct RS
                 {
                     ref int ri;
@@ -29672,17 +29681,26 @@ Block[B2] - Exit
                     {
                         ref int local = ref ri; // 1
                     }
+
+                    public RS(bool ignored)
+                    {
+                        ref int local = ref ri; // 2
+                        Console.Write(local);
+                    }
                 }
                 """,
                 options: TestOptions.DebugExe.WithSpecificDiagnosticOptions(ReportStructInitializationWarnings),
                 verify: Verification.Skipped,
                 targetFramework: TargetFramework.NetCoreApp,
-                expectedOutput: "1");
+                expectedOutput: "12");
 
             verifier.VerifyDiagnostics(
-                // (11,29): warning CS9210: 'ref' field 'ri' should be ref-assigned before use.
+                // (20,29): warning CS9201: ref field 'ri' should be ref-assigned before use.
                 //         ref int local = ref ri; // 1
-                Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(11, 29));
+                Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(20, 29),
+                // (25,29): warning CS9201: ref field 'ri' should be ref-assigned before use.
+                //         ref int local = ref ri; // 2
+                Diagnostic(ErrorCode.WRN_UseDefViolationRefField, "ri").WithArguments("ri").WithLocation(25, 29));
 
             verifier.VerifyIL("RS..ctor", """
                 {
@@ -29700,6 +29718,43 @@ Block[B2] - Exit
                   IL_0010:  ret
                 }
                 """);
+        }
+
+        [Fact]
+        public void RefField_Assignment_AutoDefault_04()
+        {
+            var verifier = CompileAndVerify("""
+                using System;
+
+                var i = 1;
+                var rs = new RS(ref i);
+
+                i = 2;
+                rs = new RS(ref i, ignored: true);
+
+                ref struct RS
+                {
+                    ref int ri;
+
+                    public RS(ref int ri)
+                    {
+                        this.ri = ref ri;
+                        Console.Write(this.ri);
+                    }
+
+                    public RS(ref int ri, bool ignored)
+                    {
+                        this = default(RS) with { ri = ref ri };
+                        Console.Write(this.ri);
+                    }
+                }
+                """,
+                options: TestOptions.DebugExe.WithSpecificDiagnosticOptions(ReportStructInitializationWarnings),
+                verify: Verification.Skipped,
+                targetFramework: TargetFramework.NetCoreApp,
+                expectedOutput: "12");
+
+            verifier.VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -425,6 +425,7 @@ class X
                         case ErrorCode.WRN_RefReturnOnlyParameter:
                         case ErrorCode.WRN_RefReturnOnlyParameter2:
                         case ErrorCode.WRN_RefAssignValEscapeWider:
+                        case ErrorCode.WRN_UseDefViolationRefField:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:


### PR DESCRIPTION
Closes #69148

Fixes an issue where a value-assignment to an unassigned ref-field was not treated as a read of the ref field, but was treated as a write of the ref field. It seems like it should be both. Have added dataflow tests accordingly.

Also adds an enabled-by-default warning when a ref field is used before being ref-assigned. I feel this is likely enough to *not be what you wanted to do* that it's worth reporting. Note that only a disabled-by-default warning is reported if you exit the constructor without assigning the field.