### PR TITLE
Improve EOL consistency for Add Using

### DIFF
--- a/src/Analyzers/CSharp/Tests/ForEachCast/ForEachCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/ForEachCast/ForEachCastTests.cs
@@ -89,7 +89,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -130,7 +129,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -172,7 +170,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
                 using System;
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -212,7 +209,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -252,7 +248,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -293,7 +288,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -383,7 +377,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -480,7 +473,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -526,7 +518,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -602,7 +593,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
                 using System;
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -717,7 +707,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -761,7 +750,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -810,7 +798,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
                 using System;
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program
@@ -931,7 +918,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ForEachCast
             var fixedCode = """
                 using System.Collections.Generic;
                 using System.Linq;
-
                 namespace ConsoleApplication1
                 {
                     class Program

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.cs
@@ -730,7 +730,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryImport
                 """
                 #if true
 
-
                 #endif
 
                 class Program
@@ -805,7 +804,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryImport
                 namespace N
                 {
                 #if true
-
 
                 #endif
 

--- a/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.CustomFixAllProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.CustomFixAllProvider.cs
@@ -85,11 +85,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.MatchFolderAndNamespace
                 var documentIdToDiagnosticsMap = diagnostics
                     .GroupBy(diagnostic => diagnostic.Location.SourceTree)
                     .Where(group => group.Key is not null)
-                    .ToImmutableDictionary(group => solution.GetRequiredDocument(group.Key!).Id, group => group.ToImmutableArray());
+                    .SelectAsArray(group => (id: solution.GetRequiredDocument(group.Key!).Id, diagnostics: group.ToImmutableArray()));
 
                 var newSolution = solution;
 
-                progressTracker.AddItems(documentIdToDiagnosticsMap.Count);
+                progressTracker.AddItems(documentIdToDiagnosticsMap.Length);
 
                 foreach (var (documentId, diagnosticsInTree) in documentIdToDiagnosticsMap)
                 {

--- a/src/Analyzers/VisualBasic/Tests/AliasAmbiguousType/AliasAmbiguousTypeTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/AliasAmbiguousType/AliasAmbiguousTypeTests.vb
@@ -139,7 +139,6 @@ End Class
             Dim expectedMarkup = "
 Imports N1, N2
 Imports Goo = N1.Goo
-
 Namespace N1
     Module K
         Class Goo
@@ -178,7 +177,6 @@ End Class
             Dim expectedMarkup = "
 Imports N1, N2
 Imports I1 = N1.I1
-
 Namespace N1
     Interface I1
     End Interface

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -171,6 +171,27 @@ namespace Roslyn.Utilities
         public static IReadOnlyCollection<T> ToCollection<T>(this IEnumerable<T> sequence)
             => (sequence is IReadOnlyCollection<T> collection) ? collection : sequence.ToList();
 
+        public static T? FirstOrDefault<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            foreach (var item in source)
+            {
+                if (predicate(item, arg))
+                    return item;
+            }
+
+            return default;
+        }
+
         public static T? FirstOrNull<T>(this IEnumerable<T> source)
             where T : struct
         {
@@ -190,7 +211,28 @@ namespace Roslyn.Utilities
                 throw new ArgumentNullException(nameof(source));
             }
 
-            return source.Cast<T?>().FirstOrDefault(v => predicate(v!.Value));
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return source.Cast<T?>().FirstOrDefault(static (v, predicate) => predicate(v!.Value), predicate);
+        }
+
+        public static T? FirstOrNull<T, TArg>(this IEnumerable<T> source, Func<T, TArg, bool> predicate, TArg arg)
+            where T : struct
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return source.Cast<T?>().FirstOrDefault(static (v, arg) => arg.predicate(v!.Value, arg.arg), (predicate, arg));
         }
 
         public static T? LastOrNull<T>(this IEnumerable<T> source)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -853,6 +853,8 @@ namespace Foo
 $$
 ";
             var expectedCodeAfterCommit = @"using Foo;
+
+
 Bar$$
 ";
             var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);
@@ -880,6 +882,7 @@ $$
             var expectedCodeAfterCommit = @"
 using System;
 using Foo;
