### PR TITLE
Add LanguageName to telemetry information passed in for CodeRefactoring_Delay and CodeFix_Delay telemetry calls

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -138,9 +138,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                         var providerName = provider.GetType().Name;
                         RefactoringToMetadataMap.TryGetValue(provider, out var providerMetadata);
 
+                        var logMessage = KeyValueLogMessage.Create(m =>
+                        {
+                            m[TelemetryLogging.KeyName] = providerName;
+                            m[TelemetryLogging.KeyLanguageName] = document.Project.Language;
+                        });
+
                         using (addOperationScope(providerName))
                         using (RoslynEventSource.LogInformationalBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, providerName, cancellationToken))
-                        using (TelemetryLogging.LogBlockTime(FunctionId.CodeRefactoring_Delay, $"{providerName}", CodeRefactoringTelemetryDelay))
+                        using (TelemetryLogging.LogBlockTime(FunctionId.CodeRefactoring_Delay, logMessage, CodeRefactoringTelemetryDelay))
                         {
                             return await GetRefactoringFromProviderAsync(document, state, provider, providerMetadata,
                                 extensionManager, options, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -512,7 +512,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         const int CodeFixTelemetryDelay = 500;
 
                         var fixerName = fixer.GetType().Name;
-                        using var _ = TelemetryLogging.LogBlockTime(FunctionId.CodeFix_Delay, $"{fixerName}", CodeFixTelemetryDelay);
+                        var logMessage = KeyValueLogMessage.Create(m =>
+                        {
+                            m[TelemetryLogging.KeyName] = fixerName;
+                            m[TelemetryLogging.KeyLanguageName] = document.Project.Language;
+                        });
+
+                        using var _ = TelemetryLogging.LogBlockTime(FunctionId.CodeFix_Delay, logMessage, CodeFixTelemetryDelay);
 
                         var codeFixCollection = await TryGetFixesOrConfigurationsAsync(
                             document, span, diagnostics, fixAllForInSpan, fixer,

--- a/src/VisualStudio/Core/Def/Telemetry/TimedTelemetryLogBlock.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/TimedTelemetryLogBlock.cs
@@ -16,15 +16,15 @@ namespace Microsoft.CodeAnalysis.Telemetry
     internal sealed class TimedTelemetryLogBlock : IDisposable
     {
 #pragma warning disable IDE0052 // Remove unread private members - Not used in debug builds
-        private readonly string _name;
+        private readonly KeyValueLogMessage _logMessage;
         private readonly int _minThresholdMs;
         private readonly ITelemetryLog _telemetryLog;
         private readonly SharedStopwatch _stopwatch;
 #pragma warning restore IDE0052 // Remove unread private members
 
-        public TimedTelemetryLogBlock(string name, int minThresholdMs, ITelemetryLog telemetryLog)
+        public TimedTelemetryLogBlock(KeyValueLogMessage logMessage, int minThresholdMs, ITelemetryLog telemetryLog)
         {
-            _name = name;
+            _logMessage = logMessage;
             _minThresholdMs = minThresholdMs;
             _telemetryLog = telemetryLog;
             _stopwatch = SharedStopwatch.StartNew();
@@ -42,8 +42,9 @@ namespace Microsoft.CodeAnalysis.Telemetry
             {
                 var logMessage = KeyValueLogMessage.Create(m =>
                 {
-                    m[TelemetryLogging.AggregatedKeyName] = _name;
-                    m[TelemetryLogging.AggregatedKeyValue] = elapsed;
+                    m[TelemetryLogging.KeyValue] = elapsed;
+
+                    m.AddRange(_logMessage.Properties);
                 });
 
                 _telemetryLog.Log(logMessage);

--- a/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLog.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VisualStudioTelemetryLog.cs
@@ -19,14 +19,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             _functionId = functionId;
         }
 
-        public void Log(LogMessage logMessage)
+        public void Log(KeyValueLogMessage logMessage)
         {
             _telemetryLogger.Log(_functionId, logMessage);
         }
 
-        public IDisposable? LogBlockTime(string name, int minThresholdMs)
+        public IDisposable? LogBlockTime(KeyValueLogMessage logMessage, int minThresholdMs)
         {
-            return new TimedTelemetryLogBlock(name, minThresholdMs, telemetryLog: this);
+            return new TimedTelemetryLogBlock(logMessage, minThresholdMs, telemetryLog: this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Telemetry/ITelemetryLog.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/ITelemetryLog.cs
@@ -12,13 +12,14 @@ namespace Microsoft.CodeAnalysis.Telemetry
         /// <summary>
         /// Adds a telemetry event with values obtained from context message <paramref name="logMessage"/>
         /// </summary>
-        public void Log(LogMessage logMessage);
+        public void Log(KeyValueLogMessage logMessage);
 
         /// <summary>
-        /// Adds an execution time telemetry event representing the <paramref name="name"/> operation
+        /// Adds an execution time telemetry event representing <paramref name="logMessage"/>
         /// only if  block duration meets or exceeds <paramref name="minThresholdMs"/> milliseconds.
         /// </summary>
+        /// <param name="logMessage">Event data to be sent</param>
         /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event (in milliseconds)</param>
-        public IDisposable? LogBlockTime(string name, int minThresholdMs = -1);
+        public IDisposable? LogBlockTime(KeyValueLogMessage logMessage, int minThresholdMs = -1);
     }
 }

--- a/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
+++ b/src/Workspaces/Core/Portable/Telemetry/TelemetryLogging.cs
@@ -15,8 +15,9 @@ namespace Microsoft.CodeAnalysis.Telemetry
     {
         private static ITelemetryLogProvider? s_logProvider;
 
-        public const string AggregatedKeyName = "Name";
-        public const string AggregatedKeyValue = "Value";
+        public const string KeyName = "Name";
+        public const string KeyValue = "Value";
+        public const string KeyLanguageName = "LanguageName";
 
         public static void SetLogProvider(ITelemetryLogProvider logProvider)
         {
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Telemetry
         /// <summary>
         /// Posts a telemetry event representing the <paramref name="functionId"/> operation with context message <paramref name="logMessage"/>
         /// </summary>
-        public static void Log(FunctionId functionId, LogMessage logMessage)
+        public static void Log(FunctionId functionId, KeyValueLogMessage logMessage)
         {
             GetLog(functionId)?.Log(logMessage);
         }
@@ -34,13 +35,13 @@ namespace Microsoft.CodeAnalysis.Telemetry
         /// <summary>
         /// Posts a telemetry event representing the <paramref name="functionId"/> operation 
         /// only if the block duration meets or exceeds <paramref name="minThresholdMs"/> milliseconds.
-        /// This event will contain properties from which both <paramref name="name"/> and <paramref name="minThresholdMs"/>.
-        /// and block execution time can be determined.
+        /// This event will contain properties from <paramref name="logMessage"/> and the actual execution time.
         /// </summary>
+        /// <param name="logMessage">Properties to be set on the telemetry event</param>
         /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event</param>
-        public static IDisposable? LogBlockTime(FunctionId functionId, TelemetryLoggingInterpolatedStringHandler name, int minThresholdMs = -1)
+        public static IDisposable? LogBlockTime(FunctionId functionId, KeyValueLogMessage logMessage, int minThresholdMs = -1)
         {
-            return GetLog(functionId)?.LogBlockTime(name.GetFormattedText(), minThresholdMs);
+            return GetLog(functionId)?.LogBlockTime(logMessage, minThresholdMs);
         }
 
         /// <summary>
@@ -54,8 +55,8 @@ namespace Microsoft.CodeAnalysis.Telemetry
 
             var logMessage = KeyValueLogMessage.Create(m =>
             {
-                m[AggregatedKeyName] = name.GetFormattedText();
-                m[AggregatedKeyValue] = value;
+                m[KeyName] = name.GetFormattedText();
+                m[KeyValue] = value;
             });
 
             aggregatingLog.Log(logMessage);
@@ -68,7 +69,15 @@ namespace Microsoft.CodeAnalysis.Telemetry
         /// <param name="minThresholdMs">Optional parameter used to determine whether to send the telemetry event</param>
         public static IDisposable? LogBlockTimeAggregated(FunctionId functionId, TelemetryLoggingInterpolatedStringHandler metricName, int minThresholdMs = -1)
         {
-            return GetAggregatingLog(functionId)?.LogBlockTime(metricName.GetFormattedText(), minThresholdMs);
+            if (GetAggregatingLog(functionId) is not { } aggregatingLog)
+                return null;
+
+            var logMessage = KeyValueLogMessage.Create(m =>
+            {
+                m[KeyName] = metricName.GetFormattedText();
+            });
+
+            return aggregatingLog.LogBlockTime(logMessage, minThresholdMs);
         }
 
         /// <summary>


### PR DESCRIPTION
This was noticed during inspecting the perf dashboard for slow code fixers. The highest item on the dashboard pointed to the AddDesignDataContextCodeFixProvider code fixer from xaml. Putting this information in the telemetry will allow our dashboard to filter based on the language name.

This required the non-aggregating TelemetryLogging APIs to allow callers to specify more than just the name. Instead, it now is passed a KeyValueLogMessage (which allows the caller to specify an arbitrary number of key/value pairs).