### PR TITLE
Move from LanguageVersion.Preview to LanguageVersionExtensions.CSharpNext

### DIFF
--- a/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.AddAccessibilityModifiers;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -227,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             };
 
             await test.RunAsync();
@@ -594,7 +595,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             };
 
             await test.RunAsync();
@@ -622,7 +623,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = source,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = Testing.ReferenceAssemblies.Net.Net60
             };
 
@@ -645,7 +646,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = source,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 
@@ -658,7 +659,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = source,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 
@@ -690,7 +691,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 
@@ -714,7 +715,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 CodeActionEquivalenceKey = nameof(AnalyzersResources.Add_accessibility_modifiers),
             };
 
@@ -741,7 +742,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddAccessibilityModifie
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 CodeActionEquivalenceKey = nameof(AnalyzersResources.Remove_accessibility_modifiers),
                 Options =
                 {

--- a/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
+++ b/src/Analyzers/CSharp/Tests/AddParameter/AddParameterTests.cs
@@ -2938,7 +2938,7 @@ var b = ""B"";
 var r = new R(1, b);
 
 class R(int A, string b);
-", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview));
+", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54408")]
@@ -2980,7 +2980,7 @@ var b = ""B"";
 var r = new R(1, b);
 
 struct R(int A, string b);
-", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview));
+", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/56952")]

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
@@ -717,7 +718,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
                     }
                 }
                 """",
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 Options =
                 {
                     { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
@@ -769,7 +770,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
                     void M2(System.ReadOnlySpan<byte> x) {}
                 }
                 """",
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 Options =
                 {

--- a/src/Analyzers/CSharp/Tests/MakeRefStruct/MakeRefStructTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeRefStruct/MakeRefStructTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.MakeRefStruct;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MakeRefStruct
                     Span<int>[||] m;
                 }
                 """);
-            await TestMissingInRegularAndScriptAsync(text, new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview)));
+            await TestMissingInRegularAndScriptAsync(text, new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext)));
         }
 
         [Fact]

--- a/src/Analyzers/CSharp/Tests/MakeStructReadOnly/MakeStructReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructReadOnly/MakeStructReadOnlyTests.cs
@@ -5,6 +5,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.MakeStructReadOnly;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
@@ -19,10 +20,10 @@ using VerifyCS = CSharpCodeFixVerifier<
 [Trait(Traits.Feature, Traits.Features.CodeActionsMakeStructReadOnly)]
 public class MakeStructReadOnlyTests
 {
-    private static Task TestMissingAsync(string testCode, LanguageVersion version = LanguageVersion.Preview)
+    private static Task TestMissingAsync(string testCode, LanguageVersion version = LanguageVersionExtensions.CSharpNext)
         => TestAsync(testCode, testCode, version);
 
-    private static async Task TestAsync(string testCode, string fixedCode, LanguageVersion version = LanguageVersion.Preview)
+    private static async Task TestAsync(string testCode, string fixedCode, LanguageVersion version = LanguageVersionExtensions.CSharpNext)
     {
         await new VerifyCS.Test
         {
@@ -434,7 +435,7 @@ LanguageVersion.CSharp7_2);
 {
     readonly int i;
 }",
-LanguageVersion.Preview);
+LanguageVersionExtensions.CSharpNext);
     }
 
     [Fact]

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryLambdaExpression;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryLambda
         private static async Task TestInRegularAndScriptAsync(
             string testCode,
             string fixedCode,
-            LanguageVersion version = LanguageVersion.Preview,
+            LanguageVersion version = LanguageVersionExtensions.CSharpNext,
             OutputKind? outputKind = null)
         {
             await new VerifyCS.Test
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryLambda
 
         private static Task TestMissingInRegularAndScriptAsync(
             string testCode,
-            LanguageVersion version = LanguageVersion.Preview,
+            LanguageVersion version = LanguageVersionExtensions.CSharpNext,
             OutputKind? outputKind = null)
             => TestInRegularAndScriptAsync(testCode, testCode, version, outputKind);
 
@@ -120,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryLambda
             {
                 TestCode = code,
                 FixedCode = code,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 Options = { { CSharpCodeStyleOptions.PreferMethodGroupConversion, new CodeStyleOption2<bool>(false, NotificationOption2.None) } }
             }.RunAsync();
         }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -28,7 +29,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             ReferenceAssemblies = Testing.ReferenceAssemblies.NetCore.NetCoreApp31,
             TestCode = testCode,
             FixedCode = fixedCode,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
             TestState = { OutputKind = outputKind }
         }.RunAsync();
     }
@@ -1499,7 +1500,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 }
             }
             """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 

