### PR TITLE
Use PooledStringBuilder in StringTextWriter

### DIFF
--- a/src/Compilers/Core/Portable/Text/CompositeText.cs
+++ b/src/Compilers/Core/Portable/Text/CompositeText.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Text
                         var encoding = segments[i].Encoding;
                         var algorithm = segments[i].ChecksumAlgorithm;
 
-                        var writer = SourceTextWriter.Create(encoding, algorithm, combinedLength);
+                        using var writer = SourceTextWriter.Create(encoding, algorithm, combinedLength);
 
                         while (count > 0)
                         {
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.Text
                 var encoding = segments[0].Encoding;
                 var algorithm = segments[0].ChecksumAlgorithm;
 
-                var writer = SourceTextWriter.Create(encoding, algorithm, length);
+                using var writer = SourceTextWriter.Create(encoding, algorithm, length);
                 foreach (var segment in segments)
                 {
                     segment.Write(writer);

--- a/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
+++ b/src/Compilers/Core/Portable/Text/LargeTextWriter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Text
     {
         private readonly Encoding? _encoding;
         private readonly SourceHashAlgorithm _checksumAlgorithm;
-        private readonly ArrayBuilder<char[]> _chunks;
+        private ArrayBuilder<char[]> _chunks;
 
         private readonly int _bufferSize;
         private char[]? _buffer;
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Text
         public override SourceText ToSourceText()
         {
             this.Flush();
-            return new LargeText(_chunks.ToImmutableAndFree(), _encoding, default(ImmutableArray<byte>), _checksumAlgorithm, default(ImmutableArray<byte>));
+            return new LargeText(_chunks.ToImmutable(), _encoding, default(ImmutableArray<byte>), _checksumAlgorithm, default(ImmutableArray<byte>));
         }
 
         // https://github.com/dotnet/roslyn/issues/40830
@@ -153,6 +153,17 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 _buffer = new char[_bufferSize];
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _chunks is not null)
+            {
+                _chunks.Free();
+                _chunks = null!;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -94,8 +94,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public static PooledStringBuilder GetInstance(int capacity)
         {
-            var builder = s_poolInstance.Allocate();
-            Debug.Assert(builder.Builder.Length == 0);
+            var builder = GetInstance();
             builder.Builder.EnsureCapacity(capacity);
             return builder;
         }

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -92,6 +92,14 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             return builder;
         }
 
+        public static PooledStringBuilder GetInstance(int capacity)
+        {
+            var builder = s_poolInstance.Allocate();
+            Debug.Assert(builder.Builder.Length == 0);
+            builder.Builder.EnsureCapacity(capacity);
+            return builder;
+        }
+
         public static implicit operator StringBuilder(PooledStringBuilder obj)
         {
             return obj.Builder;


### PR DESCRIPTION
From https://github.com/dotnet/roslyn/pull/69369#pullrequestreview-1561852978:

@Neme12:
> 🤔 Is there a reason why this isn't using `PooledStringBuilder`? It seems like all other places in the compiler that use a `StringBuilder` use the pooled one.

@CyrusNajmabadi:
> size is likely so large that pooling would be undesirable. Also, this scales with # files, which is low. We want pooling for when tehre are literally insane numbers of allocations otherwise.

@Neme12:
> `PooledStringBuilder` already has a check for the size and only pools ones smaller than 1024 chars.

@Neme12:
> Given that `SourceTextWriter` is used inside `CompositeText`, which is used by `WithChanges`, I'd say the lengths here probably are very small most often. And for really large text, `LargeTextWriter` is used instead.
