### PR TITLE
Exceptions.ThrowEFail() should always be thrown.

### DIFF
--- a/src/VisualStudio/Core/Def/Utilities/Exceptions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/Exceptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         {
             Marshal.ThrowExceptionForHR(VSConstants.E_FAIL, new IntPtr(-1));
 
-            // never reached...
+            // The return exception should be used to avoid detection of the codepath not returning a value
             return null;
         }
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         {
             Marshal.ThrowExceptionForHR(VSConstants.E_INVALIDARG, new IntPtr(-1));
 
-            // never reached...
+            // The return exception should be used to avoid detection of the codepath not returning a value
             return null;
         }
 
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         {
             Marshal.ThrowExceptionForHR(VSConstants.E_NOTIMPL, new IntPtr(-1));
 
-            // never reached...
+            // The return exception should be used to avoid detection of the codepath not returning a value
             return null;
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         {
             Marshal.ThrowExceptionForHR(VSConstants.E_UNEXPECTED, new IntPtr(-1));
 
-            // never reached...
+            // The return exception should be used to avoid detection of the codepath not returning a value
             return null;
         }
     }

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
                     if (!workspace.TryApplyChanges(newSolution))
                     {
-                        Exceptions.ThrowEFail();
+                        throw Exceptions.ThrowEFail();
                     }
 
                     // Notify third parties about the completed rename operation on the workspace, and


### PR DESCRIPTION
I've added an explanation on why the class Exceptions should return an exception and added throwStatement to one of its method usages. 