--- a/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundCoalesceAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundCoalesceAssignmentTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -915,7 +916,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCompoundAssignment
 
                     static byte* Get() => null;
                 }
-                """, LanguageVersion.Preview);
+                """, LanguageVersionExtensions.CSharpNext);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/62473")]
@@ -935,7 +936,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCompoundAssignment
 
                     static byte* Get() => null;
                 }
-                """, LanguageVersion.Preview);
+                """, LanguageVersionExtensions.CSharpNext);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/63551")]
@@ -958,7 +959,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCompoundAssignment
                         return func;
                     }
                 }
-                """, LanguageVersion.Preview);
+                """, LanguageVersionExtensions.CSharpNext);
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseObjectInitializer;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
             {
                 TestCode = testCode,
                 FixedCode = fixedCode,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestState = { OutputKind = outputKind }
             }.RunAsync();
         }

--- a/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePrimaryConstructor/UsePrimaryConstructorTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UsePrimaryConstructor;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -35,7 +36,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -69,7 +70,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -91,7 +92,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -112,7 +113,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -141,7 +142,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -178,7 +179,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -215,7 +216,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -254,7 +255,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -293,7 +294,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -334,7 +335,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -350,7 +351,7 @@ public partial class UsePrimaryConstructorTests
                         => System.Console.WriteLine(i);
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -368,7 +369,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -392,7 +393,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -416,7 +417,7 @@ public partial class UsePrimaryConstructorTests
                     private int I { get; } = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -440,7 +441,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = j;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -464,7 +465,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = j;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -485,7 +486,7 @@ public partial class UsePrimaryConstructorTests
                         => this.i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -506,7 +507,7 @@ public partial class UsePrimaryConstructorTests
                         => base.i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -524,7 +525,7 @@ public partial class UsePrimaryConstructorTests
                         => this.i += i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -545,7 +546,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -569,7 +570,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = i * 2;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -598,7 +599,7 @@ public partial class UsePrimaryConstructorTests
                     public int j = j;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -625,7 +626,7 @@ public partial class UsePrimaryConstructorTests
                     public int i = i, j = j;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -653,7 +654,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -681,7 +682,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -710,7 +711,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -733,7 +734,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -788,7 +789,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -827,7 +828,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -866,7 +867,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -905,7 +906,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -946,7 +947,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -989,7 +990,7 @@ public partial class UsePrimaryConstructorTests
             }
             """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1032,7 +1033,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1054,7 +1055,7 @@ public partial class UsePrimaryConstructorTests
                     int M(int y) => y;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1076,7 +1077,7 @@ public partial class UsePrimaryConstructorTests
                     int M(int y) => y;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1106,7 +1107,7 @@ public partial class UsePrimaryConstructorTests
                     static int M(int y) => y;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1142,7 +1143,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1182,7 +1183,7 @@ public partial class UsePrimaryConstructorTests
                 #endif
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1212,7 +1213,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1260,7 +1261,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1304,7 +1305,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1344,7 +1345,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1393,7 +1394,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1440,7 +1441,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1482,7 +1483,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1524,7 +1525,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1572,7 +1573,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1620,7 +1621,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1667,7 +1668,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1716,7 +1717,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1749,7 +1750,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1781,7 +1782,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1822,7 +1823,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1881,7 +1882,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
             CodeActionIndex = 1,
             NumberOfFixAllIterations = 1,
         }.RunAsync();
@@ -1909,7 +1910,7 @@ public partial class UsePrimaryConstructorTests
                {
                }
                """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1937,7 +1938,7 @@ public partial class UsePrimaryConstructorTests
                {
                }
                """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -1971,7 +1972,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2007,7 +2008,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2044,7 +2045,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2083,7 +2084,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2115,7 +2116,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2150,7 +2151,7 @@ public partial class UsePrimaryConstructorTests
                     int x;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2178,7 +2179,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2212,7 +2213,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2242,7 +2243,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2278,7 +2279,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2306,7 +2307,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2340,7 +2341,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2370,7 +2371,7 @@ public partial class UsePrimaryConstructorTests
                 {
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2406,7 +2407,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2435,7 +2436,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2468,7 +2469,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2497,7 +2498,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2530,7 +2531,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2551,7 +2552,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2577,7 +2578,7 @@ public partial class UsePrimaryConstructorTests
                     private int i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2603,7 +2604,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2625,7 +2626,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2647,7 +2648,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2671,7 +2672,7 @@ public partial class UsePrimaryConstructorTests
                 #endif
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2695,7 +2696,7 @@ public partial class UsePrimaryConstructorTests
                 #endif
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2719,7 +2720,7 @@ public partial class UsePrimaryConstructorTests
                 #endif
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2743,7 +2744,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2769,7 +2770,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2795,7 +2796,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2828,7 +2829,7 @@ public partial class UsePrimaryConstructorTests
 
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2869,7 +2870,7 @@ public partial class UsePrimaryConstructorTests
 
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2901,7 +2902,7 @@ public partial class UsePrimaryConstructorTests
                     private int _i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2933,7 +2934,7 @@ public partial class UsePrimaryConstructorTests
                 }
                 """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2961,7 +2962,7 @@ public partial class UsePrimaryConstructorTests
                     private int _i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -2989,7 +2990,7 @@ public partial class UsePrimaryConstructorTests
                     private int _i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -3017,7 +3018,7 @@ public partial class UsePrimaryConstructorTests
                     private int _i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 
