### PR TITLE
Forbid declaring parameters of `void` type in 'Change Signature'->"Add parameter" dialog

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ChangeSignature/CSharpChangeSignatureViewModelFactoryService.cs
+++ b/src/VisualStudio/CSharp/Impl/ChangeSignature/CSharpChangeSignatureViewModelFactoryService.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;
 using static Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature.ChangeSignatureDialogViewModel;
@@ -55,5 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ChangeSignature
         public override bool IsTypeNameValid(string typeName) => !SyntaxFactory.ParseTypeName(typeName, options: s_langVersionLatestParseOptions).ContainsDiagnostics;
 
         public override SyntaxNode GetTypeNode(string typeName) => SyntaxFactory.ParseTypeName(typeName);
+
+        public override bool IsVoidTypeSyntax(SyntaxNode node) => node is PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword };
     }
 }

--- a/src/VisualStudio/Core/Def/ChangeSignature/AddParameterDialog.xaml
+++ b/src/VisualStudio/Core/Def/ChangeSignature/AddParameterDialog.xaml
@@ -49,7 +49,7 @@
                      AutomationProperties.LabeledBy="{Binding ElementName=TypeNameLabelName}"/>
                     <StackPanel Orientation="Horizontal" Grid.Row="2" Margin="0,5,0,5">
                         <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.StatusInformation}" Visibility="{Binding TypeIsEmptyImage, Mode=OneWay}"/>
-                        <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}" Visibility="{Binding TypeDoesNotParseImage, Mode=OneWay}"/>
+                        <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.StatusError}" Visibility="{Binding TypeDoesNotParseOrInvalidTypeImage, Mode=OneWay}"/>
                         <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.StatusOK}" Visibility="{Binding TypeBindsImage, Mode=OneWay}"/>
                         <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.StatusWarning}" Visibility="{Binding TypeDoesNotBindImage, Mode=OneWay}"/>
                         <vs:LiveTextBlock Padding="5 0 0 0" Grid.Row="2" x:Name="TypeBindsTextBlock"

--- a/src/VisualStudio/Core/Def/ChangeSignature/AddParameterDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/ChangeSignature/AddParameterDialogViewModel.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
             TypeIsEmptyImage = Visibility.Visible;
             TypeBindsImage = Visibility.Collapsed;
-            TypeDoesNotParseImage = Visibility.Collapsed;
+            TypeDoesNotParseOrInvalidTypeImage = Visibility.Collapsed;
             TypeDoesNotBindImage = Visibility.Collapsed;
             TypeBindsDynamicStatus = ServicesVSResources.Please_enter_a_type_name;
 
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         public string TypeBindsDynamicStatus { get; set; }
         public Visibility TypeBindsImage { get; set; }
         public Visibility TypeDoesNotBindImage { get; set; }
-        public Visibility TypeDoesNotParseImage { get; set; }
+        public Visibility TypeDoesNotParseOrInvalidTypeImage { get; set; }
         public Visibility TypeIsEmptyImage { get; set; }
 
         private string _verbatimTypeName = string.Empty;
@@ -120,11 +120,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             }
         }
 
