### PR TITLE
Add support for quick info in embedded languages

### DIFF
--- a/src/Features/CSharp/Portable/QuickInfo/CSharpEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpEmbeddedLanguageQuickInfoProvider.cs
@@ -11,18 +11,17 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.QuickInfo;
 
-namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
+namespace Microsoft.CodeAnalysis.CSharp.QuickInfo;
+
+[ExportQuickInfoProvider(QuickInfoProviderNames.EmbeddedLanguages, LanguageNames.CSharp)]
+[ExtensionOrder(Before = QuickInfoProviderNames.Semantic)]
+[Shared]
+internal sealed class CSharpEmbeddedLanguageQuickInfoProvider : AbstractEmbeddedLanguageQuickInfoProvider
 {
-    [ExportQuickInfoProvider(QuickInfoProviderNames.EmbeddedLanguages, LanguageNames.CSharp)]
-    [ExtensionOrder(Before = QuickInfoProviderNames.Semantic)]
-    [Shared]
-    internal class CSharpEmbeddedLanguageQuickInfoProvider : AbstractEmbeddedLanguageQuickInfoProvider
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public CSharpEmbeddedLanguageQuickInfoProvider([ImportMany] IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> services)
+        : base(LanguageNames.CSharp, CSharpEmbeddedLanguagesProvider.Info, CSharpSyntaxKinds.Instance, services)
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpEmbeddedLanguageQuickInfoProvider([ImportMany] IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> services)
-            : base(LanguageNames.CSharp, CSharpEmbeddedLanguagesProvider.Info, CSharpSyntaxKinds.Instance, services)
-        {
-        }
     }
 }

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpEmbeddedLanguageQuickInfoProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.LanguageServices;
+using Microsoft.CodeAnalysis.CSharp.LanguageService;
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.QuickInfo;
+
+namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
+{
+    [ExportQuickInfoProvider(QuickInfoProviderNames.EmbeddedLanguages, LanguageNames.CSharp)]
+    [ExtensionOrder(Before = QuickInfoProviderNames.Semantic)]
+    [Shared]
+    internal class CSharpEmbeddedLanguageQuickInfoProvider : AbstractEmbeddedLanguageQuickInfoProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpEmbeddedLanguageQuickInfoProvider([ImportMany] IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> services)
+            : base(LanguageNames.CSharp, CSharpEmbeddedLanguagesProvider.Info, CSharpSyntaxKinds.Instance, services)
+        {
+        }
+    }
+}

