### PR TITLE
A better descriptor Id for an F# analyzer

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
     [DiagnosticAnalyzer(LanguageNames.FSharp)]
     internal class FSharpUnusedDeclarationsDiagnosticAnalyzer : DocumentDiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        private const string DescriptorId = "FS1182";
+        private const string DescriptorId = IDEDiagnosticIds.ValueAssignedIsUnusedDiagnosticId;
 
         private readonly DiagnosticDescriptor _descriptor =
             new DiagnosticDescriptor(


### PR DESCRIPTION
Related to [this ticket](https://github.com/dotnet/fsharp/issues/15620).

Basically we ended up having our compiler and this analyzer often emitting the same diagnostics which causes confusion. The right way is to distinguish them, this is what C# compiler does and what other F# analyzers to here, so it's basically aligning the approach.

Picking [IDE0059](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059) because this is the closest match to what we need.