### PR TITLE
Fix run tests on older versions of the SDK

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -41,9 +41,11 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
 
         var projectOutputPath = context.Document.Project.OutputFilePath;
         Contract.ThrowIfFalse(File.Exists(projectOutputPath), $"Output path {projectOutputPath} is missing");
+        var projectOutputDirectory = Path.GetDirectoryName(projectOutputPath);
+        Contract.ThrowIfNull(projectOutputDirectory, $"Could not get project output directory from {projectOutputPath}");
 
         // Find the appropriate vstest.console.dll from the SDK.
-        var vsTestConsolePath = await dotnetCliHelper.GetVsTestConsolePathAsync(cancellationToken);
+        var vsTestConsolePath = await dotnetCliHelper.GetVsTestConsolePathAsync(projectOutputDirectory, cancellationToken);
 
         // Instantiate the test platform wrapper.
         var vsTestConsoleWrapper = new VsTestConsoleWrapper(vsTestConsolePath, new ConsoleParameters

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestRunner.cs
@@ -19,6 +19,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Testing;
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
 internal partial class TestRunner(ILoggerFactory loggerFactory)
 {
+    /// <summary>
+    /// A default value for run settings.  While the vstest console included with newer SDKs does
+    /// support passing in a null run settings value, the vstest console in older SDKs (.net 6 for example)
+    /// will throw if we pass a null value.  So for our default we hardcode an empty XML configuration.
+    /// TODO - Support configuring run settings - https://github.com/dotnet/vscode-csharp/issues/5719
+    /// </summary>
+    private const string DefaultRunSettings = "<RunSettings/>";
     private readonly ILogger _logger = loggerFactory.CreateLogger<TestRunner>();
 
     public async Task RunTestsAsync(
@@ -53,13 +60,12 @@ internal partial class TestRunner(ILoggerFactory loggerFactory)
         if (attachDebugger)
         {
             // When we want to debug tests we need to use a custom test launcher so that we get called back with the process to attach to.
-            vsTestConsoleWrapper.RunTestsWithCustomTestHost(testCases, runSettings: null, handler, new DebugTestHostLauncher(progress, clientLanguageServerManager));
+            vsTestConsoleWrapper.RunTestsWithCustomTestHost(testCases, runSettings: DefaultRunSettings, handler, new DebugTestHostLauncher(progress, clientLanguageServerManager));
         }
         else
         {
             // The async APIs for vs test are broken (current impl ends up just hanging), so we must use the sync API instead.
-            // TODO - run settings. https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1799066/
-            vsTestConsoleWrapper.RunTests(testCases, runSettings: null, handler);
+            vsTestConsoleWrapper.RunTests(testCases, runSettings: DefaultRunSettings, handler);
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6022

There are two parts to this.

b9a4f2b289401104e5abf5deb2f5da04ea67cbda is not the actual bug, however it was preventing me from finding the actual bug.  Essentially we were not respecting the user's global.json configured for the workspace because we ran dotnet --info outside of the project.  This meant we always used whatever the machine default dotnet value was and the global.json was ignored.

f46a316c8b60aae7fb3ecf928c4885b5f570524c Fixes the actual issue - the vstest console included in older SDKs (e.g. .net6) will throw if we pass a null run settings value to the API.  The fix is to pass an empty run settings value instead.

Before:
```
Starting test discovery
Logging TestHost Diagnostics in file: c:\Users\WDAGUtilityAccount\AppData\Roaming\Code\logs\20230803T165938\window1\exthost\ms-dotnettools.csharp\testLogs\vsTestLogs.host.23-08-03_18-01-59_40586_9.txt
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.3+1b45f5407b (64-bit .NET 6.0.20)
[xUnit.net 00:00:00.28]   Discovering: UnitTests
[xUnit.net 00:00:00.31]   Discovered:  UnitTests
Found 1 tests in 851ms

Starting test run
Test run error: System.Exception: Value cannot be null.
   at Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.UpdateRunSettingsIfRequired(String runsettingsXml, IList`1 sources, IBaseTestEventsRegistrar registrar, String& updatedRunSettingsXml, IDictionary`2& sourceToArchitectureMap, IDictionary`2& sourceToFrameworkMap)
   at Microsoft.VisualStudio.TestPlatform.CommandLine.TestPlatformHelpers.TestRequestManager.RunTests(TestRunRequestPayload testRunRequestPayload, ITestHostLauncher3 testHostLauncher, ITestRunEventsRegistrar testRunEventsRegistrar, ProtocolConfig protocolConfig)
   at Microsoft.VisualStudio.TestPlatform.Client.DesignMode.DesignModeClient.<>c__DisplayClass23_0.<StartTestRun>b__0()
```

After
```
Starting test discovery
Logging TestHost Diagnostics in file: c:\Users\WDAGUtilityAccount\AppData\Roaming\Code\logs\20230803T165938\window1\exthost\ms-dotnettools.csharp\testLogs\vsTestLogs.host.23-08-03_18-06-35_59571_9.txt
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.3+1b45f5407b (64-bit .NET 6.0.20)
[xUnit.net 00:00:00.20]   Discovering: UnitTests
[xUnit.net 00:00:00.22]   Discovered:  UnitTests
Found 1 tests in 693ms

Starting test run
[Passed] UnitTests.UnitTest1.Test1
==== Summary ====
Passed!  - Failed:    0, Passed:    1, Skipped:    0, Total:    1, Duration: 237ms
```