### PR TITLE
Fix issue where we stale tagger tags could remain in a buffer

### DIFF
--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     var version = await document.Project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
 
                     // Let the context know that this was the span we actually tried to tag.
-                    context.SetSpansTagged(ImmutableArray.Create(snapshotSpan));
+                    context.AddActuallyTaggedSpan(snapshotSpan);
                     context.State = version;
                 }
             }

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTaggerProvider.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTaggerProvider.cs
@@ -93,9 +93,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     context.AddTag(new TagSpan<ITextMarkerTag>(snapshotSpan, ActiveStatementTag.Instance));
                 }
             }
-
-            // Let the context know that this was the span we actually tried to tag.
-            context.SetSpansTagged(ImmutableArray.Create(spanToTag.SnapshotSpan));
         }
 
         protected override bool TagEquals(ITextMarkerTag tag1, ITextMarkerTag tag2)

--- a/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
             var onExistingTags = context.HasExistingContainingTags(new SnapshotPoint(snapshot, position));
             if (onExistingTags)
             {
-                context.SetSpansTagged(ImmutableArray<SnapshotSpan>.Empty);
+                context.ClearSpansActuallyTagged();
                 return;
             }
 

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
             var onExistingTags = context.HasExistingContainingTags(caretPosition);
             if (onExistingTags)
             {
-                context.SetSpansTagged(ImmutableArray<SnapshotSpan>.Empty);
+                context.ClearSpansActuallyTagged();
                 return Task.CompletedTask;
             }
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -324,11 +324,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var newTagsByBuffer =
                     context.TagSpans.Where(ts => buffersToTag.Contains(ts.Span.Snapshot.TextBuffer))
                                     .ToLookup(t => t.Span.Snapshot.TextBuffer);
-                var spansTagged = context._spansTagged;
+                var spansActuallyTagged = context.GetSpansActuallyTagged();
 
-                var spansToInvalidateByBuffer = spansTagged.ToLookup(
-                    keySelector: span => span.Snapshot.TextBuffer,
-                    elementSelector: span => span);
+                var spansToInvalidateByBuffer = spansActuallyTagged.ToLookup(
+                    keySelector: static span => span.Snapshot.TextBuffer,
+                    elementSelector: static span => span);
 
                 // Walk through each relevant buffer and decide what the interval tree should be
                 // for that buffer.  In general this will work by keeping around old tags that


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1863986

This is a *targeted* fix for the issue.  A larger fix may be appropriate for 17.8.

Backstory: Tagging was updated in https://github.com/dotnet/roslyn/pull/67698 to introduce the following idea.  First, the user's buffer would be split into the following:

```
--------------------------
|       Untagged         |
|------------------------|
| Above the visible view |
|------------------------|
|                        |
|     The visible view   |
|                        |
|------------------------|
| Below the visible view |
--------------------------
|       Untagged         |
--------------------------
```

Prior to this we would tag everything in the above/middle/below section at the same cadence.  This was often very fast (since we want the editor to do things like responsively colorize), but had the downside that we were often tagging sections of the document the user may not see.  We still wanted these sections tagged though so that scrolling/navigation nearby where the user was coding would not show ugly pop-in of tags.

With the above PR, there were now *two* effective regions we tagged.  The 'visible' region (tagged with the same feature-level cadence from before), and the non-visible region (tagged at much slower cadence).  By doign this, we still use the necessary resources for what a user can see, but we significantly dropped memory and CPU for the regions the user could not.

This worked well for all taggers *except* for classification.  Specifically, due to how some data was managed in the tagging stack, when classification participated in the above, *stale* information about the above/below region could stick around, then showing bogus results when text changed in the visible region.  For example, if you commented out code, you might still see some semantic classification tags stick around perpetually.

The cause for this was due to stored data in the tagging stack which didn't play nicely with the above assumptions.  *Specifically*, when a tagger runs, it is allowed to tell the tagging engine "here is the region i *actually* tagged" (versus the region they were *requested* to tag).  This happens with semantic classification because the semantic classifier can be smart and can tag a subset of hte requested region when it sees, for example, that an edit was entirely within a method body.  There's no need to classify outside of hte method body as the edit could not affect it.  This narrowing of the requested region then allows less CPU/memory to be needed to tag that portion, and less diff'ing against the prior tags to notify as to what has changed.

Unfortunately, these two systems didn't play well together.  Specifically, when classifying the above/below sections,  the 'above' region would first say "i actually classified span [x,y)".  However, when classifying teh 'below' region, that information would be *overwritten* saying "i actually classified span [a, b)" (losing the [x, y)) span.  

Because we didn't even realize we were classifying the different parts, we didn't update the information properly for a portion of the buffer, allowing stale data to creep in.

The trivial fix here is to fix this system so that it's not an 'overwriting' mechanism, where the last call wins.  But is instead an accumulating one, that can keep track of all the data.  

--

In the future, the cleaner approach (IMO) is to not have hte actual tagging step overwrite this at all.  But, rather, have the tag engine do a pre-call (on the background) into the actual tagger, saying "here are the spans we think you should tag, if you think a different set should be tagged instead, please give us those".  ANd then run all tagging with that narrower set of spans.  