### PR TITLE
Add custom project contexts endpoint

### DIFF
--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/GetProjectContextsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/GetProjectContextsHandler.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(GetProjectContextsHandler)), Shared]
+[Method(GetProjectContextsName)]
+internal class GetProjectContextsHandler : ILspServiceDocumentRequestHandler<ProjectContextsParams, ProjectContextList?>
+{
+    private const string GetProjectContextsName = "roslyn/getProjectContexts";
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public GetProjectContextsHandler()
+    {
+    }
+
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(ProjectContextsParams request)
+        => request.TextDocument;
+
+    public Task<ProjectContextList?> HandleRequestAsync(ProjectContextsParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        Contract.ThrowIfNull(context.Workspace);
+        Contract.ThrowIfNull(context.Solution);
+
+        // We specifically don't use context.Document here because we want multiple
+        var documents = context.Solution.GetDocuments(request.TextDocument.Uri);
+
+        if (!documents.Any())
+        {
+            return SpecializedTasks.Null<ProjectContextList>();
+        }
+
+        var idToIntermediateOutputMap = new Dictionary<string, string>();
+        var contexts = new List<VSProjectContext>();
+
+        foreach (var document in documents)
+        {
+            var project = document.Project;
+            var projectContext = ProtocolConversions.ProjectToProjectContext(project);
+            contexts.Add(projectContext);
+            idToIntermediateOutputMap[projectContext.Id] = project.OutputFilePath ?? "";
+        }
+
+        // If the document is open, it doesn't matter which DocumentId we pass to GetDocumentIdInCurrentContext since
+        // all the documents are linked at that point, so we can just pass the first arbitrarily. If the document is closed
+        // GetDocumentIdInCurrentContext will just return the same ID back, which means we're going to pick the first
+        // ID in GetDocumentIdsWithFilePath, but there's really nothing we can do since we don't have contexts for
+        // close documents anyways.
+        var openDocument = documents.First();
+        var currentContextDocumentId = context.Workspace.GetDocumentIdInCurrentContext(openDocument.Id);
+
+        return Task.FromResult<ProjectContextList?>(new ProjectContextList
+        {
+            ProjectContexts = contexts.ToArray(),
+            DefaultIndex = documents.IndexOf(d => d.Id == currentContextDocumentId),
+            ProjectIdToIntermediatePathMap = idToIntermediateOutputMap
+        });
+    }
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/GetProjectContextsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/GetProjectContextsHandler.cs
@@ -49,7 +49,7 @@ internal class GetProjectContextsHandler : ILspServiceDocumentRequestHandler<Pro
             return SpecializedTasks.Null<ProjectContextList>();
         }
 
-        var idToIntermediateOutputMap = new Dictionary<string, string>();
+        var idToIntermediateOutputMap = new Dictionary<string, string?>();
         var contexts = new List<VSProjectContext>();
 
         foreach (var document in documents)
@@ -57,7 +57,7 @@ internal class GetProjectContextsHandler : ILspServiceDocumentRequestHandler<Pro
             var project = document.Project;
             var projectContext = ProtocolConversions.ProjectToProjectContext(project);
             contexts.Add(projectContext);
-            idToIntermediateOutputMap[projectContext.Id] = project.OutputFilePath ?? "";
+            idToIntermediateOutputMap[projectContext.Id] = project.CompilationOutputInfo.AssemblyPath;
         }
 
         // If the document is open, it doesn't matter which DocumentId we pass to GetDocumentIdInCurrentContext since

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+
+internal class ProjectContextList : VSProjectContextList
+{
+    //
+    // Summary:
+    //     Gets or sets the value which maps project ids to intermediate output paths
+    [DataMember(Name = "_roslyn_projectIdMap")]
+    public required Dictionary<string, string> ProjectIdToIntermediatePathMap { get; set; }
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
@@ -14,5 +14,5 @@ internal class ProjectContextList : VSProjectContextList
     // Summary:
     //     Gets or sets the value which maps project ids to intermediate output paths
     [DataMember(Name = "_roslyn_projectIdMap")]
-    public required Dictionary<string, string> ProjectIdToIntermediatePathMap { get; set; }
+    public required Dictionary<string, string?> ProjectIdToIntermediatePathMap { get; set; }
 }

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextList.cs
@@ -8,8 +8,14 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
 