+
 Bar$$
 ";
             var markup = CreateMarkupForSingleProject(file2, file1, LanguageNames.CSharp);

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -467,14 +467,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             TestParameters parameters)
         {
             MarkupTestFile.GetSpans(
-                initialMarkup.NormalizeLineEndings(),
+                initialMarkup,
                 out var initialMarkupWithoutSpans, out IDictionary<string, ImmutableArray<TextSpan>> initialSpanMap);
 
             const string UnnecessaryMarkupKey = "Unnecessary";
             var unnecessarySpans = initialSpanMap.GetOrAdd(UnnecessaryMarkupKey, _ => ImmutableArray<TextSpan>.Empty);
 
             MarkupTestFile.GetSpans(
-                expectedMarkup.NormalizeLineEndings(),
+                expectedMarkup,
                 out var expected, out IDictionary<string, ImmutableArray<TextSpan>> expectedSpanMap);
 
             var conflictSpans = expectedSpanMap.GetOrAdd("Conflict", _ => ImmutableArray<TextSpan>.Empty);

--- a/src/EditorFeatures/TestUtilities/RefactoringHelpers/RefactoringHelpersTestBase.cs
+++ b/src/EditorFeatures/TestUtilities/RefactoringHelpers/RefactoringHelpersTestBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RefactoringHelpers
 
         private static string GetSelectionSpan(string text, out TextSpan selection)
         {
-            MarkupTestFile.GetSpans(text.NormalizeLineEndings(), out text, out IDictionary<string, ImmutableArray<TextSpan>> spans);
+            MarkupTestFile.GetSpans(text, out text, out IDictionary<string, ImmutableArray<TextSpan>> spans);
 
             if (spans.Count != 1 ||
                 !spans.TryGetValue(string.Empty, out var selections) || selections.Length != 1)
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RefactoringHelpers
 
         private static string GetSelectionAndResultSpans(string text, out TextSpan selection, out TextSpan result)
         {
-            MarkupTestFile.GetSpans(text.NormalizeLineEndings(), out text, out IDictionary<string, ImmutableArray<TextSpan>> spans);
+            MarkupTestFile.GetSpans(text, out text, out IDictionary<string, ImmutableArray<TextSpan>> spans);
 
             if (spans.Count != 2 ||
                 !spans.TryGetValue(string.Empty, out var selections) || selections.Length != 1 ||

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -346,7 +346,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
                 var name = GetFileName(workspace, sourceGeneratedDocumentElement, ref documentId);
 
-                var markupCode = sourceGeneratedDocumentElement.NormalizedValue();
+                var markupCode = (bool?)sourceGeneratedDocumentElement.Attribute(NormalizeAttributeName) is false
+                    ? sourceGeneratedDocumentElement.Value
+                    : sourceGeneratedDocumentElement.NormalizedValue();
                 MarkupTestFile.GetPositionAndSpans(markupCode,
                     out var code, out var cursorPosition, out IDictionary<string, ImmutableArray<TextSpan>> spans);
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlCreation.cs
@@ -176,8 +176,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             var element = new XElement(DocumentElementName,
                 new XAttribute(FilePathAttributeName, filePath),
+                new XAttribute(NormalizeAttributeName, false),
                 CreateParseOptionsElement(parseOptions),
-                code.Replace("\r\n", "\n"));
+                code);
 
             if (!isMarkup)
                 element.Add(new XAttribute(MarkupAttributeName, isMarkup));
@@ -189,8 +190,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             return new XElement(DocumentFromSourceGeneratorElementName,
                 new XAttribute(FilePathAttributeName, hintName),
+                new XAttribute(NormalizeAttributeName, false),
                 CreateParseOptionsElement(parseOptions),
-                code.Replace("\r\n", "\n"));
+                code);
         }
 
         private static XElement CreateParseOptionsElement(ParseOptions parseOptions)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -50,13 +50,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Suppre
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestPragmaWarningDirective() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
         [|Dim x As Integer|]
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -67,7 +67,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -85,14 +85,14 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective1() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
         [|Dim x _
             As Integer|]
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -104,7 +104,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -123,7 +123,7 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective2() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
@@ -132,7 +132,7 @@ Class C
             Console.WriteLine(i)
         End If
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -146,7 +146,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -167,7 +167,7 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective3() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
@@ -176,7 +176,7 @@ Class C
             Console.WriteLine(i)
         End If
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -190,7 +190,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -211,14 +211,14 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective4() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
         Dim [|x As Integer|],
             y As Integer
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -230,7 +230,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -249,14 +249,14 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective5() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
         Dim x As Integer,
             [|y As Integer|]
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -268,7 +268,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -287,7 +287,7 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective6() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method(i As Integer, j As Short)
@@ -295,7 +295,7 @@ Class C
                     <condition value=<%= i < [|j.MaxValue|] %>/>
                 </root>
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -308,7 +308,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -328,7 +328,7 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestMultilineStatementPragmaWarningDirective7() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method(j As Short)
@@ -336,7 +336,7 @@ Class C
                 Where i < [|j.MaxValue|]
                 Select i
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -349,7 +349,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -369,7 +369,7 @@ End Class]]>
 
                 <Fact>
                 Public Async Function TestMultilineStatementPragmaWarningDirective8() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
@@ -377,7 +377,7 @@ Class C
             As Integer|] _
         : Return
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -390,7 +390,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -410,7 +410,7 @@ End Class]]>
 
                 <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/56165")>
                 Public Async Function TestMultilineInterpolatedString() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 <Obsolete>
 Class C
@@ -418,11 +418,11 @@ End Class
 
 Module Module1
     Sub Main
-        Dim s = $"
+        Dim s = $""
 Hi {[|new C()|]}
-"
+""
     End Sub
-End Module]]>
+End Module"
                     Dim expected = $"
 Imports System
 <Obsolete>
@@ -439,7 +439,7 @@ Hi {{new C()}}
     End Sub
 End Module"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -463,7 +463,7 @@ End Module]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
                 Public Async Function TestPragmaWarningDirectiveWithExistingTrivia() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 Class C
     Sub Method()
@@ -471,7 +471,7 @@ Class C
         [|Dim x As Integer|]    ' Trivia same line
         ' Trivia next line
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 Class C
@@ -484,7 +484,7 @@ Class C
     End Sub
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -504,7 +504,7 @@ End Class]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/970129")>
                 Public Async Function TestSuppressionAroundSingleToken() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Imports System
 <Obsolete>
 Class C
@@ -514,7 +514,7 @@ Module Module1
     Sub Main
       [|C|]
     End Sub
-End Module]]>
+End Module"
                     Dim expected = $"
 Imports System
 <Obsolete>
@@ -529,7 +529,7 @@ Module Module1
     End Sub
 End Module"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -551,16 +551,16 @@ End Module]]>
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
                 Public Async Function TestPragmaWarningDirectiveAroundTrivia1() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 Class C
 
 ' Comment
 ' Comment
-''' <summary><see [|cref="abc"|]/></summary>
+''' <summary><see [|cref=""abc""|]/></summary>
     Sub M() ' Comment  
 
     End Sub
-End Class]]>
+End Class"
                     Dim expected = $"
 Class C
 
@@ -575,7 +575,7 @@ Class C
 End Class"
 
                     Dim enableDocCommentProcessing = VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose)
-                    Await TestAsync(source.Value, expected, enableDocCommentProcessing)
+                    Await TestAsync(source, expected, enableDocCommentProcessing)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = $"
@@ -617,12 +617,12 @@ End Class"
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
                 Public Async Function TestPragmaWarningDirectiveAroundTrivia4() As Task
-                    Dim source = <![CDATA[
+                    Dim source = "
 
-'''<summary><see [|cref="abc"|]/></summary>
+'''<summary><see [|cref=""abc""|]/></summary>
 Class C : End Class
 
-]]>
+"
                     Dim expected = $"
 
 #Disable Warning BC42309 ' {VBResources.WRN_XMLDocCrefAttributeNotFound1_Title}
