### PR TITLE
Avoid boxing when structs are used as collection keys.

### DIFF
--- a/src/Features/Core/Portable/DocumentHighlighting/IDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IDocumentHighlightsService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
     }
 
     [DataContract]
-    internal readonly struct HighlightSpan
+    internal readonly record struct HighlightSpan
     {
         [DataMember(Order = 0)]
         public TextSpan TextSpan { get; }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
@@ -63,11 +62,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 => Name + ", " + ParentIndex;
         }
 
-        private readonly struct ParameterTypeInfo(string name, bool isComplex, bool isArray)
+        private readonly record struct ParameterTypeInfo(string name, bool isComplex, bool isArray)
         {
             /// <summary>
             /// This is the type name of the parameter when <see cref="IsComplexType"/> is false. 
-            /// For array types, this is just the elemtent type name.
+            /// For array types, this is just the element type name.
             /// e.g. `int` for `int[][,]` 
             /// </summary>
             public readonly string Name = name;
@@ -96,11 +95,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public readonly bool IsComplexType = isComplex;
         }
 
-        public readonly struct ExtensionMethodInfo(string fullyQualifiedContainerName, string name)
+        public readonly record struct ExtensionMethodInfo(string fullyQualifiedContainerName, string name)
         {
             /// <summary>
             /// Name of the extension method. 
-            /// This can be used to retrive corresponding symbols via <see cref="INamespaceOrTypeSymbol.GetMembers(string)"/>
+            /// This can be used to retrieve corresponding symbols via <see cref="INamespaceOrTypeSymbol.GetMembers(string)"/>
             /// </summary>
             public readonly string Name = name;
 


### PR DESCRIPTION
Change several structs to record structs such that they no longer are boxed when used as keys in MultiDictionary's internal ImmutableHashSet. When MultiDictionary's value is a struct and is created without specifying the value's IEqualityComparer, the default struct comparer is used. This equality comparer is notoriously slow due to boxing. By switching these structs to record structs, an implementation of IEquatable is generated and the default struct equality comparer isn't used.

Addresses https://github.com/dotnet/roslyn/issues/69165

Sam mentioned that there is an issue already logged in the roslyn-analyzers repo around adding an analyzer to detect this.

https://github.com/dotnet/roslyn-analyzers/issues/1640