### PR TITLE
Upgrade NuGet.Frameworks to fix loading projects with the 7.0.4xx SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -227,7 +227,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.7.0-preview.2.50</NuGetCommonVersion>
+    <NuGetCommonVersion>6.7.0-rc.127</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>


### PR DESCRIPTION
The 7.0.4xx SDKs ship with a newer version of NuGet.Frameworks than we are shipping. Due to a complicated set of interactions of how the various AssemblyLoadingContexts work (or don't work as expected!), this means that when our LSP server uses MSBuildWorkspace to load projects, it'll end up using the NuGet.Frameworks we use here rather than the MSBuild one, causing load issues.

The underlying problem is tracked with https://github.com/dotnet/roslyn/issues/61454, although I still need to write up the full situation in that bug since back in June we ended up running into a similar issue and had lots of deep analysis of it. Fixing the problem requires changes in several different repositories (and all involving AssemblyLoadContexts, so the changes are very technical) so for now we'll just bump the version.

Fixes https://github.com/dotnet/vscode-csharp/issues/5980