@@ -632,15 +632,15 @@ Class C : End Class
 
 "
 
-                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
                 Public Async Function TestPragmaWarningDirectiveAroundTrivia5() As Task
-                    Dim source = <![CDATA[class C1 : End Class
-'''<summary><see [|cref="abc"|]/></summary>
+                    Dim source = "class C1 : End Class
+'''<summary><see [|cref=""abc""|]/></summary>
 Class C2 : End Class
-Class C3 : End Class]]>
+Class C3 : End Class"
                     Dim expected = $"class C1 : End Class
 #Disable Warning BC42309 ' {VBResources.WRN_XMLDocCrefAttributeNotFound1_Title}
 '''<summary><see cref=""abc""/></summary>
@@ -648,7 +648,7 @@ Class C2 : End Class
 #Enable Warning BC42309 ' {VBResources.WRN_XMLDocCrefAttributeNotFound1_Title}
 Class C3 : End Class"
 
-                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
@@ -716,9 +716,11 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
-                Public Async Function TestInfoDiagnosticSuppressed() As Task
+                <InlineData(vbLf, Skip:="https://github.com/dotnet/roslyn/issues/69358")>
+                <InlineData(vbCrLf)>
+                Public Async Function TestInfoDiagnosticSuppressed(endOfLine As String) As Task
 
                     Dim source = <![CDATA[
 Imports System
@@ -737,7 +739,7 @@ Class C
     End Sub
 End Class]]>
 
-                    Await TestAsync(source.Value, expected.Value)
+                    Await TestAsync(source.Value.ReplaceLineEndings(endOfLine), expected.Value.ReplaceLineEndings(endOfLine))
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -833,9 +835,11 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730770")>
-                Public Async Function TestWarningDiagnosticWithNameMatchingKeywordSuppressed() As Task
+                <InlineData(vbLf, Skip:="https://github.com/dotnet/roslyn/issues/69358")>
+                <InlineData(vbCrLf)>
+                Public Async Function TestWarningDiagnosticWithNameMatchingKeywordSuppressed(endOfLine As String) As Task
                     Dim source = <![CDATA[
 Imports System
 
@@ -853,7 +857,7 @@ Class C
     End Sub
 End Class]]>
 
-                    Await TestAsync(source.Value, expected.Value)
+                    Await TestAsync(source.Value.ReplaceLineEndings(endOfLine), expected.Value.ReplaceLineEndings(endOfLine))
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -897,8 +901,10 @@ End Class]]>
                     Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New UserDiagnosticAnalyzer(), New VisualBasicSuppressionCodeFixProvider())
                 End Function
 
-                <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
-                Public Async Function TestErrorDiagnosticCanBeSuppressed() As Task
+                <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
+                <InlineData(vbLf, Skip:="https://github.com/dotnet/roslyn/issues/69358")>
+                <InlineData(vbCrLf)>
+                Public Async Function TestErrorDiagnosticCanBeSuppressed(endOfLine As String) As Task
                     Dim source = <![CDATA[
 Imports System
 
@@ -916,7 +922,7 @@ Class C
     End Sub
 End Class]]>
 
-                    Await TestAsync(source.Value, expected.Value)
+                    Await TestAsync(source.Value.ReplaceLineEndings(endOfLine), expected.Value.ReplaceLineEndings(endOfLine))
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
                     Dim fixedSource = <![CDATA[
@@ -1762,7 +1768,7 @@ Imports System.Diagnostics.CodeAnalysis
 
                 <Fact>
                 Public Async Function TestSuppressionOnSimpleType() As Task
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 ' Some Trivia
@@ -1771,7 +1777,7 @@ Imports System
         Dim x
     End Sub
 End Class
-]]>
+"
                     Dim expected = $"
 Imports System
 
@@ -1784,7 +1790,7 @@ Class C
 End Class
 "
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1795,17 +1801,17 @@ End Class
                 <Fact>
                 Public Async Function TestSuppressionOnSimpleType2() As Task
                     ' Type already has attributes.
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 ' Some Trivia
-<Diagnostics.CodeAnalysis.SuppressMessage("SomeOtherDiagnostic", "SomeOtherDiagnostic:Title", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification:=""<Pending>"")>
 [|Class C|]
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
                     Dim expected = $"
 Imports System
 
@@ -1819,7 +1825,7 @@ Class C
 End Class
 "
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1830,7 +1836,7 @@ End Class
                 <Fact>
                 Public Async Function TestSuppressionOnSimpleType3() As Task
                     ' Type has structured trivia.
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 ' Some Trivia
@@ -1842,7 +1848,7 @@ Imports System
         Dim x
     End Sub
 End Class
-]]>
+"
                     Dim expected = $"
 Imports System
 
@@ -1858,7 +1864,7 @@ Class C
 End Class
 "
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1869,20 +1875,20 @@ End Class
                 <Fact>
                 Public Async Function TestSuppressionOnSimpleType4() As Task
                     ' Type has structured trivia and attributes.
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 ' Some Trivia
 ''' <summary>
 ''' My custom type
 ''' </summary>
-<Diagnostics.CodeAnalysis.SuppressMessage("SomeOtherDiagnostic", "SomeOtherDiagnostic:Title", Justification:="<Pending>")>
+<Diagnostics.CodeAnalysis.SuppressMessage(""SomeOtherDiagnostic"", ""SomeOtherDiagnostic:Title"", Justification:=""<Pending>"")>
 [|Class C|]
     Sub Method()
         Dim x
     End Sub
 End Class
-]]>
+"
                     Dim expected = $"
 Imports System
 
@@ -1899,7 +1905,7 @@ Class C
 End Class
 "
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1909,7 +1915,7 @@ End Class
 
                 <Fact>
                 Public Async Function TestSuppressionOnTypeInsideNamespace() As Task
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 Namespace N
@@ -1919,7 +1925,7 @@ Namespace N
             Dim x
         End Sub
     End Class
