### PR TITLE
Add support for assembly/module-level `[Experimental]` and contextual suppression

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -276,15 +276,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <summary>
-        /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
-        /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        /// </summary>
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
-        {
-            get { return null; }
-        }
-
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -66,6 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
 #nullable enable
         private DiagnosticInfo? _lazyCachedCompilerFeatureRequiredDiagnosticInfo = CSDiagnosticInfo.EmptyErrorInfo;
+
+        private ObsoleteAttributeData? _lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
 #nullable disable
 
         internal PEAssemblySymbol(PEAssembly assembly, DocumentationProvider documentationProvider, bool isLinked, MetadataImportOptions importOptions)
@@ -311,5 +313,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override bool HasUnsupportedMetadata
             => GetCompilerFeatureRequiredDiagnostic()?.Code == (int)ErrorCode.ERR_UnsupportedCompilerFeature || base.HasUnsupportedMetadata;
+
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+        {
+            get
+            {
+                if (_lazyObsoleteAttributeData == ObsoleteAttributeData.Uninitialized)
+                {
+                    Interlocked.CompareExchange(ref _lazyObsoleteAttributeData, computeObsoleteAttributeData(), ObsoleteAttributeData.Uninitialized);
+                }
+
+                return _lazyObsoleteAttributeData;
+
+                ObsoleteAttributeData? computeObsoleteAttributeData()
+                {
+                    foreach (var attrData in GetAttributes())
+                    {
+                        if (attrData.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+                        {
+                            return attrData.DecodeExperimentalAttribute();
+                        }
+                    }
+
+                    return null;
+                }
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -118,6 +118,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
 #nullable enable
         private DiagnosticInfo? _lazyCachedCompilerFeatureRequiredDiagnosticInfo = CSDiagnosticInfo.EmptyErrorInfo;
+
+        private ObsoleteAttributeData? _lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
 #nullable disable
 
         internal PEModuleSymbol(PEAssemblySymbol assemblySymbol, PEModule module, MetadataImportOptions importOptions, int ordinal)
@@ -854,6 +856,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     return foundAttributeType
                         ? RefSafetyRulesAttributeVersion.UnrecognizedAttribute
                         : RefSafetyRulesAttributeVersion.NoAttribute;
+                }
+            }
+        }
+
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+        {
+            get
+            {
+                if (_lazyObsoleteAttributeData == ObsoleteAttributeData.Uninitialized)
+                {
+                    Interlocked.CompareExchange(ref _lazyObsoleteAttributeData, computeObsoleteAttributeData(), ObsoleteAttributeData.Uninitialized);
+                }
+
+                return _lazyObsoleteAttributeData;
+
+                ObsoleteAttributeData? computeObsoleteAttributeData()
+                {
+                    foreach (var attrData in GetAttributes())
+                    {
+                        if (attrData.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+                        {
+                            return attrData.DecodeExperimentalAttribute();
+                        }
+                    }
+
+                    return null;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -209,5 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return SpecializedCollections.EmptyEnumerable<NamedTypeSymbol>();
         }
+
+#nullable enable
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -198,6 +198,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool UseUpdatedEscapeRules => false;
+
+#nullable enable
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData => null;
+#nullable disable
     }
 
     internal sealed class MissingModuleSymbolWithName : MissingModuleSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -185,15 +185,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <summary>
-        /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
-        /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        /// </summary>
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
-        {
-            get { return null; }
-        }
-
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
@@ -109,9 +109,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ObsoleteDiagnosticKind.NotObsolete;
             }
 
-            Debug.Assert(symbol.ContainingModule.ObsoleteKind is not ObsoleteAttributeKind.Uninitialized);
-            Debug.Assert(symbol.ContainingAssembly.ObsoleteKind is not ObsoleteAttributeKind.Uninitialized);
-
             if (symbol.ContainingModule.ObsoleteKind is ObsoleteAttributeKind.Experimental
                 || symbol.ContainingAssembly.ObsoleteKind is ObsoleteAttributeKind.Experimental)
             {
@@ -121,6 +118,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             switch (symbol.ObsoleteKind)
             {
                 case ObsoleteAttributeKind.None:
+                    if (symbol.ContainingModule.ObsoleteKind is ObsoleteAttributeKind.Uninitialized
+                        || symbol.ContainingAssembly.ObsoleteKind is ObsoleteAttributeKind.Uninitialized)
+                    {
+                        return ObsoleteDiagnosticKind.Lazy;
+                    }
+
                     return ObsoleteDiagnosticKind.NotObsolete;
                 case ObsoleteAttributeKind.WindowsExperimental:
                     return ObsoleteDiagnosticKind.Diagnostic;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -284,6 +284,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         }
 
 #nullable enable
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+            => _underlyingAssembly.ObsoleteAttributeData;
 
         internal override NamedTypeSymbol? TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -318,5 +318,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         }
 
         internal override bool UseUpdatedEscapeRules => _underlyingModule.UseUpdatedEscapeRules;
+
+#nullable enable
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+            => _underlyingModule.ObsoleteAttributeData;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2554,7 +2554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
             {
                 var obsoleteData = attribute.DecodeExperimentalAttribute();
-                arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
+                arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().ExperimentalAttributeData = obsoleteData;
             }
         }
 
@@ -2868,8 +2868,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 // [assembly: Experimental] may have been specified in the assembly or one of the modules
-                var result = GetSourceDecodedWellKnownAttributeData()?.ObsoleteAttributeData
-                    ?? GetNetModuleDecodedWellKnownAttributeData()?.ObsoleteAttributeData;
+                var result = GetSourceDecodedWellKnownAttributeData()?.ExperimentalAttributeData
+                    ?? GetNetModuleDecodedWellKnownAttributeData()?.ExperimentalAttributeData;
 
                 Debug.Assert(result is null || result is { Kind: ObsoleteAttributeKind.Experimental });
                 return result;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -657,7 +657,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /// <summary>
+        /// Returns data decoded from <see cref="ObsoleteAttribute"/> attribute or null if there is no <see cref="ObsoleteAttribute"/> attribute.
+        /// This property returns <see cref="Microsoft.CodeAnalysis.ObsoleteAttributeData.Uninitialized"/> if attribute arguments haven't been decoded yet.
+        /// </summary>
         internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
-            => GetDecodedWellKnownAttributeData()?.ExperimentalAttributeData;
+        {
+            get
+            {
+                var attributesBag = _lazyCustomAttributesBag;
+                if (attributesBag != null && attributesBag.IsDecodedWellKnownAttributeDataComputed)
+                {
+                    var decodedData = (ModuleWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+                    return decodedData?.ExperimentalAttributeData;
+                }
+
+                var attributesDeclarations = ((SourceAssemblySymbol)ContainingAssembly).GetAttributeDeclarations();
+                if (attributesDeclarations.IsEmpty)
+                {
+                    return null;
+                }
+
+                return ObsoleteAttributeData.Uninitialized;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -533,7 +533,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
             {
-                arguments.GetOrCreateData<ModuleWellKnownAttributeData>().ObsoleteAttributeData = attribute.DecodeExperimentalAttribute();
+                arguments.GetOrCreateData<ModuleWellKnownAttributeData>().ExperimentalAttributeData = attribute.DecodeExperimentalAttribute();
             }
         }
 
@@ -658,6 +658,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
-            => GetDecodedWellKnownAttributeData()?.ObsoleteAttributeData;
+            => GetDecodedWellKnownAttributeData()?.ExperimentalAttributeData;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -531,6 +531,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<ModuleWellKnownAttributeData>(DeclaringCompilation, ref arguments);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExperimentalAttribute))
+            {
+                arguments.GetOrCreateData<ModuleWellKnownAttributeData>().ObsoleteAttributeData = attribute.DecodeExperimentalAttribute();
+            }
         }
 
 #nullable enable
@@ -652,5 +656,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _lazyUseUpdatedEscapeRules == ThreeState.True;
             }
         }
+
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+            => GetDecodedWellKnownAttributeData()?.ObsoleteAttributeData;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1309,6 +1309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion
 
+#nullable enable
         /// <summary>
         /// True if this symbol has been marked with the <see cref="ObsoleteAttribute"/> attribute. 
         /// This property returns <see cref="ThreeState.Unknown"/> if the <see cref="ObsoleteAttribute"/> attribute hasn't been cracked yet.
