### PR TITLE
Fix issues with Uri escaping certain Unicode characters

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <ILAsmPackageVersion>6.0.0-rtm.21518.12</ILAsmPackageVersion>
     <ILDAsmPackageVersion>6.0.0-rtm.21518.12</ILDAsmPackageVersion>
     <MicrosoftVisualStudioLanguageServerClientPackagesVersion>17.7.4-preview</MicrosoftVisualStudioLanguageServerClientPackagesVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.8.3-preview</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.8.8-preview</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.7.35038-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <RefOnlyMicrosoftBuildPackagesVersion>16.10.0</RefOnlyMicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -67,14 +67,14 @@ namespace Roslyn.Test.Utilities
         internal class TestSpanMapper : ISpanMappingService
         {
             private static readonly LinePositionSpan s_mappedLinePosition = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 5));
-            private static readonly string s_mappedFilePath = "c:\\MappedFile.cs";
+            private static readonly string s_mappedFilePath = "c:\\MappedFile_\ue25b\ud86d\udeac.cs";
 
-            internal static readonly string GeneratedFileName = "GeneratedFile.cs";
+            internal static readonly string GeneratedFileName = "GeneratedFile_\ue25b\ud86d\udeac.cs";
 
             internal static readonly LSP.Location MappedFileLocation = new LSP.Location
             {
                 Range = ProtocolConversions.LinePositionToRange(s_mappedLinePosition),
-                Uri = new Uri(s_mappedFilePath)
+                Uri = ProtocolConversions.GetUriFromFilePath(s_mappedFilePath)
             };
 
             /// <summary>
@@ -444,8 +444,10 @@ namespace Roslyn.Test.Utilities
                 var text = await document.GetTextAsync(CancellationToken.None);
                 foreach (var (name, spans) in testDocument.AnnotatedSpans)
                 {
+                    Contract.ThrowIfNull(document.FilePath);
+
                     var locationsForName = locations.GetValueOrDefault(name, new List<LSP.Location>());
-                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, new Uri(document.FilePath))));
+                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, ProtocolConversions.GetUriFromFilePath(document.FilePath))));
 
                     // Linked files will return duplicate annotated Locations for each document that links to the same file.
                     // Since the test output only cares about the actual file, make sure we de-dupe before returning.

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
@@ -17,7 +17,7 @@ public class ServerInitializationTests : AbstractLanguageServerHostTests
     public async Task TestServerHandlesTextSyncRequestsAsync()
     {
         await using var server = await CreateLanguageServerAsync();
-        var document = new VersionedTextDocumentIdentifier { Uri = new Uri(@"C:\file.cs") };
+        var document = new VersionedTextDocumentIdentifier { Uri = ProtocolConversions.GetUriFromFilePath("C:\\\ue25b\ud86d\udeac.cs") };
         var response = await server.ExecuteRequestAsync<DidOpenTextDocumentParams, object>(Methods.TextDocumentDidOpenName, new DidOpenTextDocumentParams
         {
             TextDocument = new TextDocumentItem

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -151,11 +151,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             }
         }
 
-        // If we have a file:///xyz URI, we'll store the actual file path string in the document file path.
-        // Otherwise we have a URI that doesn't point to an actual file. In such a scenario, we'll store the full URI string (including schema).
-        // This will allow correct round-tripping of the URI for features that need it until we support URI as a first class document concept.
-        // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
-        public static string GetDocumentFilePathFromUri(Uri uri) => uri.IsFile ? uri.LocalPath : uri.OriginalString;
+        // We should always use the original string used for creating the Uri to avoid any
+        // escaping or normalization performed by Uri.LocalPath or Uri.AbsolutePath.
+        public static string GetDocumentFilePathFromUri(Uri uri)
+            => uri.OriginalString;
 
         public static Uri GetUriFromFilePath(string filePath)
         {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
                         locations.Add(new LSP.Location
                         {
-                            Uri = new Uri(declarationFile.FilePath),
+                            Uri = ProtocolConversions.GetUriFromFilePath(declarationFile.FilePath),
                             Range = ProtocolConversions.LinePositionToRange(linePosSpan),
                         });
                     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsRefreshQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticsRefreshQueue.cs
@@ -94,7 +94,7 @@ internal sealed class DiagnosticsRefreshQueue : AbstractRefreshQueue
     }
 
     private void WorkspaceRefreshRequested()
-        => EnqueueRefreshNotification(documentUri: null);
+        => EnqueueRefreshNotification(documentPath: null);
 
     protected override string GetFeatureAttribute()
         => FeatureAttribute.DiagnosticService;

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 return ImmutableArray<IDiagnosticSource>.Empty;
             }
 
