### PR TITLE
Fix misleading lsp server logs

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/LanguageServerHost.cs
@@ -48,7 +48,6 @@ internal sealed class LanguageServerHost
 
     public void Start()
     {
-        _logger.LogInformation("Starting server...");
         _jsonRpc.StartListening();
 
         // Now that the server is started, update the our instance reference

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -51,6 +51,8 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         ));
     });
 
+    var logger = loggerFactory.CreateLogger<Program>();
+
     if (serverConfiguration.LaunchDebugger)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -60,7 +62,6 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         }
         else
         {
-            var logger = loggerFactory.CreateLogger<Program>();
             var timeout = TimeSpan.FromMinutes(1);
             logger.LogCritical($"Server started with process ID {Environment.ProcessId}");
             logger.LogCritical($"Waiting {timeout:g} for a debugger to attach");
@@ -102,6 +103,8 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
 
     var server = new LanguageServerHost(Console.OpenStandardInput(), Console.OpenStandardOutput(), exportProvider, loggerFactory.CreateLogger(nameof(LanguageServerHost)));
     server.Start();
+
+    logger.LogInformation("Language server initialized");
 
     try
     {


### PR DESCRIPTION
We've gotten a fair number of reports of the language server hanging on startup because the logs look like
```
Dotnet path: c:\Users\dabarbet\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\7.0.9\dotnet.exe
Activating C# + C# Dev Kit + C# IntelliCode...
info: LanguageServerHost[0]
      Starting server...
```

This updates the last line to instead indicate that the server has started.