### PR TITLE
Refactor chunked text manipulation & override Write in all SourceText implementations

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var largeText = CreateLargeText(chunk1);
 
             // chunks are considered large because they are bigger than the expected size
-            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, 10);
+            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, largeText.Length);
             largeText.Write(writer);
 
             var newText = (LargeText)writer.ToSourceText();
@@ -612,7 +612,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var largeText = CreateLargeText(chunk1);
 
             // chunks are considered small because they fit within the buffer (which is the expected length for this test)
-            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, chunk1.Length * 4);
+            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, text.Length + largeText.Length);
 
             // write preamble so buffer is allocated and has contents.
             text.Write(writer);

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -148,6 +150,11 @@ namespace Microsoft.CodeAnalysis.Text
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {
             _newText.CopyTo(sourceIndex, destination, destinationIndex, count);
+        }
+
+        public override void Write(TextWriter writer, TextSpan span, CancellationToken cancellationToken = default)
+        {
+            _newText.Write(writer, span, cancellationToken);
         }
 
         public override SourceText WithChanges(IEnumerable<TextChange> changes)

--- a/src/Compilers/Core/Portable/Text/ChunkedTextUtilities.cs
+++ b/src/Compilers/Core/Portable/Text/ChunkedTextUtilities.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Text
+{
+    internal static class ChunkedTextUtilities
+    {
+        public static void GetIndexAndOffset(
+            int[] chunkStartOffsets,
+            int position,
+            out int index,
+            out int offset)
+        {
+            // Binary search to find the chunk that contains the given position.
+            int idx = chunkStartOffsets.BinarySearch(position);
+            index = idx >= 0 ? idx : (~idx - 1);
+            offset = position - chunkStartOffsets[index];
+        }
+
+        public static SubTextChunkEnumerator<TChunk, TChunkHelper> EnumerateSubTextChunks<TChunk, TChunkHelper>(
+            ImmutableArray<TChunk> chunks,
+            int[] chunkStartOffsets,
+            int start,
+            int length)
+            where TChunkHelper : struct, IChunkHelper<TChunk>
+        {
+            return new SubTextChunkEnumerator<TChunk, TChunkHelper>(chunks, chunkStartOffsets, start, length);
+        }
+
+        [NonCopyable]
+        public struct SubTextChunkEnumerator<TChunk, TChunkHelper>
+            where TChunkHelper : struct, IChunkHelper<TChunk>
+        {
+            private readonly ImmutableArray<TChunk> _chunks;
+            private (TChunk chunk, int start, int length) _current;
+            private int _count;
+            private int _chunkIndex;
+            private int _chunkOffset;
+
+            public SubTextChunkEnumerator(
+                ImmutableArray<TChunk> chunks,
+                int[] chunkStartOffsets,
+                int start,
+                int length)
+            {
+                _chunks = chunks;
+                _count = length;
+                GetIndexAndOffset(chunkStartOffsets, start, out _chunkIndex, out _chunkOffset);
+            }
+
+            public readonly (TChunk chunk, int start, int length) Current
+                => _current;
+
+            public bool MoveNext()
+            {
+                if (_chunkIndex < _chunks.Length && _count > 0)
+                {
+                    var chunk = _chunks[_chunkIndex];
+                    var length = Math.Min(_count, default(TChunkHelper).GetLength(chunk) - _chunkOffset);
+
+                    _current = (chunk, _chunkOffset, length);
+                    _count -= length;
+                    _chunkIndex++;
+                    _chunkOffset = 0;
+
+                    return true;
+                }
+
+                return false;
+            }
+
+#pragma warning disable RS0042 // Do not copy value
+            public readonly SubTextChunkEnumerator<TChunk, TChunkHelper> GetEnumerator() => this;
+#pragma warning restore RS0042 // Do not copy value
+        }
+
+        public interface IChunkHelper<TChunk>
+        {
+            int GetLength(TChunk chunk);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Text
     {
         private const int CharBufferSize = 32 * 1024;
         private const int CharBufferCount = 5;
-        internal const int LargeObjectHeapLimitInChars = 40 * 1024; // 40KB
+        internal const int LargeObjectHeapLimitInChars = 40 * 1024; // 40K Unicode chars is 80KB which is less than the large object heap limit.
 
         private static readonly ObjectPool<char[]> s_charArrayPool = new ObjectPool<char[]>(() => new char[CharBufferSize], CharBufferCount);
 
@@ -452,6 +452,27 @@ namespace Microsoft.CodeAnalysis.Text
         public abstract char this[int position] { get; }
 
         /// <summary>
+        /// Validates the arguments passed to <see cref="CopyTo"/> against the published contract.
+        /// </summary>
+        /// <returns>True if should bother to proceed with copying.</returns>
+        private protected bool ValidateCopyToArguments(int sourceIndex, char[] destination, int destinationIndex, int count)
+        {
+            if (destination is null)
+                throw new ArgumentNullException(nameof(destination));
+
+            if (sourceIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(sourceIndex));
+
+            if (destinationIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(destinationIndex));
+
+            if (count < 0 || count > this.Length - sourceIndex || count > destination.Length - destinationIndex)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            return count > 0;
+        }
+
+        /// <summary>
         /// Copy a range of characters from this SourceText to a destination array.
         /// </summary>
         public abstract void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count);
@@ -472,14 +493,14 @@ namespace Microsoft.CodeAnalysis.Text
             }
         }
 
-        internal void CheckSubSpan(TextSpan span)
+        private protected bool ValidateSubSpan(TextSpan span)
         {
-            Debug.Assert(0 <= span.Start && span.Start <= span.End);
-
             if (span.End > this.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(span));
             }
+
+            return span.Length > 0;
         }
 
         /// <summary>
