### PR TITLE
Fix SyntaxGenerator handling of special type constants

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -9,7 +9,6 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Xml.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
@@ -178,6 +177,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers modifiers,
             SyntaxNode? initializer)
         {
+            // some constant types will also appear as readonly when read from metadata
+            modifiers = modifiers.IsConst ? modifiers.WithIsReadOnly(false) : modifiers;
+
             return SyntaxFactory.FieldDeclaration(
                 default,
                 AsModifierList(accessibility, modifiers, SyntaxKind.FieldDeclaration),

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2542,6 +2542,39 @@ public class C { } // end").Members[0];
                 "public const global::System.Int32 F;");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69376")]
+        public void TestConstantDecimalFieldDeclarationFromMetadata()
+        {
+            var compilation = _emptyCompilation.
+                WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)).
+                AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree("""
+                class C
+                {
+                    public const decimal F = 8675309000000M;
+                }
+                """));
+            var reference = compilation.EmitToPortableExecutableReference();
+
+            compilation = _emptyCompilation.AddReferences(reference);
+
+            var type = compilation.GetTypeByMetadataName("C");
+            var field = type.GetMembers("F").Single();
+
+            VerifySyntax<FieldDeclarationSyntax>(
+                Generator.Declaration(field),
+                "public const global::System.Decimal F = 8675309000000M;");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69380")]
+        public void TestConstantFieldDeclarationSpecialTypes()
+        {
+            var field = _emptyCompilation.GetSpecialType(SpecialType.System_UInt32).GetMembers(nameof(UInt32.MaxValue)).Single();
+
+            VerifySyntax<FieldDeclarationSyntax>(
+                Generator.Declaration(field),
+                "public const global::System.UInt32 MaxValue = 4294967295U;");
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66374")]
         public void TestDestructor1()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/LiteralSpecialValues.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/LiteralSpecialValues.cs
@@ -12,6 +12,27 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     /// </summary>
     internal static class LiteralSpecialValues
     {
+        // Keep in sync with special values below.
+        public static bool HasSpecialValues(SpecialType specialType)
+        {
+            switch (specialType)
+            {
+                case SpecialType.System_SByte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                case SpecialType.System_Decimal:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         // Let's not have special values for byte. byte.MaxValue seems overkill versus 255.
         public static readonly IEnumerable<KeyValuePair<byte, string>> ByteSpecialValues = new Dictionary<byte, string>();
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -762,6 +762,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function FieldDeclaration(name As String, type As SyntaxNode, Optional accessibility As Accessibility = Nothing, Optional modifiers As DeclarationModifiers = Nothing, Optional initializer As SyntaxNode = Nothing) As SyntaxNode
+            modifiers = If(modifiers.IsConst(), modifiers.WithIsReadOnly(False), modifiers)
             Return SyntaxFactory.FieldDeclaration(
                 attributeLists:=Nothing,
                 modifiers:=GetModifierList(accessibility, modifiers And s_fieldModifiers, declaration:=Nothing, DeclarationKind.Field),

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2431,6 +2431,33 @@ End Class"))
 End Sub")
         End Sub
 
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69376")>
+        Public Sub TestConstantDecimalFieldDeclarationFromMetadata()
+            Dim compilation = _emptyCompilation.
+                WithOptions(New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)).
+                AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree(
+"Class C
+    Public Const F As Decimal = 8675309000000 
+End Class"))
+            Dim reference = compilation.EmitToPortableExecutableReference()
+
+            compilation = _emptyCompilation.AddReferences(reference)
+
+            Dim type = compilation.GetTypeByMetadataName("C")
+            Dim field = type.GetMembers("F").Single()
+
+            VerifySyntax(Of FieldDeclarationSyntax)(Generator.Declaration(field),
+                "Public Const F As System.Decimal = 8675309000000D")
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69380")>
+        Public Sub TestConstantFieldDeclarationSpecialTypes()
+            Dim field = _emptyCompilation.GetSpecialType(SpecialType.System_UInt32).GetMembers(NameOf(UInt32.MaxValue)).Single()
+
+            VerifySyntax(Of FieldDeclarationSyntax)(Generator.Declaration(field),
+                "Public Const MaxValue As System.UInt32 = 4294967295UI")
+        End Sub
+
 #End Region
 
 #Region "Add/Insert/Remove/Get/Set members & elements"


### PR DESCRIPTION
Fixes: #69380
Works-around: #69376

Handle decimal constants when read from metadata - they'll appear as both IsConst and IsReadOnly -- ignore readonly.

Don't reference special values constants when defining those constants.

@CyrusNajmabadi 