-            if (!context.IsTracking(document.GetURI()))
+            if (!context.IsTracking(ProtocolConversions.GetDocumentFilePathFromUri(document.GetURI())))
             {
                 context.TraceWarning($"Ignoring diagnostics request for untracked document: {document.GetURI()}");
                 return ImmutableArray<IDiagnosticSource>.Empty;

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         {
             // Only consider closed documents here (and only open ones in the DocumentPullDiagnosticHandler).
             // Each handler treats those as separate worlds that they are responsible for.
-            if (context.IsTracking(document.GetURI()))
+            if (context.IsTracking(ProtocolConversions.GetDocumentFilePathFromUri(document.GetURI())))
             {
                 context.TraceInformation($"Skipping tracked document: {document.GetURI()}");
                 return true;

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 
         public Task<object?> HandleRequestAsync(LSP.DidChangeTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var text = context.GetTrackedDocumentSourceText(request.TextDocument.Uri);
+            var documentPath = ProtocolConversions.GetDocumentFilePathFromUri(request.TextDocument.Uri);
+            var text = context.GetTrackedDocumentSourceText(documentPath);
 
             // Per the LSP spec, each text change builds upon the previous, so we don't need to translate
             // any text positions between changes, which makes this quite easy.

--- a/src/Features/LanguageServer/Protocol/Handler/InlayHint/InlayHintRefreshQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/InlayHint/InlayHintRefreshQueue.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.InlayHint
                 e.Option.Equals(InlineHintsOptionsStorage.ForLambdaParameterTypes) ||
                 e.Option.Equals(InlineHintsOptionsStorage.ForImplicitObjectCreation))
             {
-                EnqueueRefreshNotification(documentUri: null);
+                EnqueueRefreshNotification(documentPath: null);
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -42,7 +42,7 @@ internal readonly struct RequestContext
     /// It contains text that is consistent with all prior LSP text sync notifications, but LSP text sync requests
     /// which are ordered after this one in the queue are not reflected here.
     /// </remarks>
-    private readonly ImmutableDictionary<Uri, (SourceText Text, string LanguageId)> _trackedDocuments;
+    private readonly ImmutableDictionary<string, (SourceText Text, string LanguageId)> _trackedDocuments;
 
     private readonly ILspServices _lspServices;
 
@@ -151,7 +151,7 @@ internal readonly struct RequestContext
         WellKnownLspServerKinds serverKind,
         Document? document,
         IDocumentChangeTracker documentChangeTracker,
-        ImmutableDictionary<Uri, (SourceText Text, string LanguageId)> trackedDocuments,
+        ImmutableDictionary<string, (SourceText Text, string LanguageId)> trackedDocuments,
         ImmutableArray<string> supportedLanguages,
         ILspServices lspServices,
         CancellationToken queueCancellationToken)
@@ -280,10 +280,10 @@ internal readonly struct RequestContext
     public void UpdateTrackedDocument(Uri uri, SourceText changedText)
         => _documentChangeTracker.UpdateTrackedDocument(uri, changedText);
 
-    public SourceText GetTrackedDocumentSourceText(Uri documentUri)
+    public SourceText GetTrackedDocumentSourceText(string documentPath)
     {
-        Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentUri), $"Attempted to get text for {documentUri} which is not open.");
-        return _trackedDocuments[documentUri].Text;
+        Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(documentPath), $"Attempted to get text for {documentPath} which is not open.");
+        return _trackedDocuments[documentPath].Text;
     }
 
     /// <summary>
@@ -293,8 +293,8 @@ internal readonly struct RequestContext
     public ValueTask StopTrackingAsync(Uri uri, CancellationToken cancellationToken)
         => _documentChangeTracker.StopTrackingAsync(uri, cancellationToken);
 
-    public bool IsTracking(Uri documentUri)
-        => _trackedDocuments.ContainsKey(documentUri);
+    public bool IsTracking(string documentPath)
+        => _trackedDocuments.ContainsKey(documentPath);
 
     public void ClearSolutionContext()
     {

--- a/src/Features/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SpellCheck/DocumentSpellCheckHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SpellCheck
                 return ImmutableArray<Document>.Empty;
             }
 