+        private bool _isVoidParameterType;
+
         internal bool CanSubmit([NotNullWhen(false)] out string? message)
         {
             if (string.IsNullOrEmpty(VerbatimTypeName) || string.IsNullOrEmpty(ParameterName))
             {
                 message = ServicesVSResources.A_type_and_name_must_be_provided;
+                return false;
+            }
+
+            if (_isVoidParameterType)
+            {
+                message = ServicesVSResources.void_is_not_a_valid_type_for_a_parameter;
                 return false;
             }
 
@@ -175,11 +183,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         private void SetCurrentTypeTextAndUpdateBindingStatus(string typeName)
         {
             VerbatimTypeName = typeName;
+            _isVoidParameterType = false;
 
             if (string.IsNullOrWhiteSpace(typeName))
             {
                 TypeIsEmptyImage = Visibility.Visible;
-                TypeDoesNotParseImage = Visibility.Collapsed;
+                TypeDoesNotParseOrInvalidTypeImage = Visibility.Collapsed;
                 TypeDoesNotBindImage = Visibility.Collapsed;
                 TypeBindsImage = Visibility.Collapsed;
                 TypeBindsDynamicStatus = ServicesVSResources.Please_enter_a_type_name;
@@ -191,12 +200,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 TypeIsEmptyImage = Visibility.Collapsed;
 
                 var languageService = Document.GetRequiredLanguageService<IChangeSignatureViewModelFactoryService>();
-                TypeSymbol = _semanticModel.GetSpeculativeTypeInfo(PositionForTypeBinding, languageService.GetTypeNode(typeName), SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
+                var typeNode = languageService.GetTypeNode(typeName);
+                TypeSymbol = _semanticModel.GetSpeculativeTypeInfo(PositionForTypeBinding, typeNode, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
 
-                var typeParses = IsParameterTypeSyntacticallyValid(typeName);
-                if (!typeParses || TypeSymbol == null)
+                if (languageService.IsVoidTypeSyntax(typeNode) || TypeSymbol is { SpecialType: SpecialType.System_Void })
                 {
-                    TypeDoesNotParseImage = Visibility.Visible;
+                    _isVoidParameterType = true;
+                    TypeDoesNotParseOrInvalidTypeImage = Visibility.Visible;
+                    TypeDoesNotBindImage = Visibility.Collapsed;
+                    TypeBindsImage = Visibility.Collapsed;
+                    TypeBindsDynamicStatus = ServicesVSResources.void_is_not_a_valid_type_for_a_parameter;
+                }
+                else if (!IsParameterTypeSyntacticallyValid(typeName) || TypeSymbol == null)
+                {
+                    TypeDoesNotParseOrInvalidTypeImage = Visibility.Visible;
                     TypeDoesNotBindImage = Visibility.Collapsed;
                     TypeBindsImage = Visibility.Collapsed;
                     TypeBindsDynamicStatus = ServicesVSResources.Type_name_has_a_syntax_error;
@@ -204,7 +221,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 else
                 {
                     var parameterTypeBinds = DoesTypeFullyBind(TypeSymbol);
-                    TypeDoesNotParseImage = Visibility.Collapsed;
+                    TypeDoesNotParseOrInvalidTypeImage = Visibility.Collapsed;
 
                     TypeBindsImage = parameterTypeBinds ? Visibility.Visible : Visibility.Collapsed;
                     TypeDoesNotBindImage = !parameterTypeBinds ? Visibility.Visible : Visibility.Collapsed;
@@ -217,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             NotifyPropertyChanged(nameof(TypeBindsDynamicStatus));
             NotifyPropertyChanged(nameof(TypeBindsImage));
             NotifyPropertyChanged(nameof(TypeDoesNotBindImage));
-            NotifyPropertyChanged(nameof(TypeDoesNotParseImage));
+            NotifyPropertyChanged(nameof(TypeDoesNotParseOrInvalidTypeImage));
             NotifyPropertyChanged(nameof(TypeIsEmptyImage));
         }
 

--- a/src/VisualStudio/Core/Def/ChangeSignature/ChangeSignatureViewModelFactoryService.cs
+++ b/src/VisualStudio/Core/Def/ChangeSignature/ChangeSignatureViewModelFactoryService.cs
@@ -18,5 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         public abstract bool IsTypeNameValid(string typeName);
 
         public abstract SyntaxNode GetTypeNode(string typeName);
+
+        public abstract bool IsVoidTypeSyntax(SyntaxNode node);
     }
 }

--- a/src/VisualStudio/Core/Def/ChangeSignature/IChangeSignatureViewModelFactoryService.cs
+++ b/src/VisualStudio/Core/Def/ChangeSignature/IChangeSignatureViewModelFactoryService.cs
@@ -15,5 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         bool IsTypeNameValid(string typeName);
 
         SyntaxNode GetTypeNode(string typeName);
+
+        bool IsVoidTypeSyntax(SyntaxNode node);
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -2025,4 +2025,8 @@ Additional information: {1}</value>
   <data name="Prefer_collection_expression" xml:space="preserve">
     <value>Prefer collection expression</value>
   </data>
+  <data name="void_is_not_a_valid_type_for_a_parameter" xml:space="preserve">
+    <value>'void' is not a valid type for a parameter</value>
+    <comment>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -2848,6 +2848,11 @@ Další informace: {1}</target>
         <target state="translated">na pravém okraji okna editoru</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">s ostatními členy stejného druhu</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -2848,6 +2848,11 @@ Zusätzliche Informationen: {1}</target>
         <target state="translated">am rechten Rand des Editorfensters</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">mit anderen Mitgliedern derselben Art</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -2848,6 +2848,11 @@ Información adicional: {1}</target>
         <target state="translated">En el borde derecho de la ventana del editor</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">Con otros miembros de la misma clase</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -2848,6 +2848,11 @@ Informations supplémentaires : {1}</target>
         <target state="translated">sur le bord droit de la fenêtre de l'éditeur</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">avec d'autres membres du même type</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -2848,6 +2848,11 @@ Informazioni aggiuntive: {1}</target>
         <target state="translated">sul bordo destro della finestra dell'editor</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">con altri membri dello stesso tipo</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -2848,6 +2848,11 @@ Additional information: {1}</source>
         <target state="translated">エディター ウィンドウの右端</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">同じ種類の他のメンバーと共に</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -2848,6 +2848,11 @@ Additional information: {1}</source>
         <target state="translated">편집기 창의 오른쪽 가장자리</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">같은 종류의 다른 멤버와 함께 있는 경우</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -2848,6 +2848,11 @@ Dodatkowe informacje: {1}</target>
         <target state="translated">na prawej krawędzi okna edytora</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">z innymi składowymi tego samego rodzaju</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -2848,6 +2848,11 @@ Informações adicionais: {1}</target>
         <target state="translated">na borda direita da janela do editor</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">com outros membros do mesmo tipo</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -2848,6 +2848,11 @@ Additional information: {1}</source>
         <target state="translated">на правом краю окна редактора</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">вместе с другими элементами того же типа</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -2848,6 +2848,11 @@ Ek bilgiler: {1}</target>
         <target state="translated">düzenleyici penceresinin sağ kenarına</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">aynı türden başka üyelerle birlikte</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -2848,6 +2848,11 @@ Additional information: {1}</source>
         <target state="translated">在编辑器窗口的右边缘</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">与同一类型的其他成员一起</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -2848,6 +2848,11 @@ Additional information: {1}</source>
         <target state="translated">在編輯器視窗的右邊緣</target>
         <note />
       </trans-unit>
+      <trans-unit id="void_is_not_a_valid_type_for_a_parameter">
+        <source>'void' is not a valid type for a parameter</source>
+        <target state="new">'void' is not a valid type for a parameter</target>
+        <note>{Locked="void"} "void" represents CLR's 'System.Void' type and should not be localized</note>
+      </trans-unit>
       <trans-unit id="with_other_members_of_the_same_kind">
         <source>with other members of the same kind</source>
         <target state="translated">與其他相同種類的成員</target>

--- a/src/VisualStudio/Core/Test/ChangeSignature/AddParameterViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ChangeSignature/AddParameterViewModelTests.vb
@@ -61,7 +61,7 @@ class MyClass<T>
             Dim monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -75,7 +75,7 @@ class MyClass<T>
             monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -89,7 +89,7 @@ class MyClass<T>
             monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -98,12 +98,12 @@ class MyClass<T>
             monitor.VerifyExpectations()
             monitor.Detach()
 
-            AssertTypeBindingIconAndTextIs(viewModel, NameOf(viewModel.TypeDoesNotParseImage), ServicesVSResources.Type_name_has_a_syntax_error)
+            AssertTypeBindingIconAndTextIs(viewModel, NameOf(viewModel.TypeDoesNotParseOrInvalidTypeImage), ServicesVSResources.Type_name_has_a_syntax_error)
 
             monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -117,7 +117,7 @@ class MyClass<T>
             monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -159,7 +159,7 @@ class MyClass
             Dim monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -236,7 +236,7 @@ class MyClass
             Dim monitor = New PropertyChangedTestMonitor(viewModel)
             monitor.AddExpectation(Function() viewModel.TypeBindsDynamicStatus)
             monitor.AddExpectation(Function() viewModel.TypeIsEmptyImage)
-            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseImage)
+            monitor.AddExpectation(Function() viewModel.TypeDoesNotParseOrInvalidTypeImage)
             monitor.AddExpectation(Function() viewModel.TypeDoesNotBindImage)
             monitor.AddExpectation(Function() viewModel.TypeBindsImage)
 
@@ -255,7 +255,7 @@ class MyClass
 
         Private Shared Sub AssertTypeBindingIconAndTextIs(viewModel As AddParameterDialogViewModel, currentIcon As String, expectedMessage As String)
             Assert.True(viewModel.TypeIsEmptyImage = If(NameOf(viewModel.TypeIsEmptyImage) = currentIcon, Visibility.Visible, Visibility.Collapsed))
-            Assert.True(viewModel.TypeDoesNotParseImage = If(NameOf(viewModel.TypeDoesNotParseImage) = currentIcon, Visibility.Visible, Visibility.Collapsed))
+            Assert.True(viewModel.TypeDoesNotParseOrInvalidTypeImage = If(NameOf(viewModel.TypeDoesNotParseOrInvalidTypeImage) = currentIcon, Visibility.Visible, Visibility.Collapsed))
             Assert.True(viewModel.TypeDoesNotBindImage = If(NameOf(viewModel.TypeDoesNotBindImage) = currentIcon, Visibility.Visible, Visibility.Collapsed))
             Assert.True(viewModel.TypeBindsImage = If(NameOf(viewModel.TypeBindsImage) = currentIcon, Visibility.Visible, Visibility.Collapsed))
 
@@ -266,7 +266,7 @@ class MyClass
             Assert.True(viewModel.TypeBindsDynamicStatus = ServicesVSResources.Please_enter_a_type_name)
 
             Assert.True(viewModel.TypeIsEmptyImage = Visibility.Visible)
-            Assert.True(viewModel.TypeDoesNotParseImage = Visibility.Collapsed)
+            Assert.True(viewModel.TypeDoesNotParseOrInvalidTypeImage = Visibility.Collapsed)
             Assert.True(viewModel.TypeDoesNotBindImage = Visibility.Collapsed)
             Assert.True(viewModel.TypeBindsImage = Visibility.Collapsed)
 
@@ -347,6 +347,31 @@ class MyClass
             viewModel.VerbatimTypeName = "params int[]"
             Assert.False(viewModel.CanSubmit(message))
             Assert.Equal(ServicesVSResources.Parameter_type_contains_invalid_characters, message)
+        End Sub
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/44959")>
+        Public Sub AddParameter_CannotSubmitVoidParameterType()
+            Dim markup = <Text><![CDATA[
+class MyClass
+{
+    public void M($$) { }
+}"]]></Text>
+
+            Dim viewModelTestState = GetViewModelTestStateAsync(markup, LanguageNames.CSharp)
+            Dim viewModel = viewModelTestState.ViewModel
+
+            VerifyOpeningState(viewModel)
+
+            viewModel.ParameterName = "test"
+            Dim message As String = Nothing
+
+            viewModel.VerbatimTypeName = "void"
+            Assert.False(viewModel.CanSubmit(message))
+            Assert.Equal(ServicesVSResources.void_is_not_a_valid_type_for_a_parameter, message)
+
+            viewModel.VerbatimTypeName = "System.Void"
+            Assert.False(viewModel.CanSubmit(message))
+            Assert.Equal(ServicesVSResources.void_is_not_a_valid_type_for_a_parameter, message)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/ChangeSignature/VisualBasicChangeSignatureViewModelFactoryService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ChangeSignature/VisualBasicChangeSignatureViewModelFactoryService.vb
@@ -50,5 +50,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ChangeSignature
         Public Overrides Function GetTypeNode(typeName As String) As SyntaxNode
             Return SyntaxFactory.ParseTypeName(typeName)
         End Function
+
+        Public Overrides Function IsVoidTypeSyntax(node As SyntaxNode) As Boolean
+            ' VB doesn't have a concept of 'void' type syntax since it represents void-returning methods as 'Sub's
+            Return False
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44959

`System.Void` is a very special type in .NET ecosystem, so I think, it is ok for an IDE to treat it in a special way as well

Looks like this:
![devenv_GXJmagBDbP](https://github.com/dotnet/roslyn/assets/70431552/c85920f3-4fff-4bdc-862e-88dcc263b0bc)