@@ -1331,6 +1332,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// True if this symbol has been marked with the System.Diagnostics.CodeAnalysis.ExperimentalAttribute attribute. 
+        /// This property returns <see cref="ThreeState.Unknown"/> if the attribute hasn't been cracked yet.
+        /// </summary>
+        internal ThreeState ExperimentalState
+        {
+            get
+            {
+                switch (ObsoleteKind)
+                {
+                    case ObsoleteAttributeKind.Experimental:
+                        return ThreeState.True;
+                    case ObsoleteAttributeKind.Uninitialized:
+                        return ThreeState.Unknown;
+                    default:
+                        return ThreeState.False;
+                }
+            }
+        }
+
         internal ObsoleteAttributeKind ObsoleteKind
         {
             get
@@ -1344,7 +1365,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns data decoded from <see cref="ObsoleteAttribute"/> attribute or null if there is no <see cref="ObsoleteAttribute"/> attribute.
         /// This property returns <see cref="Microsoft.CodeAnalysis.ObsoleteAttributeData.Uninitialized"/> if attribute arguments haven't been decoded yet.
         /// </summary>
-        internal abstract ObsoleteAttributeData ObsoleteAttributeData { get; }
+        internal abstract ObsoleteAttributeData? ObsoleteAttributeData { get; }
+#nullable disable
 
         /// <summary>
         /// Returns true and a <see cref="string"/> from the first <see cref="GuidAttribute"/> on the symbol, 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1362,7 +1362,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Returns data decoded from <see cref="ObsoleteAttribute"/> attribute or null if there is no <see cref="ObsoleteAttribute"/> attribute.
+        /// Returns data decoded from <see cref="ObsoleteAttribute"/>/Experimental attribute or null if there is no <see cref="ObsoleteAttribute"/>/Experimental attribute.
         /// This property returns <see cref="Microsoft.CodeAnalysis.ObsoleteAttributeData.Uninitialized"/> if attribute arguments haven't been decoded yet.
         /// </summary>
         internal abstract ObsoleteAttributeData? ObsoleteAttributeData { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -932,15 +932,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Ensure that attributes are bound and the ObsoleteState of this symbol is known.
+        /// Ensure that attributes are bound and the ObsoleteState/ExperimentalState of this symbol is known.
         /// </summary>
         internal void ForceCompleteObsoleteAttribute()
         {
-            if (this.ObsoleteState == ThreeState.Unknown)
+            if (this.ObsoleteKind == ObsoleteAttributeKind.Uninitialized)
             {
                 this.GetAttributes();
             }
             Debug.Assert(this.ObsoleteState != ThreeState.Unknown, "ObsoleteState should be true or false now.");
+            Debug.Assert(this.ExperimentalState != ThreeState.Unknown, "ExperimentalState should be true or false now.");
+
+            this.ContainingSymbol?.ForceCompleteObsoleteAttribute();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -2060,7 +2060,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                    IsContainedInNamespace(type, "System", "Numerics");
         }
 
-        private static bool IsWellKnownDiagnosticsCodeAnalysisTopLevelType(this TypeSymbol typeSymbol)
+        internal static bool IsWellKnownDiagnosticsCodeAnalysisTopLevelType(this TypeSymbol typeSymbol)
             => typeSymbol.ContainingType is null && IsContainedInNamespace(typeSymbol, "System", "Diagnostics", "CodeAnalysis");
 
         private static bool IsContainedInNamespace(this TypeSymbol typeSymbol, string outerNS, string midNS, string? innerNS = null)

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
@@ -4,9 +4,13 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
@@ -63,9 +67,68 @@ C.M();
     }
 
     [Fact]
-    public void OnAssembly()
+    public void OnAssembly_UsedFromSource()
     {
-        // Ignored on assemblies
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+        var comp = CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc });
+        comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnAssembly_UsedFromMetadata()
+    {
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+
+        // Note: the assembly-level [Experimental] is equivalent to marking every type and member as experimental,
+        // whereas a type-level [Experimental] is not equivalent to marking every nested type and member as experimental.
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        foreach (var diag in comp.GetDiagnostics())
+        {
+            Assert.Equal("DiagID1", diag.Id);
+            Assert.Equal(ErrorCode.WRN_Experimental, (ErrorCode)diag.Code);
+            Assert.Equal(DefaultHelpLinkUri, diag.Descriptor.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void OnAssembly_DefinedInMetadata_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
         var libSrc = """
 [assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
 public class C
@@ -78,14 +141,186 @@ public class C
 C.M();
 """;
 
-        var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef });
         comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnAssembly_DefinedInMetadata_UsedFromMetadata()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef }).EmitToImageReference(), attrRef });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        foreach (var diag in comp.GetDiagnostics())