@@ -487,14 +508,11 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         public virtual SourceText GetSubText(TextSpan span)
         {
-            CheckSubSpan(span);
-
-            int spanLength = span.Length;
-            if (spanLength == 0)
+            if (!ValidateSubSpan(span))
             {
                 return SourceText.From(string.Empty, this.Encoding, this.ChecksumAlgorithm);
             }
-            else if (spanLength == this.Length && span.Start == 0)
+            else if (span.Length == this.Length && span.Start == 0)
             {
                 return this;
             }
@@ -524,10 +542,18 @@ namespace Microsoft.CodeAnalysis.Text
             }
         }
 
+        private protected bool ValidateWriteArguments(TextWriter writer, TextSpan span)
+        {
+            if (writer is null)
+                throw new ArgumentNullException(nameof(writer));
+
+            return ValidateSubSpan(span);
+        }
+
         /// <summary>
         /// Write this <see cref="SourceText"/> to a text writer.
         /// </summary>
-        public void Write(TextWriter textWriter, CancellationToken cancellationToken = default(CancellationToken))
+        public void Write(TextWriter textWriter, CancellationToken cancellationToken = default)
         {
             this.Write(textWriter, new TextSpan(0, this.Length), cancellationToken);
         }
@@ -535,9 +561,10 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Write a span of text to a text writer.
         /// </summary>
-        public virtual void Write(TextWriter writer, TextSpan span, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual void Write(TextWriter writer, TextSpan span, CancellationToken cancellationToken = default)
         {
-            CheckSubSpan(span);
+            if (!ValidateWriteArguments(writer, span))
+                return;
 
             var buffer = s_charArrayPool.Allocate();
             try
@@ -609,7 +636,8 @@ namespace Microsoft.CodeAnalysis.Text
         /// <exception cref="ArgumentOutOfRangeException">When given span is outside of the text range.</exception>
         public virtual string ToString(TextSpan span)
         {
-            CheckSubSpan(span);
+            if (!ValidateSubSpan(span))
+                return string.Empty;
 
             // default implementation constructs text using CopyTo
             var builder = PooledStringBuilder.GetInstance();
@@ -1145,7 +1173,7 @@ namespace Microsoft.CodeAnalysis.Text
             return null;
         }
 
-        private class StaticContainer : SourceTextContainer
+        private sealed class StaticContainer : SourceTextContainer
         {
             private readonly SourceText _text;
 

--- a/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Text;
 
@@ -21,6 +22,18 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 return new LargeTextWriter(encoding, checksumAlgorithm, length);
             }
+        }
+
+        protected static void ValidateWriteArguments(char[] buffer, int index, int count)
+        {
+            if (buffer is null)
+                throw new ArgumentNullException(nameof(buffer));
+
+            if (index < 0 || index >= buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            if (count < 0 || count > buffer.Length - index)
+                throw new ArgumentOutOfRangeException(nameof(count));
         }
     }
 }

