### PR TITLE
Don't treat user-defined casts as constants in analyzers for "use pattern matching" and "convert if to switch"

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
         private static bool IsConstant(IOperation operation)
         {
             // By-design, constants will not propagate to conversions.
-            return operation is IConversionOperation { Conversion.IsUserDefined: false) op
+            return operation is IConversionOperation { Conversion.IsUserDefined: false } op
                 ? IsConstant(op.Operand)
                 : operation.ConstantValue.HasValue;
         }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
@@ -159,8 +159,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
         private static bool IsConstant(IOperation operation)
         {
             // By-design, constants will not propagate to conversions.
-            return operation is IConversionOperation op
-                ? !op.Conversion.IsUserDefined && IsConstant(op.Operand)
+            return operation is IConversionOperation { Conversion.IsUserDefined: false) op
+                ? IsConstant(op.Operand)
                 : operation.ConstantValue.HasValue;
         }
     }

--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsAnalyzer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
         {
             // By-design, constants will not propagate to conversions.
             return operation is IConversionOperation op
-                ? IsConstant(op.Operand)
+                ? !op.Conversion.IsUserDefined && IsConstant(op.Operand)
                 : operation.ConstantValue.HasValue;
         }
     }

--- a/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternCombinators
                 """);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66787")]
         public async Task TestConvertedConstants()
         {
             await TestAllAsync(
@@ -421,7 +421,7 @@ public class C
 }}");
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66787")]
         public async Task TestMissingForImplicitUserDefinedCasts1()
         {
             await TestMissingAsync(
@@ -439,7 +439,7 @@ public class C
                 """);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66787")]
         public async Task TestMissingForImplicitUserDefinedCasts2()
         {
             await TestMissingAsync(

--- a/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/Features/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -259,6 +259,30 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternCombinators
         }
 
         [Fact]
+        public async Task TestConvertedConstants()
+        {
+            await TestAllAsync(
+                """
+                class C
+                {
+                    bool M(long l)
+                    {
+                        return {|FixAllInDocument:(l > int.MaxValue || l < int.MinValue)|};
+                    }
+                }
+                """,
+                """
+                class C
+                {
+                    bool M(long l)
+                    {
+                        return (l is > int.MaxValue or < int.MinValue);
+                    }
+                }
+                """);
+        }
+
+        [Fact]
         public async Task TestMissingInExpressionTree()
         {
             await TestMissingAsync(
@@ -395,6 +419,42 @@ public class C
         return count == 1 [|{logicalOperator}|] ch[0] == 'S';
     }}
 }}");
+        }
+
+        [Fact]
+        public async Task TestMissingForImplicitUserDefinedCasts1()
+        {
+            await TestMissingAsync(
+                """
+                using System;
+                class C
+                {
+                    void M0(Int128 i)
+                    {
+                        if (i == int.MaxValue [||] i == int.MinValue)
+                        {
+                        }
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestMissingForImplicitUserDefinedCasts2()
+        {
+            await TestMissingAsync(
+                """
+                using System;
+                class C
+                {
+                    void M0(Int128 i)
+                    {
+                        if (i > int.MaxValue [||] i < int.MinValue)
+                        {
+                        }
+                    }
+                }
+                """);
         }
 
         [Fact]

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
@@ -434,8 +434,8 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             private static bool IsConstant(IOperation operation)
             {
                 // Constants do not propagate to conversions
-                return operation is IConversionOperation op
-                    ? !op.Conversion.IsUserDefined && IsConstant(op.Operand)
+                return operation is IConversionOperation { Conversion.IsUserDefined: false } op
+                    ? IsConstant(op.Operand)
                     : operation.ConstantValue.HasValue;
             }
 

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             {
                 // Constants do not propagate to conversions
                 return operation is IConversionOperation op
-                    ? IsConstant(op.Operand)
+                    ? !op.Conversion.IsUserDefined && IsConstant(op.Operand)
                     : operation.ConstantValue.HasValue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66787 by treating user-defined conversion operations as being non-constant.