-            if (!context.IsTracking(context.Document.GetURI()))
+            if (!context.IsTracking(ProtocolConversions.GetDocumentFilePathFromUri(context.Document.GetURI())))
             {
                 context.TraceInformation($"Ignoring spell check request for untracked document: {context.Document.GetURI()}");
                 return ImmutableArray<Document>.Empty;

--- a/src/Features/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SpellCheck/WorkspaceSpellCheckHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SpellCheck
 
                     // Only consider closed documents here (and only open ones in the DocumentSpellCheckingHandler).
                     // Each handler treats those as separate worlds that they are responsible for.
-                    if (context.IsTracking(document.GetURI()))
+                    if (context.IsTracking(ProtocolConversions.GetDocumentFilePathFromUri(document.GetURI())))
                     {
                         context.TraceInformation($"Skipping tracked document: {document.GetURI()}");
                         continue;

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" />

--- a/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Definitions
             var position = new LSP.Position { Line = 5, Character = 18 };
             var results = await RunGotoDefinitionAsync(testLspServer, new LSP.Location
             {
-                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Uri = ProtocolConversions.GetUriFromFilePath($"C:\\{TestSpanMapper.GeneratedFileName}"),
                 Range = new LSP.Range { Start = position, End = position }
             });
             AssertLocationsEqual(ImmutableArray.Create(TestSpanMapper.MappedFileLocation), results);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -1313,7 +1313,7 @@ class A {";
 
             var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
             Assert.Equal(3, results.Length);
-            Assert.Equal(new Uri("C:/test1.cs"), results[0].TextDocument!.Uri);
+            Assert.Equal(ProtocolConversions.GetUriFromFilePath(@"C:\test1.cs"), results[0].TextDocument!.Uri);
             Assert.Equal("CS1513", results[0].Diagnostics.Single().Code);
             Assert.Equal(1, results[0].Diagnostics.Single().Range.Start.Line);
             Assert.Empty(results[1].Diagnostics);

--- a/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
@@ -73,7 +73,7 @@ comment */|}";
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.FoldingRangeParams()
             {
-                TextDocument = CreateTextDocumentIdentifier(new Uri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.GetUriFromFilePath(document.FilePath))
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.FoldingRangeParams, LSP.FoldingRange[]>(LSP.Methods.TextDocumentFoldingRangeName,

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 TextDocument = new TextDocumentItem
                 {
                     Text = "sometext",
-                    Uri = new Uri("C:\\location\\file.json"),
+                    Uri = ProtocolConversions.GetUriFromFilePath(@"C:\location\file.json"),
                 }
             };
 
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 TextDocument = new TextDocumentItem
                 {
                     Text = "sometext",
-                    Uri = new Uri("C:\\location\\file.json"),
+                    Uri = ProtocolConversions.GetUriFromFilePath(@"C:\location\file.json"),
                 }
             };
             var ex = await Assert.ThrowsAsync<RemoteInvocationException>(async () => await server.ExecuteRequestAsync<DidOpenTextDocumentParams, object>(Methods.TextDocumentDidOpenName, didOpenParams, CancellationToken.None));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
@@ -39,7 +39,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open an empty loose file and make a request to verify it gets added to the misc workspace.
-        var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        var looseFileUri = ProtocolConversions.GetUriFromFilePath(@"C:\SomeFile.cs");
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
 
         // Verify file is added to the misc file workspace.
@@ -65,7 +65,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
 
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
-        var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        var looseFileUri = ProtocolConversions.GetUriFromFilePath(@"C:\SomeFile.cs");
 
         // Open an empty loose file and make a request to verify it gets added to the misc workspace.
         await testLspServer.OpenDocumentAsync(looseFileUri, string.Empty).ConfigureAwait(false);
@@ -103,7 +103,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open an empty loose file and make a request to verify it gets added to the misc workspace.
-        var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        var looseFileUri = ProtocolConversions.GetUriFromFilePath(@"C:\SomeFile.cs");
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
         await AssertFileInMiscWorkspaceAsync(testLspServer, looseFileUri).ConfigureAwait(false);
 
@@ -128,7 +128,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open a file that is part of a registered workspace and verify it is not present in the misc workspace.
-        var fileInWorkspaceUri = new Uri(testLspServer.GetCurrentSolution().Projects.Single().Documents.Single().FilePath);
+        var fileInWorkspaceUri = ProtocolConversions.GetUriFromFilePath(testLspServer.GetCurrentSolution().Projects.Single().Documents.Single().FilePath);
         await testLspServer.OpenDocumentAsync(fileInWorkspaceUri).ConfigureAwait(false);
         Assert.Null(GetMiscellaneousDocument(testLspServer));
     }
@@ -149,7 +149,8 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open an empty loose file and make a request to verify it gets added to the misc workspace.
-        var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        // Include some Unicode characters to test URL handling.
+        var looseFileUri = ProtocolConversions.GetUriFromFilePath("C:\\\ue25b\ud86d\udeac.cs");
         var looseFileTextDocumentIdentifier = new LSP.TextDocumentIdentifier { Uri = looseFileUri };
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
 
@@ -164,14 +165,14 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         var project = testLspServer.GetCurrentSolution().Projects.Single();
         var documentInfo = DocumentInfo.Create(
                 DocumentId.CreateNewId(project.Id),
-                looseFileUri.AbsolutePath,
+                looseFileUri.OriginalString,
                 sourceCodeKind: SourceCodeKind.Regular,
                 loader: new TestTextLoader(source),
-                filePath: looseFileUri.AbsolutePath);
+                filePath: looseFileUri.OriginalString);
         testLspServer.TestWorkspace.OnDocumentAdded(documentInfo);
         await WaitForWorkspaceOperationsAsync(testLspServer.TestWorkspace);
 
