### PR TITLE
Fix issue where we stale tagger tags could remain in a buffer (alternate approach)

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.SingleViewportTaggerProvider.cs
@@ -96,14 +96,19 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> where T
 
             using var result = TemporaryArray<SnapshotSpan>.Empty;
 
-            var aboveSpan = new SnapshotSpan(visibleSpan.Snapshot, Span.FromBounds(widenedSpan.Span.Start, visibleSpan.Span.Start));
-            var belowSpan = new SnapshotSpan(visibleSpan.Snapshot, Span.FromBounds(visibleSpan.Span.End, widenedSpan.Span.End));
+            if (_viewPortToTag is ViewPortToTag.Above)
+            {
+                var aboveSpan = new SnapshotSpan(visibleSpan.Snapshot, Span.FromBounds(widenedSpan.Span.Start, visibleSpan.Span.Start));
+                if (!aboveSpan.IsEmpty)
+                    result.Add(aboveSpan);
+            }
+            else if (_viewPortToTag is ViewPortToTag.Below)
+            {
+                var belowSpan = new SnapshotSpan(visibleSpan.Snapshot, Span.FromBounds(visibleSpan.Span.End, widenedSpan.Span.End));
 
-            if (!aboveSpan.IsEmpty)
-                result.Add(aboveSpan);
-
-            if (!belowSpan.IsEmpty)
-                result.Add(belowSpan);
+                if (!belowSpan.IsEmpty)
+                    result.Add(belowSpan);
+            }
 
             return result.ToImmutableAndClear();
         }

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewportTaggerProvider.cs
@@ -29,7 +29,8 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
     private enum ViewPortToTag
     {
         InView,
-        AboveAndBelow,
+        Above,
+        Below,
     }
 
     /// <summary>
@@ -64,7 +65,10 @@ internal abstract partial class AsynchronousViewportTaggerProvider<TTag> : IView
 
         // Also tag what's outside the viewport if requested and it's beyond what would be in the normal InView tagger.
         if (extraLinesAroundViewportToTag > s_standardLineCountAroundViewportToTag)
-            providers.Add(CreateSingleViewportTaggerProvider(ViewPortToTag.AboveAndBelow));
+        {
+            providers.Add(CreateSingleViewportTaggerProvider(ViewPortToTag.Above));
+            providers.Add(CreateSingleViewportTaggerProvider(ViewPortToTag.Below));
+        }
 
         _viewportTaggerProviders = providers.ToImmutableAndClear();
 


### PR DESCRIPTION
Fixes [AB#1863986](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1863986)

This is a *targeted* fix for the issue.  A larger fix may be appropriate for 17.8.

This change differs from https://github.com/dotnet/roslyn/pull/69339 in that the approach taken is to not have two taggers (one for 'visible' and one for 'above/below') but instead have 3 taggers (one for 'above', one for 'visible' and one for 'below').  This is extremely simple, and involves no change in state management.  

--

Backstory: Tagging was updated in https://github.com/dotnet/roslyn/pull/67698 to introduce the following idea.  First, the user's buffer would be split into the following:

```
--------------------------
|       Untagged         |
|------------------------|
| Above the visible view |
|------------------------|
|                        |
|     The visible view   |
|                        |
|------------------------|
| Below the visible view |
--------------------------
|       Untagged         |
--------------------------
```

Prior to this we would tag everything in the above/middle/below section at the same cadence.  This was often very fast (since we want the editor to do things like responsively colorize), but had the downside that we were often tagging sections of the document the user may not see.  We still wanted these sections tagged though so that scrolling/navigation nearby where the user was coding would not show ugly pop-in of tags.

With the above PR, there were now *two* effective regions we tagged.  The 'visible' region (tagged with the same feature-level cadence from before), and the non-visible region (tagged at much slower cadence).  By doign this, we still use the necessary resources for what a user can see, but we significantly dropped memory and CPU for the regions the user could not.

This worked well for all taggers *except* for classification.  Specifically, due to how some data was managed in the tagging stack, when classification participated in the above, *stale* information about the above/below region could stick around, then showing bogus results when text changed in the visible region.  For example, if you commented out code, you might still see some semantic classification tags stick around perpetually.

The cause for this was due to stored data in the tagging stack which didn't play nicely with the above assumptions.  *Specifically*, when a tagger runs, it is allowed to tell the tagging engine "here is the region i *actually* tagged" (versus the region they were *requested* to tag).  This happens with semantic classification because the semantic classifier can be smart and can tag a subset of hte requested region when it sees, for example, that an edit was entirely within a method body.  There's no need to classify outside of hte method body as the edit could not affect it.  This narrowing of the requested region then allows less CPU/memory to be needed to tag that portion, and less diff'ing against the prior tags to notify as to what has changed.

Unfortunately, these two systems didn't play well together.  Specifically, when classifying the above/below sections,  the 'above' region would first say "i actually classified span [x,y)".  However, when classifying teh 'below' region, that information would be *overwritten* saying "i actually classified span [a, b)" (losing the [x, y)) span.  

Because we didn't even realize we were classifying the different parts, we didn't update the information properly for a portion of the buffer, allowing stale data to creep in.

--

In the future, the cleaner approach (IMO) is to not have hte actual tagging step overwrite this at all.  But, rather, have the tag engine do a pre-call (on the background) into the actual tagger, saying "here are the spans we think you should tag, if you think a different set should be tagged instead, please give us those".  ANd then run all tagging with that narrower set of spans.  