### PR TITLE
Recommend 'using static' before a top-level statement

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
@@ -456,9 +456,10 @@ global using Bar;";
         }
 
         [Fact]
-        public async Task TestNotAfterUsingInMethodBody()
+        public async Task TestAfterUsingInMethodBody()
         {
-            await VerifyAbsenceAsync(
+            // This recommendation isn't useful
+            await VerifyKeywordAsync(
 @"class C {
     void M() {
         using $$");
@@ -607,5 +608,14 @@ class C
         [Fact]
         public async Task TestInFor()
             => await VerifyKeywordAsync(AddInsideMethod(@" for (int i = 0; i < 0; $$) "));
+
+        [Fact]
+        public async Task TestAfterUsingKeywordBeforeTopLevelStatement()
+        {
+            await VerifyKeywordAsync("""
+using $$
+var i = 1;
+""");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
@@ -456,10 +456,9 @@ global using Bar;";
         }
 
         [Fact]
-        public async Task TestAfterUsingInMethodBody()
+        public async Task TestNotAfterUsingInMethodBody()
         {
-            // This recommendation isn't useful
-            await VerifyKeywordAsync(
+            await VerifyAbsenceAsync(
 @"class C {
     void M() {
         using $$");

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             return
                 context.IsGlobalStatementContext ||
-                context.TargetToken.IsUsingKeywordInUsingDirective() ||
+                context.TargetToken.IsKind(SyntaxKind.UsingKeyword) ||
                 IsValidContextForType(context, cancellationToken) ||
                 IsValidContextForMember(context, cancellationToken) ||
                 context.SyntaxTree.IsLambdaDeclarationContext(position, otherModifier: SyntaxKind.AsyncKeyword, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 
@@ -81,7 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             return
                 context.IsGlobalStatementContext ||
-                context.TargetToken.IsKind(SyntaxKind.UsingKeyword) ||
+                context.TargetToken.IsUsingKeywordInUsingDirective() ||
+                (context.TargetToken.IsKind(SyntaxKind.UsingKeyword) && context.TargetToken.Parent?.IsParentKind(SyntaxKind.GlobalStatement) == true) ||
                 IsValidContextForType(context, cancellationToken) ||
                 IsValidContextForMember(context, cancellationToken) ||
                 context.SyntaxTree.IsLambdaDeclarationContext(position, otherModifier: SyntaxKind.AsyncKeyword, cancellationToken) ||


### PR DESCRIPTION
Trying to type "using static" before a top-level statement currently fails (ends up completing to some type):
```
using $$
var x = 1;
```