-End Namespace]]>
+End Namespace"
                     Dim expected = $"
 Imports System
 
@@ -1933,7 +1939,7 @@ Namespace N
     End Class
 End Namespace"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1943,7 +1949,7 @@ End Namespace"
 
                 <Fact>
                 Public Async Function TestSuppressionOnNestedType() As Task
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 Class Generic(Of T)
@@ -1953,7 +1959,7 @@ Class Generic(Of T)
             Dim x
         End Sub
     End Class
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 
@@ -1967,7 +1973,7 @@ Class Generic(Of T)
     End Class
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Class C", "[|Class C|]")
@@ -1977,7 +1983,7 @@ End Class"
 
                 <Fact>
                 Public Async Function TestSuppressionOnMethod() As Task
-                    Dim source = <![CDATA[
+                    Dim source = $"
 Imports System
 
 Class Generic(Of T)
@@ -1987,7 +1993,7 @@ Class Generic(Of T)
             Dim x
         End Sub|]
     End Class
-End Class]]>
+End Class"
                     Dim expected = $"
 Imports System
 
@@ -2001,7 +2007,7 @@ Class Generic(Of T)
     End Class
 End Class"
 
-                    Await TestAsync(source.Value, expected)
+                    Await TestAsync(source, expected)
 
                     ' Also verify that the added attribute does indeed suppress the diagnostic.
                     Dim fixedSource = expected.Replace("Sub Method()", "[|Sub Method()|]")

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim codeWithoutMarker As String = Nothing
             Dim namedSpans = CType(New Dictionary(Of String, ImmutableArray(Of TextSpan))(), IDictionary(Of String, ImmutableArray(Of TextSpan)))
 
-            MarkupTestFile.GetSpans(codeWithMarker.NormalizedValue, codeWithoutMarker, namedSpans)
+            MarkupTestFile.GetSpans(codeWithMarker.Value, codeWithoutMarker, namedSpans)
 
             Using workspace = TestWorkspace.CreateVisualBasic(codeWithoutMarker)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)

--- a/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
@@ -3370,6 +3370,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
+
 #if DEBUG
 using System.Text;
 #endif

--- a/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
@@ -2161,7 +2161,7 @@ class Program
 input,
 @"using System.Runtime.InteropServices;
 
-[ assembly : Guid ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ", testHost);
+[assembly : Guid ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ", testHost);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546833")]

--- a/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/Features/CSharpTest/AddUsing/AddUsingTests.cs
@@ -1915,6 +1915,7 @@ class Program
 @"#define goo
 
 using System;
+
 /// Goo
 class Program
 {
@@ -2707,6 +2708,7 @@ interface MyNotifyPropertyChanged { }";
 
             var expectedText =
 @"using System.ComponentModel;
+
 /// <summary>
 /// This is just like <see cref='INotifyPropertyChanged'/>, but this one is mine.
 /// </summary>
@@ -2728,6 +2730,7 @@ interface MyNotifyPropertyChanged { }";
 
             var expectedText =
 @"using System.ComponentModel;
+
 /// <summary>
 /// This is just like <see cref='INotifyPropertyChanged.PropertyChanged'/>, but this one is mine.
 /// </summary>
@@ -3395,7 +3398,6 @@ using System.Text;
 using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
-
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", testHost);
         }
 
@@ -3421,7 +3423,6 @@ using System.Text;
 using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
-
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", testHost);
         }
 
@@ -4568,6 +4569,7 @@ class C
 ",
 @"
 using System;
+
 /// Copyright 2016 - MyCompany 
 /// All Rights Reserved 
 class C
@@ -5441,7 +5443,6 @@ namespace B
 @"
 using System.Threading.Tasks;
 using B;
