### PR TITLE
Object Favorites: Avoid name collisions on hidden properties

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -175,8 +175,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                                 browsableStateValue,
                                 previousDeclaration,
                                 inheritanceLevel,
-                                canFavorite: supportsFavorites,
-                                isFavorite: favoritesMemberNames?.ContainsKey(memberName) == true));
+                                canFavorite: supportsFavorites && !previousDeclaration.HasFlag(DeclarationInfo.IncludeTypeInMemberName),
+                                isFavorite: favoritesMemberNames?.ContainsKey(memberName) == true && !previousDeclaration.HasFlag(DeclarationInfo.IncludeTypeInMemberName)));
                     }
                 }
 


### PR DESCRIPTION
When a base class property is hidden by an extending class property, the result formatter internally uses the same name for both when computing a member expansion. If the property is added as a favorite, this will cause an ArgumentException when inserting the name a second time into the set of favorites in the expansion. This change disables favorites for hidden base class properties to prevent the issue from occurring and adds a unit test to validate the scenario.