### PR TITLE
SyntaxGenerator handle explicit interface indexer

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -738,7 +738,8 @@ namespace Microsoft.CodeAnalysis.Editing
 
                 case SymbolKind.Property:
                     var property = (IPropertySymbol)symbol;
-                    return property.IsIndexer ? IndexerDeclaration(property) : PropertyDeclaration(property);
+                    bool isIndexer = property.IsIndexer || property.ExplicitInterfaceImplementations.Any(i => i.IsIndexer);
+                    return isIndexer ? IndexerDeclaration(property) : PropertyDeclaration(property);
 
                 case SymbolKind.Event:
                     var ev = (IEventSymbol)symbol;


### PR DESCRIPTION
Not sure if this is the right fix.  This shows what is needed to workaround https://github.com/dotnet/roslyn/issues/53911 as a fix for #69284 

It's not terrible, but it feels wrong.  Especially since it's inconsistent with symbols that come from source.

cc @cston @CyrusNajmabadi 