### PR TITLE
use void instead of exception when not returning a exception but only throwing it

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/CompilerUtilities/ImmutableHashMap.cs
@@ -1093,7 +1093,7 @@ namespace Roslyn.Collections.Immutable
             }
 
             [DebuggerStepThrough]
-            public static Exception FailRange(string parameterName, string? message = null)
+            public static void FailRange(string parameterName, string? message = null)
             {
                 if (string.IsNullOrEmpty(message))
                 {


### PR DESCRIPTION
When doing statistical analysis, it would be helpful to show a method that doesn't return a value to be void.  This is in a private class and is only used once.