### PR TITLE
Configure Binskim to look for symbols on MS symbols server

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -391,7 +391,7 @@ stages:
         params: >-
           -SourceToolsList @("policheck","credscan")
           -ArtifactToolsList @("binskim")
-          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
+          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
           -TsaInstanceURL $(_TsaInstanceURL)
           -TsaProjectName $(_TsaProjectName)
           -TsaNotificationEmail $(_TsaNotificationEmail)


### PR DESCRIPTION
After enabling BinSkim scans in [Enable Binskim scan in CI builds PR](https://github.com/dotnet/roslyn/pull/69081) we noticed some issues being created because the tool can't find `pdb` files for some of the artifacts
Example: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1863566

Adding the option to search on the Microsoft symbols server resolves the issue
You can find information about the tool configuration in [Binskim documentation](https://github.com/Microsoft/binskim)