@@ -3094,7 +3095,7 @@ public partial class UsePrimaryConstructorTests
                     }
                 }
                 """,
-            LanguageVersion = LanguageVersion.Preview,
+            LanguageVersion = LanguageVersionExtensions.CSharpNext,
         }.RunAsync();
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -43,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -82,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net20.Default,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -102,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -129,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -149,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -173,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 csharp_style_prefer_utf8_string_literals = false
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -195,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -215,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -246,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -279,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -310,7 +311,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -341,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -372,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -403,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -433,7 +434,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -464,7 +465,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -495,7 +496,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -530,7 +531,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -561,7 +562,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -592,7 +593,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -613,7 +614,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -634,7 +635,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -655,7 +656,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -689,7 +690,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -770,7 +771,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -798,7 +799,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseUtf8StringLiteral
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -831,7 +832,7 @@ public class C
 ",
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -886,7 +887,7 @@ public class C
                 TestCode = input,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -917,7 +918,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -948,7 +949,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -979,7 +980,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1010,7 +1011,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1041,7 +1042,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1072,7 +1073,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1092,7 +1093,7 @@ public class C
                 }
                 """,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1123,7 +1124,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1154,7 +1155,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1185,7 +1186,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1216,7 +1217,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1247,7 +1248,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1288,7 +1289,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1343,7 +1344,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1432,7 +1433,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1463,7 +1464,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1494,7 +1495,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1525,7 +1526,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1560,7 +1561,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
 
