### PR TITLE
Fix issue causing prepare tests to pass when it actually failed

### DIFF
--- a/src/Tools/PrepareTests/TestDiscovery.cs
+++ b/src/Tools/PrepareTests/TestDiscovery.cs
@@ -58,7 +58,7 @@ internal class TestDiscovery
     {
         var testDiscoveryWorkerFolder = Path.Combine(binDirectory, "TestDiscoveryWorker");
         var configuration = Directory.Exists(Path.Combine(testDiscoveryWorkerFolder, "Debug")) ? "Debug" : "Release";
-        return (Path.Combine(testDiscoveryWorkerFolder, configuration, "net7.0", "TestDiscoveryWorker.dll"),
+        return (Path.Combine(testDiscoveryWorkerFolder, configuration, "net8.0", "TestDiscoveryWorker.dll"),
                 Path.Combine(testDiscoveryWorkerFolder, configuration, "net472", "TestDiscoveryWorker.exe"));
     }
 

--- a/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
+++ b/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   


### PR DESCRIPTION
c91e128a61b365383778497717aa9625dcf2b52e fixes an issue where prepare tests would pass when it actually failed.  From a bit of logging I verified that the RunWorker was successfully returning a failure response, but due to read+write in the parallel for it was being lost and incorrectly returning success.  For a CI example, see this run - https://dev.azure.com/dnceng-public/public/_build/results?buildId=360938&view=logs&j=86868256-cb82-53ae-480d-0cc498d0e893&t=5266d39a-6887-515c-9441-254dc333cb9c

e7e88710c966ce67b9291b56d49ab3b99f09fb02 fixes discovery by upgrade the test discovery worker to .net8