+        {
+            Assert.Equal("DiagID1", diag.Id);
+            Assert.Equal(ErrorCode.WRN_Experimental, (ErrorCode)diag.Code);
+            Assert.Equal(DefaultHelpLinkUri, diag.Descriptor.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void OnAssembly_DefinedInMetadata_AppliedWithinModule_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc1 = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+""";
+        var moduleComp = CreateCompilation(libSrc1, options: TestOptions.DebugModule, references: new[] { attrRef });
+        var moduleRef = moduleComp.EmitToImageReference();
+
+        var libSrc = """
+public class C
+{
+    public static void M() { }
+}
+""";
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef, moduleRef });
+        comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnAssembly_DefinedInMetadata_AppliedWithinModule_UsedFromMetadata()
+    {
+        // An assembly-level [Experimental] compiled into a module applies to the entire assembly
+        // the module gets compiled into
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc1 = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+""";
+        var moduleComp = CreateCompilation(libSrc1, options: TestOptions.DebugModule, references: new[] { attrRef });
+        var moduleRef = moduleComp.EmitToImageReference();
+
+        var libSrc = """
+public class C
+{
+    public static void M() { }
+}
+""";
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef, moduleRef }).EmitToImageReference(), attrRef });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        foreach (var diag in comp.GetDiagnostics())
+        {
+            Assert.Equal("DiagID1", diag.Id);
+            Assert.Equal(ErrorCode.WRN_Experimental, (ErrorCode)diag.Code);
+            Assert.Equal(DefaultHelpLinkUri, diag.Descriptor.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void OnAssembly_ObsoleteType()
+    {
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+
+[System.Obsolete("error", true)]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Obsolete, comp.GetTypeByMetadataName("C").ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // (1,1): error CS0619: 'C' is obsolete: 'error'
+            // C.M();
+            Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "C").WithArguments("C", "error").WithLocation(1, 1),
+            // (1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void OnType_ObsoleteType()
+    {
+        var libSrc = """
+[System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+[System.Obsolete("error", true)]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        Assert.Equal(ObsoleteAttributeKind.Obsolete, comp.GetTypeByMetadataName("C").ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // (1,1): error CS0619: 'C' is obsolete: 'error'
+            // C.M();
+            Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "C").WithArguments("C", "error").WithLocation(1, 1)
+            );
     }
 
     [Fact]
     public void OnModule()
     {
-        // Ignored on modules
         var libSrc = """
 [module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
 public class C
@@ -99,7 +334,662 @@ C.M();
 """;
 
         var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+        comp.VerifyDiagnostics(
+            // (1,1): warning DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C").WithArguments("C").WithLocation(1, 1),
+            // (1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+    }
+
+    [Fact]
+    public void OnModule_DefinedInMetadata_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef });
         comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnModule_DefinedInMetadata_UsedFromMetadata()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef }).EmitToImageReference(), attrRef });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        foreach (var diag in comp.GetDiagnostics())
+        {
+            Assert.Equal("DiagID1", diag.Id);
+            Assert.Equal(ErrorCode.WRN_Experimental, (ErrorCode)diag.Code);
+            Assert.Equal(DefaultHelpLinkUri, diag.Descriptor.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void OnModuleAndAssembly_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagAssembly")]
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagModule")]
+
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef });
+        comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnModuleAndAssembly_UsedFromMetadata()
+    {
+        // Prefer reporting the module-level diagnostic
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagAssembly")]
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagModule")]
+
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef }).EmitToImageReference(), attrRef });
+
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagModule: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagModule", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagModule: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagModule", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        foreach (var diag in comp.GetDiagnostics())
+        {
+            Assert.Equal("DiagModule", diag.Id);
+            Assert.Equal(ErrorCode.WRN_Experimental, (ErrorCode)diag.Code);
+            Assert.Equal(DefaultHelpLinkUri, diag.Descriptor.HelpLinkUri);
+        }
+    }
+
+    [Fact]
+    public void OnAssembly_CompiledIntoModule()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("AssemblyDiagSetInModule")]
+
+public class C
+{
+    public static void M() { }
+}
+""";
+
+        var moduleComp = CreateCompilation(libSrc, options: TestOptions.ReleaseModule, references: new[] { attrRef });
+        moduleComp.VerifyDiagnostics();
+        var moduleRef = moduleComp.EmitToImageReference();
+
+        var libSrc2 = """
+public class D
+{
+    public static void M()
+    {
+        C.M();
+    }
+}
+""";
+        var assemblyComp = CreateCompilation(libSrc2, references: new[] { moduleRef, attrRef });
+        assemblyComp.VerifyDiagnostics();
+        var assemblyRef = assemblyComp.EmitToImageReference();
+
+        var src = """
+C.M();
+D.M();
+""";
+
+        // Since the module is referenced but not linked, we also need it here, but as
+        // a result the diagnostics are suppressed
+        var comp = CreateCompilation(src, references: new[] { assemblyRef, moduleRef, attrRef });
+        comp.VerifyDiagnostics();
+
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind);
+
+        Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("D").ContainingModule.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("D").ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnTypeAndMethodAndAssembly_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("IGNORED")]
+
+[System.Diagnostics.CodeAnalysis.Experimental("DiagType")]
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagMethod")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef });
+        comp.VerifyDiagnostics();
+
+        var c = comp.GetTypeByMetadataName("C");
+        Assert.Equal(ObsoleteAttributeKind.Experimental, c.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, c.ContainingAssembly.ObsoleteKind);
+
+        var m = comp.GetMember("C.M");
+        Assert.Equal(ObsoleteAttributeKind.Experimental, m.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnTypeAndMethodAndAssembly_UsedFromMetadata()
+    {
+        // Prefer reporting the type-level and method-level diagnostic
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("IGNORED")]
+
+[System.Diagnostics.CodeAnalysis.Experimental("DiagType")]
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagMethod")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef }).EmitToImageReference(), attrRef });
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagType: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagType", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagMethod: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.M();
+            Diagnostic("DiagMethod", "C.M()").WithArguments("C.M()").WithLocation(1, 1)
+            );
+
+        var c = comp.GetTypeByMetadataName("C");
+        Assert.Equal(ObsoleteAttributeKind.Experimental, c.ObsoleteKind);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, c.ContainingAssembly.ObsoleteKind);
+
+        var m = comp.GetMember("C.M");
+        Assert.Equal(ObsoleteAttributeKind.Experimental, m.ObsoleteKind);
+    }
+
+    [Fact]
+    public void OnTypeAndAssembly_UsedFromSource()
+    {
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagAssembly")]
+
+[System.Diagnostics.CodeAnalysis.Experimental("DiagType")]
+public class C
+{
+    public class Nested
+    {
+        public static void M() { }
+    }
+}
+""";
+
+        var src = """
+C.Nested.M();
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc }, references: new[] { attrRef });
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void OnTypeAndAssembly_UsedFromMetadata()
+    {
+        // Prefer reporting the type-level and method-level diagnostic
+        var attrComp = CreateCompilation(experimentalAttributeSrc);
+        var attrRef = attrComp.EmitToImageReference();
+
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagAssembly")]
+
+[System.Diagnostics.CodeAnalysis.Experimental("DiagType")]
+public class C
+{
+    public class Nested
+    {
+        public static void M() { }
+    }
+}
+""";
+
+        var src = """
+C.Nested.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { attrRef }).EmitToImageReference(), attrRef });
+
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning DiagType: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.Nested.M();
+            Diagnostic("DiagType", "C").WithArguments("C").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagAssembly: 'C.Nested' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.Nested.M();
+            Diagnostic("DiagAssembly", "C.Nested").WithArguments("C.Nested").WithLocation(1, 1),
+            // 0.cs(1,1): warning DiagAssembly: 'C.Nested.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // C.Nested.M();
+            Diagnostic("DiagAssembly", "C.Nested.M()").WithArguments("C.Nested.M()").WithLocation(1, 1)
+            );
+    }
+
+    [Theory, CombinatorialData]
+    public void OnOverridden(bool inSource)
+    {
+        var libSrc = """
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("Diag")]
+    public virtual void M() { }
+}
+""";
+
+        var src = """
+public class Derived : C
+{
+    public override void M() { }
+
+    public void M2()
+    {
+        base.M();
+        M();
+    }
+}
+""";
+
+        var comp = inSource
+         ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+         : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics(
+            // 0.cs(7,9): warning Diag: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            //         base.M();
+            Diagnostic("Diag", "base.M()").WithArguments("C.M()").WithLocation(7, 9),
+            // 0.cs(8,9): warning Diag: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            //         M();
+            Diagnostic("Diag", "M()").WithArguments("C.M()").WithLocation(8, 9)
+            );
+    }
+
+    [Theory, CombinatorialData]
+    public void OnOverride(bool inSource)
+    {
+        var libSrc = """
+public class C
+{
+    public virtual void M() { }
+}
+""";
+
+        var src = """
+public class Derived : C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("Diag")]
+    public override void M() { }
+
+    public void M2()
+    {
+        base.M();
+        M();
+    }
+}
+
+public class DerivedDerived : Derived
+{
+    public void M3()
+    {
+        base.M(); // 1
+        M();
+    }
+}
+""";
+
+        var comp = inSource
+         ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+         : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics(
+            // 0.cs(17,9): warning Diag: 'Derived.M()' is for evaluation purposes only and is subject to change or removal in future updates.
+            //         base.M(); // 1
+            Diagnostic("Diag", "base.M()").WithArguments("Derived.M()").WithLocation(17, 9)
+            );
+    }
+
+    [Fact]
+    public void OnOverride_ExperimentalFromAssembly_UsedFromSource()
+    {
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("Diag")]
+public class C
+{
+    public virtual void M() { }
+}
+""";
+
+        var src = """
+public class Derived : C { public override void M() { } }
+""";
+
+        var comp = CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc });
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void OnOverride_ExperimentalFromAssembly_UsedFromMetadata()
+    {
+        var libSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("Diag")]
+public class C
+{
+    public virtual void M() { }
+}
+""";
+
+        var src = """
+public class Derived : C { public override void M() { } }
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        // CONSIDER narrowing the location on constructor initializer obsolete/experimental attributes
+        comp.VerifyDiagnostics(
+            // 0.cs(1,1): warning Diag: 'C.C()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // public class Derived : C { public override void M() { } }
+            Diagnostic("Diag", "public class Derived : C { public override void M() { } }").WithArguments("C.C()").WithLocation(1, 1),
+            // 0.cs(1,24): warning Diag: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+            // public class Derived : C { public override void M() { } }
+            Diagnostic("Diag", "C").WithArguments("C").WithLocation(1, 24)
+            );
+    }
+
+    [Theory, CombinatorialData]
+    public void OnExplicitMethodImplementation(bool inSource)
+    {
+        var libSrc = """
+public interface I
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("Diag")]
+    public void M();
+}
+""";
+
+        var src = """
+public class C : I
+{
+    void I.M() { }
+}
+""";
+
+        var comp = inSource
+         ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+         : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
+    }
+
+    [Theory, CombinatorialData]
+    public void OnExplicitMethodImplementation_Obsolete(bool inSource)
+    {
+        var libSrc = """
+public interface I
+{
+    [System.Obsolete("message", true)]
+    public void M();
+}
+""";
+
+        var src = """
+public class C : I
+{
+    void I.M() { }
+}
+""";
+
+        var comp = inSource
+         ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+         : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void MissingAssemblyAndModule()
+    {
+        var missingRef = CreateCompilation("public class Base { }", assemblyName: "missing").EmitToImageReference();
+
+        var libSrc = """
+public class C : Base
+{
+    public static void M() { }
+}
+""";
+
+        var src = """
+C.M();
+""";
+
+        var comp = CreateCompilation(src, references: new[] { CreateCompilation(libSrc, references: new[] { missingRef }).EmitToImageReference() });
+        comp.VerifyDiagnostics(
+            // (1,3): error CS0012: The type 'Base' is defined in an assembly that is not referenced. You must add a reference to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+            // C.M();
+            Diagnostic(ErrorCode.ERR_NoTypeDef, "M").WithArguments("Base", "missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 3)
+            );
+
+        var missingType = comp.GlobalNamespace.GetTypeMember("C").BaseTypeNoUseSiteDiagnostics;
+        Assert.True(missingType.ContainingAssembly is MissingAssemblySymbol);
+        Assert.Equal(ObsoleteAttributeKind.None, missingType.ContainingAssembly.ObsoleteKind);
+        Assert.True(missingType.ContainingModule is MissingModuleSymbol);
+        Assert.Equal(ObsoleteAttributeKind.None, missingType.ContainingModule.ObsoleteKind);
+    }
+
+    [Fact]
+    public void RetargetingAssembly_Experimental()
+    {
+        var attrRef = CreateCompilation(experimentalAttributeSrc).EmitToImageReference();
+
+        var retargetedCode = """
+public class C { }
+""";
+
+        var originalC = CreateCompilation(new AssemblyIdentity("Ret", new Version(1, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+        var retargetedC = CreateCompilation(new AssemblyIdentity("Ret", new Version(2, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+
+        var derivedSrc = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+
+public class Derived : C { }
+""";
+
+        var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
+        derivedComp.VerifyDiagnostics();
+
+        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics();
+
+        var derived = comp.GetTypeByMetadataName("Derived");
+        Assert.IsType<RetargetingNamedTypeSymbol>(derived);
+        Assert.IsType<RetargetingAssemblySymbol>(derived.ContainingAssembly);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, derived.ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void RetargetingAssembly_NotExperimental()
+    {
+        var attrRef = CreateCompilation(experimentalAttributeSrc).EmitToImageReference();
+
+        var retargetedCode = """
+public class C { }
+""";
+
+        var originalC = CreateCompilation(new AssemblyIdentity("Ret", new Version(1, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+        var retargetedC = CreateCompilation(new AssemblyIdentity("Ret", new Version(2, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+
+        var derivedSrc = """
+public class Derived : C { }
+""";
+
+        var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
+        derivedComp.VerifyDiagnostics();
+
+        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics();
+
+        var derived = comp.GetTypeByMetadataName("Derived");
+        Assert.IsType<RetargetingNamedTypeSymbol>(derived);
+        Assert.IsType<RetargetingAssemblySymbol>(derived.ContainingAssembly);
+        Assert.Equal(ObsoleteAttributeKind.None, derived.ContainingAssembly.ObsoleteKind);
+    }
+
+    [Fact]
+    public void RetargetingModule_Experimental()
+    {
+        var attrRef = CreateCompilation(experimentalAttributeSrc).EmitToImageReference();
+
+        var retargetedCode = """
+public class C { }
+""";
+
+        var originalC = CreateCompilation(new AssemblyIdentity("Ret", new Version(1, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+        var retargetedC = CreateCompilation(new AssemblyIdentity("Ret", new Version(2, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+
+        var @base = """
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+
+public class Derived : C { }
+""";
+
+        var derivedComp = CreateCompilation(@base, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
+        derivedComp.VerifyDiagnostics();
+
+        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics();
+
+        var derived = comp.GetTypeByMetadataName("Derived");
+        Assert.IsType<RetargetingNamedTypeSymbol>(derived);
+        Assert.IsType<RetargetingModuleSymbol>(derived.ContainingModule);
+        Assert.Equal(ObsoleteAttributeKind.Experimental, derived.ContainingModule.ObsoleteKind);
+    }
+
+    [Fact]
+    public void RetargetingModule_NotExperimental()
+    {
+        var attrRef = CreateCompilation(experimentalAttributeSrc).EmitToImageReference();
+
+        var retargetedCode = """
+public class C { }
+""";
+
+        var originalC = CreateCompilation(new AssemblyIdentity("Ret", new Version(1, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+        var retargetedC = CreateCompilation(new AssemblyIdentity("Ret", new Version(2, 0, 0, 0), isRetargetable: true), retargetedCode, TargetFrameworkUtil.StandardReferences);
+
+        var @base = """
+public class Derived : C { }
+""";
+
+        var derivedComp = CreateCompilation(@base, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
+        derivedComp.VerifyDiagnostics();
+
+        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics();
+
+        var derived = comp.GetTypeByMetadataName("Derived");
+        Assert.IsType<RetargetingNamedTypeSymbol>(derived);
+        Assert.IsType<RetargetingModuleSymbol>(derived.ContainingModule);
+        Assert.Equal(ObsoleteAttributeKind.None, derived.ContainingModule.ObsoleteKind);
     }
 
     [Theory, CombinatorialData]
@@ -959,7 +1849,7 @@ class D
     [Theory, CombinatorialData]
     public void InExperimentalMethod(bool inSource)
     {
-        // Diagnostics for [Experimental] are not suppressed in [Experimental] members
+        // Diagnostics for [Experimental] are suppressed in [Experimental] context
         var libSrc = """
 public class C
 {
@@ -983,11 +1873,130 @@ class D
             ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
             : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
 
-        comp.VerifyDiagnostics(
-            // (6,9): warning DiagID1: 'C.M()' is for evaluation purposes only and is subject to change or removal in future updates.
-            //         C.M();
-            Diagnostic("DiagID1", "C.M()").WithArguments("C.M()").WithLocation(6, 9)
-            );
+        comp.VerifyDiagnostics();
+    }
+
+    [Theory, CombinatorialData]
+    public void InExperimentalType(bool inSource)
+    {
+        // Diagnostics for [Experimental] are suppressed in [Experimental] context
+        var libSrc = """
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+[System.Diagnostics.CodeAnalysis.Experimental("DiagID2")]
+class D
+{
+    void M2()
+    {
+        C.M();
+    }
+}
+""";
+
+        var comp = inSource
+            ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+            : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
+    }
+
+    [Theory, CombinatorialData]
+    public void InExperimentalNestedType(bool inSource)
+    {
+        // Diagnostics for [Experimental] are suppressed in [Experimental] context
+        var libSrc = """
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+[System.Diagnostics.CodeAnalysis.Experimental("DiagID2")]
+class D
+{
+    class Nested
+    {
+        void M2()
+        {
+            C.M();
+        }
+    }
+}
+""";
+
+        var comp = inSource
+            ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+            : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
+    }
+
+    [Theory, CombinatorialData]
+    public void InExperimentalModule(bool inSource)
+    {
+        // Diagnostics for [Experimental] are suppressed in [Experimental] context
+        var libSrc = """
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+[module: System.Diagnostics.CodeAnalysis.Experimental("DiagID2")]
+class D
+{
+    void M2()
+    {
+        C.M();
+    }
+}
+""";
+
+        var comp = inSource
+            ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+            : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
+    }
+
+    [Theory, CombinatorialData]
+    public void InExperimentalAssembly(bool inSource)
+    {
+        // Diagnostics for [Experimental] are suppressed in [Experimental] context
+        var libSrc = """
+public class C
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("DiagID1")]
+    public static void M() { }
+}
+""";
+
+        var src = """
+[assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID2")]
+class D
+{
+    void M2()
+    {
+        C.M();
+    }
+}
+""";
+
+        var comp = inSource
+            ? CreateCompilation(new[] { src, libSrc, experimentalAttributeSrc })
+            : CreateCompilation(src, references: new[] { CreateCompilation(new[] { libSrc, experimentalAttributeSrc }).EmitToImageReference() });
+
+        comp.VerifyDiagnostics();
     }
 
     [Theory, CombinatorialData]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
@@ -897,7 +897,7 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        var comp = CreateCompilation("_ = new C();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
         comp.VerifyDiagnostics();
 
         var derived = comp.GetTypeByMetadataName("Derived");
@@ -925,7 +925,7 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        var comp = CreateCompilation("_ = new C();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
         comp.VerifyDiagnostics();
 
         var derived = comp.GetTypeByMetadataName("Derived");

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/ExperimentalAttributeTests.cs
@@ -897,8 +897,15 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("_ = new C();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
-        comp.VerifyDiagnostics();
+        var comp = CreateCompilation("_ = new Derived();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics(
+            // (1,5): warning DiagID1: 'Derived.Derived()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // _ = new Derived();
+            Diagnostic("DiagID1", "new Derived()").WithArguments("Derived.Derived()").WithLocation(1, 5),
+            // (1,9): warning DiagID1: 'Derived' is for evaluation purposes only and is subject to change or removal in future updates.
+            // _ = new Derived();
+            Diagnostic("DiagID1", "Derived").WithArguments("Derived").WithLocation(1, 9)
+            );
 
         var derived = comp.GetTypeByMetadataName("Derived");
         Assert.IsType<RetargetingNamedTypeSymbol>(derived);
@@ -925,7 +932,7 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(derivedSrc, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("_ = new C();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        var comp = CreateCompilation("_ = new Derived();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
         comp.VerifyDiagnostics();
 
         var derived = comp.GetTypeByMetadataName("Derived");
@@ -955,8 +962,15 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(@base, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
-        comp.VerifyDiagnostics();
+        var comp = CreateCompilation("_ = new Derived();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        comp.VerifyDiagnostics(
+            // (1,5): warning DiagID1: 'Derived.Derived()' is for evaluation purposes only and is subject to change or removal in future updates.
+            // _ = new Derived();
+            Diagnostic("DiagID1", "new Derived()").WithArguments("Derived.Derived()").WithLocation(1, 5),
+            // (1,9): warning DiagID1: 'Derived' is for evaluation purposes only and is subject to change or removal in future updates.
+            // _ = new Derived();
+            Diagnostic("DiagID1", "Derived").WithArguments("Derived").WithLocation(1, 9)
+            );
 
         var derived = comp.GetTypeByMetadataName("Derived");
         Assert.IsType<RetargetingNamedTypeSymbol>(derived);
@@ -983,7 +997,7 @@ public class Derived : C { }
         var derivedComp = CreateCompilation(@base, new[] { originalC.ToMetadataReference(), attrRef }, targetFramework: TargetFramework.Standard);
         derivedComp.VerifyDiagnostics();
 
-        var comp = CreateCompilation("", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
+        var comp = CreateCompilation("_ = new Derived();", new[] { derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference() }, targetFramework: TargetFramework.Standard);
         comp.VerifyDiagnostics();
 
         var derived = comp.GetTypeByMetadataName("Derived");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockAssemblySymbol.cs
@@ -122,5 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             throw new NotImplementedException();
         }
+
+#nullable enable
+        internal sealed override ObsoleteAttributeData? ObsoleteAttributeData
+            => null;
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAssemblyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAssemblyWellKnownAttributeData.cs
@@ -8,6 +8,7 @@ using System;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Text;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -439,6 +440,28 @@ namespace Microsoft.CodeAnalysis
             {
                 VerifySealed(expected: false);
                 _forwardedTypes = value;
+                SetDataStored();
+            }
+        }
+        #endregion
+
+        #region ExperimentalAttribute
+        private ObsoleteAttributeData _obsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
+        public ObsoleteAttributeData ObsoleteAttributeData
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _obsoleteAttributeData.IsUninitialized ? null : _obsoleteAttributeData;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value != null);
+                Debug.Assert(!value.IsUninitialized);
+                Debug.Assert(value.Kind == ObsoleteAttributeKind.Experimental);
+
+                _obsoleteAttributeData = value;
                 SetDataStored();
             }
         }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAssemblyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAssemblyWellKnownAttributeData.cs
@@ -446,13 +446,13 @@ namespace Microsoft.CodeAnalysis
         #endregion
 
         #region ExperimentalAttribute
-        private ObsoleteAttributeData _obsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
-        public ObsoleteAttributeData ObsoleteAttributeData
+        private ObsoleteAttributeData _experimentalAttributeData = ObsoleteAttributeData.Uninitialized;
+        public ObsoleteAttributeData ExperimentalAttributeData
         {
             get
             {
                 VerifySealed(expected: true);
-                return _obsoleteAttributeData.IsUninitialized ? null : _obsoleteAttributeData;
+                return _experimentalAttributeData.IsUninitialized ? null : _experimentalAttributeData;
             }
             set
             {
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(!value.IsUninitialized);
                 Debug.Assert(value.Kind == ObsoleteAttributeKind.Experimental);
 
-                _obsoleteAttributeData = value;
+                _experimentalAttributeData = value;
                 SetDataStored();
             }
         }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private ObsoleteAttributeData DecodeExperimentalAttribute()
+        internal ObsoleteAttributeData DecodeExperimentalAttribute()
         {
             // ExperimentalAttribute(string diagnosticId)
             Debug.Assert(this.CommonConstructorArguments.Length == 1);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonModuleWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonModuleWellKnownAttributeData.cs
@@ -64,5 +64,27 @@ namespace Microsoft.CodeAnalysis
             return value >= Cci.Constants.CharSet_None && value <= Cci.Constants.CharSet_Auto;
         }
         #endregion
+
+        #region ExperimentalAttribute
+        private ObsoleteAttributeData _obsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
+        public ObsoleteAttributeData ObsoleteAttributeData
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _obsoleteAttributeData.IsUninitialized ? null : _obsoleteAttributeData;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value != null);
+                Debug.Assert(!value.IsUninitialized);
+                Debug.Assert(value.Kind == ObsoleteAttributeKind.Experimental);
+
+                _obsoleteAttributeData = value;
+                SetDataStored();
+            }
+        }
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonModuleWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonModuleWellKnownAttributeData.cs
@@ -66,13 +66,13 @@ namespace Microsoft.CodeAnalysis
         #endregion
 
         #region ExperimentalAttribute
-        private ObsoleteAttributeData _obsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
-        public ObsoleteAttributeData ObsoleteAttributeData
+        private ObsoleteAttributeData _experimentalAttributeData = ObsoleteAttributeData.Uninitialized;
+        public ObsoleteAttributeData ExperimentalAttributeData
         {
             get
             {
                 VerifySealed(expected: true);
-                return _obsoleteAttributeData.IsUninitialized ? null : _obsoleteAttributeData;
+                return _experimentalAttributeData.IsUninitialized ? null : _experimentalAttributeData;
             }
             set
             {
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(!value.IsUninitialized);
                 Debug.Assert(value.Kind == ObsoleteAttributeKind.Experimental);
 
-                _obsoleteAttributeData = value;
+                _experimentalAttributeData = value;
                 SetDataStored();
             }
         }

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -33,6 +33,19 @@ Friend Module CompilationUtils
         Return CreateEmptyCompilation(source, references, options, parseOptions, assemblyName)
     End Function
 
+    Public Function CreateCompilationWithIdentity(
+            identity As AssemblyIdentity,
+            source As BasicTestSource,
+            Optional references As IEnumerable(Of MetadataReference) = Nothing,
+            Optional targetFramework As TargetFramework = TargetFramework.StandardAndVBRuntime) As VisualBasicCompilation
+
+        Dim c = CreateCompilation(source, references, assemblyName:=identity.Name)
+        Assert.NotNull(c.Assembly) ' force creation Of SourceAssemblySymbol
+        DirectCast(c.Assembly, SourceAssemblySymbol).m_lazyIdentity = identity
+
+        Return c
+    End Function
+
     Public Function CreateEmptyCompilation(
             source As BasicTestSource,
             Optional references As IEnumerable(Of MetadataReference) = Nothing,

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -747,6 +747,13 @@ Friend Class MockModuleSymbol
     Public Overrides Function GetMetadata() As ModuleMetadata
         Return Nothing
     End Function
+
+    Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+        Get
+            Return Nothing
+        End Get
+    End Property
+
 End Class
 
 Friend Class MockAssemblySymbol
@@ -861,4 +868,11 @@ Friend Class MockAssemblySymbol
     Public Overrides Function GetMetadata() As AssemblyMetadata
         Return Nothing
     End Function
+
+    Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+        Get
+            Return Nothing
+        End Get
+    End Property
+
 End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -239,16 +239,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
-        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
-        Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
-            Get
-                Return Nothing
-            End Get
-        End Property
-
-        ''' <summary>
         ''' Lookup a top level type referenced from metadata, names should be
         ''' compared case-sensitively.
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -289,10 +289,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        ''' <summary>
-        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete/Experimental/... attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 If _lazyObsoleteAttributeData Is ObsoleteAttributeData.Uninitialized Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -68,6 +68,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private _lazyCachedCompilerFeatureRequiredDiagnosticInfo As DiagnosticInfo = ErrorFactory.EmptyDiagnosticInfo
 
+        Private _lazyObsoleteAttributeData As ObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
+
         Friend Sub New(assembly As PEAssembly, documentationProvider As DocumentationProvider,
                        isLinked As Boolean, importOptions As MetadataImportOptions)
             Debug.Assert(assembly IsNot Nothing)
@@ -286,5 +288,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Return MyBase.HasUnsupportedMetadata
             End Get
         End Property
+
+        ''' <summary>
+        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete/Experimental/... attribute.
+        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
+        ''' </summary>
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                If _lazyObsoleteAttributeData Is ObsoleteAttributeData.Uninitialized Then
+                    Interlocked.CompareExchange(_lazyObsoleteAttributeData, ComputeObsoleteAttributeData(), ObsoleteAttributeData.Uninitialized)
+                End If
+
+                Return _lazyObsoleteAttributeData
+            End Get
+        End Property
+
+        Private Function ComputeObsoleteAttributeData() As ObsoleteAttributeData
+            For Each attrData In GetAttributes()
+                If attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+                    Return attrData.DecodeExperimentalAttribute()
+                End If
+            Next
+
+            Return Nothing
+        End Function
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -81,6 +81,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private _lazyCachedCompilerFeatureRequiredDiagnosticInfo As DiagnosticInfo = ErrorFactory.EmptyDiagnosticInfo
 
+        Private _lazyObsoleteAttributeData As ObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
+
         Friend Sub New(assemblySymbol As PEAssemblySymbol, [module] As PEModule, importOptions As MetadataImportOptions, ordinal As Integer)
             Me.New(DirectCast(assemblySymbol, AssemblySymbol), [module], importOptions, ordinal)
             Debug.Assert(ordinal >= 0)
@@ -507,5 +509,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Return MyBase.HasUnsupportedMetadata
             End Get
         End Property
+
+        ''' <summary>
+        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete/Experimental/... attribute.
+        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
+        ''' </summary>
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                If _lazyObsoleteAttributeData Is ObsoleteAttributeData.Uninitialized Then
+                    Interlocked.CompareExchange(_lazyObsoleteAttributeData, ComputeObsoleteAttributeData(), ObsoleteAttributeData.Uninitialized)
+                End If
+
+                Return _lazyObsoleteAttributeData
+            End Get
+        End Property
+
+        Private Function ComputeObsoleteAttributeData() As ObsoleteAttributeData
+            For Each attrData In GetAttributes()
+                If attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+                    Return attrData.DecodeExperimentalAttribute()
+                End If
+            Next
+
+            Return Nothing
+        End Function
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEModuleSymbol.vb
@@ -510,10 +510,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        ''' <summary>
-        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete/Experimental/... attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 If _lazyObsoleteAttributeData Is ObsoleteAttributeData.Uninitialized Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
@@ -165,6 +165,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides Function GetMetadata() As AssemblyMetadata
             Return Nothing
         End Function
+
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                Return Nothing
+            End Get
+        End Property
+
     End Class
 
     ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
@@ -171,6 +171,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides Function GetMetadata() As ModuleMetadata
             Return Nothing
         End Function
+
+        Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                Return Nothing
+            End Get
+        End Property
+
     End Class
 
     Friend Class MissingModuleSymbolWithName

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -293,16 +293,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend MustOverride ReadOnly Property MightContainExtensionMethods As Boolean
 
-        ''' <summary>
-        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
-        Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
-            Get
-                Return Nothing
-            End Get
-        End Property
-
 #Region "IModuleSymbol"
         Private ReadOnly Property IModuleSymbol_GlobalNamespace As INamespaceSymbol Implements IModuleSymbol.GlobalNamespace
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -72,16 +72,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(context IsNot Nothing)
             Debug.Assert(symbol IsNot Nothing)
 
+            If symbol.Kind = SymbolKind.Namespace OrElse
+                symbol.Kind = SymbolKind.ArrayType Then
+
+                Return ObsoleteDiagnosticKind.NotObsolete
+            End If
+
+            Debug.Assert(symbol.ContainingModule IsNot Nothing)
+            Debug.Assert(symbol.ContainingAssembly IsNot Nothing)
+
             Select Case symbol.ObsoleteKind
                 Case ObsoleteAttributeKind.None
-                    If symbol.ContainingModule?.ObsoleteKind = ObsoleteAttributeKind.Experimental OrElse
-                       symbol.ContainingAssembly?.ObsoleteKind = ObsoleteAttributeKind.Experimental Then
+                    Dim moduleObsoleteKind As ObsoleteAttributeKind? = symbol.ContainingModule?.ObsoleteKind
+                    Dim assemblyObsoleteKind As ObsoleteAttributeKind? = symbol.ContainingAssembly?.ObsoleteKind
+
+                    If moduleObsoleteKind = Global.Microsoft.CodeAnalysis.ObsoleteAttributeKind.Experimental OrElse
+                       assemblyObsoleteKind = Global.Microsoft.CodeAnalysis.ObsoleteAttributeKind.Experimental Then
 
                         Return GetDiagnosticKind(context, forceComplete, getStateFromSymbol:=Function(s) s.ExperimentalState)
                     End If
 
-                    If symbol.ContainingModule?.ObsoleteKind = ObsoleteAttributeKind.Uninitialized OrElse
-                       symbol.ContainingAssembly?.ObsoleteKind = ObsoleteAttributeKind.Uninitialized Then
+                    If moduleObsoleteKind = Global.Microsoft.CodeAnalysis.ObsoleteAttributeKind.Uninitialized OrElse
+                       assemblyObsoleteKind = Global.Microsoft.CodeAnalysis.ObsoleteAttributeKind.Uninitialized Then
 
                         Return ObsoleteDiagnosticKind.Lazy
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -89,9 +89,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return ObsoleteDiagnosticKind.NotObsolete
             End If
 
-            Debug.Assert(symbol.ContainingModule Is Nothing OrElse symbol.ContainingModule.ObsoleteKind <> ObsoleteAttributeKind.Uninitialized)
-            Debug.Assert(symbol.ContainingAssembly Is Nothing OrElse symbol.ContainingAssembly.ObsoleteKind <> ObsoleteAttributeKind.Uninitialized)
-
             If symbol.ContainingModule?.ObsoleteKind = ObsoleteAttributeKind.Experimental OrElse
                 symbol.ContainingAssembly?.ObsoleteKind = ObsoleteAttributeKind.Experimental Then
 
@@ -100,6 +97,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Select Case symbol.ObsoleteKind
                 Case ObsoleteAttributeKind.None
+                    If symbol.ContainingModule?.ObsoleteKind = ObsoleteAttributeKind.Uninitialized OrElse
+                       symbol.ContainingAssembly?.ObsoleteKind = ObsoleteAttributeKind.Uninitialized Then
+
+                        Return ObsoleteDiagnosticKind.Lazy
+                    End If
+
                     Return ObsoleteDiagnosticKind.NotObsolete
                 Case ObsoleteAttributeKind.WindowsExperimental
                     Return ObsoleteDiagnosticKind.Diagnostic

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -72,8 +72,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(context IsNot Nothing)
             Debug.Assert(symbol IsNot Nothing)
 
-            If symbol.Kind = SymbolKind.Namespace OrElse
-                symbol.Kind = SymbolKind.ArrayType Then
+            Dim kind As SymbolKind = symbol.Kind
+
+            If kind <> SymbolKind.NamedType AndAlso
+                kind <> SymbolKind.Method AndAlso
+                kind <> SymbolKind.Event AndAlso
+                kind <> SymbolKind.Field AndAlso
+                kind <> SymbolKind.Property Then
 
                 Return ObsoleteDiagnosticKind.NotObsolete
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -72,20 +72,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Debug.Assert(context IsNot Nothing)
             Debug.Assert(symbol IsNot Nothing)
 
-            Dim kind As SymbolKind = symbol.Kind
-
-            If kind <> SymbolKind.NamedType AndAlso
-                kind <> SymbolKind.Method AndAlso
-                kind <> SymbolKind.Event AndAlso
-                kind <> SymbolKind.Field AndAlso
-                kind <> SymbolKind.Property Then
-
-                Return ObsoleteDiagnosticKind.NotObsolete
-            End If
-
-            Debug.Assert(symbol.ContainingModule IsNot Nothing)
-            Debug.Assert(symbol.ContainingAssembly IsNot Nothing)
-
             Select Case symbol.ObsoleteKind
                 Case ObsoleteAttributeKind.None
                     Dim moduleObsoleteKind As ObsoleteAttributeKind? = symbol.ContainingModule?.ObsoleteKind

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.vb
@@ -268,5 +268,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         Public Overrides Function GetMetadata() As AssemblyMetadata
             Return _underlyingAssembly.GetMetadata()
         End Function
+
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                Return _underlyingAssembly.ObsoleteAttributeData
+            End Get
+        End Property
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingModuleSymbol.vb
@@ -290,5 +290,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         Public Overrides Function GetMetadata() As ModuleMetadata
             Return _underlyingModule.GetMetadata()
         End Function
+
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                Return _underlyingModule.ObsoleteAttributeData
+            End Get
+        End Property
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1787,10 +1787,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 ' <assembly: Experimental> may have been specified in the assembly or one of the modules
-                Dim result = If(GetSourceDecodedWellKnownAttributeData()?.ExperimentalAttributeData, GetNetModuleDecodedWellKnownAttributeData()?.ExperimentalAttributeData)
+                Dim attributesBag As CustomAttributesBag(Of VisualBasicAttributeData) = Me._lazySourceAttributesBag
+                If attributesBag IsNot Nothing AndAlso attributesBag.IsDecodedWellKnownAttributeDataComputed Then
+                    Dim experimentalData = DirectCast(attributesBag.DecodedWellKnownAttributeData, CommonAssemblyWellKnownAttributeData)?.ExperimentalAttributeData
+                    If experimentalData IsNot Nothing Then
+                        Return experimentalData
+                    End If
+                End If
 
-                Debug.Assert(result Is Nothing OrElse result.Kind = ObsoleteAttributeKind.Experimental)
-                Return result
+                attributesBag = Me._lazyNetModuleAttributesBag
+                If attributesBag IsNot Nothing AndAlso attributesBag.IsDecodedWellKnownAttributeDataComputed Then
+                    Return DirectCast(attributesBag.DecodedWellKnownAttributeData, CommonAssemblyWellKnownAttributeData)?.ExperimentalAttributeData
+                End If
+
+                If GetAttributeDeclarations().IsEmpty Then
+                    Return Nothing
+                End If
+
+                Return ObsoleteAttributeData.Uninitialized
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1780,10 +1780,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        ''' <summary>
-        ''' Returns data decoded from Experimental attribute or null if there is no Obsolete/Experimental/... attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 ' <assembly: Experimental> may have been specified in the assembly or one of the modules

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1090,7 +1090,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().HasDebuggableAttribute = True
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
-                arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().ObsoleteAttributeData = attrData.DecodeExperimentalAttribute()
+                arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().ExperimentalAttributeData = attrData.DecodeExperimentalAttribute()
             Else
                 Dim signature As Integer = attrData.GetTargetAttributeSignatureIndex(Me, AttributeDescription.AssemblyAlgorithmIdAttribute)
 
@@ -1787,7 +1787,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 ' <assembly: Experimental> may have been specified in the assembly or one of the modules
-                Dim result = If(GetSourceDecodedWellKnownAttributeData()?.ObsoleteAttributeData, GetNetModuleDecodedWellKnownAttributeData()?.ObsoleteAttributeData)
+                Dim result = If(GetSourceDecodedWellKnownAttributeData()?.ExperimentalAttributeData, GetNetModuleDecodedWellKnownAttributeData()?.ExperimentalAttributeData)
 
                 Debug.Assert(result Is Nothing OrElse result.Kind = ObsoleteAttributeKind.Experimental)
                 Return result

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1116,6 +1116,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).HasDebuggableAttribute = True
+            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
+                arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).ObsoleteAttributeData = attrData.DecodeObsoleteAttribute(ObsoleteAttributeKind.Experimental)
             End If
 
             MyBase.DecodeWellKnownAttribute(arguments)
@@ -1220,5 +1222,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides Function GetMetadata() As ModuleMetadata
             Return Nothing
         End Function
+
+        ''' <summary>
+        ''' Returns data decoded from Experimental attribute or null if there is no Obsolete/Experimental/... attribute.
+        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
+        ''' </summary>
+        Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
+            Get
+                Dim data = GetDecodedWellKnownAttributeData()
+                Return If(data IsNot Nothing, data.ObsoleteAttributeData, Nothing)
+            End Get
+        End Property
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1223,10 +1223,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        ''' <summary>
-        ''' Returns data decoded from Experimental attribute or null if there is no Obsolete/Experimental/... attribute.
-        ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 Dim attributesBag As CustomAttributesBag(Of VisualBasicAttributeData) = Me._lazyCustomAttributesBag

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1229,8 +1229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
-                Dim data = GetDecodedWellKnownAttributeData()
-                Return If(data IsNot Nothing, data.ExperimentalAttributeData, Nothing)
+                Return GetDecodedWellKnownAttributeData()?.ExperimentalAttributeData
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1117,7 +1117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DebuggableAttribute) Then
                 arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).HasDebuggableAttribute = True
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExperimentalAttribute) Then
-                arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).ObsoleteAttributeData = attrData.DecodeObsoleteAttribute(ObsoleteAttributeKind.Experimental)
+                arguments.GetOrCreateData(Of CommonModuleWellKnownAttributeData).ExperimentalAttributeData = attrData.DecodeObsoleteAttribute(ObsoleteAttributeKind.Experimental)
             End If
 
             MyBase.DecodeWellKnownAttribute(arguments)
@@ -1230,7 +1230,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
                 Dim data = GetDecodedWellKnownAttributeData()
-                Return If(data IsNot Nothing, data.ObsoleteAttributeData, Nothing)
+                Return If(data IsNot Nothing, data.ExperimentalAttributeData, Nothing)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -1229,7 +1229,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
-                Return GetDecodedWellKnownAttributeData()?.ExperimentalAttributeData
+                Dim attributesBag As CustomAttributesBag(Of VisualBasicAttributeData) = Me._lazyCustomAttributesBag
+                If attributesBag IsNot Nothing AndAlso attributesBag.IsDecodedWellKnownAttributeDataComputed Then
+                    Return DirectCast(attributesBag.DecodedWellKnownAttributeData, CommonModuleWellKnownAttributeData)?.ExperimentalAttributeData
+                End If
+
+                Dim mergedAttributes = DirectCast(Me.ContainingAssembly, SourceAssemblySymbol).GetAttributeDeclarations()
+                If mergedAttributes.IsEmpty Then
+                    Return Nothing
+                End If
+
+                Return ObsoleteAttributeData.Uninitialized
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -481,7 +481,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         ''' <summary>
-        ''' Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
+        ''' Returns data decoded from Obsolete/Experimental attribute or null if there is no Obsolete/Experimental attribute.
         ''' This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
         ''' </summary>
         Friend MustOverride ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -456,6 +456,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        ''' <summary>
+        ''' True if this symbol has been marked with the Experimental attribute. 
+        ''' This property returns Unknown if the Experimental attribute hasn't been cracked yet.
+        ''' </summary>
+        Friend ReadOnly Property ExperimentalState As ThreeState
+            Get
+                Select Case ObsoleteKind
+                    Case ObsoleteAttributeKind.Experimental
+                        Return ThreeState.True
+                    Case ObsoleteAttributeKind.Uninitialized
+                        Return ThreeState.Unknown
+                    Case Else
+                        Return ThreeState.False
+                End Select
+            End Get
+        End Property
+
         Friend ReadOnly Property ObsoleteKind As ObsoleteAttributeKind
             Get
                 Dim data = Me.ObsoleteAttributeData

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -619,13 +619,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         ''' <summary>
-        ''' Ensure that attributes are bound and the ObsoleteState of this symbol is known.
+        ''' Ensure that attributes are bound and the ObsoleteState/ExperimentalState of this symbol is known.
         ''' </summary>
         Friend Sub ForceCompleteObsoleteAttribute()
-            If Me.ObsoleteState = ThreeState.Unknown Then
+            If Me.ObsoleteKind = ObsoleteAttributeKind.Uninitialized Then
                 Me.GetAttributes()
             End If
             Debug.Assert(Me.ObsoleteState <> ThreeState.Unknown, "ObsoleteState should be true or false now.")
+            Debug.Assert(Me.ExperimentalState <> ThreeState.Unknown, "ExperimentalState should be true or false now.")
+
+            Me.ContainingSymbol?.ForceCompleteObsoleteAttribute()
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -5282,7 +5282,19 @@ End Class
             Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
-            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Class Program
+    Public Sub Main()
+        New C()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
             Dim derivedType = comp.GetTypeByMetadataName("Derived")
@@ -5321,7 +5333,19 @@ End Class
             Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
-            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Class Program
+    Public Sub Main()
+        New C()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
             Dim derivedType = comp.GetTypeByMetadataName("Derived")
@@ -5362,7 +5386,19 @@ End Class
             Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
-            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Class Program
+    Public Sub Main()
+        New C()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
             derivedComp.AssertNoDiagnostics()
 
             Dim derivedType = comp.GetTypeByMetadataName("Derived")

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -5,12 +5,14 @@
 Imports System.Collections.Immutable
 Imports System.IO
 Imports System.Reflection
+Imports System.Resources
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 
@@ -5067,7 +5069,7 @@ DiagID1: 'C' is for evaluation purposes only and is subject to change or removal
                ~
 ]]></expected>)
 
-            Dim diag = Comp.GetDiagnostics().Single()
+            Dim diag = comp.GetDiagnostics().Single()
             Assert.Equal("DiagID1", diag.Id)
             Assert.Equal(ERRID.WRN_Experimental, diag.Code)
             Assert.Equal("https://example.org/DiagID1", diag.Descriptor.HelpLinkUri)
@@ -5109,6 +5111,457 @@ DiagID1: 'C' is for evaluation purposes only and is subject to change or removal
             Assert.Equal("DiagID1", diag.Id)
             Assert.Equal(ERRID.WRN_Experimental, diag.Code)
             Assert.Equal("https://example.org/DiagID1", diag.Descriptor.HelpLinkUri)
+        End Sub
+
+        <Fact>
+        Public Sub OnAssembly_UsedFromSource()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
+
+Class C
+End Class
+
+Class D
+    Sub M(c As C)
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={attrComp.EmitToImageReference()})
+            comp.AssertNoDiagnostics()
+
+            Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub OnAssembly_UsedFromMetadata()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim libSrc = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
+
+Public Class C
+End Class
+]]>
+                             </file>
+                         </compilation>
+            Dim libComp = CreateCompilation(libSrc, references:={attrRef})
+            Dim libRef = libComp.EmitToImageReference()
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Class D
+    Sub M(c As C)
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={libRef, attrRef})
+
+            comp.AssertTheseDiagnostics(
+<expected><![CDATA[
+DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+    Sub M(c As C)
+               ~
+]]></expected>)
+
+            Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind)
+
+            Dim diag = comp.GetDiagnostics().Single()
+            Assert.Equal("DiagID1", diag.Id)
+            Assert.Equal(ERRID.WRN_Experimental, diag.Code)
+            Assert.Equal("https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(BC42380)", diag.Descriptor.HelpLinkUri)
+        End Sub
+
+        <Fact>
+        Public Sub OnAssembly_CompiledIntoModule()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim libSrc = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("AssemblyDiagSetInModule")>
+
+Public Class C
+    Public Shared Sub M()
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim moduleComp = CreateCompilation(libSrc, options:=TestOptions.ReleaseModule, references:={attrRef})
+            moduleComp.VerifyDiagnostics()
+            Dim moduleRef = moduleComp.EmitToImageReference()
+
+            Dim libSrc2 = <compilation>
+                              <file name="a.vb">
+                                  <![CDATA[
+Public Class D
+    Public Shared Sub M()
+        C.M()
+    End Sub
+End Class
+]]>
+                              </file>
+                          </compilation>
+
+            Dim assemblyComp = CreateCompilation(libSrc2, references:={moduleRef, attrRef})
+            assemblyComp.VerifyDiagnostics()
+            Dim assemblyRef = assemblyComp.EmitToImageReference()
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Public Class Program
+    Public Shared Sub Main()
+        C.M()
+        D.M()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            ' Since the module is referenced but not linked, we also need it here, but as
+            ' a result the diagnostics are suppressed
+            Dim comp = CreateCompilation(src, references:={assemblyRef, moduleRef, attrRef})
+            comp.VerifyDiagnostics()
+
+            Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind)
+
+            Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("D").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("D").ContainingAssembly.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub RetargetingAssembly_Experimental()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim retargetedCode = <compilation>
+                                     <file name="a.vb">
+                                         <![CDATA[
+Public Class C
+End Class
+]]>
+                                     </file>
+                                 </compilation>
+
+            Dim originalC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(1, 0, 0, 0), isRetargetable:=True), retargetedCode)
+            Dim retargetedC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(2, 0, 0, 0), isRetargetable:=True), retargetedCode)
+
+            Dim derivedSrc = <compilation>
+                                 <file name="a.vb">
+                                     <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
+
+Class Derived
+    Inherits C
+End Class
+]]>
+                                 </file>
+                             </compilation>
+
+            Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim derivedType = comp.GetTypeByMetadataName("Derived")
+            Assert.IsType(Of RetargetingNamedTypeSymbol)(derivedType)
+            Assert.IsType(Of RetargetingAssemblySymbol)(derivedType.ContainingAssembly)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, derivedType.ContainingAssembly.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub RetargetingAssembly_NotExperimental()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim retargetedCode = <compilation>
+                                     <file name="a.vb">
+                                         <![CDATA[
+Public Class C
+End Class
+]]>
+                                     </file>
+                                 </compilation>
+
+            Dim originalC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(1, 0, 0, 0), isRetargetable:=True), retargetedCode)
+            Dim retargetedC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(2, 0, 0, 0), isRetargetable:=True), retargetedCode)
+
+            Dim derivedSrc = <compilation>
+                                 <file name="a.vb">
+                                     <![CDATA[
+Class Derived
+    Inherits C
+End Class
+]]>
+                                 </file>
+                             </compilation>
+
+            Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim derivedType = comp.GetTypeByMetadataName("Derived")
+            Assert.IsType(Of RetargetingNamedTypeSymbol)(derivedType)
+            Assert.IsType(Of RetargetingAssemblySymbol)(derivedType.ContainingAssembly)
+            Assert.Equal(ObsoleteAttributeKind.None, derivedType.ContainingAssembly.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub RetargetingModule_Experimental()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim retargetedCode = <compilation>
+                                     <file name="a.vb">
+                                         <![CDATA[
+Public Class C
+End Class
+]]>
+                                     </file>
+                                 </compilation>
+
+            Dim originalC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(1, 0, 0, 0), isRetargetable:=True), retargetedCode)
+            Dim retargetedC = CreateCompilationWithIdentity(New AssemblyIdentity("Ret", New Version(2, 0, 0, 0), isRetargetable:=True), retargetedCode)
+
+            Dim derivedSrc = <compilation>
+                                 <file name="a.vb">
+                                     <![CDATA[
+<Module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
+
+Class Derived
+    Inherits C
+End Class
+]]>
+                                 </file>
+                             </compilation>
+
+            Dim derivedComp = CreateCompilation(derivedSrc, references:={originalC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim comp = CreateCompilation("", references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
+            derivedComp.AssertNoDiagnostics()
+
+            Dim derivedType = comp.GetTypeByMetadataName("Derived")
+            Assert.IsType(Of RetargetingNamedTypeSymbol)(derivedType)
+            Assert.IsType(Of RetargetingModuleSymbol)(derivedType.ContainingModule)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, derivedType.ContainingModule.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub MissingAssemblyAndModule()
+
+            Dim missingSrc = <compilation>
+                                 <file name="a.vb">
+                                     <![CDATA[
+Public Class Base
+End Class
+]]>
+                                 </file>
+                             </compilation>
+
+            Dim missingRef = CreateCompilation(missingSrc, assemblyName:="missing").EmitToImageReference()
+
+            Dim libSrc = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+Public Class C
+    Inherits Base
+
+    Public Shared Sub M()
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim libRef = CreateCompilation(libSrc, references:={missingRef}).EmitToImageReference()
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Public Class Program
+    Public Shared Sub Main()
+        C.M()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={libRef})
+
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30652: Reference required to assembly 'missing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'Base'. Add one to your project.
+        C.M()
+        ~~~
+                                        ]]></errors>)
+
+            Dim missingType = comp.GlobalNamespace.GetTypeMember("C").BaseTypeNoUseSiteDiagnostics
+            Assert.True(TypeOf missingType.ContainingAssembly Is MissingAssemblySymbol)
+            Assert.Equal(ObsoleteAttributeKind.None, missingType.ContainingAssembly.ObsoleteKind)
+            Assert.True(TypeOf missingType.ContainingModule Is MissingModuleSymbol)
+            Assert.Equal(ObsoleteAttributeKind.None, missingType.ContainingModule.ObsoleteKind)
+        End Sub
+
+        <Fact>
+        Public Sub Cycle()
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("Diag")>
+
+Namespace System.Diagnostics.CodeAnalysis
+    <AttributeUsage(AttributeTargets.All)>
+    Public Class ExperimentalAttribute 
+        Inherits System.Attribute
+
+        Public Sub New(diagnosticId As String)
+        End Sub
+
+        Public Property UrlFormat As String
+    End Class
+End Namespace
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src)
+            comp.AssertNoDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub OnModule_UsedFromMetadata()
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim libSrc = <compilation>
+                             <file name="a.vb">
+                                 <![CDATA[
+<Module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
+
+Public Class C
+    Public Shared Sub M()
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim libComp = CreateCompilation(libSrc, references:={attrRef})
+            Dim libRef = libComp.EmitToImageReference()
+
+            Dim src = <compilation>
+                          <file name="a.vb">
+                              <![CDATA[
+Class D
+    Sub M2()
+        C.M()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={libRef, attrRef})
+
+            comp.AssertTheseDiagnostics(
+<expected><![CDATA[
+DiagID1: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+        C.M()
+        ~
+DiagID1: 'Public Shared Sub M()' is for evaluation purposes only and is subject to change or removal in future updates.
+        C.M()
+        ~~~~~
+]]></expected>)
+
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.None, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind)
+
+            For Each diag In comp.GetDiagnostics()
+                Assert.Equal("DiagID1", diag.Id)
+                Assert.Equal(ERRID.WRN_Experimental, diag.Code)
+                Assert.Equal("https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(BC42380)", diag.Descriptor.HelpLinkUri)
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub OnModuleAndAssembly()
+            ' Prefer reporting the module-level diagnostic
+            Dim attrComp = CreateCSharpCompilation(experimentalAttributeCSharpSrc)
+            Dim attrRef = attrComp.EmitToImageReference()
+
+            Dim libSrc = <compilation>
+                             <file>
+                                 <![CDATA[
+<Assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagAssembly")>
+<Module: System.Diagnostics.CodeAnalysis.Experimental("DiagModule")>
+
+Public Class C
+    Public Shared Sub M()
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim libComp = CreateCompilation(libSrc, references:={attrRef})
+            Dim libRef = libComp.EmitToImageReference()
+
+            Dim src = <compilation>
+                          <file>
+                              <![CDATA[
+Class D
+    Sub M2()
+        C.M()
+    End Sub
+End Class
+]]>
+                          </file>
+                      </compilation>
+
+            Dim comp = CreateCompilation(src, references:={libRef, attrRef})
+
+            comp.AssertTheseDiagnostics(
+<expected><![CDATA[
+DiagModule: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+        C.M()
+        ~
+DiagModule: 'Public Shared Sub M()' is for evaluation purposes only and is subject to change or removal in future updates.
+        C.M()
+        ~~~~~
+]]></expected>)
+
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingModule.ObsoleteKind)
+            Assert.Equal(ObsoleteAttributeKind.Experimental, comp.GetTypeByMetadataName("C").ContainingAssembly.ObsoleteKind)
+
+            For Each diag In comp.GetDiagnostics()
+                Assert.Equal("DiagModule", diag.Id)
+            Next
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -5272,7 +5272,7 @@ End Class
                                      <![CDATA[
 <Assembly: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
 
-Class Derived
+Public Class Derived
     Inherits C
 End Class
 ]]>
@@ -5287,7 +5287,7 @@ End Class
                               <![CDATA[
 Class Program
     Public Sub Main()
-        New C()
+        Dim d = New Derived()
     End Sub
 End Class
 ]]>
@@ -5295,7 +5295,14 @@ End Class
                       </compilation>
 
             Dim comp = CreateCompilation(src, references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
-            derivedComp.AssertNoDiagnostics()
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+DiagID1: 'Public Sub New()' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim d = New Derived()
+                ~~~~~~~~~~~~~
+DiagID1: 'Derived' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim d = New Derived()
+                    ~~~~~~~
+]]></errors>)
 
             Dim derivedType = comp.GetTypeByMetadataName("Derived")
             Assert.IsType(Of RetargetingNamedTypeSymbol)(derivedType)
@@ -5323,7 +5330,7 @@ End Class
             Dim derivedSrc = <compilation>
                                  <file name="a.vb">
                                      <![CDATA[
-Class Derived
+Public Class Derived
     Inherits C
 End Class
 ]]>
@@ -5338,7 +5345,7 @@ End Class
                               <![CDATA[
 Class Program
     Public Sub Main()
-        New C()
+        Dim d = New Derived()
     End Sub
 End Class
 ]]>
@@ -5376,7 +5383,7 @@ End Class
                                      <![CDATA[
 <Module: System.Diagnostics.CodeAnalysis.Experimental("DiagID1")>
 
-Class Derived
+Public Class Derived
     Inherits C
 End Class
 ]]>
@@ -5391,7 +5398,7 @@ End Class
                               <![CDATA[
 Class Program
     Public Sub Main()
-        New C()
+        Dim d = New Derived()
     End Sub
 End Class
 ]]>
@@ -5399,7 +5406,14 @@ End Class
                       </compilation>
 
             Dim comp = CreateCompilation(src, references:={derivedComp.ToMetadataReference(), retargetedC.ToMetadataReference(), attrRef})
-            derivedComp.AssertNoDiagnostics()
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+DiagID1: 'Public Sub New()' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim d = New Derived()
+                ~~~~~~~~~~~~~
+DiagID1: 'Derived' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim d = New Derived()
+                    ~~~~~~~
+]]></errors>)
 
             Dim derivedType = comp.GetTypeByMetadataName("Derived")
             Assert.IsType(Of RetargetingNamedTypeSymbol)(derivedType)


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/roslyn/pull/68702 based on feedback from runtime team.
This PR makes two changes:
1. the `[Experimental]` attribute can be applied to assembly or module targets, and it will then apply to all contained types and members
2. we don't warn when using an experimental type/member and we are within an experimental context