@@ -1595,7 +1596,7 @@ public class C
                 """,
                 CodeActionValidationMode = CodeActionValidationMode.None,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }
     }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
@@ -116,7 +117,7 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
         private static SyntaxTree ParseSource(string markedSource, int documentIndex = 0)
             => SyntaxFactory.ParseSyntaxTree(
                 SourceMarkers.Clear(markedSource),
-                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview),
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext),
                 path: GetDocumentFilePath(documentIndex));
 
         internal static EditScript<SyntaxNode> GetTopEdits(string src1, string src2, int documentIndex = 0)

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
@@ -2464,7 +2465,7 @@ class C
     }
 }";
 
-            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -2485,7 +2486,7 @@ class C
     }
 }";
 
-            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -2506,7 +2507,7 @@ class C
     }
 }";
 
-            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatWithView(expected, code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -2524,7 +2525,7 @@ interface I1
     abstract static I1 operator checked +(I1 x, I1 y);
 }";
 
-            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -2542,7 +2543,7 @@ interface I1
     abstract static I1 operator checked ++(I1 x);
 }";
 
-            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -2560,7 +2561,7 @@ interface I1<T> where T : I1<T>
     abstract static explicit operator checked string(T x);
 }";
 
-            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            AssertFormatAfterTypeChar(code, expected, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -6,6 +6,7 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
@@ -3350,7 +3351,7 @@ namespace NS
                 code,
                 indentationLine: 7,
                 expectedIndentation: 12,
-                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -3370,7 +3371,7 @@ namespace NS
                 code,
                 indentationLine: 7,
                 expectedIndentation: 12,
-                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -3391,7 +3392,7 @@ namespace NS
                 code,
                 indentationLine: 8,
                 expectedIndentation: 12,
-                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]
@@ -3412,7 +3413,7 @@ namespace NS
                 code,
                 indentationLine: 8,
                 expectedIndentation: 12,
-                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                options: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [WpfFact]

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.CSharp.ExternalAccess.Pythia.Api
 Imports Microsoft.CodeAnalysis.CSharp.Formatting
+Imports Microsoft.CodeAnalysis.CSharp.[Shared].Extensions
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Editor.[Shared].Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
@@ -46,7 +47,7 @@ namespace NS
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("F")
                 Await state.AssertSelectedCompletionItem(displayText:="FC", isHardSelected:=True)
@@ -74,7 +75,7 @@ namespace NS
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("F")
                 Await state.AssertSelectedCompletionItem(displayText:="FC", isHardSelected:=True)
@@ -88,7 +89,7 @@ namespace NS
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionOnFileType_DifferentFile_NonQualified(showCompletionInArgumentLists As Boolean) As Task
             Using State = New TestState(<Workspace>
-                                            <Project Language="C#" CommonReferences="true" LanguageVersion=<%= LanguageVersion.Preview.ToDisplayString() %>>
+                                            <Project Language="C#" CommonReferences="true" LanguageVersion=<%= LanguageVersionExtensions.CSharpNext.ToDisplayString() %>>
                                                 <Document FilePath="a.cs">
 namespace NS
 {
@@ -122,7 +123,7 @@ namespace NS
         <WpfTheory, CombinatorialData>
         Public Async Function CompletionOnFileType_DifferentFile_NamespaceQualified(showCompletionInArgumentLists As Boolean) As Task
             Using State = New TestState(<Workspace>
-                                            <Project Language="C#" CommonReferences="true" LanguageVersion=<%= LanguageVersion.Preview.ToDisplayString() %>>
+                                            <Project Language="C#" CommonReferences="true" LanguageVersion=<%= LanguageVersionExtensions.CSharpNext.ToDisplayString() %>>
                                                 <Document FilePath="a.cs">
 namespace NS
 {
@@ -170,7 +171,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(".")
                 Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
@@ -202,7 +203,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 ' This is the expected behavior until we implement support for list-patterns.
                 state.SendTypeChars("CP")
@@ -275,7 +276,7 @@ public class C3
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(".")
                 Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
@@ -311,7 +312,7 @@ public class C3
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(".")
                 Await state.AssertSelectedCompletionItem(displayText:="C3Field", isHardSelected:=False)
@@ -345,7 +346,7 @@ public class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(".")
                 Await state.AssertNoCompletionSession()
@@ -372,7 +373,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("{ ")
                 Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
@@ -411,7 +412,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 ' No second completion since already tested at top-level
                 state.SendTypeChars(", ")
@@ -440,7 +441,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(", ")
                 Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
@@ -481,7 +482,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(", ")
                 Await state.AssertNoCompletionSession()
@@ -522,7 +523,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(" ")
                 Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
@@ -561,7 +562,7 @@ public class C2
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(" ")
                 Await state.AssertSelectedCompletionItem(displayText:="ShortProperty", isHardSelected:=False)
@@ -773,7 +774,7 @@ class C
     }
 }
                               </Document>,
-                              showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                              showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("w")
                 Await state.AssertSelectedCompletionItem(displayText:="with", isHardSelected:=True)
@@ -9734,7 +9735,7 @@ public class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(" [ Co")
                 Await state.AssertSelectedCompletionItem(displayText:="Constant", isHardSelected:=True)
@@ -9782,7 +9783,7 @@ public class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("..")
                 Await state.AssertNoCompletionSession()
@@ -9819,7 +9820,7 @@ public class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(".. va")
                 Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
@@ -9850,7 +9851,7 @@ public class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("..")
                 Await state.AssertNoCompletionSession()
@@ -9879,7 +9880,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9898,7 +9899,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9917,7 +9918,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9938,7 +9939,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9959,7 +9960,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9979,7 +9980,7 @@ class C
     }        
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("ne")
                 Await state.AssertSelectedCompletionItem(displayText:="new", isHardSelected:=True)
@@ -9999,7 +10000,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("int.M")
                 Await state.AssertSelectedCompletionItem(displayText:="MaxValue")
@@ -10019,7 +10020,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("int.M")
                 Await state.AssertSelectedCompletionItem(displayText:="MaxValue")
@@ -10039,7 +10040,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("int.M")
                 Await state.AssertSelectedCompletionItem(displayText:="MaxValue")
@@ -10060,7 +10061,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
                 state.SendTypeChars("my")
                 Await state.AssertCompletionItemsContain("myConst", "")
             End Using
@@ -10080,7 +10081,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
                 state.SendTypeChars("my")
                 Await state.AssertCompletionItemsContain("myConst", "")
             End Using
@@ -10100,7 +10101,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
                 state.SendTypeChars("my")
                 Await state.AssertCompletionItemsContain("myConst", "")
             End Using
@@ -10120,7 +10121,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
                 state.SendTypeChars("my")
                 Await state.AssertCompletionItemsContain("myConst", "")
             End Using
@@ -10140,7 +10141,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
                 state.SendTypeChars("my")
                 Await state.AssertCompletionItemsContain("myConst", "")
             End Using
@@ -10161,7 +10162,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("p")
                 Await state.AssertSelectedCompletionItem(displayText:="params")
@@ -10184,7 +10185,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("p")
                 Await state.AssertSelectedCompletionItem(displayText:="params")
@@ -10207,7 +10208,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("p")
                 Await state.AssertSelectedCompletionItem(displayText:="params")
@@ -10230,7 +10231,7 @@ class C
     }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("p")
                 Await state.AssertSelectedCompletionItem(displayText:="params")
@@ -11265,7 +11266,7 @@ class Program
     static bool TryParse(string s, out Program p) { }
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars("P")
                 Await state.AssertSelectedCompletionItem(displayText:="Program", isHardSelected:=True)
@@ -11291,7 +11292,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="TestField", displayTextSuffix:="")
@@ -11322,7 +11323,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="second", displayTextSuffix:="")
@@ -11354,7 +11355,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="second", displayTextSuffix:="")
@@ -11386,7 +11387,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="first", displayTextSuffix:="")
@@ -11418,7 +11419,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="second", displayTextSuffix:="")
@@ -11450,7 +11451,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="first", displayTextSuffix:="")
@@ -11482,7 +11483,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContain(displayText:="second", displayTextSuffix:="")
@@ -11514,7 +11515,7 @@ class Program
 }
 ]]>
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsDoNotContainAny("first", "second")
@@ -11543,7 +11544,7 @@ public class C1
 }
 ]]>
                 </Document>,
-                languageVersion:=LanguageVersion.Preview)
+                languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("Property0", "Field0", "Event0")
@@ -11573,7 +11574,7 @@ public class C1
 }
 ]]>
                 </Document>,
-                languageVersion:=LanguageVersion.Preview)
+                languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("Property1", "Field1", "Event1")

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DeclarationName.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DeclarationName.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.CSharp.Formatting
+Imports Microsoft.CodeAnalysis.CSharp.[Shared].Extensions
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Editor.[Shared].Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
@@ -39,7 +40,7 @@ public class C
     void M(CancellationToken$$
 }
                 </Document>,
-                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
+                showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersionExtensions.CSharpNext)
 
                 state.SendTypeChars(" ")
                 Await state.AssertSelectedCompletionItem(displayText:="myTok", isHardSelected:=False)

--- a/src/Features/CSharpTest/AddDebuggerDisplay/AddDebuggerDisplayTests.cs
+++ b/src/Features/CSharpTest/AddDebuggerDisplay/AddDebuggerDisplayTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -59,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddDebuggerDisplay
 
             await new VerifyCS.Test()
             {
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = code,
                 FixedCode = fixedCode,
             }.RunAsync();

--- a/src/Features/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/Features/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.ConvertTupleToStruct;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ConvertTupleToStruct;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.NamingStyles;
@@ -167,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
                     }
                 }
                 """;
