### PR TITLE
Do not use cached CompilationWithAnalyzers which don't contain all an…

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -151,7 +151,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return null;
                     }
 
-                    if (((WorkspaceAnalyzerOptions)projectAndCompilationWithAnalyzers.CompilationWithAnalyzers.AnalysisOptions.Options!).IdeOptions == ideOptions)
+                    if (((WorkspaceAnalyzerOptions)projectAndCompilationWithAnalyzers.CompilationWithAnalyzers.AnalysisOptions.Options!).IdeOptions == ideOptions
+                        && HasAllAnalyzers(stateSets, projectAndCompilationWithAnalyzers.CompilationWithAnalyzers))
                     {
                         return projectAndCompilationWithAnalyzers.CompilationWithAnalyzers;
                     }
@@ -160,6 +161,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var compilationWithAnalyzers = await CreateCompilationWithAnalyzersAsync(project, ideOptions, stateSets, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
                 _lastProjectAndCompilationWithAnalyzers.SetTarget(new ProjectAndCompilationWithAnalyzers(project, compilationWithAnalyzers));
                 return compilationWithAnalyzers;
+
+                static bool HasAllAnalyzers(IEnumerable<StateSet> stateSets, CompilationWithAnalyzers compilationWithAnalyzers)
+                {
+                    foreach (var stateSet in stateSets)
+                    {
+                        if (!compilationWithAnalyzers.Analyzers.Contains(stateSet.Analyzer))
+                            return false;
+                    }
+
+                    return true;
+                }
             }
 
             private LatestDiagnosticsForSpanGetter(


### PR DESCRIPTION
…alyzers to be analyzed

Fixes https://github.com/dotnet/vscode-csharp/issues/6057

We were not accounting for the fact that changing the background analysis scope option can increase the set of analyzers to analyze (when option value is changed from None to OpenFiles or FullSolution). Hence we ended up using a cached CompilationWithAnalyzers instance which only had compiler analyzer instance, causing the given ArgumentException.