### PR TITLE
Add test to make sure option names won't change

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
         /// Example:Full name of <see cref="ImplementTypeOptionsStorage.InsertionBehavior"/> would be:
         /// implement_type.dotnet_insertion_behavior
         /// </remarks>
-        private static string GenerateFullNameForOption(IOption2 option)
+        internal static string GenerateFullNameForOption(IOption2 option)
         {
             var optionGroupName = GenerateOptionGroupName(option);
             // All options send to the client should have group name and config name.

--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             ImplementTypeOptionsStorage.PropertyGenerationBehavior,
             // Completion
             CompletionOptionsStorage.ShowNameSuggestions,
-            CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces,
             CompletionOptionsStorage.ProvideRegexCompletions,
             CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces,
             QuickInfoOptionsStorage.ShowRemarksInQuickInfo,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -102,6 +103,48 @@ public class A { }";
 
             await server.ExecuteRequestAsync<DidChangeConfigurationParams, object>(Methods.WorkspaceDidChangeConfigurationName, new DidChangeConfigurationParams(), CancellationToken.None).ConfigureAwait(false);
             VerifyValuesInServer(server.TestWorkspace, clientCallbackTarget.MockClientSideValues);
+        }
+
+        [Fact]
+        public void VerifyLspClientOptionNames()
+        {
+            var actualNames = DidChangeConfigurationNotificationHandler.SupportedOptions.Select(
+                DidChangeConfigurationNotificationHandler.GenerateFullNameForOption).ToArray();
+            // These options are persist in the LSP client. Please make sure also modify the LSP client code if these strings are changed.
+            var expectedNames = new[]
+            {
+                "symbol_search.dotnet_search_reference_assemblies",
+                "implement_type.dotnet_insertion_behavior",
+                "implement_type.dotnet_property_generation_behavior",
+                "completion.dotnet_show_name_completion_suggestions",
+                "completion.dotnet_provide_regex_completions",
+                "completion.dotnet_show_completion_items_from_unimported_namespaces",
+                "quick_info.dotnet_show_remarks_in_quick_info",
+                "navigation.dotnet_navigate_to_decompiled_sources",
+                "highlighting.dotnet_highlight_related_json_components",
+                "highlighting.dotnet_highlight_related_regex_components",
+                "inlay_hints.dotnet_enable_inlay_hints_for_parameters",
+                "inlay_hints.dotnet_enable_inlay_hints_for_literal_parameters",
+                "inlay_hints.dotnet_enable_inlay_hints_for_indexer_parameters",
+                "inlay_hints.dotnet_enable_inlay_hints_for_object_creation_parameters",
+                "inlay_hints.dotnet_enable_inlay_hints_for_other_parameters",
+                "inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_differ_only_by_suffix",
+                "inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_match_method_intent",
+                "inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_match_argument_name",
+                "inlay_hints.csharp_enable_inlay_hints_for_types",
+                "inlay_hints.csharp_enable_inlay_hints_for_implicit_variable_types",
+                "inlay_hints.csharp_enable_inlay_hints_for_lambda_parameter_types",
+                "inlay_hints.csharp_enable_inlay_hints_for_implicit_object_creation",
+                "code_style.formatting.indentation_and_spacing.tab_width",
+                "code_style.formatting.indentation_and_spacing.indent_size",
+                "code_style.formatting.indentation_and_spacing.indent_style",
+                "code_style.formatting.new_line.end_of_line",
+                "code_style.formatting.new_line.insert_final_newline",
+                "background_analysis.dotnet_analyzer_diagnostics_scope",
+                "background_analysis.dotnet_compiler_diagnostics_scope"
+            };
+
+            Assert.Equal(expectedNames, actualNames);
         }
 
         private static void VerifyValuesInServer(TestWorkspace workspace, List<string> expectedValues)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -109,7 +109,7 @@ public class A { }";
         public void VerifyLspClientOptionNames()
         {
             var actualNames = DidChangeConfigurationNotificationHandler.SupportedOptions.Select(
-                DidChangeConfigurationNotificationHandler.GenerateFullNameForOption).ToArray();
+                DidChangeConfigurationNotificationHandler.GenerateFullNameForOption).OrderBy(name => name).ToArray();
             // These options are persist in the LSP client. Please make sure also modify the LSP client code if these strings are changed.
             var expectedNames = new[]
             {
@@ -142,7 +142,7 @@ public class A { }";
                 "code_style.formatting.new_line.insert_final_newline",
                 "background_analysis.dotnet_analyzer_diagnostics_scope",
                 "background_analysis.dotnet_compiler_diagnostics_scope"
-            };
+            }.OrderBy(name => name);
 
             Assert.Equal(expectedNames, actualNames);
         }


### PR DESCRIPTION
Once an option is added to the LSP server, its name and options group should not be modified.
I talked to @333fred during lunchtime and he said it doesn't meet the public API bar so these don't need to go via the API review.

Add a test to guard this