-
 namespace A
 {
     class C
@@ -5498,7 +5499,6 @@ namespace B
 @"
 using System.Threading.Tasks;
 using B;
-
 namespace A
 {
     class C
@@ -5599,7 +5599,6 @@ namespace B
 @"
 using System.Threading.Tasks;
 using B;
-
 namespace A
 {
     class C

--- a/src/Features/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/Features/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -672,7 +672,6 @@ index: 2);
                 """
                 using System;
                 using System.Runtime.Serialization;
-
                 class Program : Exception
                 {
                     public Program()

--- a/src/Features/CSharpTest/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/Features/CSharpTest/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -1234,7 +1234,6 @@ partial class Class1
 
             var expectedDocumentName = "Class2.cs";
             var destinationDocumentText = @"// Banner Text
-
 partial class Class1
 {
     class Class2
@@ -1286,7 +1285,6 @@ partial class Class1
 
             var expectedDocumentName = "Class2.cs";
             var destinationDocumentText = @"// Banner Text
-
 partial class Class1
 {
     class Class2
@@ -1340,7 +1338,6 @@ partial class Class1
 
             var expectedDocumentName = "Class2.cs";
             var destinationDocumentText = @"// Banner Text
-
 partial class Class1
 {
     class Class2
@@ -1392,7 +1389,6 @@ partial class Class1
 
             var expectedDocumentName = "Class2.cs";
             var destinationDocumentText = @"// Banner Text
-
 partial class Class1
 {
     class Class2

--- a/src/Features/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/Features/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -963,6 +963,7 @@ public class Derived : Base
 <Workspace>
     <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
         <Document FilePath = ""File1.cs"">using System;
+
 public class Base
 {
     public Uri Endpoint { get; set; }

--- a/src/Features/CSharpTest/SyncNamespace/CSharpSyncNamespaceTestsBase.cs
+++ b/src/Features/CSharpTest/SyncNamespace/CSharpSyncNamespaceTestsBase.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 
@@ -186,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.SyncNamespa
                         }));
 
                     var actualText = (await modifiedOriginalDocument.GetTextAsync()).ToString();
-                    Assert.Equal(expectedSourceOriginal, actualText);
+                    AssertEx.EqualOrDiff(expectedSourceOriginal, actualText);
 
                     if (expectedSourceReference == null)
                     {

--- a/src/Features/CSharpTest/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
+++ b/src/Features/CSharpTest/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
@@ -1702,6 +1702,7 @@ namespace Foo
             var expectedSourceOriginal =
 @"namespace A.B.C
 {
+
     /// <summary>
     /// See <see cref=""Class1""/>
     /// </summary>

--- a/src/Features/Core/Portable/AddImport/AddImportFixKind.cs
+++ b/src/Features/Core/Portable/AddImport/AddImportFixKind.cs
@@ -2,15 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace Microsoft.CodeAnalysis.AddImport
 {
     internal enum AddImportFixKind
     {
+        /// <summary>
+        /// Adding a project reference.
+        /// </summary>
         ProjectSymbol,
+
+        /// <summary>
+        /// Adding an assembly reference.
+        /// </summary>
         MetadataSymbol,
+
+        /// <summary>
+        /// Adding a package reference.
+        /// </summary>
         PackageSymbol,
+
+        /// <summary>
+        /// Adding a framework reference assembly reference.
+        /// </summary>
         ReferenceAssemblySymbol,
     }
 }

--- a/src/Features/VisualBasicTest/AddImport/AddImportTests.vb
+++ b/src/Features/VisualBasicTest/AddImport/AddImportTests.vb
@@ -503,7 +503,6 @@ Class Goo
 End Class",
                 "Imports System
 Imports System.Collections.Generic
-
 Class Goo
     Sub Test()
         Dim x As New List(Of Integer)
@@ -524,7 +523,6 @@ Namespace NS
 End Namespace",
                 "Imports System
 Imports System.Collections.Generic
-
 Namespace NS
     Class Goo
         Sub Test()
@@ -580,7 +578,6 @@ Class Test
 End Class",
                 "Imports System.Collections.Generic
 Imports System.Linq
-
 Class Test
     Private Sub Method(args As IList(Of Integer))
         args.Where()
@@ -795,7 +792,6 @@ Class Program
 End Class",
                 "Imports System.Collections.Generic
 Imports System.Linq
-
 Class Program
     Public Sub Linq1()
         Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
@@ -888,7 +884,6 @@ End Module
                 <Text>Imports B
 Imports A
 Imports System.Diagnostics
-
 Module Program
     Sub Main()
         Debug
@@ -975,7 +970,6 @@ Class C
 End Class",
                 "Imports System.Diagnostics
 Imports N
-
 Namespace N
     Public Class Log
     End Class
@@ -1027,7 +1021,6 @@ End Namespace",
                 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
-
 Namespace NS1
     Class Program
         Sub main()
@@ -1078,7 +1071,6 @@ End Namespace",
                 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
-
 Namespace NS1
     Class Program
         Sub main()
@@ -1139,7 +1131,6 @@ End Namespace",
 Imports System.Runtime.CompilerServices
 Imports NS2
 Imports NS3
-
 Namespace NS1
     Class Program
         Sub main()
@@ -1177,6 +1168,7 @@ End Namespace", testHost)
 Interface IMyInterface
 End Interface"
             Dim expectedText As String = "Imports System.ComponentModel
+
 ''' <summary>
 ''' This is just like <see cref=""INotifyPropertyChanged""/>, but this one is mine.
 ''' </summary>
@@ -1197,6 +1189,7 @@ End Interface"
 Interface IMyInterface
 End Interface"
             Dim expectedText As String = "Imports System.ComponentModel
+
 ''' <summary>
 ''' This is just like <see cref=""INotifyPropertyChanged.PropertyChanged""/>, but this one is mine.
 ''' </summary>
@@ -1384,7 +1377,6 @@ End Namespace",
                 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
-
 Namespace NS1
     Class C
         Sub Goo(ByVal m As String)
@@ -1426,7 +1418,6 @@ End Namespace",
                 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
-
 Namespace NS1
     Class C
         Sub Bar()
@@ -1691,6 +1682,7 @@ End Module",
 Imports System
 Imports System.Collections.Generic
 Imports System.IO
+
 #If Debug Then
 Imports System.Linq
 #End If
@@ -1860,7 +1852,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1902,7 +1893,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1944,7 +1934,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1986,7 +1975,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2028,7 +2016,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2077,7 +2064,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2133,7 +2119,6 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext2
-
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2181,7 +2166,6 @@ End Namespace",
                 "Imports System.Linq
 Imports System.Runtime.CompilerServices
 Imports X
-
 Module Program
     Sub Main(args As String())
         Dim i = 0.All()
@@ -2220,7 +2204,6 @@ End Namespace",
                 "Imports System.Linq
 Imports System.Runtime.CompilerServices
 Imports X
-
 Module Program
     Sub Main(args As String())
         Dim a = New Integer?
@@ -2268,7 +2251,6 @@ End Namespace",
                 "Imports System.Runtime.CompilerServices
 Imports X
 Imports Y
-
 Module Program
     Sub Main(args As String())
         Dim a = 0
@@ -2324,7 +2306,6 @@ End Namespace",
                 "Imports System.Runtime.CompilerServices
 Imports X
 Imports Y
-
 Module Program
     Sub Main(args As String())
         Dim a = New Integer?

--- a/src/Features/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/Features/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -148,7 +148,6 @@ End Class",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
-
 Class Program
     Inherits Exception
 
@@ -177,7 +176,6 @@ End Class",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
-
 Class Program
     Inherits Exception
 
@@ -260,7 +258,6 @@ End Class",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
-
 Class Program
     Inherits Exception
     Public Sub New()

--- a/src/Features/VisualBasicTest/GenerateMethod/GenerateMethodTests.vb
+++ b/src/Features/VisualBasicTest/GenerateMethod/GenerateMethodTests.vb
@@ -3883,7 +3883,6 @@ End Module",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Threading.Tasks
-
 Module Program
     Async Sub Main(args As String())
         Dim x As Boolean = Await Goo().ConfigureAwait(False)
@@ -3911,7 +3910,6 @@ End Module",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Threading.Tasks
-
 Module Program
     Async Sub Main(args As String())
         Dim x As Boolean = Await Goo().ConfigureAwait(False)
@@ -3940,7 +3938,6 @@ End Module",
 "Imports System 
 Imports System.Linq
 Imports System.Threading.Tasks
-
 Module M 
     Async Sub T() 
         Dim x As Boolean = Await F().ConfigureAwait(False)

--- a/src/Features/VisualBasicTest/GenerateType/GenerateTypeTests.vb
+++ b/src/Features/VisualBasicTest/GenerateType/GenerateTypeTests.vb
@@ -200,7 +200,6 @@ End Module",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
-
 Module Program
     Sub Main(args As String())
         Throw New Goo()

--- a/src/Features/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/Features/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -1616,8 +1616,10 @@ End Module
             Await TestMissingInRegularAndScriptAsync(source.Value)
         End Function
 
-        <Fact>
-        Public Async Function TestShowModuleNameAsUnnecessaryMemberAccess() As Task
+        <Theory>
+        <InlineData(vbLf, Skip:="https://github.com/dotnet/roslyn/issues/69358")>
+        <InlineData(vbCrLf)>
+        Public Async Function TestShowModuleNameAsUnnecessaryMemberAccess(endOfLine As String) As Task
             Dim source =
         <Code>
 Imports System
@@ -1657,7 +1659,7 @@ Namespace bar
     End Module
 End Namespace
 </Code>
-            Await TestInRegularAndScriptAsync(source.Value, expected.Value)
+            Await TestInRegularAndScriptAsync(source.Value.ReplaceLineEndings(endOfLine), expected.Value.ReplaceLineEndings(endOfLine))
         End Function
 
         <Fact>
@@ -1870,7 +1872,7 @@ End Namespace
             Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition())
                 Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
-                Assert.Equal(span.Start, expected.Value.ToString.Replace(vbLf, vbCrLf).IndexOf("new C", StringComparison.Ordinal) + 4)
+                Assert.Equal(span.Start, expected.Value.ReplaceLineEndings(vbLf).IndexOf("new C", StringComparison.Ordinal) + 4)
                 Assert.Equal(span.Length, "A.B".Length)
             End Using
         End Function
@@ -1904,7 +1906,7 @@ End Module
             Using workspace = TestWorkspace.CreateVisualBasic(source.Value, composition:=GetComposition())
                 Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
-                Assert.Equal(span.Start, expected.Value.ToString.Replace(vbLf, vbCrLf).IndexOf("Console.WriteLine(""goo"")", StringComparison.Ordinal))
+                Assert.Equal(span.Start, expected.Value.ReplaceLineEndings(vbLf).IndexOf("Console.WriteLine(""goo"")", StringComparison.Ordinal))
                 Assert.Equal(span.Length, "System".Length)
             End Using
         End Function
@@ -1942,8 +1944,10 @@ Public Class Test
             Await TestMissingInRegularAndScriptAsync(source.Value)
         End Function
 
-        <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/721694")>
-        Public Async Function TestEnableReducersInsideVBCref() As Task
+        <Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/721694")>
+        <InlineData(vbLf, Skip:="https://github.com/dotnet/roslyn/issues/69358")>
+        <InlineData(vbCrLf)>
+        Public Async Function TestEnableReducersInsideVBCref(endOfLine As String) As Task
             Dim source =
         <Code>
 Public Class Test_Dev11
@@ -1965,7 +1969,7 @@ Public Class Test_Dev11
         End Sub
     End Class
 </Code>
-            Await TestInRegularAndScriptAsync(source.Value, expected.Value)
+            Await TestInRegularAndScriptAsync(source.Value.ReplaceLineEndings(endOfLine), expected.Value.ReplaceLineEndings(endOfLine))
         End Function
 
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/736377")>

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -30,6 +30,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             Dim originalCode = ""
             Dim namespacesToAdd = {"System"}
             Dim expectedUpdatedCode = "using System;
+
 "
 
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
@@ -41,6 +42,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             Dim namespacesToAdd = {"First.Alphabetically", "System.Bar"}
             Dim expectedUpdatedCode = "using System.Bar;
 using First.Alphabetically;
+
 "
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -51,6 +53,7 @@ using First.Alphabetically;
             Dim namespacesToAdd = {"First.Alphabetically", "System.Bar"}
             Dim expectedUpdatedCode = "using First.Alphabetically;
 using System.Bar;
+
 "
 
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=False, expectedUpdatedCode:=expectedUpdatedCode)
@@ -179,6 +182,7 @@ using G=   H.I;
             Dim originalCode = ""
             Dim namespacesToAdd = {"$system"}
             Dim expectedUpdatedCode = "using $system;
+
 "
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -411,7 +415,7 @@ using G=   H.I;
                     snippetNode,
                     CancellationToken.None)
 
-                Assert.Equal(expectedUpdatedCode,
+                AssertEx.EqualOrDiff(expectedUpdatedCode,
                              (Await updatedDocument.GetTextAsync()).ToString())
             End Using
         End Function

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -29,6 +29,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             Dim originalCode = <![CDATA[]]>.Value
             Dim namespacesToAdd = {"System"}
             Dim expectedUpdatedCode = <![CDATA[Imports System
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -39,6 +40,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             Dim namespacesToAdd = {"First.Alphabetically", "System.Bar"}
             Dim expectedUpdatedCode = <![CDATA[Imports System.Bar
 Imports First.Alphabetically
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -49,6 +51,7 @@ Imports First.Alphabetically
             Dim namespacesToAdd = {"First.Alphabetically", "System.Bar"}
             Dim expectedUpdatedCode = <![CDATA[Imports First.Alphabetically
 Imports System.Bar
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=False, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -141,6 +144,7 @@ Imports G=   H.I
             Dim originalCode = <![CDATA[]]>.Value
             Dim namespacesToAdd = {"<xmlns:db=""http://example.org/database-two"">"}
             Dim expectedUpdatedCode = <![CDATA[Imports <xmlns:db="http://example.org/database-two">
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -180,6 +184,7 @@ Imports G=   H.I
             Dim originalCode = <![CDATA[]]>.Value
             Dim namespacesToAdd = {"$system"}
             Dim expectedUpdatedCode = <![CDATA[Imports $system
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -189,6 +194,7 @@ Imports G=   H.I
             Dim originalCode = <![CDATA[]]>.Value
             Dim namespacesToAdd = {"System.Data ' Trivia!"}
             Dim expectedUpdatedCode = <![CDATA[Imports System.Data ' Trivia!
+
 ]]>.Value
             Await TestSnippetAddImportsAsync(originalCode, namespacesToAdd, placeSystemNamespaceFirst:=True, expectedUpdatedCode:=expectedUpdatedCode)
         End Function
@@ -428,7 +434,7 @@ End Class</Test>
                     snippetNode,
                     CancellationToken.None)
 
-                Assert.Equal(expectedUpdatedCode.Replace(vbLf, vbCrLf),
+                AssertEx.EqualOrDiff(expectedUpdatedCode.Replace(vbLf, vbCrLf),
                              (Await updatedDocument.GetTextAsync()).ToString())
             End Using
         End Function

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
                 var formatted = await Formatter.FormatAsync(reduced, SyntaxAnnotation.ElasticAnnotation, formattingOptions, CancellationToken.None);
 
                 var actualText = (await formatted.GetTextAsync()).ToString();
-                Assert.Equal(simplifiedText, actualText);
+                AssertEx.EqualOrDiff(simplifiedText, actualText);
             }
 
             if (performCheck)
@@ -304,7 +304,8 @@ class C
     public System.Int32 F;
 }",
 
-@"class C
+@"
+class C
 {
     public int F;
 }", useSymbolAnnotations: false);
@@ -486,7 +487,8 @@ class C
     public N.C F;
 }",
 
-@"namespace N
+@"
+namespace N
 {
     class C
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
@@ -243,6 +243,42 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
 
                 return resultNamespace;
             }
+
+            public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+            {
+                // Avoid recursing into a class declaration
+                return node;
+            }
+
+            public override SyntaxNode VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+            {
+                // Avoid recursing into a delegate declaration
+                return node;
+            }
+
+            public override SyntaxNode VisitEnumDeclaration(EnumDeclarationSyntax node)
+            {
+                // Avoid recursing into an enum declaration
+                return node;
+            }
+
+            public override SyntaxNode VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+            {
+                // Avoid recursing into an interface declaration
+                return node;
+            }
+
+            public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
+            {
+                // Avoid recursing into a record declaration
+                return node;
+            }
+
+            public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+            {
+                // Avoid recursing into a struct declaration
+                return node;
+            }
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.Rewriter.cs
@@ -156,6 +156,19 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
 
                 ProcessUsings(compilationUnit.Usings, usingsToRemove, out var finalUsings, out var finalTrivia);
 
+                // If all the using directives were removed, and the group was followed by a blank line, remove a single
+                // blank line as well.
+                if (compilationUnit.Usings.Count > 0 && finalUsings.Count == 0)
+                {
+                    var nextToken = compilationUnit.Usings.Last().GetLastToken().GetNextTokenOrEndOfFile();
+                    if (nextToken.HasLeadingTrivia && nextToken.LeadingTrivia[0].IsEndOfLine())
+                    {
+                        compilationUnit = compilationUnit.ReplaceToken(
+                            nextToken,
+                            nextToken.WithLeadingTrivia(nextToken.LeadingTrivia.RemoveAt(0)));
+                    }
+                }
+
                 // If there was any left over trivia, then attach it to the next token that
                 // follows the usings.
                 if (finalTrivia.Count > 0)
@@ -194,6 +207,19 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
                     return namespaceDeclaration;
 
                 ProcessUsings(namespaceDeclaration.Usings, usingsToRemove, out var finalUsings, out var finalTrivia);
+
+                // If all the using directives were removed, and the group was followed by a blank line, remove a single
+                // blank line as well.
+                if (namespaceDeclaration.Usings.Count > 0 && finalUsings.Count == 0)
+                {
+                    var nextToken = namespaceDeclaration.Usings.Last().GetLastToken().GetNextTokenOrEndOfFile();
+                    if (nextToken.HasLeadingTrivia && nextToken.LeadingTrivia[0].IsEndOfLine())
+                    {
+                        namespaceDeclaration = namespaceDeclaration.ReplaceToken(
+                            nextToken,
+                            nextToken.WithLeadingTrivia(nextToken.LeadingTrivia.RemoveAt(0)));
+                    }
+                }
 
                 // If there was any left over trivia, then attach it to the next token that
                 // follows the usings.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal static class AddImportHelpers
     {
-        public static TRootSyntax MoveTrivia<TRootSyntax, TImportDirectiveSyntax>(
+        public static (TRootSyntax root, bool addBlankLine) MoveTrivia<TRootSyntax, TImportDirectiveSyntax>(
             ISyntaxFacts syntaxFacts,
             TRootSyntax root,
             SyntaxList<TImportDirectiveSyntax> existingImports,
@@ -20,8 +20,12 @@ namespace Microsoft.CodeAnalysis.AddImport
             where TRootSyntax : SyntaxNode
             where TImportDirectiveSyntax : SyntaxNode
         {
+            var addBlankLine = false;
             if (existingImports.Count == 0)
             {
+                // We add a blank line after a brand new using group.
+                addBlankLine = newImports.Count > 0;
+
                 // We don't have any existing usings. Move any trivia on the first token 
                 // of the file to the first using.
                 // 
@@ -48,11 +52,6 @@ namespace Microsoft.CodeAnalysis.AddImport
                     if (!syntaxFacts.IsEndOfLineTrivia(trailingTrivia.Count == 0 ? default : trailingTrivia[^1]))
                     {
                         newImports[i] = newImports[i].WithAppendedTrailingTrivia(endOfLine);
-                        if (i == newImports.Count - 1)
-                        {
-                            // Add a blank line after the last using in the new group
-                            newImports[i] = newImports[i].WithAppendedTrailingTrivia(endOfLine);
-                        }
                     }
                 }
             }
@@ -94,7 +93,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 }
             }
 
-            return root;
+            return (root, addBlankLine);
         }
 
         private static bool IsDocCommentOrElastic(ISyntaxFacts syntaxFacts, SyntaxTrivia t)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AddImportHelpers.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 for (var i = 0; i < newImports.Count; i++)
                 {
                     var trailingTrivia = newImports[i].GetTrailingTrivia();
-                    if (!syntaxFacts.IsEndOfLineTrivia(trailingTrivia.Count == 0 ? default : trailingTrivia[^1]))
+                    if (!trailingTrivia.Any() || !syntaxFacts.IsEndOfLineTrivia(trailingTrivia[^1]))
                     {
                         newImports[i] = newImports[i].WithAppendedTrailingTrivia(endOfLine);
                     }
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var originalLastUsingCurrentIndex = newImports.IndexOf(originalLastUsing);
 
                 var originalFirstUsingTrailingTrivia = originalFirstUsing.GetTrailingTrivia();
-                var originalFirstUsingLineEnding = originalFirstUsingTrailingTrivia.Count > 0 && syntaxFacts.IsEndOfLineTrivia(originalFirstUsingTrailingTrivia[^1])
+                var originalFirstUsingLineEnding = originalFirstUsingTrailingTrivia.Any() && syntaxFacts.IsEndOfLineTrivia(originalFirstUsingTrailingTrivia[^1])
                     ? originalFirstUsingTrailingTrivia[^1]
                     : syntaxFacts.ElasticCarriageReturnLineFeed;
 
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 for (var i = 0; i < newImports.Count; i++)
                 {
                     var trailingTrivia = newImports[i].GetTrailingTrivia();
-                    if (!syntaxFacts.IsEndOfLineTrivia(trailingTrivia.Count == 0 ? default : trailingTrivia[^1]))
+                    if (!trailingTrivia.Any() || !syntaxFacts.IsEndOfLineTrivia(trailingTrivia[^1]))
                     {
                         newImports[i] = newImports[i].WithAppendedTrailingTrivia(originalFirstUsingLineEnding);
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/CompilationUnitSyntaxExtensions.vb
@@ -6,6 +6,7 @@ Imports System.Runtime.CompilerServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.AddImport
+Imports Microsoft.CodeAnalysis.LanguageService
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -78,11 +79,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 [imports].Sort(comparers.Item2)
             End If
 
-            root = AddImportHelpers.MoveTrivia(
+            Dim rootAndAddBlankLine = AddImportHelpers.MoveTrivia(
                 VisualBasicSyntaxFacts.Instance, root, root.Imports, [imports])
+            root = rootAndAddBlankLine.root
+            Dim addBlankLine = rootAndAddBlankLine.addBlankLine
 
-            Return root.WithImports(
+            Dim rootWithNewImports = root.WithImports(
                 [imports].Select(Function(u) u.WithAdditionalAnnotations(annotations)).ToSyntaxList())
+            If addBlankLine Then
+                Dim lastImport = rootWithNewImports.Imports.Last()
+                Dim nextToken = lastImport.GetLastToken(includeZeroWidth:=True, includeSkipped:=True).GetNextTokenOrEndOfFile(includeZeroWidth:=True, includeSkipped:=True)
+                Dim endOfLine = lastImport.GetTrailingTrivia().LastOrDefault(Function(trivia) VisualBasicSyntaxFacts.Instance.IsEndOfLineTrivia(trivia))
+                Debug.Assert(Not endOfLine.IsKind(SyntaxKind.None))
+                If Not endOfLine.IsKind(SyntaxKind.None) Then
+                    rootWithNewImports = rootWithNewImports.ReplaceToken(nextToken, nextToken.WithPrependedLeadingTrivia(endOfLine))
+                End If
+            End If
+
+            Return rootWithNewImports
         End Function
 
         Private Function AddImportsStatements(root As CompilationUnitSyntax, importsStatements As IList(Of ImportsStatementSyntax)) As List(Of ImportsStatementSyntax)

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
@@ -107,7 +107,7 @@ End NameSpace"
                 Dim reduced = Await Simplifier.ReduceAsync(imported, simplifierOptions, CancellationToken.None)
                 Dim formatted = Await Formatter.FormatAsync(reduced, SyntaxAnnotation.ElasticAnnotation, formattingOptions, CancellationToken.None)
                 Dim actualText = (Await formatted.GetTextAsync()).ToString()
-                Assert.Equal(simplifiedText, actualText)
+                AssertEx.EqualOrDiff(simplifiedText, actualText)
             End If
 
             If performCheck Then
@@ -272,7 +272,8 @@ End Class",
 Class C
     Public F As System.Int32
 End Class",
-"Class C
+"
+Class C
     Public F As Integer
 End Class", useSymbolAnnotations:=False)
         End Function
@@ -362,7 +363,8 @@ Class C
     Private F As N.C
 End Class
 ",
-"Namespace N
+"
+Namespace N
     Class C
     End Class
 End Namespace


### PR DESCRIPTION
* Update the test infrastructure to avoid automatic normalization of end-of-line sequences in string literals being fed in to the test infrastructure.
* Preserve existing EOL sequence when adding new using directives. Due to the way sorting occurs, it's not straightforward to use the line ending from each insertion point, so the new code uses the current line ending from the first using directive already in the file (or otherwise the first line ending in the file) to determine the EOL sequence. The `end_of_line` setting from .editorconfig is intentionally ignored, since it may or may not match the contents of the current file and the Add Using operation only impacts a few lines in the file.
* Update tests to reflect new behavior. Most cases are updated in fc15ab5, and show that the new behavior of the product produces better consistency (retaining or omitting blank lines to match the state of the code before applying the refactoring). One case, separately made in 36be2a8, appears to be less consistent, but I was not able to determine the reason why the change was occurring.

Fixes #62976
Fixes #65081
Fixes [AB#1862690](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1862690)