### PR TITLE
Source text writer encoding

### DIFF
--- a/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
@@ -33,12 +33,6 @@ namespace Microsoft.CodeAnalysis.Text
             return new LargeText(_chunks.ToImmutableAndFree(), _encoding, default(ImmutableArray<byte>), _checksumAlgorithm, default(ImmutableArray<byte>));
         }
 
-        // https://github.com/dotnet/roslyn/issues/40830
-        public override Encoding Encoding
-        {
-            get { return _encoding!; }
-        }
-
         public bool CanFitInAllocatedBuffer(int chars)
         {
             return _buffer != null && chars <= (_buffer.Length - _currentUsed);

--- a/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Text
     internal abstract class SourceTextWriter : TextWriter
     {
         // Unicode since the data is always stored in-memory as UTF-16 chars.
-        public override Encoding Encoding => Encoding.Unicode;
+        public override Encoding Encoding => new UnicodeEncoding(bigEndian: false, byteOrderMark: false);
 
         public abstract SourceText ToSourceText();
 

--- a/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextWriter.cs
@@ -9,6 +9,9 @@ namespace Microsoft.CodeAnalysis.Text
 {
     internal abstract class SourceTextWriter : TextWriter
     {
+        // Unicode since the data is always stored in-memory as UTF-16 chars.
+        public override Encoding Encoding => Encoding.Unicode;
+
         public abstract SourceText ToSourceText();
 
         public static SourceTextWriter Create(Encoding? encoding, SourceHashAlgorithm checksumAlgorithm, int length)

--- a/src/Compilers/Core/Portable/Text/StringTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/StringTextWriter.cs
@@ -27,12 +27,6 @@ namespace Microsoft.CodeAnalysis.Text
             _checksumAlgorithm = checksumAlgorithm;
         }
 
-        // https://github.com/dotnet/roslyn/issues/40830
-        public override Encoding Encoding
-        {
-            get { return _encoding!; }
-        }
-
         public override SourceText ToSourceText()
         {
             return new StringText(_builder.ToString(), _encoding, checksumAlgorithm: _checksumAlgorithm);


### PR DESCRIPTION
Closes #40830

Since this type is internal and the `Encoding` property isn't really used, we might as well throw a `NotSupportedException` as an alternative. Although returning `new UnicodeEncoding(false, false)` matches the built-in `StringWriter` (see https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/StringWriter.cs#L60).