### PR TITLE
Add assertions for length to StringTextWriter & LargeTextWriter

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var largeText = CreateLargeText(chunk1);
 
             // chunks are considered large because they are bigger than the expected size
-            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, 10);
+            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, largeText.Length);
             largeText.Write(writer);
 
             var newText = (LargeText)writer.ToSourceText();
@@ -612,7 +612,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var largeText = CreateLargeText(chunk1);
 
             // chunks are considered small because they fit within the buffer (which is the expected length for this test)
-            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, chunk1.Length * 4);
+            var writer = new LargeTextWriter(largeText.Encoding, largeText.ChecksumAlgorithm, text.Length + largeText.Length);
 
             // write preamble so buffer is allocated and has contents.
             text.Write(writer);

--- a/src/Compilers/Core/Portable/Text/CompositeText.cs
+++ b/src/Compilers/Core/Portable/Text/CompositeText.cs
@@ -288,13 +288,10 @@ namespace Microsoft.CodeAnalysis.Text
 
                     // count how many contiguous segments are reducible
                     int count = 1;
-                    for (int j = i + 1; j < segments.Count; j++)
+                    for (int j = i + 1; j < segments.Count && segments[j].Length <= segmentSize; j++)
                     {
-                        if (segments[j].Length <= segmentSize)
-                        {
-                            count++;
-                            combinedLength += segments[j].Length;
-                        }
+                        count++;
+                        combinedLength += segments[j].Length;
                     }
 
                     // if we've got at least two, then combine them into a single text

--- a/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
 {
@@ -13,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Text
     {
         private readonly Encoding? _encoding;
         private readonly SourceHashAlgorithm _checksumAlgorithm;
+        private readonly int _length;
         private readonly ArrayBuilder<char[]> _chunks;
 
         private readonly int _bufferSize;
@@ -23,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             _encoding = encoding;
             _checksumAlgorithm = checksumAlgorithm;
+            _length = length;
             _chunks = ArrayBuilder<char[]>.GetInstance(1 + length / LargeText.ChunkSize);
             _bufferSize = Math.Min(LargeText.ChunkSize, length);
         }
@@ -30,6 +34,8 @@ namespace Microsoft.CodeAnalysis.Text
         public override SourceText ToSourceText()
         {
             this.Flush();
+
+            RoslynDebug.Assert(_chunks.Sum(chunk => chunk.Length) == _length);
             return new LargeText(_chunks.ToImmutableAndFree(), _encoding, default(ImmutableArray<byte>), _checksumAlgorithm, default(ImmutableArray<byte>));
         }
 

--- a/src/Compilers/Core/Portable/Text/StringTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/StringTextWriter.cs
@@ -2,29 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
 {
-    internal class StringTextWriter : SourceTextWriter
+    internal sealed class StringTextWriter : SourceTextWriter
     {
         private readonly StringBuilder _builder;
         private readonly Encoding? _encoding;
         private readonly SourceHashAlgorithm _checksumAlgorithm;
+        private readonly int _length;
 
-        public StringTextWriter(Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, int capacity)
+        public StringTextWriter(Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, int length)
         {
-            _builder = new StringBuilder(capacity);
+            _builder = new StringBuilder(length);
             _encoding = encoding;
             _checksumAlgorithm = checksumAlgorithm;
+            _length = length;
         }
 
         // https://github.com/dotnet/roslyn/issues/40830
@@ -35,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         public override SourceText ToSourceText()
         {
+            RoslynDebug.Assert(_builder.Length == _length);
             return new StringText(_builder.ToString(), _encoding, checksumAlgorithm: _checksumAlgorithm);
         }
 


### PR DESCRIPTION
Split from #69359

I discovered a minor issue thanks to these assertions - see the review comment.