### PR TITLE
Workaround issues with Uri escaping certain Unicode characters

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <ILAsmPackageVersion>6.0.0-rtm.21518.12</ILAsmPackageVersion>
     <ILDAsmPackageVersion>6.0.0-rtm.21518.12</ILDAsmPackageVersion>
     <MicrosoftVisualStudioLanguageServerClientPackagesVersion>17.7.4-preview</MicrosoftVisualStudioLanguageServerClientPackagesVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.8.3-preview</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.8.8-preview</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.7.35038-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <RefOnlyMicrosoftBuildPackagesVersion>16.10.0</RefOnlyMicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -67,14 +67,14 @@ namespace Roslyn.Test.Utilities
         internal class TestSpanMapper : ISpanMappingService
         {
             private static readonly LinePositionSpan s_mappedLinePosition = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 5));
-            private static readonly string s_mappedFilePath = "c:\\MappedFile.cs";
+            private static readonly string s_mappedFilePath = "c:\\MappedFile_\ue25b\ud86d\udeac.cs";
 
-            internal static readonly string GeneratedFileName = "GeneratedFile.cs";
+            internal static readonly string GeneratedFileName = "GeneratedFile_\ue25b\ud86d\udeac.cs";
 
             internal static readonly LSP.Location MappedFileLocation = new LSP.Location
             {
                 Range = ProtocolConversions.LinePositionToRange(s_mappedLinePosition),
-                Uri = new Uri(s_mappedFilePath)
+                Uri = ProtocolConversions.CreateAbsoluteUri(s_mappedFilePath)
             };
 
             /// <summary>
@@ -151,7 +151,7 @@ namespace Roslyn.Test.Utilities
 
         protected static int CompareLocations(LSP.Location l1, LSP.Location l2)
         {
-            var compareDocument = l1.Uri.OriginalString.CompareTo(l2.Uri.OriginalString);
+            var compareDocument = l1.Uri.AbsoluteUri.CompareTo(l2.Uri.AbsoluteUri);
             var compareRange = CompareRange(l1.Range, l2.Range);
             return compareDocument != 0 ? compareDocument : compareRange;
         }
@@ -444,8 +444,10 @@ namespace Roslyn.Test.Utilities
                 var text = await document.GetTextAsync(CancellationToken.None);
                 foreach (var (name, spans) in testDocument.AnnotatedSpans)
                 {
+                    Contract.ThrowIfNull(document.FilePath);
+
                     var locationsForName = locations.GetValueOrDefault(name, new List<LSP.Location>());
-                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, new Uri(document.FilePath))));
+                    locationsForName.AddRange(spans.Select(span => ConvertTextSpanWithTextToLocation(span, text, ProtocolConversions.CreateAbsoluteUri(document.FilePath))));
 
                     // Linked files will return duplicate annotated Locations for each document that links to the same file.
                     // Since the test output only cares about the actual file, make sure we de-dupe before returning.

--- a/src/Features/LanguageServer/BannedSymbols.txt
+++ b/src/Features/LanguageServer/BannedSymbols.txt
@@ -1,0 +1,10 @@
+M:System.Uri.#ctor(System.String); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.String,System.Boolean); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.String,System.UriCreationOptions); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.String,System.UriKind); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.Uri,System.String); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.Uri,System.Uri); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.#ctor(System.Uri,System.String,System.Boolean); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.TryCreate(System.String,System.UriKind,System.Uri@); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.TryCreate(System.Uri,System.String,System.Uri@); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath
+M:System.Uri.TryCreate(System.Uri,System.Uri,System.Uri@); Use ProtocolConversions.CreateAbsoluteUri or ProtocolConversions.CreateUriFromSourceGeneratedFilePath

