### PR TITLE
Adjust OptProf config

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -8,55 +8,67 @@
           "filteredTestCases": [
             {
               "filename": "/Microsoft.CodeAnalysis.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.Text.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
-              "filename": "/Microsoft.CodeAnalysis.VisualBasic.Features.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "filename": "/Microsoft.CodeAnalysis.CSharp.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             },
             {
-              "filename": "/Microsoft.CodeAnalysis.Remote.Workspaces.dll",
+              "filename": "/Microsoft.CodeAnalysis.CSharp.Features.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_cs" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.VisualBasic.Features.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.Remote.Workspaces.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" , "WinForms.OptProfTests.winforms_largeform_cs"]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.EditorFeatures.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Features.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
-            },
-            {
-              "filename": "/Microsoft.CodeAnalysis.CSharp.Workspaces.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs"]
             },
             {
               "filename": "/Microsoft.VisualStudio.LanguageServices.Implementation.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
             },
             {
+              "filename": "/Microsoft.VisualStudio.LanguageServices.CSharp.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_cs" ]
+            },            
+            {
               "filename": "/Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
               "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+            },
+            {
+              "filename": "/Microsoft.CodeAnalysis.CSharp.Workspaces.dll",
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_cs" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll",
@@ -64,7 +76,7 @@
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Workspaces.dll",
-              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb" ]
+              "testCases":[ "WinForms.OptProfTests.winforms_largeform_vb", "WinForms.OptProfTests.winforms_largeform_cs" ]
             }
           ]
         },


### PR DESCRIPTION
Fix internal [bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1861566)

Also, what I observed locally when opening a VB winform project is "MS.CA.CSharp.dll" being loaded after solution load, and "MS.CA.CSharp.Workspace.dll" being loaded when triggering completion in a VB file. I suspect there's common type that VB also depends on resides in our C# proejcts.

![image](https://github.com/dotnet/roslyn/assets/788783/1406a1c2-cb44-45b4-bde7-5a15ee09b709)