--- a/src/Compilers/Core/Portable/Text/StringText.cs
+++ b/src/Compilers/Core/Portable/Text/StringText.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -70,10 +69,8 @@ namespace Microsoft.CodeAnalysis.Text
         /// <exception cref="ArgumentOutOfRangeException">When given span is outside of the text range.</exception>
         public override string ToString(TextSpan span)
         {
-            if (span.End > this.Source.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(span));
-            }
+            if (!ValidateSubSpan(span))
+                return string.Empty;
 
             if (span.Start == 0 && span.Length == this.Length)
             {
@@ -85,18 +82,29 @@ namespace Microsoft.CodeAnalysis.Text
 
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {
+            if (!ValidateCopyToArguments(sourceIndex, destination, destinationIndex, count))
+                return;
+
             this.Source.CopyTo(sourceIndex, destination, destinationIndex, count);
         }
 
-        public override void Write(TextWriter textWriter, TextSpan span, CancellationToken cancellationToken = default(CancellationToken))
+        public override void Write(TextWriter writer, TextSpan span, CancellationToken cancellationToken = default)
         {
-            if (span.Start == 0 && span.End == this.Length)
+            if (!ValidateWriteArguments(writer, span))
+                return;
+
+            if (span.Start == 0 && span.Length == Length)
             {
-                textWriter.Write(this.Source);
+                writer.Write(this.Source);
             }
             else
             {
-                base.Write(textWriter, span, cancellationToken);
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                writer.Write(Source.AsSpan(span.Start, span.Length));
+#else
+
+                base.Write(writer, span, cancellationToken);
+#endif
             }
         }
     }

--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Text
                 return s_textSnapshotMap.GetValue(editorSnapshot, s => new SnapshotSourceText(textBufferCloneService, s, SourceHashAlgorithms.OpenDocumentChecksumAlgorithm, container));
             }
 
-            public override Encoding? Encoding
+            public sealed override Encoding? Encoding
             {
                 get { return _encoding; }
             }
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Text
             public ITextSnapshot? TryFindEditorSnapshot()
                 => TryFindEditorSnapshot(this.TextImage);
 
-            public override SourceTextContainer Container
+            public sealed override SourceTextContainer Container
             {
                 get
                 {
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             }
 
-            public override int Length
+            public sealed override int Length
             {
                 get
                 {
@@ -129,16 +129,16 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             }
 
-            public override char this[int position]
+            public sealed override char this[int position]
             {
                 get { return this.TextImage[position]; }
             }
 
             #region Lines
-            protected override TextLineCollection GetLinesCore()
+            protected sealed override TextLineCollection GetLinesCore()
                 => new LineInfo(this);
 
-            private class LineInfo : TextLineCollection
+            private sealed class LineInfo : TextLineCollection
             {
                 private readonly SnapshotSourceText _text;
 
@@ -173,17 +173,17 @@ namespace Microsoft.CodeAnalysis.Text
             }
             #endregion
 
-            public override string ToString()
+            public sealed override string ToString()
                 => this.TextImage.GetText();
 
-            public override string ToString(TextSpan textSpan)
+            public sealed override string ToString(TextSpan textSpan)
             {
                 var editorSpan = new Span(textSpan.Start, textSpan.Length);
                 var res = this.TextImage.GetText(editorSpan);
                 return res;
             }
 
-            public override SourceText WithChanges(IEnumerable<TextChange> changes)
+            public sealed override SourceText WithChanges(IEnumerable<TextChange> changes)
             {
                 if (changes == null)
                 {
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Text
             /// <summary>
             /// Perf: Optimize calls to GetChangeRanges after WithChanges by using editor snapshots
             /// </summary>
-            private class ChangedSourceText : SnapshotSourceText
+            private sealed class ChangedSourceText : SnapshotSourceText
             {
                 private readonly SnapshotSourceText _baseText;
                 private readonly ITextImage _baseSnapshot;
@@ -308,10 +308,10 @@ namespace Microsoft.CodeAnalysis.Text
                 }
             }
 
-            public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+            public sealed override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
                 => this.TextImage.CopyTo(sourceIndex, destination, destinationIndex, count);
 
-            public override void Write(TextWriter textWriter, TextSpan span, CancellationToken cancellationToken)
+            public sealed override void Write(TextWriter textWriter, TextSpan span, CancellationToken cancellationToken)
                 => this.TextImage.Write(textWriter, span.ToSpan());
 
             #region GetChangeRangesImplementation 


### PR DESCRIPTION
- Adds a new helper for chunked text manipulation inside `LargeText` and `CompositeText`
- Overrides `SourceText.Write` in all `SourceText` implementations for consistency and to provide a more straightforward and more efficient implementation than the base one that copies the text to a temporary buffer