--- a/src/Features/LanguageServer/Directory.Build.targets
+++ b/src/Features/LanguageServer/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" />
+  </ItemGroup>
+</Project>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
@@ -17,7 +17,7 @@ public class ServerInitializationTests : AbstractLanguageServerHostTests
     public async Task TestServerHandlesTextSyncRequestsAsync()
     {
         await using var server = await CreateLanguageServerAsync();
-        var document = new VersionedTextDocumentIdentifier { Uri = new Uri(@"C:\file.cs") };
+        var document = new VersionedTextDocumentIdentifier { Uri = ProtocolConversions.CreateAbsoluteUri("C:\\\ue25b\ud86d\udeac.cs") };
         var response = await server.ExecuteRequestAsync<DidOpenTextDocumentParams, object>(Methods.TextDocumentDidOpenName, new DidOpenTextDocumentParams
         {
             TextDocument = new TextDocumentItem

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
@@ -77,7 +77,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 {
                     GlobPattern = new RelativePattern
                     {
-                        BaseUri = ProtocolConversions.GetUriFromFilePath(d.Path),
+                        BaseUri = ProtocolConversions.CreateAbsoluteUri(d.Path),
                         Pattern = d.ExtensionFilter is not null ? "**/*" + d.ExtensionFilter : "**/*"
                     }
                 }).ToArray();
@@ -140,7 +140,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 // TODO: figure out how I just can do an absolute path watch
                 GlobPattern = new RelativePattern
                 {
-                    BaseUri = ProtocolConversions.GetUriFromFilePath(Path.GetDirectoryName(filePath)!),
+                    BaseUri = ProtocolConversions.CreateAbsoluteUri(Path.GetDirectoryName(filePath)!),
                     Pattern = Path.GetFileName(filePath)
                 }
             };

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/RazorDynamicFileInfoProvider.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/RazorDynamicFileInfoProvider.cs
@@ -58,7 +58,7 @@ internal class RazorDynamicFileInfoProvider : IDynamicFileInfoProvider
     {
         _razorWorkspaceListenerInitializer.Value.NotifyDynamicFile(projectId);
 
-        var requestParams = new ProvideDynamicFileParams { RazorFiles = new[] { ProtocolConversions.GetUriFromFilePath(filePath) } };
+        var requestParams = new ProvideDynamicFileParams { RazorFiles = new[] { ProtocolConversions.CreateAbsoluteUri(filePath) } };
 
         Contract.ThrowIfNull(LanguageServerHost.Instance, "We don't have an LSP channel yet to send this request through.");
         var clientLanguageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();
@@ -82,7 +82,7 @@ internal class RazorDynamicFileInfoProvider : IDynamicFileInfoProvider
 
     public Task RemoveDynamicFileInfoAsync(ProjectId projectId, string? projectFilePath, string filePath, CancellationToken cancellationToken)
     {
-        var notificationParams = new RemoveDynamicFileParams { RazorFiles = new[] { ProtocolConversions.GetUriFromFilePath(filePath) } };
+        var notificationParams = new RemoveDynamicFileParams { RazorFiles = new[] { ProtocolConversions.CreateAbsoluteUri(filePath) } };
 
         Contract.ThrowIfNull(LanguageServerHost.Instance, "We don't have an LSP channel yet to send this request through.");
         var clientLanguageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         {
             Contract.ThrowIfNull(document.FilePath);
             return document is SourceGeneratedDocument
-                ? ProtocolConversions.GetUriFromPartialFilePath(document.FilePath)
-                : ProtocolConversions.GetUriFromFilePath(document.FilePath);
+                ? ProtocolConversions.CreateUriFromSourceGeneratedFilePath(document.FilePath)
+                : ProtocolConversions.CreateAbsoluteUri(document.FilePath);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
             Contract.ThrowIfNull(directoryName);
             var path = Path.Combine(directoryName, document.Name);
-            return ProtocolConversions.GetUriFromFilePath(path);
+            return ProtocolConversions.CreateAbsoluteUri(path);
         }
 
         /// <summary>
@@ -56,15 +56,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             Contract.ThrowIfNull(directoryName);
 
             var path = Path.Combine(directoryName, document.Name);
-            return ProtocolConversions.GetUriFromFilePath(path);
+            return ProtocolConversions.CreateAbsoluteUri(path);
         }
 
-        public static Uri? TryGetURI(this TextDocument document, RequestContext? context = null)
-            => ProtocolConversions.TryGetUriFromFilePath(document.FilePath, context);
-
         public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri)
+            => GetDocuments(solution, ProtocolConversions.GetDocumentFilePathFromUri(documentUri));
+
+        public static ImmutableArray<Document> GetDocuments(this Solution solution, string documentPath)
         {
-            var documentIds = GetDocumentIds(solution, documentUri);
+            var documentIds = solution.GetDocumentIdsWithFilePath(documentPath);
 
             // We don't call GetRequiredDocument here as the id could be referring to an additional document.
             var documents = documentIds.Select(solution.GetDocument).WhereNotNull().ToImmutableArray();
@@ -72,29 +72,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         }
 
         public static ImmutableArray<DocumentId> GetDocumentIds(this Solution solution, Uri documentUri)
-        {
-            // This logic needs to be cleaned up when we support URIs as a first class concept.
-            // For now we do our best to handle as many cases as we can.
-            // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
-
-            // If the uri is a file then use the simplified absolute or local path.
-            // In other cases (e.g. git files) use the full uri string. This ensures documents
-            // with the same local path (e.g. git://someFilePath and file://someFilePath) are differentiated.
-            if (documentUri.IsFile)
-            {
-                var fileDocumentIds = solution.GetDocumentIdsWithFilePath(documentUri.AbsolutePath);
-                if (fileDocumentIds.Any())
-                    return fileDocumentIds;
-
-                fileDocumentIds = solution.GetDocumentIdsWithFilePath(documentUri.LocalPath);
-                return fileDocumentIds;
-            }
-            else
-            {
-                var documentIds = solution.GetDocumentIdsWithFilePath(documentUri.OriginalString);
-                return documentIds;
-            }
-        }
+            => solution.GetDocumentIdsWithFilePath(ProtocolConversions.GetDocumentFilePathFromUri(documentUri));
 
         public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier)
         {

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -32,7 +34,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     {
         private const string CSharpMarkdownLanguageName = "csharp";
         private const string VisualBasicMarkdownLanguageName = "vb";
-        private static readonly Uri SourceGeneratedDocumentBaseUri = new("gen://");
+        private const string SourceGeneratedDocumentBaseUri = "source-generated:///";
+
+#pragma warning disable RS0030 // Do not use banned APIs
+        private static readonly Uri s_sourceGeneratedDocumentBaseUri = new(SourceGeneratedDocumentBaseUri, UriKind.Absolute);
+#pragma warning restore
+
+        private static readonly char[] s_dirSeparators = new[] { PathUtilities.DirectorySeparatorChar, PathUtilities.AltDirectorySeparatorChar };
 
         private static readonly Regex s_markdownEscapeRegex = new(@"([\\`\*_\{\}\[\]\(\)#+\-\.!])", RegexOptions.Compiled);
 
@@ -151,35 +159,88 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             }
         }
 
-        // If we have a file:///xyz URI, we'll store the actual file path string in the document file path.
-        // Otherwise we have a URI that doesn't point to an actual file. In such a scenario, we'll store the full URI string (including schema).
-        // This will allow correct round-tripping of the URI for features that need it until we support URI as a first class document concept.
-        // Tracking issue - https://github.com/dotnet/roslyn/issues/68083
-        public static string GetDocumentFilePathFromUri(Uri uri) => uri.IsFile ? uri.LocalPath : uri.OriginalString;
+        public static string GetDocumentFilePathFromUri(Uri uri)
+            => uri.IsFile ? uri.LocalPath : uri.AbsoluteUri;
 
-        public static Uri GetUriFromFilePath(string filePath)
+        /// <summary>
+        /// Converts an absolute local file path or an absolute URL string to <see cref="Uri"/>.
+        /// </summary>
+        /// <exception cref="UriFormatException">
+        /// The <paramref name="absolutePath"/> can't be represented as <see cref="Uri"/>.
+        /// For example, UNC paths with invalid characters in server name.
+        /// </exception>
+        public static Uri CreateAbsoluteUri(string absolutePath)
+#pragma warning disable RS0030 // Do not use banned APIs
+            => new(IsAscii(absolutePath) ? absolutePath : GetAbsoluteUriString(absolutePath), UriKind.Absolute);
+#pragma warning restore
+
+        // Implements workaround for https://github.com/dotnet/runtime/issues/89538:
+        internal static string GetAbsoluteUriString(string absolutePath)
         {
-            if (filePath is null)
-                throw new ArgumentNullException(nameof(filePath));
+            if (!PathUtilities.IsAbsolute(absolutePath))
+            {
+                return absolutePath;
+            }
 
-            return new Uri(filePath, UriKind.Absolute);
+            var parts = absolutePath.Split(s_dirSeparators);
+
+            if (PathUtilities.IsUnixLikePlatform)
+            {
+                // Unix path: first part is empty, all parts should be escaped
+                return "file://" + string.Join("/", parts.Select(EscapeUriPart));
+            }
+
+            if (parts is ["", "", var serverName, ..])
+            {
+                // UNC path: first non-empty part is server name and shouldn't be escaped
+                return "file://" + serverName + "/" + string.Join("/", parts.Skip(3).Select(EscapeUriPart));
+            }
+
+            // Drive-rooted path: first part is "C:" and shouldn't be escaped
+            return "file:///" + parts[0] + "/" + string.Join("/", parts.Skip(1).Select(EscapeUriPart));
+
+#pragma warning disable SYSLIB0013 // Type or member is obsolete
+            static string EscapeUriPart(string stringToEscape)
+                => Uri.EscapeUriString(stringToEscape).Replace("#", "%23");
+#pragma warning restore
         }
 
