### PR TITLE
Fix CodeStylePage EditorConfigOptionsGenerator service 

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/CodeStylePage.cs
@@ -5,16 +5,11 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.EditorConfig;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 {
@@ -23,7 +18,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
     {
         protected override AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider, OptionStore optionStore)
         {
-            var editorService = (EditorConfigOptionsGenerator)serviceProvider.GetService(typeof(EditorConfigOptionsGenerator));
+            var editorService = serviceProvider.GetMefService<EditorConfigOptionsGenerator>();
+
             return new GridOptionPreviewControl(
                 serviceProvider,
                 optionStore,

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -2,14 +2,9 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Options.EditorConfig
-Imports Microsoft.CodeAnalysis.PooledObjects
-Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
-Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/Formatting/CodeStylePage.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
     <Guid(Guids.VisualBasicOptionPageCodeStyleIdString)>
@@ -18,7 +19,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options.Formatting
         Inherits AbstractOptionPage
 
         Protected Overrides Function CreateOptionPage(serviceProvider As IServiceProvider, optionStore As OptionStore) As AbstractOptionPageControl
-            Dim editorService = DirectCast(serviceProvider.GetService(GetType(EditorConfigOptionsGenerator)), EditorConfigOptionsGenerator)
+            Dim editorService = serviceProvider.GetMefService(Of EditorConfigOptionsGenerator)()
             Return New GridOptionPreviewControl(serviceProvider,
                                                 optionStore,
                                                 Function(o, s) New StyleViewModel(o, s),


### PR DESCRIPTION
Fix the Code style options page for C# and VB. 

![image](https://github.com/dotnet/roslyn/assets/9122518/c677eb39-ad9a-4e33-93fb-b1712009d700)