-            await TestAsync(text, expected, languageVersion: LanguageVersion.Preview, options: PreferImplicitTypeWithInfo(), testHost: host);
+            await TestAsync(text, expected, languageVersion: LanguageVersionExtensions.CSharpNext, options: PreferImplicitTypeWithInfo(), testHost: host);
         }
 
         [Theory, CombinatorialData]
@@ -208,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
                     }
                 }
                 """;
-            await TestAsync(text, expected, languageVersion: LanguageVersion.Preview, options: PreferImplicitTypeWithInfo(), testHost: host);
+            await TestAsync(text, expected, languageVersion: LanguageVersionExtensions.CSharpNext, options: PreferImplicitTypeWithInfo(), testHost: host);
         }
 
         [Theory, CombinatorialData]
@@ -245,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
                     }
                 }
                 """;
-            await TestAsync(text, expected, languageVersion: LanguageVersion.Preview, options: PreferImplicitTypeWithInfo(), testHost: host);
+            await TestAsync(text, expected, languageVersion: LanguageVersionExtensions.CSharpNext, options: PreferImplicitTypeWithInfo(), testHost: host);
         }
 
         [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/45451"), CombinatorialData]

--- a/src/Features/CSharpTest/EmbeddedLanguages/JsonStringDetectorTests.cs
+++ b/src/Features/CSharpTest/EmbeddedLanguages/JsonStringDetectorTests.cs
@@ -5,6 +5,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EmbeddedLanguages
                     }
                 }
                 """",
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 

--- a/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/Features/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ExtractClass;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -287,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             await new Test
             {
                 TestCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 FixedState =
                 {
@@ -408,7 +409,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             await new Test
             {
                 TestCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 FixedState =
                 {
@@ -453,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             {
                 TestCode = input,
                 FixedCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }
@@ -469,7 +470,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             {
                 TestCode = input,
                 FixedCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }
@@ -487,7 +488,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             {
                 TestCode = input,
                 FixedCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }
@@ -503,7 +504,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             {
                 TestCode = input,
                 FixedCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }
@@ -545,7 +546,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
             {
                 TestCode = input,
                 FixedCode = input,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }

--- a/src/Features/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/Features/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -5,6 +5,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.GenerateDefaultConstructors;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -1585,7 +1586,7 @@ index: 2);
             {
                 TestCode = source.Replace("[||]", ""),
                 FixedCode = fixedSource,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
 
             await TestRefactoringMissingAsync(source);

--- a/src/Features/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/Features/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.GenerateVariable;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
@@ -10001,7 +10002,7 @@ index: PropertyIndex);
                         public (int y, int z) X { get; internal set; }
                     }
                 }
-                """ + TestResources.NetFX.ValueTuple.tuplelib_cs, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                """ + TestResources.NetFX.ValueTuple.tuplelib_cs, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [Fact]
@@ -10045,7 +10046,7 @@ index: PropertyIndex);
                     {
                     }
                 }
-                """, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                """, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [Fact]
@@ -10091,7 +10092,7 @@ index: PropertyIndex);
                     {
                     }
                 }
-                """, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+                """, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersionExtensions.CSharpNext));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/9090")]

--- a/src/Features/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/Features/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ImplementInterface;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles;
 using Microsoft.CodeAnalysis.ImplementType;
@@ -70,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
                 Options = { AllOptionsOff },
                 CodeActionEquivalenceKey = codeAction?.equivalenceKey,
                 CodeActionIndex = codeAction?.index,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
                 FixedCode = expectedMarkup,
                 CodeActionEquivalenceKey = codeAction?.equivalenceKey,
                 CodeActionIndex = codeAction?.index,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
             }.RunAsync();
         }
 
@@ -144,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
         {
             await new VerifyCS.Test
             {
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface IInterface
                 {
@@ -10418,7 +10419,7 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I
                 {
@@ -10451,7 +10452,7 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I
                 {
@@ -10484,7 +10485,7 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I
                 {
@@ -10517,7 +10518,7 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I
                 {
@@ -10554,7 +10555,7 @@ codeAction: ("False;False;False:global::System.Collections.Generic.IList<object>
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = $@"
 interface I
 {{
@@ -10944,7 +10945,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -10981,7 +10982,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11018,7 +11019,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11055,7 +11056,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11090,7 +11091,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11125,7 +11126,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11167,7 +11168,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11202,7 +11203,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11237,7 +11238,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11273,7 +11274,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11309,7 +11310,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest
                 {
@@ -11345,7 +11346,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11381,7 +11382,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11417,7 +11418,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface ITest<T> where T : ITest<T>
                 {
@@ -11453,7 +11454,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I1<T> where T : I1<T>
                 {
@@ -11529,7 +11530,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I1<T> where T : I1<T>
                 {
@@ -11605,7 +11606,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 interface I1<T> where T : I1<T>
                 {
@@ -11759,7 +11760,7 @@ interface I
             await new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = """
                 using System;
 

