### PR TITLE
Collection expressions: use inline array for spans in local initializers and method arguments when possible

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -3960,7 +3960,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return GetValEscape(switchExpr.SwitchArms.SelectAsArray(a => a.Value), scopeOfTheContainingExpression);
 
                 case BoundKind.CollectionExpression:
-                    return CallingMethodScope;
+                    return ((BoundCollectionExpression)expr).HasLocalScope
+                        ? scopeOfTheContainingExpression
+                        : CallingMethodScope;
 
                 default:
                     // in error situations some unexpected nodes could make here
@@ -4489,6 +4491,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.CollectionExpression:
+                    if (((BoundCollectionExpression)expr).HasLocalScope && escapeTo < _localScopeDepth)
+                    {
+                        Error(diagnostics, ErrorCode.ERR_CollectionExpressionEscape, node, expr.Type);
+                        return false;
+                    }
                     return true;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -598,7 +598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, syntax).Construct(elementType),
                     wasCompilerGenerated: wasCompilerGenerated,
                     diagnostics);
-                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, targetType);
+                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, result.HasLocalScope, targetType);
             }
 
             var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, targetType) { WasCompilerGenerated = true };
@@ -614,6 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionCreation: null,
                 collectionBuilderMethod: null,
                 builder.ToImmutableAndFree(),
+                hasLocalScope: false,
                 targetType)
             { WasCompilerGenerated = wasCompilerGenerated };
         }
@@ -706,6 +707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionCreation,
                 collectionBuilderMethod: null,
                 builder.ToImmutableAndFree(),
+                hasLocalScope: false,
                 targetType,
                 hasErrors)
             { WasCompilerGenerated = wasCompilerGenerated };
@@ -725,7 +727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, node.Syntax).Construct(elementType),
                 wasCompilerGenerated: wasCompilerGenerated,
                 diagnostics);
-            return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, targetType);
+            return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, result.HasLocalScope, targetType);
         }
 
         private BoundCollectionExpression BindCollectionExpressionForErrorRecovery(
@@ -746,6 +748,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionCreation: null,
                 collectionBuilderMethod: null,
                 elements: builder.ToImmutableAndFree(),
+                hasLocalScope: false,
                 targetType,
                 hasErrors: true);
         }
@@ -802,7 +805,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, syntax).Construct(elementType),
                     wasCompilerGenerated: wasCompilerGenerated,
                     diagnostics);
-                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, constructMethod, result.Elements, targetType);
+                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, constructMethod, result.Elements, result.HasLocalScope, targetType);
             }
 
             var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, readOnlySpanType) { WasCompilerGenerated = true };
@@ -818,6 +821,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 collectionCreation: null,
                 collectionBuilderMethod: constructMethod,
                 builder.ToImmutableAndFree(),
+                hasLocalScope: false,
                 targetType)
             { WasCompilerGenerated = wasCompilerGenerated };
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1891,6 +1891,8 @@
     <Field Name="CollectionBuilderMethod" Type="MethodSymbol?" Null="allow"/>
     <!-- Collection expression elements. -->
     <Field Name="Elements" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <!-- Collection expression must not escape current scope. -->
+    <Field Name="HasLocalScope" Type="bool"/>
   </Node>
 
   <Node Name="BoundCollectionExpressionSpreadElement" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6849,6 +6849,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_CollectionBuilderAttributeInvalidMethodName" xml:space="preserve">
     <value>The CollectionBuilderAttribute method name is invalid.</value>
   </data>
+  <data name="ERR_CollectionExpressionEscape" xml:space="preserve">
+    <value>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</value>
+  </data>
   <data name="ERR_EqualityContractRequiresGetter" xml:space="preserve">
     <value>Record equality contract property '{0}' must have a get accessor.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2265,6 +2265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_TargetDifferentRefness = 9198,
         ERR_OutAttrOnRefReadonlyParam = 9199,
         WRN_RefReadonlyParameterDefaultValue = 9200,
+        ERR_CollectionExpressionEscape = 9201,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2396,6 +2396,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_OutAttrOnRefReadonlyParam:
                 case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                 case ErrorCode.WRN_ByValArraySizeConstRequired:
+                case ErrorCode.ERR_CollectionExpressionEscape:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6311,7 +6311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundCollectionExpression : BoundExpression
     {
-        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, ImmutableArray<BoundExpression> elements, TypeSymbol type, bool hasErrors = false)
+        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, ImmutableArray<BoundExpression> elements, bool hasLocalScope, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.CollectionExpression, syntax, type, hasErrors || placeholder.HasErrors() || collectionCreation.HasErrors() || elements.HasErrors())
         {
 
@@ -6323,6 +6323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.CollectionCreation = collectionCreation;
             this.CollectionBuilderMethod = collectionBuilderMethod;
             this.Elements = elements;
+            this.HasLocalScope = hasLocalScope;
         }
 
         public new TypeSymbol Type => base.Type!;
@@ -6331,15 +6332,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression? CollectionCreation { get; }
         public MethodSymbol? CollectionBuilderMethod { get; }
         public ImmutableArray<BoundExpression> Elements { get; }
+        public bool HasLocalScope { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitCollectionExpression(this);
 
-        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, ImmutableArray<BoundExpression> elements, TypeSymbol type)
+        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, ImmutableArray<BoundExpression> elements, bool hasLocalScope, TypeSymbol type)
         {
-            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(collectionBuilderMethod, this.CollectionBuilderMethod) || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(collectionBuilderMethod, this.CollectionBuilderMethod) || elements != this.Elements || hasLocalScope != this.HasLocalScope || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, type, this.HasErrors);
+                var result = new BoundCollectionExpression(this.Syntax, collectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, hasLocalScope, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11574,7 +11576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? collectionCreation = node.CollectionCreation;
             ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, node.CollectionBuilderMethod, elements, type);
+            return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, node.CollectionBuilderMethod, elements, node.HasLocalScope, type);
         }
         public override BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node)
         {
@@ -13799,12 +13801,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, infoAndType.Type!);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, node.HasLocalScope, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, node.Type);
+                updatedNode = node.Update(node.CollectionTypeKind, placeholder, collectionCreation, collectionBuilderMethod, elements, node.HasLocalScope, node.Type);
             }
             return updatedNode;
         }
@@ -16205,6 +16207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("collectionCreation", null, new TreeDumperNode[] { Visit(node.CollectionCreation, null) }),
             new TreeDumperNode("collectionBuilderMethod", node.CollectionBuilderMethod, null),
             new TreeDumperNode("elements", null, from x in node.Elements select Visit(x, null)),
