### PR TITLE
Improve de-duping of project load failure toasts

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -182,7 +182,7 @@ internal sealed class LanguageServerProjectSystem
                     if (errorKind is not null)
                     {
                         // We should display a toast when the value of displayedToast is 0.  This will also update the value to 1 meaning we won't send any more toasts.
-                        var shouldShowToast = Interlocked.CompareExchange(ref displayedToast, 1, 0) == 0;
+                        var shouldShowToast = Interlocked.CompareExchange(ref displayedToast, value: 1, comparand: 0) == 0;
                         if (shouldShowToast)
                         {
                             var message = string.Format(LanguageServerResources.There_were_problems_loading_project_0_See_log_for_details, Path.GetFileName(projectPathToLoadOrReload));


### PR DESCRIPTION
I discovered that the de-duping on the vscode side of notifications is not quite good enough for this scenario.  While vscode does only show a max of 3 notifications at once - if the projects load slowly enough the 3 toasts will keep getting replaced by new ones after they are dismissed.

Instead, we now only show 1 toast for a single call to sln/projects loading no matter how many load failures there are.  The logs will still contain the full list load failures.  Additionally, we do not wait for all the projects to load to show a failure as that can take some time.  We always display the first error we hit.

e.g. in roslyn you can see there are many project load failures.  We end up showing just the first one we find.

<img width="1361" alt="image" src="https://github.com/dotnet/roslyn/assets/5749229/b2b55ab8-ef5e-4c57-afb4-c955770cd1bf">