-        public static Uri GetUriFromPartialFilePath(string? filePath)
+        public static Uri CreateUriFromSourceGeneratedFilePath(string filePath)
         {
-            if (filePath is null)
-                throw new ArgumentNullException(nameof(filePath));
+            Debug.Assert(!PathUtilities.IsAbsolute(filePath));
 
-            return new Uri(SourceGeneratedDocumentBaseUri, filePath);
+            // Fast path for common cases:
+            if (IsAscii(filePath))
+            {
+#pragma warning disable RS0030 // Do not use banned APIs
+                return new Uri(s_sourceGeneratedDocumentBaseUri, filePath);
+#pragma warning restore
+            }
+
+            // Workaround for https://github.com/dotnet/runtime/issues/89538:
+
+            var parts = filePath.Split(s_dirSeparators);
+            var url = SourceGeneratedDocumentBaseUri + string.Join("/", parts.Select(Uri.EscapeDataString));
+
+#pragma warning disable RS0030 // Do not use banned APIs
+            return new Uri(url, UriKind.Absolute);
+#pragma warning restore
         }
 
-        public static Uri? TryGetUriFromFilePath(string? filePath, RequestContext? context = null)
-        {
-            if (Uri.TryCreate(filePath, UriKind.Absolute, out var uri))
-                return uri;
+        private static bool IsAscii(char c)
+            => (uint)c <= '\x007f';
 
-            context?.TraceInformation($"Could not convert '{filePath}' to uri");
-            return null;
+        private static bool IsAscii(string filePath)
+        {
+            for (var i = 0; i < filePath.Length; i++)
+            {
+                if (!IsAscii(filePath[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public static LSP.TextDocumentPositionParams PositionToTextDocumentPositionParams(int position, SourceText text, Document document)
@@ -323,7 +384,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                         var textChange = textChanges[i];
                         if (!mappedSpan.IsDefault)
                         {
-                            uriToTextEdits.Add((GetUriFromFilePath(mappedSpan.FilePath), new LSP.TextEdit
+                            uriToTextEdits.Add((CreateAbsoluteUri(mappedSpan.FilePath), new LSP.TextEdit
                             {
                                 Range = MappedSpanResultToRange(mappedSpan),
                                 NewText = textChange.NewText ?? string.Empty
@@ -358,17 +419,31 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             RequestContext? context,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(document.FilePath != null);
+
             var result = await GetMappedSpanResultAsync(document, ImmutableArray.Create(textSpan), cancellationToken).ConfigureAwait(false);
             if (result == null)
-                return await TryConvertTextSpanToLocation(document, textSpan, isStale, context, cancellationToken).ConfigureAwait(false);
+                return await ConvertTextSpanToLocation(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
 
             var mappedSpan = result.Value.Single();
             if (mappedSpan.IsDefault)
-                return await TryConvertTextSpanToLocation(document, textSpan, isStale, context, cancellationToken).ConfigureAwait(false);
+                return await ConvertTextSpanToLocation(document, textSpan, isStale, cancellationToken).ConfigureAwait(false);
 
-            var uri = TryGetUriFromFilePath(mappedSpan.FilePath, context);
+            Uri? uri = null;
+            try
+            {
+                if (PathUtilities.IsAbsolute(mappedSpan.FilePath))
+                    uri = CreateAbsoluteUri(mappedSpan.FilePath);
+            }
+            catch (UriFormatException)
+            {
+            }
+
             if (uri == null)
+            {
+                context?.TraceInformation($"Could not convert '{mappedSpan.FilePath}' to uri");
                 return null;
+            }
 
             return new LSP.Location
             {
@@ -376,16 +451,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 Range = MappedSpanResultToRange(mappedSpan)
             };
 
-            static async Task<LSP.Location?> TryConvertTextSpanToLocation(
+            static async Task<LSP.Location?> ConvertTextSpanToLocation(
                 Document document,
                 TextSpan span,
                 bool isStale,
-                RequestContext? context,
                 CancellationToken cancellationToken)
             {
-                var uri = document.TryGetURI(context);
-                if (uri == null)
-                    return null;
+                Debug.Assert(document.FilePath != null);
+                var uri = CreateAbsoluteUri(document.FilePath);
 
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 if (isStale)

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
                         locations.Add(new LSP.Location
                         {
-                            Uri = new Uri(declarationFile.FilePath),
+                            Uri = ProtocolConversions.CreateAbsoluteUri(declarationFile.FilePath),
                             Range = ProtocolConversions.LinePositionToRange(linePosSpan),
                         });
                     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                     Location = new LSP.Location
                     {
                         Range = GetRange(l),
-                        Uri = ProtocolConversions.GetUriFromFilePath(l.UnmappedFileSpan.Path)
+                        Uri = ProtocolConversions.CreateAbsoluteUri(l.UnmappedFileSpan.Path)
                     },
                     Message = diagnostic.Message
                 }).ToArray();

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
@@ -18,7 +18,7 @@ internal sealed record class ProjectDiagnosticSource(Project Project, Func<Diagn
     public Project GetProject() => Project;
     public TextDocumentIdentifier? GetDocumentIdentifier()
         => !string.IsNullOrEmpty(Project.FilePath)
-            ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.GetUriFromFilePath(Project.FilePath) }
+            ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.CreateAbsoluteUri(Project.FilePath) }
             : null;
 
     public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindUsagesLSPContext.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 return new LSP.Location
                 {
-                    Uri = ProtocolConversions.GetUriFromFilePath(declarationFile.FilePath),
+                    Uri = ProtocolConversions.CreateAbsoluteUri(declarationFile.FilePath),
                     Range = ProtocolConversions.LinePositionToRange(linePosSpan),
                 };
             }

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" />

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
@@ -340,7 +340,7 @@ class BCD
             var actualResolvedAction = await RunGetCodeActionResolveAsync(testLspServer, unresolvedCodeAction);
 
             var project = testWorkspace.CurrentSolution.Projects.Single();
-            var newDocumentUri = ProtocolConversions.GetUriFromFilePath(Path.Combine(Path.GetDirectoryName(project.FilePath), "ABC.cs"));
+            var newDocumentUri = ProtocolConversions.CreateAbsoluteUri(Path.Combine(Path.GetDirectoryName(project.FilePath), "ABC.cs"));
             var existingDocumentUri = testWorkspace.CurrentSolution.GetRequiredDocument(testWorkspace.Documents.Single().Id).GetURI();
             var workspaceEdit = new WorkspaceEdit()
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -207,7 +207,7 @@ class A { }";
 
         Assert.Equal(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand, resolvedItem.Command.CommandIdentifier);
         Assert.Equal(nameof(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand), resolvedItem.Command.Title);
-        Assert.Equal(completionParams.TextDocument.Uri, new System.Uri((string)resolvedItem.Command.Arguments[0]));
+        Assert.Equal(completionParams.TextDocument.Uri, ProtocolConversions.CreateAbsoluteUri((string)resolvedItem.Command.Arguments[0]));
         AssertJsonEquals(expectedEdit, resolvedItem.Command.Arguments[1]);
         Assert.Equal(false, resolvedItem.Command.Arguments[2]);
         Assert.Equal((long)14, resolvedItem.Command.Arguments[3]);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Definitions
             var position = new LSP.Position { Line = 5, Character = 18 };
             var results = await RunGotoDefinitionAsync(testLspServer, new LSP.Location
             {
-                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Uri = ProtocolConversions.CreateAbsoluteUri($"C:\\{TestSpanMapper.GeneratedFileName}"),
                 Range = new LSP.Range { Start = position, End = position }
             });
             AssertLocationsEqual(ImmutableArray.Create(TestSpanMapper.MappedFileLocation), results);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -1361,7 +1361,7 @@ class A {";
 
             var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
             Assert.Equal(3, results.Length);
-            Assert.Equal(new Uri("C:/test1.cs"), results[0].TextDocument!.Uri);
+            Assert.Equal(ProtocolConversions.CreateAbsoluteUri(@"C:\test1.cs"), results[0].TextDocument!.Uri);
             Assert.Equal("CS1513", results[0].Diagnostics.Single().Code);
             Assert.Equal(1, results[0].Diagnostics.Single().Range.Start.Line);
             Assert.Empty(results[1].Diagnostics);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
@@ -33,7 +33,7 @@ public class WorkspaceProjectDiagnosticsTests : AbstractPullDiagnosticTestsBase
         Assert.Equal(2, results.Length);
         Assert.Empty(results[0].Diagnostics);
         Assert.Equal(MockProjectDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
-        Assert.Equal(ProtocolConversions.GetUriFromFilePath(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteUri(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
 
         // Asking again should give us back an unchanged diagnostic.
         var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: CreateDiagnosticParamsFromPreviousReports(results));
@@ -52,7 +52,7 @@ public class WorkspaceProjectDiagnosticsTests : AbstractPullDiagnosticTestsBase
         Assert.Equal(2, results.Length);
         Assert.Empty(results[0].Diagnostics);
         Assert.Equal(MockProjectDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
-        Assert.Equal(ProtocolConversions.GetUriFromFilePath(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteUri(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
 
         var initialSolution = testLspServer.GetCurrentSolution();
         var newSolution = initialSolution.RemoveProject(initialSolution.Projects.First().Id);

--- a/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/FoldingRanges/FoldingRangesTests.cs
@@ -73,7 +73,7 @@ comment */|}";
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.FoldingRangeParams()
             {
-                TextDocument = CreateTextDocumentIdentifier(new Uri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.CreateAbsoluteUri(document.FilePath))
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.FoldingRangeParams, LSP.FoldingRange[]>(LSP.Methods.TextDocumentFoldingRangeName,

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 TextDocument = new TextDocumentItem
                 {
                     Text = "sometext",
-                    Uri = new Uri("C:\\location\\file.json"),
+                    Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\location\file.json"),
                 }
             };
 
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 TextDocument = new TextDocumentItem
                 {
                     Text = "sometext",
-                    Uri = new Uri("C:\\location\\file.json"),
+                    Uri = ProtocolConversions.CreateAbsoluteUri(@"C:\location\file.json"),
                 }
             };
             var ex = await Assert.ThrowsAsync<RemoteInvocationException>(async () => await server.ExecuteRequestAsync<DidOpenTextDocumentParams, object>(Methods.TextDocumentDidOpenName, didOpenParams, CancellationToken.None));

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -3,9 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
@@ -13,6 +16,137 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
     public class ProtocolConversionsTests
     {
+        [Fact]
+        public void CreateAbsoluteUri_LocalPaths_AllAscii()
+        {
+            var invalidFileNameChars = Path.GetInvalidFileNameChars();
+            var unescaped = "!$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~";
+
+            for (var c = '\0'; c < '\u0080'; c++)
+            {
+                if (invalidFileNameChars.Contains(c))
+                {
+                    // no need to validate escaping for characters that can't appear in a file/directory name
+                    continue;
+                }
+
+                var filePath = PathUtilities.IsUnixLikePlatform ? $"/_{c}/" : $"C:\\_{c}\\";
+                var uriPrefix = PathUtilities.IsUnixLikePlatform ? "" : "C:/_";
+
+                var expectedAbsoluteUri = "file:///" + uriPrefix + (unescaped.Contains(c) ? c : "%" + ((int)c).ToString("X2")) + "/";
+
+                Assert.Equal(expectedAbsoluteUri, ProtocolConversions.GetAbsoluteUriString(filePath));
+
+                var uri = ProtocolConversions.CreateAbsoluteUri(filePath);
+                Assert.Equal(expectedAbsoluteUri, uri.AbsoluteUri);
+                Assert.Equal(filePath, uri.LocalPath);
+            }
+        }
+
+        [ConditionalTheory(typeof(WindowsOnly))]
+        [InlineData("C:/", "file:///C:/")]
+        [InlineData("C:\\", "file:///C:/")]
+        [InlineData("C:\\a\\b", "file:///C:/a/b")]
+        [InlineData("C:\\a\\\\b", "file:///C:/a//b")]
+        [InlineData("C:\\%25\ue25b/a\\b", "file:///C:/%2525%EE%89%9B/a/b")]
+        [InlineData("C:\\%25\ue25b/a\\\\b", "file:///C:/%2525%EE%89%9B/a//b")]
+        [InlineData("C:\\\u0089\uC7BD", "file:///C:/%C2%89%EC%9E%BD")]
+        [InlineData("/\\server\ue25b\\%25\ue25b\\b", "file://server/%2525%EE%89%9B/b")]
+        [InlineData("\\\\server\ue25b\\%25\ue25b\\b", "file://server/%2525%EE%89%9B/b")]
+        [InlineData("C:\\ !$&'()+,-;=@[]_~#", "file:///C:/%20!$&'()+,-;=@[]_~%23")]
+        [InlineData("C:\\ !$&'()+,-;=@[]_~#\ue25b", "file:///C:/%20!$&'()+,-;=@[]_~%23%EE%89%9B")]
+        [InlineData("C:\\\u0073\u0323\u0307", "file:///C:/s%CC%A3%CC%87")] // combining marks
+        [InlineData("A:/\\\u200e//", "file:///A://%E2%80%8E//")] // cases from https://github.com/dotnet/runtime/issues/1487
+        [InlineData("B:\\/\u200e", "file:///B://%E2%80%8E")]
+        [InlineData("C:/\\\\-Ā\r", "file:///C:///-%C4%80%0D")]
+        [InlineData("D:\\\\\\\\\\\u200e", "file:///D://///%E2%80%8E")]
+        public void CreateAbsoluteUri_LocalPaths_Windows(string filePath, string expectedAbsoluteUri)
+        {
+            Assert.Equal(expectedAbsoluteUri, ProtocolConversions.GetAbsoluteUriString(filePath));
+
+            var uri = ProtocolConversions.CreateAbsoluteUri(filePath);
+            Assert.Equal(expectedAbsoluteUri, uri.AbsoluteUri);
+            Assert.Equal(filePath.Replace('/', '\\'), uri.LocalPath);
+        }
+
+        [ConditionalTheory(typeof(WindowsOnly))]
+        [InlineData("C:\\a\\.\\b", "file:///C:/a/./b", "file:///C:/a/b")]
+        [InlineData("C:\\a\\..\\b", "file:///C:/a/../b", "file:///C:/b")]
+        [InlineData("C:\\\ue25b\\.\\\ue25c", "file:///C:/%EE%89%9B/./%EE%89%9C", "file:///C:/%EE%89%9B/%EE%89%9C")]
+        [InlineData("C:\\\ue25b\\..\\\ue25c", "file:///C:/%EE%89%9B/../%EE%89%9C", "file:///C:/%EE%89%9C")]
+        public void CreateAbsoluteUri_LocalPaths_Normalized_Windows(string filePath, string expectedRawUri, string expectedNormalizedUri)
+        {
+            Assert.Equal(expectedRawUri, ProtocolConversions.GetAbsoluteUriString(filePath));
+
+            var uri = ProtocolConversions.CreateAbsoluteUri(filePath);
+            Assert.Equal(expectedNormalizedUri, uri.AbsoluteUri);
+            Assert.Equal(Path.GetFullPath(filePath).Replace('/', '\\'), uri.LocalPath);
+        }
+
+        [ConditionalTheory(typeof(UnixLikeOnly))]
+        [InlineData("/", "file:///")]
+        [InlineData("/u", "file:///u")]
+        [InlineData("/unix/path", "file:///unix/path")]
+        [InlineData("/%25\ue25b/\u0089\uC7BD", "file:///%2525%EE%89%9B/%C2%89%EC%9E%BD")]
+        [InlineData("/!$&'()+,-;=@[]_~#", "file:///!$&'()+,-;=@[]_~%23")]
+        [InlineData("/!$&'()+,-;=@[]_~#", "file:///!$&'()+,-;=@[]_~%23%EE%89%9B")]
+        [InlineData("/\\\u200e//", "file:////%E2%80%8E//")] // cases from https://github.com/dotnet/runtime/issues/1487
+        [InlineData("\\/\u200e", "file:////%E2%80%8E")]
+        [InlineData("/\\\\-Ā\r", "file://///-%C4%80%0D")]
+        [InlineData("\\\\\\\\\\\u200e", "file:///////%E2%80%8E")]
+        public void CreateAbsoluteUri_LocalPaths_Unix(string filePath, string expectedAbsoluteUri)
+        {
+            Assert.Equal(expectedAbsoluteUri, ProtocolConversions.GetAbsoluteUriString(filePath));
+
+            var uri = ProtocolConversions.CreateAbsoluteUri(filePath);
+            Assert.Equal(expectedAbsoluteUri, uri.AbsoluteUri);
+            Assert.Equal(filePath, uri.LocalPath);
+        }
+
+        [ConditionalTheory(typeof(UnixLikeOnly))]
+        [InlineData("/a/./b", "file:///a/./b", "file:///a/b")]
+        [InlineData("/a/../b", "file:///a/../b", "file:///b")]
+        [InlineData("/\ue25b/./\ue25c", "file:///%EE%89%9B/./%EE%89%9C", "file:///%EE%89%9B/%EE%89%9C")]
+        [InlineData("/\ue25b/../\ue25c", "file:///%EE%89%9B/../%EE%89%9C", "file:///%EE%89%9C")]
+        public void CreateAbsoluteUri_LocalPaths_Normalized_Unix(string filePath, string expectedRawUri, string expectedNormalizedUri)
+        {
+            Assert.Equal(expectedRawUri, ProtocolConversions.GetAbsoluteUriString(filePath));
+
+            var uri = ProtocolConversions.CreateAbsoluteUri(filePath);
+            Assert.Equal(expectedNormalizedUri, uri.AbsoluteUri);
+            Assert.Equal(filePath, uri.LocalPath);
+        }
+
+        [Theory]
+        [InlineData("git:/x:/%2525%EE%89%9B/%C2%89%EC%9E%BD?abc")]
+        [InlineData("git://host/%2525%EE%89%9B/%C2%89%EC%9E%BD")]
+        [InlineData("xy://host/%2525%EE%89%9B/%C2%89%EC%9E%BD")]
+        public void CreateAbsoluteUri_Urls(string url)
+        {
+            Assert.Equal(url, ProtocolConversions.CreateAbsoluteUri(url).AbsoluteUri);
+        }
+
+        [ConditionalTheory(typeof(WindowsOnly))]
+        [InlineData("a\\b", "source-generated:///a/b")]
+        [InlineData("a//b", "source-generated:///a//b")]
+        [InlineData("a/b", "source-generated:///a/b")]
+        [InlineData("%25\ue25b//\u0089\uC7BD/a", "source-generated:///%2525%EE%89%9B//%C2%89%EC%9E%BD/a")]
+        [InlineData("%25\ue25b\\\u0089\uC7BD", "source-generated:///%2525%EE%89%9B/%C2%89%EC%9E%BD")]
+        public void GetUriFromSourceGeneratedFilePath_Windows(string filePath, string expectedAbsoluteUri)
+        {
+            var url = ProtocolConversions.CreateUriFromSourceGeneratedFilePath(filePath);
+            Assert.Equal(expectedAbsoluteUri, url.AbsoluteUri);
+        }
+
+        [ConditionalTheory(typeof(UnixLikeOnly))]
+        [InlineData("a/b", "source-generated:///a/b")]
+        [InlineData("%25\ue25b/\u0089\uC7BD", "source-generated:///%2525%EE%89%9B/%C2%89%EC%9E%BD")]
+        public void GetUriFromSourceGeneratedFilePath_Unix(string filePath, string expectedAbsoluteUri)
+        {
+            var url = ProtocolConversions.CreateUriFromSourceGeneratedFilePath(filePath);
+            Assert.Equal(expectedAbsoluteUri, url.AbsoluteUri);
+        }
+
         [Fact]
         public void CompletionItemKind_DoNotUseMethodAndFunction()
         {

--- a/src/Features/LanguageServer/ProtocolUnitTests/References/FindImplementationsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/References/FindImplementationsTests.cs
@@ -92,7 +92,7 @@ class A : IA
             var position = new LSP.Position { Line = 2, Character = 9 };
             var results = await RunFindImplementationAsync(testLspServer, new LSP.Location
             {
-                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Uri = ProtocolConversions.CreateAbsoluteUri($"C:\\{TestSpanMapper.GeneratedFileName}"),
                 Range = new LSP.Range { Start = position, End = position }
             });
             AssertLocationsEqual(ImmutableArray.Create(TestSpanMapper.MappedFileLocation), results);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -171,7 +171,7 @@ $@"<Workspace>
             var renameText = "RENAME";
             var renameParams = CreateRenameParams(new LSP.Location
             {
-                Uri = new Uri($"C:\\{TestSpanMapper.GeneratedFileName}"),
+                Uri = ProtocolConversions.CreateAbsoluteUri($"C:\\{TestSpanMapper.GeneratedFileName}"),
                 Range = new LSP.Range { Start = startPosition, End = endPosition }
             }, "RENAME");
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
             var request = new LSP.DocumentSymbolParams
             {
-                TextDocument = CreateTextDocumentIdentifier(new Uri(document.FilePath))
+                TextDocument = CreateTextDocumentIdentifier(ProtocolConversions.CreateAbsoluteUri(document.FilePath))
             };
 
             return await testLspServer.ExecuteRequestAsync<LSP.DocumentSymbolParams, TReturn>(LSP.Methods.TextDocumentDocumentSymbolName,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -241,9 +241,11 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
         // Create a new document, but do not update the workspace solution yet.
         var newDocumentId = DocumentId.CreateNewId(testLspServer.TestWorkspace.CurrentSolution.ProjectIds[0]);
-        var newDocumentFilePath = @"C:/NewDoc.cs";
+
+        // Include some Unicode characters to test URL handling.
+        var newDocumentFilePath = "C:\\NewDoc\\\ue25b\ud86d\udeac.cs";
         var newDocumentInfo = DocumentInfo.Create(newDocumentId, "NewDoc.cs", filePath: newDocumentFilePath, loader: new TestTextLoader("New Doc"));
-        var newDocumentUri = ProtocolConversions.GetUriFromFilePath(newDocumentFilePath);
+        var newDocumentUri = ProtocolConversions.CreateAbsoluteUri(newDocumentFilePath);
 
         // Open the document via LSP before the workspace sees it.
         await testLspServer.OpenDocumentAsync(newDocumentUri, "LSP text");
@@ -369,8 +371,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
         Assert.True(IsWorkspaceRegistered(testLspServer.TestWorkspace, testLspServer));
         Assert.True(IsWorkspaceRegistered(testWorkspaceTwo, testLspServer));
 
-        var firstWorkspaceDocumentUri = ProtocolConversions.GetUriFromFilePath(@"C:\FirstWorkspace.cs");
-        var secondWorkspaceDocumentUri = ProtocolConversions.GetUriFromFilePath(@"C:\SecondWorkspace.cs");
+        var firstWorkspaceDocumentUri = ProtocolConversions.CreateAbsoluteUri(@"C:\FirstWorkspace.cs");
+        var secondWorkspaceDocumentUri = ProtocolConversions.CreateAbsoluteUri(@"C:\SecondWorkspace.cs");
         await testLspServer.OpenDocumentAsync(firstWorkspaceDocumentUri);
 
         // Verify we can get both documents from their respective workspaces.
@@ -424,8 +426,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
         // Wait for workspace operations to complete for the second workspace.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
 
-        var firstWorkspaceDocumentUri = ProtocolConversions.GetUriFromFilePath(@"C:\FirstWorkspace.cs");
-        var secondWorkspaceDocumentUri = ProtocolConversions.GetUriFromFilePath(@"C:\SecondWorkspace.cs");
+        var firstWorkspaceDocumentUri = ProtocolConversions.CreateAbsoluteUri(@"C:\FirstWorkspace.cs");
+        var secondWorkspaceDocumentUri = ProtocolConversions.CreateAbsoluteUri(@"C:\SecondWorkspace.cs");
         await testLspServer.OpenDocumentAsync(firstWorkspaceDocumentUri);
 
         // Verify we can get both documents from their respective workspaces.
@@ -542,8 +544,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
             Array.Empty<string>(), mutatingLspWorkspace: true, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         // Open the doc
-        var filePath = @"c:\Test1.cs";
-        var documentUri = new Uri("file://" + filePath, UriKind.Absolute);
+        var filePath = "c:\\\ue25b\ud86d\udeac.cs";
+        var documentUri = ProtocolConversions.CreateAbsoluteUri(filePath);
         await testLspServer.OpenDocumentAsync(documentUri, "Text");
 
         // Initially the doc will be in the lsp misc workspace.

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             var projectVertex = new Graph.LsifProject(
                 kind: GetLanguageKind(compilation.Language),
-                new Uri(projectPath),
+                ProtocolConversions.CreateAbsoluteUri(projectPath),
                 Path.GetFileNameWithoutExtension(projectPath),
                 _idFactory);
 
@@ -206,7 +207,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             var (uri, contentBase64Encoded) = await GetUriAndContentAsync(document, cancellationToken);
 
-            var documentVertex = new Graph.LsifDocument(new Uri(uri, UriKind.RelativeOrAbsolute), GetLanguageKind(semanticModel.Language), contentBase64Encoded, idFactory);
+            var documentVertex = new Graph.LsifDocument(uri, GetLanguageKind(semanticModel.Language), contentBase64Encoded, idFactory);
             lsifJsonWriter.Write(documentVertex);
             lsifJsonWriter.Write(new Event(Event.EventKind.Begin, documentVertex.GetId(), idFactory));
 
@@ -399,11 +400,13 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             }
         }
 
-        private static async Task<(string uri, string? contentBase64Encoded)> GetUriAndContentAsync(
+        private static async Task<(Uri uri, string? contentBase64Encoded)> GetUriAndContentAsync(
             Document document, CancellationToken cancellationToken)
         {
+            Contract.ThrowIfNull(document.FilePath);
+
             string? contentBase64Encoded = null;
-            var uri = document.FilePath ?? "";
+            Uri uri;
 
             if (document is SourceGeneratedDocument)
             {
@@ -415,7 +418,11 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
                 // There is a triple slash here, so the "host" portion of the URI is empty, similar to
                 // how file URIs work.
-                uri = "source-generated:///" + uri.Replace('\\', '/');
+                uri = ProtocolConversions.CreateUriFromSourceGeneratedFilePath(document.FilePath);
+            }
+            else
+            {
+                uri = ProtocolConversions.CreateAbsoluteUri(document.FilePath);
             }
 
             return (uri, contentBase64Encoded);

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -16,19 +16,21 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Dim stringWriter = New StringWriter()
             Dim jsonWriter = New LineModeLsifJsonWriter(stringWriter)
 
+            Dim dir = "Z:\" & ChrW(&HE25B)
+
             Await TestLsifOutput.GenerateForWorkspaceAsync(
                 TestWorkspace.CreateWorkspace(
                     <Workspace>
-                        <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
-                            <Document Name="A.cs" FilePath="Z:\A.cs"/>
+                        <Project Language="C#" Name="TestProject" FilePath=<%= dir & "\TestProject.csproj" %>>
+                            <Document Name="A.cs" FilePath=<%= dir & "\a.cs" %>/>
                         </Project>
                     </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition), jsonWriter)
 
             AssertEx.EqualOrDiff(
 "{""hoverProvider"":true,""declarationProvider"":false,""definitionProvider"":true,""referencesProvider"":true,""typeDefinitionProvider"":false,""documentSymbolProvider"":false,""foldingRangeProvider"":true,""diagnosticProvider"":false,""semanticTokensProvider"":{""tokenTypes"":[""namespace"",""type"",""class"",""enum"",""interface"",""struct"",""typeParameter"",""parameter"",""variable"",""property"",""enumMember"",""event"",""function"",""method"",""macro"",""keyword"",""modifier"",""comment"",""string"",""number"",""regexp"",""operator"",""class name"",""constant name"",""delegate name"",""enum member name"",""enum name"",""event name"",""excluded code"",""extension method name"",""field name"",""interface name"",""json - array"",""json - comment"",""json - constructor name"",""json - keyword"",""json - number"",""json - object"",""json - operator"",""json - property name"",""json - punctuation"",""json - string"",""json - text"",""keyword - control"",""label name"",""local name"",""method name"",""module name"",""namespace name"",""operator - overloaded"",""parameter name"",""preprocessor keyword"",""preprocessor text"",""property name"",""punctuation"",""record class name"",""record struct name"",""regex - alternation"",""regex - anchor"",""regex - character class"",""regex - comment"",""regex - grouping"",""regex - other escape"",""regex - quantifier"",""regex - self escaped character"",""regex - text"",""string - escape character"",""string - verbatim"",""struct name"",""text"",""type parameter name"",""whitespace"",""xml doc comment - attribute name"",""xml doc comment - attribute quotes"",""xml doc comment - attribute value"",""xml doc comment - cdata section"",""xml doc comment - comment"",""xml doc comment - delimiter"",""xml doc comment - entity reference"",""xml doc comment - name"",""xml doc comment - processing instruction"",""xml doc comment - text"",""xml literal - attribute name"",""xml literal - attribute quotes"",""xml literal - attribute value"",""xml literal - cdata section"",""xml literal - comment"",""xml literal - delimiter"",""xml literal - embedded expression"",""xml literal - entity reference"",""xml literal - name"",""xml literal - processing instruction"",""xml literal - text""],""tokenModifiers"":[""static""]},""id"":1,""type"":""vertex"",""label"":""capabilities""}
-{""kind"":""csharp"",""resource"":""file:///Z:/TestProject.csproj"",""name"":""TestProject"",""id"":2,""type"":""vertex"",""label"":""project""}
+{""kind"":""csharp"",""resource"":""file:///Z:/%EE%89%9B/TestProject.csproj"",""name"":""TestProject"",""id"":2,""type"":""vertex"",""label"":""project""}
 {""kind"":""begin"",""scope"":""project"",""data"":2,""id"":3,""type"":""vertex"",""label"":""$event""}
-{""uri"":""file:///Z:/A.cs"",""languageId"":""csharp"",""id"":4,""type"":""vertex"",""label"":""document""}
+{""uri"":""file:///Z:/%EE%89%9B/a.cs"",""languageId"":""csharp"",""id"":4,""type"":""vertex"",""label"":""document""}
 {""kind"":""begin"",""scope"":""document"",""data"":4,""id"":5,""type"":""vertex"",""label"":""$event""}
 {""outV"":4,""inVs"":[],""id"":6,""type"":""edge"",""label"":""contains""}
 {""result"":[],""id"":7,""type"":""vertex"",""label"":""foldingRangeResult""}

--- a/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
@@ -168,6 +168,7 @@ Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorTestAnalyzerLoader.RazorTestAna
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorTestWorkspaceRegistrationService
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorTestWorkspaceRegistrationService.RazorTestWorkspaceRegistrationService() -> void
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorTestWorkspaceRegistrationService.Register(Microsoft.CodeAnalysis.Workspace! workspace) -> void
+Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorUri
 override Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorCSharpInterceptionMiddleLayerWrapper.CanHandle(string! methodName) -> bool
 override Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorCSharpInterceptionMiddleLayerWrapper.HandleNotificationAsync(string! methodName, Newtonsoft.Json.Linq.JToken! methodParam, System.Func<Newtonsoft.Json.Linq.JToken!, System.Threading.Tasks.Task!>! sendNotification) -> System.Threading.Tasks.Task!
 override Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorCSharpInterceptionMiddleLayerWrapper.HandleRequestAsync(string! methodName, Newtonsoft.Json.Linq.JToken! methodParam, System.Func<Newtonsoft.Json.Linq.JToken!, System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JToken?>!>! sendRequest) -> System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JToken?>!
@@ -411,6 +412,8 @@ static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorSemanticTokensAccessor.G
 static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorSemanticTokensAccessor.GetTokenTypes(Microsoft.VisualStudio.LanguageServer.Protocol.ClientCapabilities! capabilities) -> System.Collections.Immutable.ImmutableArray<string!>
 static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorSemanticTokensAccessor.RoslynTokenTypes.get -> System.Collections.Immutable.ImmutableArray<string!>
 static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorTestAnalyzerLoader.CreateAnalyzerAssemblyLoader() -> Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader!
+static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorUri.CreateAbsoluteUri(string! absolutePath) -> System.Uri!
+static Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorUri.CreateUri(this Microsoft.CodeAnalysis.TextDocument! document) -> System.Uri!
 static readonly Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorRemoteServiceCallbackDispatcherRegistry.Empty -> Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorRemoteServiceCallbackDispatcherRegistry!
 ~override Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorIndentationOptions.Equals(object obj) -> bool
 ~override Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorIndentationOptions.ToString() -> string

--- a/src/Tools/ExternalAccess/Razor/RazorUri.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorUri.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+internal static class RazorUri
+{
+    public static Uri CreateAbsoluteUri(string absolutePath)
+        => ProtocolConversions.CreateAbsoluteUri(absolutePath);
+
+    public static Uri CreateUri(this TextDocument document)
+    {
+        Contract.ThrowIfNull(document.FilePath);
+        return document is SourceGeneratedDocument
+            ? ProtocolConversions.CreateUriFromSourceGeneratedFilePath(document.FilePath)
+            : ProtocolConversions.CreateAbsoluteUri(document.FilePath);
+    }
+}

--- a/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTests.cs
+++ b/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTests.cs
@@ -55,7 +55,8 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
         {
         }
 
-        private async Task<(DocumentOutlineTestMocks mocks, (ImmutableArray<DocumentSymbolData> DocumentSymbolData, ITextSnapshot OriginalSnapshot), ImmutableArray<DocumentSymbolDataViewModel> uiItems)> InitializeMocksAndDataModelAndUIItems(string testCode)
+        private async Task<(DocumentOutlineTestMocks mocks, (ImmutableArray<DocumentSymbolData> DocumentSymbolData, ITextSnapshot OriginalSnapshot), ImmutableArray<DocumentSymbolDataViewModel> uiItems)>
+            InitializeMocksAndDataModelAndUIItems(string testCode)
         {
             await using var mocks = await CreateMocksAsync(testCode);
             var response = await DocumentOutlineViewModel.DocumentSymbolsRequestAsync(mocks.TextBuffer, mocks.LanguageServiceBroker, mocks.FilePath, CancellationToken.None);

--- a/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTestsBase.cs
+++ b/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTestsBase.cs
@@ -35,6 +35,8 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
     [UseExportProvider]
     public abstract class DocumentOutlineTestsBase
     {
+        private const string PathRoot = "C:\\\ue25b\\";
+
         private readonly TestOutputLspLogger _logger;
         protected DocumentOutlineTestsBase(ITestOutputHelper testOutputHelper)
         {
@@ -66,7 +68,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
             internal ITextBuffer TextBuffer { get; }
 
             internal string FilePath
-                => "C:\\" + _workspace.Documents.Single().FilePath!;
+                => PathRoot + _workspace.Documents.Single().FilePath!;
 
             public ValueTask DisposeAsync()
                 => _disposable.DisposeAsync();
@@ -121,7 +123,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
                 if (document.IsSourceGenerated)
                     continue;
 
-                solution = solution.WithDocumentFilePath(document.Id, "C:\\" + document.Name);
+                solution = solution.WithDocumentFilePath(document.Id, PathRoot + document.Name);
 
                 var documentText = await solution.GetRequiredDocument(document.Id).GetTextAsync(CancellationToken.None);
                 solution = solution.WithDocumentText(document.Id, SourceText.From(documentText.ToString(), System.Text.Encoding.UTF8));
@@ -130,7 +132,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
             foreach (var project in workspace.Projects)
             {
                 // Ensure all the projects have a valid file path.
-                solution = solution.WithProjectFilePath(project.Id, "C:\\" + project.Name);
+                solution = solution.WithProjectFilePath(project.Id, PathRoot + project.Name);
             }
 
             solution = solution.WithAnalyzerReferences(new[] { new TestAnalyzerReferenceByLanguage(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()) });

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineViewModel_Utilities.cs
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineViewModel_Utilities.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
                     UseHierarchicalSymbols = true,
                     TextDocument = new TextDocumentIdentifier()
                     {
-                        Uri = new Uri(textViewFilePath)
+                        Uri = ProtocolConversions.CreateAbsoluteUri(textViewFilePath)
                     }
                 });
             }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
             if (sourceDefinition.Span != null)
             {
                 // If the Span is not null, use the span.
-                var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
+                var document = context.Solution?.GetDocuments(ProtocolConversions.CreateAbsoluteUri(sourceDefinition.FilePath)).FirstOrDefault();
                 if (document != null)
                 {
                     return await ProtocolConversions.TextSpanToLocationAsync(


### PR DESCRIPTION
Contributes to fix of https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1842233

Workaround for `Uri` escaping certain Unicode characters in `LocalPath` and `AbsolutePath` properties.
Tracked by issue: https://github.com/dotnet/runtime/issues/89538

```C#
> new Uri("c:\\\ue25b").AbsolutePath
"c:/%25EE%2589%259B"
> new Uri("c:\\\ue25b").LocalPath
"c:\\%EE%89%9B"
```

When the `Uri` is constructed from ULR string (as opposed to local path), the escaping works correctly:
```C#
> new Uri("file://c:/\ue25b").LocalPath
"c:\\"
```

Implement custom conversion from absolute local path to `Uri` instance. We split the path into parts by directory separator and use `Uri.EscapeUriString` on each of the part. Then join the escaped parts together.

Also avoid using `Uri` internally, unless we need to communicate to LSP client.