+            new TreeDumperNode("hasLocalScope", node.HasLocalScope, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -422,6 +422,11 @@
         <target state="new">'{0}' has a CollectionBuilderAttribute but no element type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CollectionExpressionEscape">
+        <source>A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</source>
+        <target state="new">A collection expression of type '{0}' cannot be used in this context because it may be exposed outside of the current scope.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CollectionExpressionNoTargetType">
         <source>There is no target type for the collection expression.</source>
         <target state="new">There is no target type for the collection expression.</target>

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -10048,9 +10048,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [CombinatorialData]
-        [Theory]
-        public void SpanArgument_04([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        [Fact]
+        public void SpanArgument_04()
         {
             string source = """
                 using System;
@@ -10087,191 +10086,105 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var verifier = CompileAndVerify(
                 new[] { source, s_collectionExtensionsWithSpan },
-                targetFramework: targetFramework,
+                targetFramework: TargetFramework.Net80,
                 verify: Verification.Skipped,
                 expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], [5], [6], "));
-            if (targetFramework == TargetFramework.Net80)
-            {
-                verifier.VerifyIL("Program.Main", """
-                    {
-                      // Code size      258 (0x102)
-                      .maxstack  5
-                      .locals init (S V_0, //s
-                                    R1 V_1, //r1
-                                    R2 V_2, //r2
-                                    <>y__InlineArray1<int?> V_3)
-                      IL_0000:  ldloca.s   V_0
-                      IL_0002:  initobj    "S"
-                      IL_0008:  ldloca.s   V_0
-                      IL_000a:  ldloca.s   V_3
-                      IL_000c:  initobj    "<>y__InlineArray1<int?>"
-                      IL_0012:  ldloca.s   V_3
-                      IL_0014:  ldc.i4.0
-                      IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_001a:  ldc.i4.1
-                      IL_001b:  newobj     "int?..ctor(int)"
-                      IL_0020:  stobj      "int?"
-                      IL_0025:  ldloca.s   V_3
-                      IL_0027:  ldc.i4.1
-                      IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_002d:  call       "void S.M(System.ReadOnlySpan<int?>)"
-                      IL_0032:  ldloca.s   V_0
-                      IL_0034:  ldloca.s   V_3
-                      IL_0036:  initobj    "<>y__InlineArray1<int?>"
-                      IL_003c:  ldloca.s   V_3
-                      IL_003e:  ldc.i4.0
-                      IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_0044:  ldc.i4.2
-                      IL_0045:  newobj     "int?..ctor(int)"
-                      IL_004a:  stobj      "int?"
-                      IL_004f:  ldloca.s   V_3
-                      IL_0051:  ldc.i4.1
-                      IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_0057:  ldnull
-                      IL_0058:  call       "void S.this[System.ReadOnlySpan<int?>].set"
-                      IL_005d:  ldloca.s   V_1
-                      IL_005f:  initobj    "R1"
-                      IL_0065:  ldloca.s   V_1
-                      IL_0067:  ldc.i4.1
-                      IL_0068:  newarr     "int?"
-                      IL_006d:  dup
-                      IL_006e:  ldc.i4.0
-                      IL_006f:  ldc.i4.3
-                      IL_0070:  newobj     "int?..ctor(int)"
-                      IL_0075:  stelem     "int?"
-                      IL_007a:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_007f:  call       "void R1.M(System.ReadOnlySpan<int?>)"
-                      IL_0084:  ldloca.s   V_1
-                      IL_0086:  ldc.i4.1
-                      IL_0087:  newarr     "int?"
-                      IL_008c:  dup
-                      IL_008d:  ldc.i4.0
-                      IL_008e:  ldc.i4.4
-                      IL_008f:  newobj     "int?..ctor(int)"
-                      IL_0094:  stelem     "int?"
-                      IL_0099:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_009e:  ldnull
-                      IL_009f:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
-                      IL_00a4:  ldloca.s   V_2
-                      IL_00a6:  initobj    "R2"
-                      IL_00ac:  ldloca.s   V_2
-                      IL_00ae:  ldloca.s   V_3
-                      IL_00b0:  initobj    "<>y__InlineArray1<int?>"
-                      IL_00b6:  ldloca.s   V_3
-                      IL_00b8:  ldc.i4.0
-                      IL_00b9:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_00be:  ldc.i4.5
-                      IL_00bf:  newobj     "int?..ctor(int)"
-                      IL_00c4:  stobj      "int?"
-                      IL_00c9:  ldloca.s   V_3
-                      IL_00cb:  ldc.i4.1
-                      IL_00cc:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_00d1:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
-                      IL_00d6:  ldloca.s   V_2
-                      IL_00d8:  ldloca.s   V_3
-                      IL_00da:  initobj    "<>y__InlineArray1<int?>"
-                      IL_00e0:  ldloca.s   V_3
-                      IL_00e2:  ldc.i4.0
-                      IL_00e3:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_00e8:  ldc.i4.6
-                      IL_00e9:  newobj     "int?..ctor(int)"
-                      IL_00ee:  stobj      "int?"
-                      IL_00f3:  ldloca.s   V_3
-                      IL_00f5:  ldc.i4.1
-                      IL_00f6:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_00fb:  ldnull
-                      IL_00fc:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
-                      IL_0101:  ret
-                    }
-                    """);
-            }
-            else
-            {
-                verifier.VerifyIL("Program.Main", """
-                    {
-                      // Code size      214 (0xd6)
-                      .maxstack  5
-                      .locals init (S V_0, //s
-                                    R1 V_1, //r1
-                                    R2 V_2) //r2
-                      IL_0000:  ldloca.s   V_0
-                      IL_0002:  initobj    "S"
-                      IL_0008:  ldloca.s   V_0
-                      IL_000a:  ldc.i4.1
-                      IL_000b:  newarr     "int?"
-                      IL_0010:  dup
-                      IL_0011:  ldc.i4.0
-                      IL_0012:  ldc.i4.1
-                      IL_0013:  newobj     "int?..ctor(int)"
-                      IL_0018:  stelem     "int?"
-                      IL_001d:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0022:  call       "void S.M(System.ReadOnlySpan<int?>)"
-                      IL_0027:  ldloca.s   V_0
-                      IL_0029:  ldc.i4.1
-                      IL_002a:  newarr     "int?"
-                      IL_002f:  dup
-                      IL_0030:  ldc.i4.0
-                      IL_0031:  ldc.i4.2
-                      IL_0032:  newobj     "int?..ctor(int)"
-                      IL_0037:  stelem     "int?"
-                      IL_003c:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0041:  ldnull
-                      IL_0042:  call       "void S.this[System.ReadOnlySpan<int?>].set"
-                      IL_0047:  ldloca.s   V_1
-                      IL_0049:  initobj    "R1"
-                      IL_004f:  ldloca.s   V_1
-                      IL_0051:  ldc.i4.1
-                      IL_0052:  newarr     "int?"
-                      IL_0057:  dup
-                      IL_0058:  ldc.i4.0
-                      IL_0059:  ldc.i4.3
-                      IL_005a:  newobj     "int?..ctor(int)"
-                      IL_005f:  stelem     "int?"
-                      IL_0064:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0069:  call       "void R1.M(System.ReadOnlySpan<int?>)"
-                      IL_006e:  ldloca.s   V_1
-                      IL_0070:  ldc.i4.1
-                      IL_0071:  newarr     "int?"
-                      IL_0076:  dup
-                      IL_0077:  ldc.i4.0
-                      IL_0078:  ldc.i4.4
-                      IL_0079:  newobj     "int?..ctor(int)"
-                      IL_007e:  stelem     "int?"
-                      IL_0083:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0088:  ldnull
-                      IL_0089:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
-                      IL_008e:  ldloca.s   V_2
-                      IL_0090:  initobj    "R2"
-                      IL_0096:  ldloca.s   V_2
-                      IL_0098:  ldc.i4.1
-                      IL_0099:  newarr     "int?"
-                      IL_009e:  dup
-                      IL_009f:  ldc.i4.0
-                      IL_00a0:  ldc.i4.5
-                      IL_00a1:  newobj     "int?..ctor(int)"
-                      IL_00a6:  stelem     "int?"
-                      IL_00ab:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_00b0:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
-                      IL_00b5:  ldloca.s   V_2
-                      IL_00b7:  ldc.i4.1
-                      IL_00b8:  newarr     "int?"
-                      IL_00bd:  dup
-                      IL_00be:  ldc.i4.0
-                      IL_00bf:  ldc.i4.6
-                      IL_00c0:  newobj     "int?..ctor(int)"
-                      IL_00c5:  stelem     "int?"
-                      IL_00ca:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_00cf:  ldnull
-                      IL_00d0:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
-                      IL_00d5:  ret
-                    }
-                    """);
-            }
+            verifier.VerifyIL("Program.Main", """
+                {
+                    // Code size      258 (0x102)
+                    .maxstack  5
+                    .locals init (S V_0, //s
+                                R1 V_1, //r1
+                                R2 V_2, //r2
+                                <>y__InlineArray1<int?> V_3)
+                    IL_0000:  ldloca.s   V_0
+                    IL_0002:  initobj    "S"
+                    IL_0008:  ldloca.s   V_0
+                    IL_000a:  ldloca.s   V_3
+                    IL_000c:  initobj    "<>y__InlineArray1<int?>"
+                    IL_0012:  ldloca.s   V_3
+                    IL_0014:  ldc.i4.0
+                    IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_001a:  ldc.i4.1
+                    IL_001b:  newobj     "int?..ctor(int)"
+                    IL_0020:  stobj      "int?"
+                    IL_0025:  ldloca.s   V_3
+                    IL_0027:  ldc.i4.1
+                    IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_002d:  call       "void S.M(System.ReadOnlySpan<int?>)"
+                    IL_0032:  ldloca.s   V_0
+                    IL_0034:  ldloca.s   V_3
+                    IL_0036:  initobj    "<>y__InlineArray1<int?>"
+                    IL_003c:  ldloca.s   V_3
+                    IL_003e:  ldc.i4.0
+                    IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_0044:  ldc.i4.2
+                    IL_0045:  newobj     "int?..ctor(int)"
+                    IL_004a:  stobj      "int?"
+                    IL_004f:  ldloca.s   V_3
+                    IL_0051:  ldc.i4.1
+                    IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_0057:  ldnull
+                    IL_0058:  call       "void S.this[System.ReadOnlySpan<int?>].set"
+                    IL_005d:  ldloca.s   V_1
+                    IL_005f:  initobj    "R1"
+                    IL_0065:  ldloca.s   V_1
+                    IL_0067:  ldc.i4.1
+                    IL_0068:  newarr     "int?"
+                    IL_006d:  dup
+                    IL_006e:  ldc.i4.0
+                    IL_006f:  ldc.i4.3
+                    IL_0070:  newobj     "int?..ctor(int)"
+                    IL_0075:  stelem     "int?"
+                    IL_007a:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                    IL_007f:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                    IL_0084:  ldloca.s   V_1
+                    IL_0086:  ldc.i4.1
+                    IL_0087:  newarr     "int?"
+                    IL_008c:  dup
+                    IL_008d:  ldc.i4.0
+                    IL_008e:  ldc.i4.4
+                    IL_008f:  newobj     "int?..ctor(int)"
+                    IL_0094:  stelem     "int?"
+                    IL_0099:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                    IL_009e:  ldnull
+                    IL_009f:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
+                    IL_00a4:  ldloca.s   V_2
+                    IL_00a6:  initobj    "R2"
+                    IL_00ac:  ldloca.s   V_2
+                    IL_00ae:  ldloca.s   V_3
+                    IL_00b0:  initobj    "<>y__InlineArray1<int?>"
+                    IL_00b6:  ldloca.s   V_3
+                    IL_00b8:  ldc.i4.0
+                    IL_00b9:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_00be:  ldc.i4.5
+                    IL_00bf:  newobj     "int?..ctor(int)"
+                    IL_00c4:  stobj      "int?"
+                    IL_00c9:  ldloca.s   V_3
+                    IL_00cb:  ldc.i4.1
+                    IL_00cc:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_00d1:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
+                    IL_00d6:  ldloca.s   V_2
+                    IL_00d8:  ldloca.s   V_3
+                    IL_00da:  initobj    "<>y__InlineArray1<int?>"
+                    IL_00e0:  ldloca.s   V_3
+                    IL_00e2:  ldc.i4.0
+                    IL_00e3:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_00e8:  ldc.i4.6
+                    IL_00e9:  newobj     "int?..ctor(int)"
+                    IL_00ee:  stobj      "int?"
+                    IL_00f3:  ldloca.s   V_3
+                    IL_00f5:  ldc.i4.1
+                    IL_00f6:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_00fb:  ldnull
+                    IL_00fc:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
+                    IL_0101:  ret
+                }
+                """);
         }
 
-        [CombinatorialData]
-        [Theory]
-        public void SpanArgument_05([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        [Fact]
+        public void SpanArgument_05()
         {
             string source = """
                 using System;
@@ -10300,138 +10213,77 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var verifier = CompileAndVerify(
                 new[] { source, s_collectionExtensionsWithSpan },
-                targetFramework: targetFramework,
+                targetFramework: TargetFramework.Net80,
                 verify: Verification.Skipped,
                 expectedOutput: IncludeExpectedOutput("[3], [4], [5], [6], "));
-            if (targetFramework == TargetFramework.Net80)
-            {
-                verifier.VerifyIL("Program.Main", """
-                    {
-                      // Code size      187 (0xbb)
-                      .maxstack  3
-                      .locals init (R1 V_0, //r1
-                                    R2 V_1, //r2
-                                    <>y__InlineArray1<int?> V_2)
-                      IL_0000:  ldloca.s   V_0
-                      IL_0002:  initobj    "R1"
-                      IL_0008:  ldloca.s   V_0
-                      IL_000a:  ldloca.s   V_2
-                      IL_000c:  initobj    "<>y__InlineArray1<int?>"
-                      IL_0012:  ldloca.s   V_2
-                      IL_0014:  ldc.i4.0
-                      IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_001a:  ldc.i4.3
-                      IL_001b:  newobj     "int?..ctor(int)"
-                      IL_0020:  stobj      "int?"
-                      IL_0025:  ldloca.s   V_2
-                      IL_0027:  ldc.i4.1
-                      IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_002d:  call       "void R1.M(System.ReadOnlySpan<int?>)"
-                      IL_0032:  ldloca.s   V_0
-                      IL_0034:  ldloca.s   V_2
-                      IL_0036:  initobj    "<>y__InlineArray1<int?>"
-                      IL_003c:  ldloca.s   V_2
-                      IL_003e:  ldc.i4.0
-                      IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_0044:  ldc.i4.4
-                      IL_0045:  newobj     "int?..ctor(int)"
-                      IL_004a:  stobj      "int?"
-                      IL_004f:  ldloca.s   V_2
-                      IL_0051:  ldc.i4.1
-                      IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_0057:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
-                      IL_005c:  pop
-                      IL_005d:  ldloca.s   V_1
-                      IL_005f:  initobj    "R2"
-                      IL_0065:  ldloca.s   V_1
-                      IL_0067:  ldloca.s   V_2
-                      IL_0069:  initobj    "<>y__InlineArray1<int?>"
-                      IL_006f:  ldloca.s   V_2
-                      IL_0071:  ldc.i4.0
-                      IL_0072:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_0077:  ldc.i4.5
-                      IL_0078:  newobj     "int?..ctor(int)"
-                      IL_007d:  stobj      "int?"
-                      IL_0082:  ldloca.s   V_2
-                      IL_0084:  ldc.i4.1
-                      IL_0085:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_008a:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
-                      IL_008f:  ldloca.s   V_1
-                      IL_0091:  ldloca.s   V_2
-                      IL_0093:  initobj    "<>y__InlineArray1<int?>"
-                      IL_0099:  ldloca.s   V_2
-                      IL_009b:  ldc.i4.0
-                      IL_009c:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
-                      IL_00a1:  ldc.i4.6
-                      IL_00a2:  newobj     "int?..ctor(int)"
-                      IL_00a7:  stobj      "int?"
-                      IL_00ac:  ldloca.s   V_2
-                      IL_00ae:  ldc.i4.1
-                      IL_00af:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
-                      IL_00b4:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
-                      IL_00b9:  pop
-                      IL_00ba:  ret
-                    }
-                    """);
-            }
-            else
-            {
-                verifier.VerifyIL("Program.Main", """
-                    {
-                      // Code size      143 (0x8f)
-                      .maxstack  5
-                      .locals init (R1 V_0, //r1
-                                    R2 V_1) //r2
-                      IL_0000:  ldloca.s   V_0
-                      IL_0002:  initobj    "R1"
-                      IL_0008:  ldloca.s   V_0
-                      IL_000a:  ldc.i4.1
-                      IL_000b:  newarr     "int?"
-                      IL_0010:  dup
-                      IL_0011:  ldc.i4.0
-                      IL_0012:  ldc.i4.3
-                      IL_0013:  newobj     "int?..ctor(int)"
-                      IL_0018:  stelem     "int?"
-                      IL_001d:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0022:  call       "void R1.M(System.ReadOnlySpan<int?>)"
-                      IL_0027:  ldloca.s   V_0
-                      IL_0029:  ldc.i4.1
-                      IL_002a:  newarr     "int?"
-                      IL_002f:  dup
-                      IL_0030:  ldc.i4.0
-                      IL_0031:  ldc.i4.4
-                      IL_0032:  newobj     "int?..ctor(int)"
-                      IL_0037:  stelem     "int?"
-                      IL_003c:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0041:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
-                      IL_0046:  pop
-                      IL_0047:  ldloca.s   V_1
-                      IL_0049:  initobj    "R2"
-                      IL_004f:  ldloca.s   V_1
-                      IL_0051:  ldc.i4.1
-                      IL_0052:  newarr     "int?"
-                      IL_0057:  dup
-                      IL_0058:  ldc.i4.0
-                      IL_0059:  ldc.i4.5
-                      IL_005a:  newobj     "int?..ctor(int)"
-                      IL_005f:  stelem     "int?"
-                      IL_0064:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0069:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
-                      IL_006e:  ldloca.s   V_1
-                      IL_0070:  ldc.i4.1
-                      IL_0071:  newarr     "int?"
-                      IL_0076:  dup
-                      IL_0077:  ldc.i4.0
-                      IL_0078:  ldc.i4.6
-                      IL_0079:  newobj     "int?..ctor(int)"
-                      IL_007e:  stelem     "int?"
-                      IL_0083:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
-                      IL_0088:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
-                      IL_008d:  pop
-                      IL_008e:  ret
-                    }
-                    """);
-            }
+            verifier.VerifyIL("Program.Main", """
+                {
+                    // Code size      187 (0xbb)
+                    .maxstack  3
+                    .locals init (R1 V_0, //r1
+                                R2 V_1, //r2
+                                <>y__InlineArray1<int?> V_2)
+                    IL_0000:  ldloca.s   V_0
+                    IL_0002:  initobj    "R1"
+                    IL_0008:  ldloca.s   V_0
+                    IL_000a:  ldloca.s   V_2
+                    IL_000c:  initobj    "<>y__InlineArray1<int?>"
+                    IL_0012:  ldloca.s   V_2
+                    IL_0014:  ldc.i4.0
+                    IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_001a:  ldc.i4.3
+                    IL_001b:  newobj     "int?..ctor(int)"
+                    IL_0020:  stobj      "int?"
+                    IL_0025:  ldloca.s   V_2
+                    IL_0027:  ldc.i4.1
+                    IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_002d:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                    IL_0032:  ldloca.s   V_0
+                    IL_0034:  ldloca.s   V_2
+                    IL_0036:  initobj    "<>y__InlineArray1<int?>"
+                    IL_003c:  ldloca.s   V_2
+                    IL_003e:  ldc.i4.0
+                    IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_0044:  ldc.i4.4
+                    IL_0045:  newobj     "int?..ctor(int)"
+                    IL_004a:  stobj      "int?"
+                    IL_004f:  ldloca.s   V_2
+                    IL_0051:  ldc.i4.1
+                    IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_0057:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
+                    IL_005c:  pop
+                    IL_005d:  ldloca.s   V_1
+                    IL_005f:  initobj    "R2"
+                    IL_0065:  ldloca.s   V_1
+                    IL_0067:  ldloca.s   V_2
+                    IL_0069:  initobj    "<>y__InlineArray1<int?>"
+                    IL_006f:  ldloca.s   V_2
+                    IL_0071:  ldc.i4.0
+                    IL_0072:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_0077:  ldc.i4.5
+                    IL_0078:  newobj     "int?..ctor(int)"
+                    IL_007d:  stobj      "int?"
+                    IL_0082:  ldloca.s   V_2
+                    IL_0084:  ldc.i4.1
+                    IL_0085:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_008a:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
+                    IL_008f:  ldloca.s   V_1
+                    IL_0091:  ldloca.s   V_2
+                    IL_0093:  initobj    "<>y__InlineArray1<int?>"
+                    IL_0099:  ldloca.s   V_2
+                    IL_009b:  ldc.i4.0
+                    IL_009c:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                    IL_00a1:  ldc.i4.6
+                    IL_00a2:  newobj     "int?..ctor(int)"
+                    IL_00a7:  stobj      "int?"
+                    IL_00ac:  ldloca.s   V_2
+                    IL_00ae:  ldc.i4.1
+                    IL_00af:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                    IL_00b4:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
+                    IL_00b9:  pop
+                    IL_00ba:  ret
+                }
+                """);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -4494,8 +4494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     static void Main()
                     {
-                        {{collectionType}} c;
-                        c = [];
+                        {{collectionType}} c = [];
                         c = Append(c);
                         c.Report();
                     }
@@ -4986,7 +4985,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     static void Main()
                     {
                         {{collectionType}}<int> a = [1, 2, 3];
-                        {{collectionType}}<object> b;
+                        {{collectionType}}<object> b = [];
                         b = F1(a);
                         b.Report();
                         b = F2<int, object>(a);
@@ -9647,6 +9646,1453 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // 0.cs(6,49): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
                 // [CollectionBuilder(typeof(MyCollectionBuilder), MyCollectionBuilder.GetName([1, 2, 3]))]
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, "MyCollectionBuilder.GetName([1, 2, 3])").WithLocation(6, 49));
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanArgument_01([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F1<object>([1]);
+                        F2<int?>([2]);
+                        F3<int?>([3]);
+                        F4<object>([4]);
+                    }
+                    static void F1<T>(Span<T> s) { s.Report(); }
+                    static void F2<T>(ReadOnlySpan<T> s) { s.Report(); }
+                    static void F3<T>(in Span<T> s) { s.Report(); }
+                    static void F4<T>(in ReadOnlySpan<T> s) { s.Report(); }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], "));
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      159 (0x9f)
+                      .maxstack  2
+                      .locals init (<>y__InlineArray1<object> V_0,
+                                    <>y__InlineArray1<int?> V_1,
+                                    System.Span<int?> V_2,
+                                    System.ReadOnlySpan<object> V_3)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.1
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_0
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001f:  call       "void Program.F1<object>(System.Span<object>)"
+                      IL_0024:  ldloca.s   V_1
+                      IL_0026:  initobj    "<>y__InlineArray1<int?>"
+                      IL_002c:  ldloca.s   V_1
+                      IL_002e:  ldc.i4.0
+                      IL_002f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_0034:  ldc.i4.2
+                      IL_0035:  newobj     "int?..ctor(int)"
+                      IL_003a:  stobj      "int?"
+                      IL_003f:  ldloca.s   V_1
+                      IL_0041:  ldc.i4.1
+                      IL_0042:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_0047:  call       "void Program.F2<int?>(System.ReadOnlySpan<int?>)"
+                      IL_004c:  ldloca.s   V_1
+                      IL_004e:  initobj    "<>y__InlineArray1<int?>"
+                      IL_0054:  ldloca.s   V_1
+                      IL_0056:  ldc.i4.0
+                      IL_0057:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_005c:  ldc.i4.3
+                      IL_005d:  newobj     "int?..ctor(int)"
+                      IL_0062:  stobj      "int?"
+                      IL_0067:  ldloca.s   V_1
+                      IL_0069:  ldc.i4.1
+                      IL_006a:  call       "InlineArrayAsSpan<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_006f:  stloc.2
+                      IL_0070:  ldloca.s   V_2
+                      IL_0072:  call       "void Program.F3<int?>(in System.Span<int?>)"
+                      IL_0077:  ldloca.s   V_0
+                      IL_0079:  initobj    "<>y__InlineArray1<object>"
+                      IL_007f:  ldloca.s   V_0
+                      IL_0081:  ldc.i4.0
+                      IL_0082:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0087:  ldc.i4.4
+                      IL_0088:  box        "int"
+                      IL_008d:  stind.ref
+                      IL_008e:  ldloca.s   V_0
+                      IL_0090:  ldc.i4.1
+                      IL_0091:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_0096:  stloc.3
+                      IL_0097:  ldloca.s   V_3
+                      IL_0099:  call       "void Program.F4<object>(in System.ReadOnlySpan<object>)"
+                      IL_009e:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      115 (0x73)
+                      .maxstack  4
+                      .locals init (System.Span<int?> V_0,
+                                    System.ReadOnlySpan<object> V_1)
+                      IL_0000:  ldc.i4.1
+                      IL_0001:  newarr     "object"
+                      IL_0006:  dup
+                      IL_0007:  ldc.i4.0
+                      IL_0008:  ldc.i4.1
+                      IL_0009:  box        "int"
+                      IL_000e:  stelem.ref
+                      IL_000f:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0014:  call       "void Program.F1<object>(System.Span<object>)"
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  newarr     "int?"
+                      IL_001f:  dup
+                      IL_0020:  ldc.i4.0
+                      IL_0021:  ldc.i4.2
+                      IL_0022:  newobj     "int?..ctor(int)"
+                      IL_0027:  stelem     "int?"
+                      IL_002c:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0031:  call       "void Program.F2<int?>(System.ReadOnlySpan<int?>)"
+                      IL_0036:  ldc.i4.1
+                      IL_0037:  newarr     "int?"
+                      IL_003c:  dup
+                      IL_003d:  ldc.i4.0
+                      IL_003e:  ldc.i4.3
+                      IL_003f:  newobj     "int?..ctor(int)"
+                      IL_0044:  stelem     "int?"
+                      IL_0049:  newobj     "System.Span<int?>..ctor(int?[])"
+                      IL_004e:  stloc.0
+                      IL_004f:  ldloca.s   V_0
+                      IL_0051:  call       "void Program.F3<int?>(in System.Span<int?>)"
+                      IL_0056:  ldc.i4.1
+                      IL_0057:  newarr     "object"
+                      IL_005c:  dup
+                      IL_005d:  ldc.i4.0
+                      IL_005e:  ldc.i4.4
+                      IL_005f:  box        "int"
+                      IL_0064:  stelem.ref
+                      IL_0065:  newobj     "System.ReadOnlySpan<object>..ctor(object[])"
+                      IL_006a:  stloc.1
+                      IL_006b:  ldloca.s   V_1
+                      IL_006d:  call       "void Program.F4<object>(in System.ReadOnlySpan<object>)"
+                      IL_0072:  ret
+                    }
+                    """);
+            }
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanArgument_02([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                struct S { }
+                ref struct R { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        ReturnsStruct<object>([1]);
+                        ReturnsRefStruct<object>([2]);
+                        ReturnsRef<object>([3]);
+                        ReturnsRefReadOnly<object>([4]);
+                    }
+                    static int _f = 0;
+                    static S ReturnsStruct<T>(Span<T> s) { s.Report(); return default; }
+                    static R ReturnsRefStruct<T>(Span<T> s) { s.Report(); return default; }
+                    static ref int ReturnsRef<T>(Span<T> s) { s.Report(); return ref _f; }
+                    static ref readonly int ReturnsRefReadOnly<T>(Span<T> s) { s.Report(); return ref _f; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], "));
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      116 (0x74)
+                      .maxstack  4
+                      .locals init (<>y__InlineArray1<object> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.1
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_0
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001f:  call       "S Program.ReturnsStruct<object>(System.Span<object>)"
+                      IL_0024:  pop
+                      IL_0025:  ldc.i4.1
+                      IL_0026:  newarr     "object"
+                      IL_002b:  dup
+                      IL_002c:  ldc.i4.0
+                      IL_002d:  ldc.i4.2
+                      IL_002e:  box        "int"
+                      IL_0033:  stelem.ref
+                      IL_0034:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0039:  call       "R Program.ReturnsRefStruct<object>(System.Span<object>)"
+                      IL_003e:  pop
+                      IL_003f:  ldc.i4.1
+                      IL_0040:  newarr     "object"
+                      IL_0045:  dup
+                      IL_0046:  ldc.i4.0
+                      IL_0047:  ldc.i4.3
+                      IL_0048:  box        "int"
+                      IL_004d:  stelem.ref
+                      IL_004e:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0053:  call       "ref int Program.ReturnsRef<object>(System.Span<object>)"
+                      IL_0058:  pop
+                      IL_0059:  ldc.i4.1
+                      IL_005a:  newarr     "object"
+                      IL_005f:  dup
+                      IL_0060:  ldc.i4.0
+                      IL_0061:  ldc.i4.4
+                      IL_0062:  box        "int"
+                      IL_0067:  stelem.ref
+                      IL_0068:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_006d:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(System.Span<object>)"
+                      IL_0072:  pop
+                      IL_0073:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      105 (0x69)
+                      .maxstack  4
+                      IL_0000:  ldc.i4.1
+                      IL_0001:  newarr     "object"
+                      IL_0006:  dup
+                      IL_0007:  ldc.i4.0
+                      IL_0008:  ldc.i4.1
+                      IL_0009:  box        "int"
+                      IL_000e:  stelem.ref
+                      IL_000f:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0014:  call       "S Program.ReturnsStruct<object>(System.Span<object>)"
+                      IL_0019:  pop
+                      IL_001a:  ldc.i4.1
+                      IL_001b:  newarr     "object"
+                      IL_0020:  dup
+                      IL_0021:  ldc.i4.0
+                      IL_0022:  ldc.i4.2
+                      IL_0023:  box        "int"
+                      IL_0028:  stelem.ref
+                      IL_0029:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_002e:  call       "R Program.ReturnsRefStruct<object>(System.Span<object>)"
+                      IL_0033:  pop
+                      IL_0034:  ldc.i4.1
+                      IL_0035:  newarr     "object"
+                      IL_003a:  dup
+                      IL_003b:  ldc.i4.0
+                      IL_003c:  ldc.i4.3
+                      IL_003d:  box        "int"
+                      IL_0042:  stelem.ref
+                      IL_0043:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0048:  call       "ref int Program.ReturnsRef<object>(System.Span<object>)"
+                      IL_004d:  pop
+                      IL_004e:  ldc.i4.1
+                      IL_004f:  newarr     "object"
+                      IL_0054:  dup
+                      IL_0055:  ldc.i4.0
+                      IL_0056:  ldc.i4.4
+                      IL_0057:  box        "int"
+                      IL_005c:  stelem.ref
+                      IL_005d:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0062:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(System.Span<object>)"
+                      IL_0067:  pop
+                      IL_0068:  ret
+                    }
+                    """);
+            }
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanArgument_03([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                struct S { }
+                ref struct R { }
+                class Program
+                {
+                    static void Main()
+                    {
+                        ReturnsRefStruct<object>([2]);
+                        ReturnsRef<object>([3]);
+                        ReturnsRefReadOnly<object>([4]);
+                    }
+                    static int _f = 0;
+                    static R ReturnsRefStruct<T>(scoped Span<T> s) { s.Report(); return default; }
+                    static ref int ReturnsRef<T>(scoped Span<T> s) { s.Report(); return ref _f; }
+                    static ref readonly int ReturnsRefReadOnly<T>(scoped Span<T> s) { s.Report(); return ref _f; }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[2], [3], [4], "));
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      112 (0x70)
+                      .maxstack  2
+                      .locals init (<>y__InlineArray1<object> V_0)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.2
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_0
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001f:  call       "R Program.ReturnsRefStruct<object>(scoped System.Span<object>)"
+                      IL_0024:  pop
+                      IL_0025:  ldloca.s   V_0
+                      IL_0027:  initobj    "<>y__InlineArray1<object>"
+                      IL_002d:  ldloca.s   V_0
+                      IL_002f:  ldc.i4.0
+                      IL_0030:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0035:  ldc.i4.3
+                      IL_0036:  box        "int"
+                      IL_003b:  stind.ref
+                      IL_003c:  ldloca.s   V_0
+                      IL_003e:  ldc.i4.1
+                      IL_003f:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0044:  call       "ref int Program.ReturnsRef<object>(scoped System.Span<object>)"
+                      IL_0049:  pop
+                      IL_004a:  ldloca.s   V_0
+                      IL_004c:  initobj    "<>y__InlineArray1<object>"
+                      IL_0052:  ldloca.s   V_0
+                      IL_0054:  ldc.i4.0
+                      IL_0055:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_005a:  ldc.i4.4
+                      IL_005b:  box        "int"
+                      IL_0060:  stind.ref
+                      IL_0061:  ldloca.s   V_0
+                      IL_0063:  ldc.i4.1
+                      IL_0064:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0069:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(scoped System.Span<object>)"
+                      IL_006e:  pop
+                      IL_006f:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size       79 (0x4f)
+                      .maxstack  4
+                      IL_0000:  ldc.i4.1
+                      IL_0001:  newarr     "object"
+                      IL_0006:  dup
+                      IL_0007:  ldc.i4.0
+                      IL_0008:  ldc.i4.2
+                      IL_0009:  box        "int"
+                      IL_000e:  stelem.ref
+                      IL_000f:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0014:  call       "R Program.ReturnsRefStruct<object>(scoped System.Span<object>)"
+                      IL_0019:  pop
+                      IL_001a:  ldc.i4.1
+                      IL_001b:  newarr     "object"
+                      IL_0020:  dup
+                      IL_0021:  ldc.i4.0
+                      IL_0022:  ldc.i4.3
+                      IL_0023:  box        "int"
+                      IL_0028:  stelem.ref
+                      IL_0029:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_002e:  call       "ref int Program.ReturnsRef<object>(scoped System.Span<object>)"
+                      IL_0033:  pop
+                      IL_0034:  ldc.i4.1
+                      IL_0035:  newarr     "object"
+                      IL_003a:  dup
+                      IL_003b:  ldc.i4.0
+                      IL_003c:  ldc.i4.4
+                      IL_003d:  box        "int"
+                      IL_0042:  stelem.ref
+                      IL_0043:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0048:  call       "ref readonly int Program.ReturnsRefReadOnly<object>(scoped System.Span<object>)"
+                      IL_004d:  pop
+                      IL_004e:  ret
+                    }
+                    """);
+            }
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanArgument_04([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                struct S
+                {
+                    public void M(ReadOnlySpan<int?> s) { s.Report(); }
+                    public object this[ReadOnlySpan<int?> s] { set { s.Report(); } }
+                }
+                ref struct R1
+                {
+                    public void M(ReadOnlySpan<int?> s) { s.Report(); }
+                    public object this[ReadOnlySpan<int?> s] { set { s.Report(); } }
+                }
+                ref struct R2
+                {
+                    public void M(scoped ReadOnlySpan<int?> s) { s.Report(); }
+                    public object this[scoped ReadOnlySpan<int?> s] { set { s.Report(); } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var s = new S();
+                        s.M([1]);
+                        s[[2]] = null;
+                        var r1 = new R1();
+                        r1.M([3]);
+                        r1[[4]] = null;
+                        var r2 = new R2();
+                        r2.M([5]);
+                        r2[[6]] = null;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], [5], [6], "));
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      258 (0x102)
+                      .maxstack  5
+                      .locals init (S V_0, //s
+                                    R1 V_1, //r1
+                                    R2 V_2, //r2
+                                    <>y__InlineArray1<int?> V_3)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "S"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldloca.s   V_3
+                      IL_000c:  initobj    "<>y__InlineArray1<int?>"
+                      IL_0012:  ldloca.s   V_3
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_001a:  ldc.i4.1
+                      IL_001b:  newobj     "int?..ctor(int)"
+                      IL_0020:  stobj      "int?"
+                      IL_0025:  ldloca.s   V_3
+                      IL_0027:  ldc.i4.1
+                      IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_002d:  call       "void S.M(System.ReadOnlySpan<int?>)"
+                      IL_0032:  ldloca.s   V_0
+                      IL_0034:  ldloca.s   V_3
+                      IL_0036:  initobj    "<>y__InlineArray1<int?>"
+                      IL_003c:  ldloca.s   V_3
+                      IL_003e:  ldc.i4.0
+                      IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_0044:  ldc.i4.2
+                      IL_0045:  newobj     "int?..ctor(int)"
+                      IL_004a:  stobj      "int?"
+                      IL_004f:  ldloca.s   V_3
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_0057:  ldnull
+                      IL_0058:  call       "void S.this[System.ReadOnlySpan<int?>].set"
+                      IL_005d:  ldloca.s   V_1
+                      IL_005f:  initobj    "R1"
+                      IL_0065:  ldloca.s   V_1
+                      IL_0067:  ldc.i4.1
+                      IL_0068:  newarr     "int?"
+                      IL_006d:  dup
+                      IL_006e:  ldc.i4.0
+                      IL_006f:  ldc.i4.3
+                      IL_0070:  newobj     "int?..ctor(int)"
+                      IL_0075:  stelem     "int?"
+                      IL_007a:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_007f:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                      IL_0084:  ldloca.s   V_1
+                      IL_0086:  ldc.i4.1
+                      IL_0087:  newarr     "int?"
+                      IL_008c:  dup
+                      IL_008d:  ldc.i4.0
+                      IL_008e:  ldc.i4.4
+                      IL_008f:  newobj     "int?..ctor(int)"
+                      IL_0094:  stelem     "int?"
+                      IL_0099:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_009e:  ldnull
+                      IL_009f:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
+                      IL_00a4:  ldloca.s   V_2
+                      IL_00a6:  initobj    "R2"
+                      IL_00ac:  ldloca.s   V_2
+                      IL_00ae:  ldloca.s   V_3
+                      IL_00b0:  initobj    "<>y__InlineArray1<int?>"
+                      IL_00b6:  ldloca.s   V_3
+                      IL_00b8:  ldc.i4.0
+                      IL_00b9:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_00be:  ldc.i4.5
+                      IL_00bf:  newobj     "int?..ctor(int)"
+                      IL_00c4:  stobj      "int?"
+                      IL_00c9:  ldloca.s   V_3
+                      IL_00cb:  ldc.i4.1
+                      IL_00cc:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_00d1:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
+                      IL_00d6:  ldloca.s   V_2
+                      IL_00d8:  ldloca.s   V_3
+                      IL_00da:  initobj    "<>y__InlineArray1<int?>"
+                      IL_00e0:  ldloca.s   V_3
+                      IL_00e2:  ldc.i4.0
+                      IL_00e3:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_00e8:  ldc.i4.6
+                      IL_00e9:  newobj     "int?..ctor(int)"
+                      IL_00ee:  stobj      "int?"
+                      IL_00f3:  ldloca.s   V_3
+                      IL_00f5:  ldc.i4.1
+                      IL_00f6:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_00fb:  ldnull
+                      IL_00fc:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
+                      IL_0101:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      214 (0xd6)
+                      .maxstack  5
+                      .locals init (S V_0, //s
+                                    R1 V_1, //r1
+                                    R2 V_2) //r2
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "S"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldc.i4.1
+                      IL_000b:  newarr     "int?"
+                      IL_0010:  dup
+                      IL_0011:  ldc.i4.0
+                      IL_0012:  ldc.i4.1
+                      IL_0013:  newobj     "int?..ctor(int)"
+                      IL_0018:  stelem     "int?"
+                      IL_001d:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0022:  call       "void S.M(System.ReadOnlySpan<int?>)"
+                      IL_0027:  ldloca.s   V_0
+                      IL_0029:  ldc.i4.1
+                      IL_002a:  newarr     "int?"
+                      IL_002f:  dup
+                      IL_0030:  ldc.i4.0
+                      IL_0031:  ldc.i4.2
+                      IL_0032:  newobj     "int?..ctor(int)"
+                      IL_0037:  stelem     "int?"
+                      IL_003c:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0041:  ldnull
+                      IL_0042:  call       "void S.this[System.ReadOnlySpan<int?>].set"
+                      IL_0047:  ldloca.s   V_1
+                      IL_0049:  initobj    "R1"
+                      IL_004f:  ldloca.s   V_1
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  newarr     "int?"
+                      IL_0057:  dup
+                      IL_0058:  ldc.i4.0
+                      IL_0059:  ldc.i4.3
+                      IL_005a:  newobj     "int?..ctor(int)"
+                      IL_005f:  stelem     "int?"
+                      IL_0064:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0069:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                      IL_006e:  ldloca.s   V_1
+                      IL_0070:  ldc.i4.1
+                      IL_0071:  newarr     "int?"
+                      IL_0076:  dup
+                      IL_0077:  ldc.i4.0
+                      IL_0078:  ldc.i4.4
+                      IL_0079:  newobj     "int?..ctor(int)"
+                      IL_007e:  stelem     "int?"
+                      IL_0083:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0088:  ldnull
+                      IL_0089:  call       "void R1.this[System.ReadOnlySpan<int?>].set"
+                      IL_008e:  ldloca.s   V_2
+                      IL_0090:  initobj    "R2"
+                      IL_0096:  ldloca.s   V_2
+                      IL_0098:  ldc.i4.1
+                      IL_0099:  newarr     "int?"
+                      IL_009e:  dup
+                      IL_009f:  ldc.i4.0
+                      IL_00a0:  ldc.i4.5
+                      IL_00a1:  newobj     "int?..ctor(int)"
+                      IL_00a6:  stelem     "int?"
+                      IL_00ab:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_00b0:  call       "void R2.M(scoped System.ReadOnlySpan<int?>)"
+                      IL_00b5:  ldloca.s   V_2
+                      IL_00b7:  ldc.i4.1
+                      IL_00b8:  newarr     "int?"
+                      IL_00bd:  dup
+                      IL_00be:  ldc.i4.0
+                      IL_00bf:  ldc.i4.6
+                      IL_00c0:  newobj     "int?..ctor(int)"
+                      IL_00c5:  stelem     "int?"
+                      IL_00ca:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_00cf:  ldnull
+                      IL_00d0:  call       "void R2.this[scoped System.ReadOnlySpan<int?>].set"
+                      IL_00d5:  ret
+                    }
+                    """);
+            }
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanArgument_05([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                readonly ref struct R1
+                {
+                    public void M(ReadOnlySpan<int?> s) { s.Report(); }
+                    public object this[ReadOnlySpan<int?> s] { get { s.Report(); return null; } }
+                }
+                ref struct R2
+                {
+                    public readonly void M(ReadOnlySpan<int?> s) { s.Report(); }
+                    public readonly object this[ReadOnlySpan<int?> s] { get { s.Report(); return null; } }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        var r1 = new R1();
+                        r1.M([3]);
+                        _ = r1[[4]];
+                        var r2 = new R2();
+                        r2.M([5]);
+                        _ = r2[[6]];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[3], [4], [5], [6], "));
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      187 (0xbb)
+                      .maxstack  3
+                      .locals init (R1 V_0, //r1
+                                    R2 V_1, //r2
+                                    <>y__InlineArray1<int?> V_2)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "R1"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldloca.s   V_2
+                      IL_000c:  initobj    "<>y__InlineArray1<int?>"
+                      IL_0012:  ldloca.s   V_2
+                      IL_0014:  ldc.i4.0
+                      IL_0015:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_001a:  ldc.i4.3
+                      IL_001b:  newobj     "int?..ctor(int)"
+                      IL_0020:  stobj      "int?"
+                      IL_0025:  ldloca.s   V_2
+                      IL_0027:  ldc.i4.1
+                      IL_0028:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_002d:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                      IL_0032:  ldloca.s   V_0
+                      IL_0034:  ldloca.s   V_2
+                      IL_0036:  initobj    "<>y__InlineArray1<int?>"
+                      IL_003c:  ldloca.s   V_2
+                      IL_003e:  ldc.i4.0
+                      IL_003f:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_0044:  ldc.i4.4
+                      IL_0045:  newobj     "int?..ctor(int)"
+                      IL_004a:  stobj      "int?"
+                      IL_004f:  ldloca.s   V_2
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_0057:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
+                      IL_005c:  pop
+                      IL_005d:  ldloca.s   V_1
+                      IL_005f:  initobj    "R2"
+                      IL_0065:  ldloca.s   V_1
+                      IL_0067:  ldloca.s   V_2
+                      IL_0069:  initobj    "<>y__InlineArray1<int?>"
+                      IL_006f:  ldloca.s   V_2
+                      IL_0071:  ldc.i4.0
+                      IL_0072:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_0077:  ldc.i4.5
+                      IL_0078:  newobj     "int?..ctor(int)"
+                      IL_007d:  stobj      "int?"
+                      IL_0082:  ldloca.s   V_2
+                      IL_0084:  ldc.i4.1
+                      IL_0085:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_008a:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
+                      IL_008f:  ldloca.s   V_1
+                      IL_0091:  ldloca.s   V_2
+                      IL_0093:  initobj    "<>y__InlineArray1<int?>"
+                      IL_0099:  ldloca.s   V_2
+                      IL_009b:  ldc.i4.0
+                      IL_009c:  call       "InlineArrayElementRef<<>y__InlineArray1<int?>, int?>(ref <>y__InlineArray1<int?>, int)"
+                      IL_00a1:  ldc.i4.6
+                      IL_00a2:  newobj     "int?..ctor(int)"
+                      IL_00a7:  stobj      "int?"
+                      IL_00ac:  ldloca.s   V_2
+                      IL_00ae:  ldc.i4.1
+                      IL_00af:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<int?>, int?>(in <>y__InlineArray1<int?>, int)"
+                      IL_00b4:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
+                      IL_00b9:  pop
+                      IL_00ba:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.Main", """
+                    {
+                      // Code size      143 (0x8f)
+                      .maxstack  5
+                      .locals init (R1 V_0, //r1
+                                    R2 V_1) //r2
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  initobj    "R1"
+                      IL_0008:  ldloca.s   V_0
+                      IL_000a:  ldc.i4.1
+                      IL_000b:  newarr     "int?"
+                      IL_0010:  dup
+                      IL_0011:  ldc.i4.0
+                      IL_0012:  ldc.i4.3
+                      IL_0013:  newobj     "int?..ctor(int)"
+                      IL_0018:  stelem     "int?"
+                      IL_001d:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0022:  call       "void R1.M(System.ReadOnlySpan<int?>)"
+                      IL_0027:  ldloca.s   V_0
+                      IL_0029:  ldc.i4.1
+                      IL_002a:  newarr     "int?"
+                      IL_002f:  dup
+                      IL_0030:  ldc.i4.0
+                      IL_0031:  ldc.i4.4
+                      IL_0032:  newobj     "int?..ctor(int)"
+                      IL_0037:  stelem     "int?"
+                      IL_003c:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0041:  call       "object R1.this[System.ReadOnlySpan<int?>].get"
+                      IL_0046:  pop
+                      IL_0047:  ldloca.s   V_1
+                      IL_0049:  initobj    "R2"
+                      IL_004f:  ldloca.s   V_1
+                      IL_0051:  ldc.i4.1
+                      IL_0052:  newarr     "int?"
+                      IL_0057:  dup
+                      IL_0058:  ldc.i4.0
+                      IL_0059:  ldc.i4.5
+                      IL_005a:  newobj     "int?..ctor(int)"
+                      IL_005f:  stelem     "int?"
+                      IL_0064:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0069:  call       "readonly void R2.M(System.ReadOnlySpan<int?>)"
+                      IL_006e:  ldloca.s   V_1
+                      IL_0070:  ldc.i4.1
+                      IL_0071:  newarr     "int?"
+                      IL_0076:  dup
+                      IL_0077:  ldc.i4.0
+                      IL_0078:  ldc.i4.6
+                      IL_0079:  newobj     "int?..ctor(int)"
+                      IL_007e:  stelem     "int?"
+                      IL_0083:  newobj     "System.ReadOnlySpan<int?>..ctor(int?[])"
+                      IL_0088:  call       "readonly object R2.this[System.ReadOnlySpan<int?>].get"
+                      IL_008d:  pop
+                      IL_008e:  ret
+                    }
+                    """);
+            }
+        }
+
+        [Fact]
+        public void SpanArgument_06()
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F1<object>(y: [1], x: [2]);
+                        F2<object>(y: [3], x: [4]);
+                    }
+                    static Span<T> F1<T>(Span<T> x, scoped Span<T> y)
+                    {
+                        x.Report();
+                        y.Report();
+                        return x;
+                    }
+                    static ReadOnlySpan<T> F2<T>(scoped ReadOnlySpan<T> x, ReadOnlySpan<T> y)
+                    {
+                        x.Report();
+                        y.Report();
+                        return y;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Skipped,
+                expectedOutput: IncludeExpectedOutput("[2], [1], [4], [3], "));
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size      120 (0x78)
+                  .maxstack  5
+                  .locals init (<>y__InlineArray1<object> V_0,
+                                System.Span<object> V_1,
+                                System.ReadOnlySpan<object> V_2)
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "<>y__InlineArray1<object>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0010:  ldc.i4.1
+                  IL_0011:  box        "int"
+                  IL_0016:  stind.ref
+                  IL_0017:  ldloca.s   V_0
+                  IL_0019:  ldc.i4.1
+                  IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_001f:  stloc.1
+                  IL_0020:  ldc.i4.1
+                  IL_0021:  newarr     "object"
+                  IL_0026:  dup
+                  IL_0027:  ldc.i4.0
+                  IL_0028:  ldc.i4.2
+                  IL_0029:  box        "int"
+                  IL_002e:  stelem.ref
+                  IL_002f:  newobj     "System.Span<object>..ctor(object[])"
+                  IL_0034:  ldloc.1
+                  IL_0035:  call       "System.Span<object> Program.F1<object>(System.Span<object>, scoped System.Span<object>)"
+                  IL_003a:  pop
+                  IL_003b:  ldloca.s   V_2
+                  IL_003d:  ldc.i4.1
+                  IL_003e:  newarr     "object"
+                  IL_0043:  dup
+                  IL_0044:  ldc.i4.0
+                  IL_0045:  ldc.i4.3
+                  IL_0046:  box        "int"
+                  IL_004b:  stelem.ref
+                  IL_004c:  call       "System.ReadOnlySpan<object>..ctor(object[])"
+                  IL_0051:  ldloca.s   V_0
+                  IL_0053:  initobj    "<>y__InlineArray1<object>"
+                  IL_0059:  ldloca.s   V_0
+                  IL_005b:  ldc.i4.0
+                  IL_005c:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0061:  ldc.i4.4
+                  IL_0062:  box        "int"
+                  IL_0067:  stind.ref
+                  IL_0068:  ldloca.s   V_0
+                  IL_006a:  ldc.i4.1
+                  IL_006b:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_0070:  ldloc.2
+                  IL_0071:  call       "System.ReadOnlySpan<object> Program.F2<object>(scoped System.ReadOnlySpan<object>, System.ReadOnlySpan<object>)"
+                  IL_0076:  pop
+                  IL_0077:  ret
+                }
+                """);
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_01(
+            [CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework,
+            [CombinatorialValues("Span<object>", "ReadOnlySpan<object>")] string spanType)
+        {
+            string source = $$"""
+                using System;
+                class Program
+                {
+                    static {{spanType}} F1()
+                    {
+                        {{spanType}} s1 = [];
+                        return s1;
+                    }
+                    static {{spanType}} F2()
+                    {
+                        {{spanType}} s2 = [2];
+                        return s2;
+                    }
+                    static {{spanType}} F3()
+                    {
+                        {{spanType}} s3;
+                        s3 = [3];
+                        return s3;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: targetFramework);
+            comp.VerifyEmitDiagnostics(
+                // (7,16): error CS8352: Cannot use variable 's1' in this context because it may expose referenced variables outside of their declaration scope
+                //         return s1;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "s1").WithArguments("s1").WithLocation(7, 16),
+                // (12,16): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
+                //         return s2;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "s2").WithArguments("s2").WithLocation(12, 16),
+                // (17,14): error CS9201: A collection expression of type 'Span<object>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         s3 = [3];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[3]").WithArguments($"System.{spanType}").WithLocation(17, 14));
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_02([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        F1().Report();
+                        F2().Report();
+                        F3().Report();
+                        F4().Report();
+                    }
+                    static Span<object> F1()
+                    {
+                        return [1];
+                    }
+                    static object[] F2()
+                    {
+                        Span<object> s2 = [2];
+                        return s2.ToArray();
+                    }
+                    static object[] F3()
+                    {
+                        ReadOnlySpan<object> s3 = [3];
+                        return s3.ToArray();
+                    }
+                    static Span<object> F4()
+                    {
+                        Span<object> s4 = [4];
+                        return [..s4];
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Fails,
+                expectedOutput: IncludeExpectedOutput("[1], [2], [3], [4], "));
+            verifier.VerifyIL("Program.F1", """
+                {
+                  // Code size       21 (0x15)
+                  .maxstack  4
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  newarr     "object"
+                  IL_0006:  dup
+                  IL_0007:  ldc.i4.0
+                  IL_0008:  ldc.i4.1
+                  IL_0009:  box        "int"
+                  IL_000e:  stelem.ref
+                  IL_000f:  newobj     "System.Span<object>..ctor(object[])"
+                  IL_0014:  ret
+                }
+                """);
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.F2", """
+                    {
+                      // Code size       40 (0x28)
+                      .maxstack  2
+                      .locals init (System.Span<object> V_0, //s2
+                                    <>y__InlineArray1<object> V_1)
+                      IL_0000:  ldloca.s   V_1
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_1
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.2
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_1
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001f:  stloc.0
+                      IL_0020:  ldloca.s   V_0
+                      IL_0022:  call       "object[] System.Span<object>.ToArray()"
+                      IL_0027:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.F2", """
+                    {
+                      // Code size       30 (0x1e)
+                      .maxstack  5
+                      .locals init (System.Span<object> V_0) //s2
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.1
+                      IL_0003:  newarr     "object"
+                      IL_0008:  dup
+                      IL_0009:  ldc.i4.0
+                      IL_000a:  ldc.i4.2
+                      IL_000b:  box        "int"
+                      IL_0010:  stelem.ref
+                      IL_0011:  call       "System.Span<object>..ctor(object[])"
+                      IL_0016:  ldloca.s   V_0
+                      IL_0018:  call       "object[] System.Span<object>.ToArray()"
+                      IL_001d:  ret
+                    }
+                    """);
+            }
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.F3", """
+                    {
+                      // Code size       40 (0x28)
+                      .maxstack  2
+                      .locals init (System.ReadOnlySpan<object> V_0, //s3
+                                    <>y__InlineArray1<object> V_1)
+                      IL_0000:  ldloca.s   V_1
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_1
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.3
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_1
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                      IL_001f:  stloc.0
+                      IL_0020:  ldloca.s   V_0
+                      IL_0022:  call       "object[] System.ReadOnlySpan<object>.ToArray()"
+                      IL_0027:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.F3", """
+                    {
+                      // Code size       30 (0x1e)
+                      .maxstack  5
+                      .locals init (System.ReadOnlySpan<object> V_0) //s3
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.1
+                      IL_0003:  newarr     "object"
+                      IL_0008:  dup
+                      IL_0009:  ldc.i4.0
+                      IL_000a:  ldc.i4.3
+                      IL_000b:  box        "int"
+                      IL_0010:  stelem.ref
+                      IL_0011:  call       "System.ReadOnlySpan<object>..ctor(object[])"
+                      IL_0016:  ldloca.s   V_0
+                      IL_0018:  call       "object[] System.ReadOnlySpan<object>.ToArray()"
+                      IL_001d:  ret
+                    }
+                    """);
+            }
+            if (targetFramework == TargetFramework.Net80)
+            {
+                verifier.VerifyIL("Program.F4", """
+                    {
+                      // Code size       87 (0x57)
+                      .maxstack  2
+                      .locals init (System.Span<object> V_0, //s4
+                                    <>y__InlineArray1<object> V_1,
+                                    System.Collections.Generic.List<object> V_2,
+                                    System.Span<object>.Enumerator V_3,
+                                    object V_4)
+                      IL_0000:  ldloca.s   V_1
+                      IL_0002:  initobj    "<>y__InlineArray1<object>"
+                      IL_0008:  ldloca.s   V_1
+                      IL_000a:  ldc.i4.0
+                      IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_0010:  ldc.i4.4
+                      IL_0011:  box        "int"
+                      IL_0016:  stind.ref
+                      IL_0017:  ldloca.s   V_1
+                      IL_0019:  ldc.i4.1
+                      IL_001a:  call       "InlineArrayAsSpan<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                      IL_001f:  stloc.0
+                      IL_0020:  newobj     "System.Collections.Generic.List<object>..ctor()"
+                      IL_0025:  stloc.2
+                      IL_0026:  ldloca.s   V_0
+                      IL_0028:  call       "System.Span<object>.Enumerator System.Span<object>.GetEnumerator()"
+                      IL_002d:  stloc.3
+                      IL_002e:  br.s       IL_0042
+                      IL_0030:  ldloca.s   V_3
+                      IL_0032:  call       "ref object System.Span<object>.Enumerator.Current.get"
+                      IL_0037:  ldind.ref
+                      IL_0038:  stloc.s    V_4
+                      IL_003a:  ldloc.2
+                      IL_003b:  ldloc.s    V_4
+                      IL_003d:  callvirt   "void System.Collections.Generic.List<object>.Add(object)"
+                      IL_0042:  ldloca.s   V_3
+                      IL_0044:  call       "bool System.Span<object>.Enumerator.MoveNext()"
+                      IL_0049:  brtrue.s   IL_0030
+                      IL_004b:  ldloc.2
+                      IL_004c:  callvirt   "object[] System.Collections.Generic.List<object>.ToArray()"
+                      IL_0051:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_0056:  ret
+                    }
+                    """);
+            }
+            else
+            {
+                verifier.VerifyIL("Program.F4", """
+                    {
+                      // Code size       75 (0x4b)
+                      .maxstack  5
+                      .locals init (System.Span<object> V_0, //s4
+                                    System.Collections.Generic.List<object> V_1,
+                                    System.Span<object>.Enumerator V_2,
+                                    object V_3)
+                      IL_0000:  ldloca.s   V_0
+                      IL_0002:  ldc.i4.1
+                      IL_0003:  newarr     "object"
+                      IL_0008:  dup
+                      IL_0009:  ldc.i4.0
+                      IL_000a:  ldc.i4.4
+                      IL_000b:  box        "int"
+                      IL_0010:  stelem.ref
+                      IL_0011:  call       "System.Span<object>..ctor(object[])"
+                      IL_0016:  newobj     "System.Collections.Generic.List<object>..ctor()"
+                      IL_001b:  stloc.1
+                      IL_001c:  ldloca.s   V_0
+                      IL_001e:  call       "System.Span<object>.Enumerator System.Span<object>.GetEnumerator()"
+                      IL_0023:  stloc.2
+                      IL_0024:  br.s       IL_0036
+                      IL_0026:  ldloca.s   V_2
+                      IL_0028:  call       "ref object System.Span<object>.Enumerator.Current.get"
+                      IL_002d:  ldind.ref
+                      IL_002e:  stloc.3
+                      IL_002f:  ldloc.1
+                      IL_0030:  ldloc.3
+                      IL_0031:  callvirt   "void System.Collections.Generic.List<object>.Add(object)"
+                      IL_0036:  ldloca.s   V_2
+                      IL_0038:  call       "bool System.Span<object>.Enumerator.MoveNext()"
+                      IL_003d:  brtrue.s   IL_0026
+                      IL_003f:  ldloc.1
+                      IL_0040:  callvirt   "object[] System.Collections.Generic.List<object>.ToArray()"
+                      IL_0045:  newobj     "System.Span<object>..ctor(object[])"
+                      IL_004a:  ret
+                    }
+                    """);
+            }
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_Parameter([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void Main()
+                    {
+                        Span<object> s = default;
+                        F1(s).Report();
+                        F2(ref s).Report();
+                        F3(out s).Report();
+                    }
+                    static Span<object> F1(Span<object> s1)
+                    {
+                        s1 = [1];
+                        return s1;
+                    }
+                    static Span<object> F2(ref Span<object> s2)
+                    {
+                        s2 = [2];
+                        return s2;
+                    }
+                    static Span<object> F3(out Span<object> s3)
+                    {
+                        s3 = [3];
+                        return s3;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Fails,
+                expectedOutput: IncludeExpectedOutput("[1], [2], [3], "));
+            verifier.VerifyIL("Program.F1", """
+                {
+                  // Code size       24 (0x18)
+                  .maxstack  5
+                  IL_0000:  ldarga.s   V_0
+                  IL_0002:  ldc.i4.1
+                  IL_0003:  newarr     "object"
+                  IL_0008:  dup
+                  IL_0009:  ldc.i4.0
+                  IL_000a:  ldc.i4.1
+                  IL_000b:  box        "int"
+                  IL_0010:  stelem.ref
+                  IL_0011:  call       "System.Span<object>..ctor(object[])"
+                  IL_0016:  ldarg.0
+                  IL_0017:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.F2", """
+                {
+                  // Code size       33 (0x21)
+                  .maxstack  5
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.1
+                  IL_0002:  newarr     "object"
+                  IL_0007:  dup
+                  IL_0008:  ldc.i4.0
+                  IL_0009:  ldc.i4.2
+                  IL_000a:  box        "int"
+                  IL_000f:  stelem.ref
+                  IL_0010:  newobj     "System.Span<object>..ctor(object[])"
+                  IL_0015:  stobj      "System.Span<object>"
+                  IL_001a:  ldarg.0
+                  IL_001b:  ldobj      "System.Span<object>"
+                  IL_0020:  ret
+                }
+                """);
+            verifier.VerifyIL("Program.F3", """
+                {
+                  // Code size       33 (0x21)
+                  .maxstack  5
+                  IL_0000:  ldarg.0
+                  IL_0001:  ldc.i4.1
+                  IL_0002:  newarr     "object"
+                  IL_0007:  dup
+                  IL_0008:  ldc.i4.0
+                  IL_0009:  ldc.i4.3
+                  IL_000a:  box        "int"
+                  IL_000f:  stelem.ref
+                  IL_0010:  newobj     "System.Span<object>..ctor(object[])"
+                  IL_0015:  stobj      "System.Span<object>"
+                  IL_001a:  ldarg.0
+                  IL_001b:  ldobj      "System.Span<object>"
+                  IL_0020:  ret
+                }
+                """);
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_LocalField([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                ref struct R<T>
+                {
+                    public ReadOnlySpan<T> F;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        F().Report();
+                    }
+                    static ReadOnlySpan<object> F()
+                    {
+                        R<object> r = default;
+                        r.F = [1];
+                        return r.F;
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: targetFramework,
+                verify: Verification.Fails,
+                expectedOutput: IncludeExpectedOutput("[1], "));
+            verifier.VerifyIL("Program.F", """
+                {
+                  // Code size       42 (0x2a)
+                  .maxstack  5
+                  .locals init (R<object> V_0) //r
+                  IL_0000:  ldloca.s   V_0
+                  IL_0002:  initobj    "R<object>"
+                  IL_0008:  ldloca.s   V_0
+                  IL_000a:  ldc.i4.1
+                  IL_000b:  newarr     "object"
+                  IL_0010:  dup
+                  IL_0011:  ldc.i4.0
+                  IL_0012:  ldc.i4.1
+                  IL_0013:  box        "int"
+                  IL_0018:  stelem.ref
+                  IL_0019:  newobj     "System.ReadOnlySpan<object>..ctor(object[])"
+                  IL_001e:  stfld      "System.ReadOnlySpan<object> R<object>.F"
+                  IL_0023:  ldloc.0
+                  IL_0024:  ldfld      "System.ReadOnlySpan<object> R<object>.F"
+                  IL_0029:  ret
+                }
+                """);
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_RefLocal([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static Span<object> F()
+                    {
+                        Span<object> s = default;
+                        ref Span<object> r = ref s;
+                        r = new Span<object>(new object[] { 1 });
+                        r = [1];
+                        return r;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: targetFramework);
+            comp.VerifyEmitDiagnostics(
+                // (9,13): error CS9201: A collection expression of type 'Span<object>' cannot be used in this context because it may be exposed outside of the current scope.
+                //         r = [1];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[1]").WithArguments("System.Span<object>").WithLocation(9, 13));
+        }
+
+        [CombinatorialData]
+        [Theory]
+        public void SpanAssignment_DifferentLocalScope([CombinatorialValues(TargetFramework.Net70, TargetFramework.Net80)] TargetFramework targetFramework)
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void F(bool b)
+                    {
+                        ReadOnlySpan<object> x = [1];
+                        if (b)
+                        {
+                            x = [2];
+                        }
+                        else
+                        {
+                            ReadOnlySpan<object> y = [3];
+                            x = y;
+                        }
+                        ReadOnlySpan<object> z = [4];
+                        x = z;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: targetFramework);
+            comp.VerifyEmitDiagnostics(
+                // (9,17): error CS9201: A collection expression of type 'ReadOnlySpan<object>' cannot be used in this context because it may be exposed outside of the current scope.
+                //             x = [2];
+                Diagnostic(ErrorCode.ERR_CollectionExpressionEscape, "[2]").WithArguments("System.ReadOnlySpan<object>").WithLocation(9, 17),
+                // (14,17): error CS8352: Cannot use variable 'y' in this context because it may expose referenced variables outside of their declaration scope
+                //             x = y;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "y").WithArguments("y").WithLocation(14, 17));
+        }
+
+        [Fact]
+        public void SpanAssignment_WithUsingDeclaration()
+        {
+            string source = """
+                using System;
+                class Disposable : IDisposable
+                {
+                    void IDisposable.Dispose() { Console.Write("Disposed, "); }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        ReadOnlySpan<object> x = [1];
+                        using var d = new Disposable();
+                        ReadOnlySpan<object> y = [2];
+                        x.Report();
+                        y.Report();
+                    }
+                }
+                """;
+            var verifier = CompileAndVerify(
+                new[] { source, s_collectionExtensionsWithSpan },
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Fails,
+                expectedOutput: IncludeExpectedOutput("[1], [2], Disposed, "));
+            verifier.VerifyIL("Program.Main", """
+                {
+                  // Code size       97 (0x61)
+                  .maxstack  2
+                  .locals init (System.ReadOnlySpan<object> V_0, //x
+                                Disposable V_1, //d
+                                System.ReadOnlySpan<object> V_2, //y
+                                <>y__InlineArray1<object> V_3,
+                                <>y__InlineArray1<object> V_4)
+                  IL_0000:  ldloca.s   V_3
+                  IL_0002:  initobj    "<>y__InlineArray1<object>"
+                  IL_0008:  ldloca.s   V_3
+                  IL_000a:  ldc.i4.0
+                  IL_000b:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                  IL_0010:  ldc.i4.1
+                  IL_0011:  box        "int"
+                  IL_0016:  stind.ref
+                  IL_0017:  ldloca.s   V_3
+                  IL_0019:  ldc.i4.1
+                  IL_001a:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                  IL_001f:  stloc.0
+                  IL_0020:  newobj     "Disposable..ctor()"
+                  IL_0025:  stloc.1
+                  .try
+                  {
+                    IL_0026:  ldloca.s   V_4
+                    IL_0028:  initobj    "<>y__InlineArray1<object>"
+                    IL_002e:  ldloca.s   V_4
+                    IL_0030:  ldc.i4.0
+                    IL_0031:  call       "InlineArrayElementRef<<>y__InlineArray1<object>, object>(ref <>y__InlineArray1<object>, int)"
+                    IL_0036:  ldc.i4.2
+                    IL_0037:  box        "int"
+                    IL_003c:  stind.ref
+                    IL_003d:  ldloca.s   V_4
+                    IL_003f:  ldc.i4.1
+                    IL_0040:  call       "InlineArrayAsReadOnlySpan<<>y__InlineArray1<object>, object>(in <>y__InlineArray1<object>, int)"
+                    IL_0045:  stloc.2
+                    IL_0046:  ldloca.s   V_0
+                    IL_0048:  call       "void CollectionExtensions.Report<object>(in System.ReadOnlySpan<object>)"
+                    IL_004d:  ldloca.s   V_2
+                    IL_004f:  call       "void CollectionExtensions.Report<object>(in System.ReadOnlySpan<object>)"
+                    IL_0054:  leave.s    IL_0060
+                  }
+                  finally
+                  {
+                    IL_0056:  ldloc.1
+                    IL_0057:  brfalse.s  IL_005f
+                    IL_0059:  ldloc.1
+                    IL_005a:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_005f:  endfinally
+                  }
+                  IL_0060:  ret
+                }
+                """);
         }
 
         [ConditionalFact(typeof(DesktopOnly))]


### PR DESCRIPTION
Update ref safety to treat a collection expression assigned to a ref struct local as not returnable; use inline arrays for collection expressions with span target types in local assignments and method arguments - see [WG meeting notes](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-06-26.md#collection-expression-lifetimes).