-        Assert.Contains(looseFileUri.AbsolutePath, testLspServer.GetCurrentSolution().Projects.Single().Documents.Select(d => d.FilePath));
+        Assert.Contains(looseFileUri.OriginalString, testLspServer.GetCurrentSolution().Projects.Single().Documents.Select(d => d.FilePath));
 
         // Verify that the manager returns the file that has been added to the main workspace.
         await AssertFileInMainWorkspaceAsync(testLspServer, looseFileUri).ConfigureAwait(false);
@@ -197,7 +198,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         // Open an empty loose file and make a request to verify it gets added to the misc workspace.
-        var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        var looseFileUri = ProtocolConversions.GetUriFromFilePath(@"C:\SomeFile.cs");
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
 
         // Trigger a request and assert we got a file in the misc workspace.

--- a/src/Features/LanguageServer/ProtocolUnitTests/References/FindImplementationsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/References/FindImplementationsTests.cs
@@ -92,7 +92,7 @@ class A : IA
             var position = new LSP.Position { Line = 2, Character = 9 };
             var results = await RunFindImplementationAsync(testLspServer, new LSP.Location
             {
-                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Uri = ProtocolConversions.GetUriFromFilePath($"C:\\{TestSpanMapper.GeneratedFileName}"),
                 Range = new LSP.Range { Start = position, End = position }
             });
             AssertLocationsEqual(ImmutableArray.Create(TestSpanMapper.MappedFileLocation), results);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.DocumentSymbolParams
             {
-                TextDocument = CreateTextDocumentIdentifier(new Uri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.GetUriFromFilePath(document.FilePath))
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.DocumentSymbolParams, TReturn>(LSP.Methods.TextDocumentDocumentSymbolName,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -241,7 +241,9 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
         // Create a new document, but do not update the workspace solution yet.
         var newDocumentId = DocumentId.CreateNewId(testLspServer.TestWorkspace.CurrentSolution.ProjectIds[0]);
-        var newDocumentFilePath = @"C:/NewDoc.cs";
+
+        // Include some Unicode characters to test URL handling.
+        var newDocumentFilePath = "C:\\NewDoc\\\ue25b\ud86d\udeac.cs";
         var newDocumentInfo = DocumentInfo.Create(newDocumentId, "NewDoc.cs", filePath: newDocumentFilePath, loader: new TestTextLoader("New Doc"));
         var newDocumentUri = ProtocolConversions.GetUriFromFilePath(newDocumentFilePath);
 
@@ -542,8 +544,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
             Array.Empty<string>(), mutatingLspWorkspace: true, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         // Open the doc
-        var filePath = @"c:\Test1.cs";
-        var documentUri = new Uri("file://" + filePath, UriKind.Absolute);
+        var filePath = "c:\\\ue25b\ud86d\udeac.cs";
+        var documentUri = ProtocolConversions.GetUriFromFilePath(filePath);
         await testLspServer.OpenDocumentAsync(documentUri, "Text");
 
         // Initially the doc will be in the lsp misc workspace.


### PR DESCRIPTION
Contributes to fix of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1842233

Workaround for `Uri` escaping certain Unicode characters in `LocalPath` and `AbsolutePath` properties.

```C#
> new Uri("c:\\\ue25b").AbsolutePath
"c:/%25EE%2589%259B"
> new Uri("c:\\\ue25b").LocalPath
"c:\\%EE%89%9B"
```

Use `OriginalString` instead to avoid issues like that.
Also avoid using `Uri` internally, unless we need to communicate to LSP client.

Interestingly enough, when the `Uri` is constructed from ULR string (as opposed to local path), the escaping works correctly:
```C#
> new Uri("file://c:/\ue25b").LocalPath
"c:\\"
```

`Uri` issue: https://github.com/dotnet/runtime/issues/89538