--- a/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageFeatureService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageFeatureService.cs
@@ -52,18 +52,18 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages
             ISyntaxKinds syntaxKinds,
             IEnumerable<Lazy<TService, EmbeddedLanguageMetadata>> allServices)
         {
-            // Order the classifiers to respect the [Order] annotations.
-            var orderedClassifiers = ExtensionOrderer.Order(allServices).Where(c => c.Metadata.Languages.Contains(languageName)).ToImmutableArray();
+            // Order the feature providers to respect the [Order] annotations.
+            var orderedFeatureProviders = ExtensionOrderer.Order(allServices).Where(c => c.Metadata.Languages.Contains(languageName)).ToImmutableArray();
 
             // Grab out the services that handle unannotated literals and APIs.
-            _legacyServices = orderedClassifiers.WhereAsArray(c => c.Metadata.SupportsUnannotatedAPIs);
+            _legacyServices = orderedFeatureProviders.WhereAsArray(c => c.Metadata.SupportsUnannotatedAPIs);
 
             using var _ = PooledDictionary<string, ArrayBuilder<Lazy<TService, EmbeddedLanguageMetadata>>>.GetInstance(out var map);
 
-            foreach (var classifier in orderedClassifiers)
+            foreach (var featureProvider in orderedFeatureProviders)
             {
-                foreach (var identifier in classifier.Metadata.Identifiers)
-                    map.MultiAdd(identifier, classifier);
+                foreach (var identifier in featureProvider.Metadata.Identifiers)
+                    map.MultiAdd(identifier, featureProvider);
             }
 
             foreach (var (_, services) in map)
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages
             CancellationToken cancellationToken)
         {
             // First, see if this is a string annotated with either a comment or [StringSyntax] attribute. If
-            // so, delegate to the first classifier we have registered for whatever language ID we find.
+            // so, delegate to the first feature provider we have registered for whatever language ID we find.
             if (this._detector.IsEmbeddedLanguageToken(token, semanticModel, cancellationToken, out var identifier, out _) &&
                 _identifierToServices.TryGetValue(identifier, out var services))
             {

--- a/src/Features/Core/Portable/QuickInfo/AbstractEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/AbstractEmbeddedLanguageQuickInfoProvider.cs
@@ -11,70 +11,69 @@ using Microsoft.CodeAnalysis.EmbeddedLanguages;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
-namespace Microsoft.CodeAnalysis.QuickInfo
+namespace Microsoft.CodeAnalysis.QuickInfo;
+
+internal abstract class AbstractEmbeddedLanguageQuickInfoProvider : CommonQuickInfoProvider
 {
-    internal class AbstractEmbeddedLanguageQuickInfoProvider : CommonQuickInfoProvider
+    private readonly EmbeddedLanguageProviderFeatureService _embeddedLanguageProviderFeature;
+
+    public AbstractEmbeddedLanguageQuickInfoProvider(
+        string languageName,
+        EmbeddedLanguageInfo info,
+        ISyntaxKinds syntaxKinds,
+        IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
     {
-        private readonly EmbeddedLanguageProviderFeatureService _embeddedLanguageProviderFeature;
+        _embeddedLanguageProviderFeature = new EmbeddedLanguageProviderFeatureService(languageName, info, syntaxKinds, allServices);
+    }
 
-        public AbstractEmbeddedLanguageQuickInfoProvider(
-            string languageName,
-            EmbeddedLanguageInfo info,
-            ISyntaxKinds syntaxKinds,
-            IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
-        {
-            _embeddedLanguageProviderFeature = new EmbeddedLanguageProviderFeatureService(languageName, info, syntaxKinds, allServices);
-        }
-
-        protected override async Task<QuickInfoItem?> BuildQuickInfoAsync(QuickInfoContext context, SyntaxToken token)
-        {
-            if (!_embeddedLanguageProviderFeature.SyntaxTokenKinds.Contains(token.RawKind))
-                return null;
-
-            var semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-
-            var quickInfoProviders = _embeddedLanguageProviderFeature.GetServices(semanticModel, token, context.CancellationToken);
-            foreach (var quickInfoProvider in quickInfoProviders)
-            {
-                // If this service added values then need to check the other ones.
-                var result = quickInfoProvider.Value.GetQuickInfo(context, semanticModel, token);
-                if (result != null)
-                    return result;
-            }
-
+    protected override async Task<QuickInfoItem?> BuildQuickInfoAsync(QuickInfoContext context, SyntaxToken token)
+    {
+        if (!_embeddedLanguageProviderFeature.SyntaxTokenKinds.Contains(token.RawKind))
             return null;
-        }
 
-        protected override Task<QuickInfoItem?> BuildQuickInfoAsync(CommonQuickInfoContext context, SyntaxToken token)
+        var semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var quickInfoProviders = _embeddedLanguageProviderFeature.GetServices(semanticModel, token, context.CancellationToken);
+        foreach (var quickInfoProvider in quickInfoProviders)
         {
-            // Not implemented as this entrypoint appears to be dead code.
-            throw new NotImplementedException();
+            // If this service added values then need to check the other ones.
+            var result = quickInfoProvider.Value.GetQuickInfo(context, semanticModel, token);
+            if (result != null)
+                return result;
         }
 
-        /// <summary>
-        /// A derivation of <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/> so we can fetch providers. Normally, our providers implement an interface,
-        /// and the combined provider directly inherits from <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/>. Unfortunately Quick Info is a bit different:
-        /// there is a class (not an interface) and a private base class that also defines some logic that we need to reuse. Since we don't
-        /// have multiple inheritance, we'll create a separate class here and delegate to the protected methods. We can remove this if we
-        /// switch Quick Info over to a pattern like the rest of our features.
-        /// </summary>
-        private class EmbeddedLanguageProviderFeatureService :
-            AbstractEmbeddedLanguageFeatureService<IEmbeddedLanguageQuickInfoProvider>
+        return null;
+    }
+
+    protected override Task<QuickInfoItem?> BuildQuickInfoAsync(CommonQuickInfoContext context, SyntaxToken token)
+    {
+        // Not implemented as this entrypoint appears to be dead code.
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// A derivation of <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/> so we can fetch providers. Normally, our providers implement an interface,
+    /// and the combined provider directly inherits from <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/>. Unfortunately Quick Info is a bit different:
+    /// there is a class (not an interface) and a private base class that also defines some logic that we need to reuse. Since we don't
+    /// have multiple inheritance, we'll create a separate class here and delegate to the protected methods. We can remove this if we
+    /// switch Quick Info over to a pattern like the rest of our features.
+    /// </summary>
+    private class EmbeddedLanguageProviderFeatureService :
+        AbstractEmbeddedLanguageFeatureService<IEmbeddedLanguageQuickInfoProvider>
+    {
+        public EmbeddedLanguageProviderFeatureService(string languageName, EmbeddedLanguageInfo info, ISyntaxKinds syntaxKinds, IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
+            : base(languageName, info, syntaxKinds, allServices)
         {
-            public EmbeddedLanguageProviderFeatureService(string languageName, EmbeddedLanguageInfo info, ISyntaxKinds syntaxKinds, IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
-                : base(languageName, info, syntaxKinds, allServices)
-            {
-            }
-
-            public new ImmutableArray<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> GetServices(
-                SemanticModel semanticModel,
-                SyntaxToken token,
-                CancellationToken cancellationToken)
-            {
-                return base.GetServices(semanticModel, token, cancellationToken);
-            }
-
-            public new HashSet<int> SyntaxTokenKinds => base.SyntaxTokenKinds;
         }
+
+        public new ImmutableArray<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> GetServices(
+            SemanticModel semanticModel,
+            SyntaxToken token,
+            CancellationToken cancellationToken)
+        {
+            return base.GetServices(semanticModel, token, cancellationToken);
+        }
+
+        public new HashSet<int> SyntaxTokenKinds => base.SyntaxTokenKinds;
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/AbstractEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/AbstractEmbeddedLanguageQuickInfoProvider.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.QuickInfo
+{
+    internal class AbstractEmbeddedLanguageQuickInfoProvider : CommonQuickInfoProvider
+    {
+        private readonly EmbeddedLanguageProviderFeatureService _embeddedLanguageProviderFeature;
+
+        public AbstractEmbeddedLanguageQuickInfoProvider(
+            string languageName,
+            EmbeddedLanguageInfo info,
+            ISyntaxKinds syntaxKinds,
+            IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
+        {
+            _embeddedLanguageProviderFeature = new EmbeddedLanguageProviderFeatureService(languageName, info, syntaxKinds, allServices);
+        }
+
+        protected override async Task<QuickInfoItem?> BuildQuickInfoAsync(QuickInfoContext context, SyntaxToken token)
+        {
+            if (!_embeddedLanguageProviderFeature.SyntaxTokenKinds.Contains(token.RawKind))
+                return null;
+
+            var semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var quickInfoProviders = _embeddedLanguageProviderFeature.GetServices(semanticModel, token, context.CancellationToken);
+            foreach (var quickInfoProvider in quickInfoProviders)
+            {
+                // If this service added values then need to check the other ones.
+                var result = quickInfoProvider.Value.GetQuickInfo(context, semanticModel, token);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
+        protected override Task<QuickInfoItem?> BuildQuickInfoAsync(CommonQuickInfoContext context, SyntaxToken token)
+        {
+            // Not implemented as this entrypoint appears to be dead code.
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// A derivation of <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/> so we can fetch providers. Normally, our providers implement an interface,
+        /// and the combined provider directly inherits from <see cref="AbstractEmbeddedLanguageFeatureService{TService}"/>. Unfortunately Quick Info is a bit different:
+        /// there is a class (not an interface) and a private base class that also defines some logic that we need to reuse. Since we don't
+        /// have multiple inheritance, we'll create a separate class here and delegate to the protected methods. We can remove this if we
+        /// switch Quick Info over to a pattern like the rest of our features.
+        /// </summary>
+        private class EmbeddedLanguageProviderFeatureService :
+            AbstractEmbeddedLanguageFeatureService<IEmbeddedLanguageQuickInfoProvider>
+        {
+            public EmbeddedLanguageProviderFeatureService(string languageName, EmbeddedLanguageInfo info, ISyntaxKinds syntaxKinds, IEnumerable<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> allServices)
+                : base(languageName, info, syntaxKinds, allServices)
+            {
+            }
+
+            public new ImmutableArray<Lazy<IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata>> GetServices(
+                SemanticModel semanticModel,
+                SyntaxToken token,
+                CancellationToken cancellationToken)
+            {
+                return base.GetServices(semanticModel, token, cancellationToken);
+            }
+
+            public new HashSet<int> SyntaxTokenKinds => base.SyntaxTokenKinds;
+        }
+    }
+}

--- a/src/Features/Core/Portable/QuickInfo/ExportEmbeddedLanguageQuickInfoProviderAttribute.cs
+++ b/src/Features/Core/Portable/QuickInfo/ExportEmbeddedLanguageQuickInfoProviderAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+
+namespace Microsoft.CodeAnalysis.QuickInfo
+{
+    internal class ExportEmbeddedLanguageQuickInfoProviderAttribute
+        : ExportEmbeddedLanguageFeatureServiceAttribute
+    {
+        public ExportEmbeddedLanguageQuickInfoProviderAttribute(string name, string[] languages, params string[] identifiers)
+            : base(typeof(IEmbeddedLanguageQuickInfoProvider), name, languages, identifiers)
+        {
+        }
+    }
+}

--- a/src/Features/Core/Portable/QuickInfo/ExportEmbeddedLanguageQuickInfoProviderAttribute.cs
+++ b/src/Features/Core/Portable/QuickInfo/ExportEmbeddedLanguageQuickInfoProviderAttribute.cs
@@ -4,14 +4,13 @@
 
 using Microsoft.CodeAnalysis.EmbeddedLanguages;
 
-namespace Microsoft.CodeAnalysis.QuickInfo
+namespace Microsoft.CodeAnalysis.QuickInfo;
+
+internal sealed class ExportEmbeddedLanguageQuickInfoProviderAttribute
+    : ExportEmbeddedLanguageFeatureServiceAttribute
 {
-    internal class ExportEmbeddedLanguageQuickInfoProviderAttribute
-        : ExportEmbeddedLanguageFeatureServiceAttribute
+    public ExportEmbeddedLanguageQuickInfoProviderAttribute(string name, string[] languages, params string[] identifiers)
+        : base(typeof(IEmbeddedLanguageQuickInfoProvider), name, languages, identifiers)
     {
-        public ExportEmbeddedLanguageQuickInfoProviderAttribute(string name, string[] languages, params string[] identifiers)
-            : base(typeof(IEmbeddedLanguageQuickInfoProvider), name, languages, identifiers)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/QuickInfo/IEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/IEmbeddedLanguageQuickInfoProvider.cs
@@ -9,17 +9,16 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.EmbeddedLanguages;
 
-namespace Microsoft.CodeAnalysis.QuickInfo
+namespace Microsoft.CodeAnalysis.QuickInfo;
+
+internal interface IEmbeddedLanguageQuickInfoProvider : IEmbeddedLanguageFeatureService
 {
-    internal interface IEmbeddedLanguageQuickInfoProvider : IEmbeddedLanguageFeatureService
-    {
-        /// <summary>
-        /// Gets the <see cref="QuickInfoItem"/> for the position in an embedded language.
-        /// </summary>
-        /// <returns>The <see cref="QuickInfoItem"/> or null if no item is available.</returns>
-        QuickInfoItem? GetQuickInfo(
-            QuickInfoContext context,
-            SemanticModel semanticModel,
-            SyntaxToken token);
-    }
+    /// <summary>
+    /// Gets the <see cref="QuickInfoItem"/> for the position in an embedded language.
+    /// </summary>
+    /// <returns>The <see cref="QuickInfoItem"/> or null if no item is available.</returns>
+    QuickInfoItem? GetQuickInfo(
+        QuickInfoContext context,
+        SemanticModel semanticModel,
+        SyntaxToken token);
 }

--- a/src/Features/Core/Portable/QuickInfo/IEmbeddedLanguageQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/IEmbeddedLanguageQuickInfoProvider.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+
+namespace Microsoft.CodeAnalysis.QuickInfo
+{
+    internal interface IEmbeddedLanguageQuickInfoProvider : IEmbeddedLanguageFeatureService
+    {
+        /// <summary>
+        /// Gets the <see cref="QuickInfoItem"/> for the position in an embedded language.
+        /// </summary>
+        /// <returns>The <see cref="QuickInfoItem"/> or null if no item is available.</returns>
+        QuickInfoItem? GetQuickInfo(
+            QuickInfoContext context,
+            SemanticModel semanticModel,
+            SyntaxToken token);
+    }
+}

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoProviderNames.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoProviderNames.cs
@@ -13,5 +13,6 @@ namespace Microsoft.CodeAnalysis.QuickInfo
         public const string Semantic = nameof(Semantic);
         public const string Syntactic = nameof(Syntactic);
         public const string DiagnosticAnalyzer = nameof(DiagnosticAnalyzer);
+        public const string EmbeddedLanguages = nameof(EmbeddedLanguages);
     }
 }

--- a/src/Features/VisualBasic/Portable/QuickInfo/VisualBasicEmbeddedLanguageQuickInfoProvider.vb
+++ b/src/Features/VisualBasic/Portable/QuickInfo/VisualBasicEmbeddedLanguageQuickInfoProvider.vb
@@ -1,0 +1,28 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.EmbeddedLanguages
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.QuickInfo
+Imports Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.QuickInfo
+    <ExportQuickInfoProvider(QuickInfoProviderNames.EmbeddedLanguages, LanguageNames.VisualBasic), [Shared]>
+    <ExtensionOrder(Before:=QuickInfoProviderNames.Semantic)>
+    Friend Class VisualBasicEmbeddedLanguageQuickInfoProvider
+        Inherits AbstractEmbeddedLanguageQuickInfoProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New(<ImportMany> services As IEnumerable(Of Lazy(Of IEmbeddedLanguageQuickInfoProvider, EmbeddedLanguageMetadata)))
+            MyBase.New(LanguageNames.VisualBasic, VisualBasicEmbeddedLanguagesProvider.Info, VisualBasicSyntaxKinds.Instance, services)
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
This introduces an interface IEmbeddedLanguageQuickInfoProvider that can be exported to provide quick info for embedded languages. This more or less mirrors the same pattern that we do for brace matching or completion.