-internal class ProjectContextList : VSProjectContextList
+internal class ProjectContextList
 {
+    //
+    // Summary:
+    //     Gets or sets the value which is the VSProjectContextList
+    [DataMember(Name = "_roslyn_projectContexts")]
+    public required VSProjectContextList ProjectContexts { get; set; }
+
     //
     // Summary:
     //     Gets or sets the value which maps project ids to intermediate output paths

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextsParams.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/ProjectContextsParams.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+
+internal record ProjectContextsParams : ITextDocumentParams
+{
+    //
+    // Summary:
+    //     Gets or sets the value which identifies the document the request came from.
+    [DataMember(Name = "textDocument")]
+    public required TextDocumentIdentifier TextDocument { get; set; }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -35,36 +35,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(context.Workspace);
             Contract.ThrowIfNull(context.Solution);
 
-            // We specifically don't use context.Document here because we want multiple
-            var documents = context.Solution.GetDocuments(request.TextDocument.Uri);
-
-            if (!documents.Any())
+            var contextList = ProjectContextHelper.GetContextList(context.Workspace, context.Solution, request.TextDocument.Uri);
+            if (contextList is null)
             {
                 return SpecializedTasks.Null<VSProjectContextList>();
             }
 
-            var contexts = new List<VSProjectContext>();
-
-            foreach (var document in documents)
-            {
-                var project = document.Project;
-                var projectContext = ProtocolConversions.ProjectToProjectContext(project);
-                contexts.Add(projectContext);
-            }
-
-            // If the document is open, it doesn't matter which DocumentId we pass to GetDocumentIdInCurrentContext since
-            // all the documents are linked at that point, so we can just pass the first arbitrarily. If the document is closed
-            // GetDocumentIdInCurrentContext will just return the same ID back, which means we're going to pick the first
-            // ID in GetDocumentIdsWithFilePath, but there's really nothing we can do since we don't have contexts for
-            // close documents anyways.
-            var openDocument = documents.First();
-            var currentContextDocumentId = context.Workspace.GetDocumentIdInCurrentContext(openDocument.Id);
-
-            return Task.FromResult<VSProjectContextList?>(new VSProjectContextList
-            {
-                ProjectContexts = contexts.ToArray(),
-                DefaultIndex = documents.IndexOf(d => d.Id == currentContextDocumentId)
-            });
+            return Task.FromResult<VSProjectContextList?>(contextList);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/ProjectContextHelper.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/ProjectContextHelper.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    internal static class ProjectContextHelper
+    {
+        public static VSProjectContextList? GetContextList(Workspace workspace, Solution solution, Uri documentUri)
+        {
+            // We specifically don't use context.Document here because we want multiple
+            var documents = solution.GetDocuments(documentUri);
+
+            if (!documents.Any())
+            {
+                return null;
+            }
+
+            var contexts = new List<VSProjectContext>();
+
+            foreach (var document in documents)
+            {
+                var project = document.Project;
+                var projectContext = ProtocolConversions.ProjectToProjectContext(project);
+                contexts.Add(projectContext);
+            }
+
+            // If the document is open, it doesn't matter which DocumentId we pass to GetDocumentIdInCurrentContext since
+            // all the documents are linked at that point, so we can just pass the first arbitrarily. If the document is closed
+            // GetDocumentIdInCurrentContext will just return the same ID back, which means we're going to pick the first
+            // ID in GetDocumentIdsWithFilePath, but there's really nothing we can do since we don't have contexts for
+            // close documents anyways.
+            var openDocument = documents.First();
+            var currentContextDocumentId = workspace.GetDocumentIdInCurrentContext(openDocument.Id);
+
+            return new VSProjectContextList
+            {
+                ProjectContexts = contexts.ToArray(),
+                DefaultIndex = documents.IndexOf(d => d.Id == currentContextDocumentId)
+            };
+        }
+    }
+}


### PR DESCRIPTION
To map correctly between a project context id and Razor's understanding of a project, we need some more information thatn ProjectContexts currently provide. This modifies the returned information to add a dictionary that Razor can use to lookup and map behavior correctly as it the editor adds more multitargeting features.

We're specifically looking to answer this [question](https://github.com/dotnet/razor/blob/67ece6826ac99eca6bdf761b5e07cd76f8f5679d/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Extensions/LSPDocumentSynchronizerExtensions.cs#L76) in code