--- a/src/Features/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/Features/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -2947,7 +2947,7 @@ class C
                 """;
             await new VerifyCS.Test
             {
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = code,
                 FixedCode = code,
             }.RunAsync();
@@ -2961,7 +2961,7 @@ class C
                 """;
             await new VerifyCS.Test
             {
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
                 TestCode = code,
                 FixedCode = code,
             }.RunAsync();

--- a/src/Features/CSharpTest/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/Features/CSharpTest/InlineTemporary/InlineTemporaryTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -4289,7 +4290,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
 
         [Theory]
         [InlineData(LanguageVersion.CSharp6)]
-        [InlineData(LanguageVersion.Preview)]
+        [InlineData(LanguageVersionExtensions.CSharpNext)]
         public async Task Tuples(LanguageVersion version)
         {
             var code = """

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/LanguageVersionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/LanguageVersionExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Shared.Extensions
     internal static class LanguageVersionExtensions
     {
         public static bool IsCSharp12OrAbove(this LanguageVersion languageVersion)
-            => languageVersion >= LanguageVersion.Preview;
+            => languageVersion >= CSharpNext;
 
         public static bool IsCSharp11OrAbove(this LanguageVersion languageVersion)
             => languageVersion >= LanguageVersion.CSharp11;


### PR DESCRIPTION
CSharpNext indicates that we're trying to reference the upcoming version of hte language, but can't (Since the compiler hasn't create an enum value for it yet).  When tehy do, they can then update these tests to reference that actual version number they add to the official enum.