### PR TITLE
Consistently use UICulture instead of Culture

### DIFF
--- a/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             {
                 // Initialize has not been called yet, no culture to set.
                 // Don't update the _cultureInfo since we don't know what it should be.
-                return CultureInfo.CurrentCulture;
+                return CultureInfo.CurrentUICulture;
             }
 
             var locale = initializeParams.Locale;
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             {
                 // The client did not provide a culture, use the OS configured value
                 // and remember that so we can short-circuit from now on.
-                _cultureInfo = CultureInfo.CurrentCulture;
+                _cultureInfo = CultureInfo.CurrentUICulture;
                 return _cultureInfo;
             }
 
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 // We couldn't parse the culture, log a warning and fallback to the OS configured value.
                 // Also remember the fallback so we don't warn on every request.
                 _logger.LogWarning($"Culture {locale} was not found, falling back to OS culture");
-                _cultureInfo = CultureInfo.CurrentCulture;
+                _cultureInfo = CultureInfo.CurrentUICulture;
                 return _cultureInfo;
             }
         }


### PR DESCRIPTION
I messed this up in the original PR - we were setting the CurrentUICulture (correct), but reading the fallback from CurrentCulture.  Fixed to also read from CurrentUICulture