### PR TITLE
Consolidate rude edit reporting

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using System.Linq;
+using Microsoft.VisualStudio.Settings;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
@@ -746,7 +747,7 @@ namespace N
 
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, "", GetResource("class", "N.C")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "N.C.Main()")));
         }
 
         [Fact]
@@ -770,7 +771,7 @@ namespace N
 
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, "namespace N", GetResource("class", "C")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method", "Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method","N.C.Main()")));
         }
 
         [Fact]
@@ -2600,7 +2601,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1", FeaturesResources.const_field));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1", GetResource("field")));
         }
 
         [Fact]
@@ -2650,8 +2651,8 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1, b = 2", FeaturesResources.const_field),
-                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1, b = 2", FeaturesResources.const_field));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1, b = 2", GetResource("field")),
+                Diagnostic(RudeEditKind.ModifiersUpdate, "const int a = 1, b = 2", GetResource("field")));
         }
 
         [Fact]
@@ -9760,7 +9761,8 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "F(b);", CSharpFeaturesResources.lambda));
+                Diagnostic(RudeEditKind.ChangingLambdaReturnType, "b", GetResource("lambda")),
+                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "F(b);", GetResource("lambda")));
         }
 
         [Fact]
@@ -11576,8 +11578,31 @@ class C
                         }),
                     DocumentResults(
                         activeStatements: GetActiveStatements(srcB1, srcB2, documentIndex: 1),
-                        // TODO: this is odd AS location https://github.com/dotnet/roslyn/issues/54758
-                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "      partial c", DeletedSymbolDisplay(FeaturesResources.method, "F()")) })
+                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "partial class C", GetResource("method", "F()")) })
+                });
+        }
+
+        [Fact]
+        public void InsertDeleteMethod_Active_EntirePartialTypeDeclaration()
+        {
+            var srcA1 = "partial class C { }";
+            var srcB1 = "partial class C { void F() { <AS:0>System.Console.WriteLine(1);</AS:0> } }";
+            var srcA2 = "partial class C { void F() { System.Console.WriteLine(1); } }";
+            var srcB2 = "<AS:0/>";
+
+            EditAndContinueValidation.VerifySemantics(
+                new[] { GetTopEdits(srcA1, srcA2, documentIndex: 0), GetTopEdits(srcB1, srcB2, documentIndex: 1) },
+                new[]
+                {
+                    DocumentResults(
+                        activeStatements: GetActiveStatements(srcA1, srcA2, documentIndex: 0),
+                        semanticEdits: new[]
+                        {
+                            SemanticEdit(SemanticEditKind.Update, c => c.GetMember<INamedTypeSymbol>("C").GetMember("F")),
+                        }),
+                    DocumentResults(
+                        activeStatements: GetActiveStatements(srcB1, srcB2, documentIndex: 1),
+                        diagnostics: new[] { Diagnostic(RudeEditKind.DeleteActiveStatement, "", GetResource("method", "C.F()")) })
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -771,7 +771,7 @@ namespace N
 
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, "namespace N", GetResource("class", "C")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method","N.C.Main()")));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "namespace N", GetResource("method", "N.C.Main()")));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/EditingTestBase.cs
@@ -61,6 +61,7 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
             => keyword switch
             {
                 "enum" => FeaturesResources.enum_,
+                "enum value" => FeaturesResources.enum_value,
                 "class" => FeaturesResources.class_,
                 "interface" => FeaturesResources.interface_,
                 "delegate" => FeaturesResources.delegate_,
@@ -70,6 +71,7 @@ namespace System.Runtime.CompilerServices { class CreateNewOnMetadataUpdateAttri
                 "static constructor" => FeaturesResources.static_constructor,
                 "constructor" => FeaturesResources.constructor,
                 "field" => FeaturesResources.field,
+                "const field" => FeaturesResources.const_field,
                 "method" => FeaturesResources.method,
                 "property" => FeaturesResources.property_,
                 "property getter" => CSharpFeaturesResources.property_getter,

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/LineEditTests.cs
@@ -659,13 +659,13 @@ class C
             var edits = GetTopEdits(src1, src2);
             edits.VerifyLineEdits(
                 Array.Empty<SequencePointUpdates>(),
-                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
+                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc bool[64]", GetResource("method")) });
 
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(
                 active,
-                new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
+                new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc bool[64]", GetResource("method")) });
         }
 
         [Fact]
@@ -694,7 +694,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             edits.VerifyLineEdits(
                 Array.Empty<SequencePointUpdates>(),
-                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("method")) });
+                diagnostics: new[] { Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc bool[64]", GetResource("method")) });
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -2003,9 +2003,9 @@ foreach (var (a, b) in e1) { }
             GetTopEdits(edits).VerifySemanticDiagnostics(
                 new[]
                 {
-                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", FeaturesResources.method),
-                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", FeaturesResources.method),
-                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", FeaturesResources.parameter)
+                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", GetResource("lambda")),
+                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", GetResource("lambda")),
+                    Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "([A]a)", GetResource("parameter"))
                 },
                 capabilities: EditAndContinueCapabilities.Baseline);
 
@@ -6179,7 +6179,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("lambda")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[20]", GetResource("lambda")));
         }
 
         [Fact]
@@ -6201,7 +6201,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("lambda")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", GetResource("lambda")));
         }
 
         [Fact]
@@ -6647,7 +6647,7 @@ class C
 
             // To be removed when we will enable EnC for local functions
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, "localF", CSharpFeaturesResources.local_function));
+                Diagnostic(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, "localF"));
         }
 
         [Fact]
@@ -6684,7 +6684,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, "a", CSharpFeaturesResources.lambda));
+                Diagnostic(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, "a"));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/21499")]
@@ -9183,7 +9183,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("local function")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[20]", GetResource("local function")));
         }
 
         [Fact]
@@ -9216,7 +9216,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("local function")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", GetResource("local function")));
         }
 
         [Fact]
@@ -10872,10 +10872,10 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("where clause")),
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("select clause")),
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("groupby clause")),
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("groupby clause")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", GetResource("where clause")),
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[40]", GetResource("select clause")),
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[20]", GetResource("groupby clause")),
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[30]", GetResource("groupby clause")));
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -1337,7 +1337,7 @@ public class A3 : System.Attribute { }
                 "Update [" + keyword + " C { }]@0 -> [" + keyword + " D { }]@0");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, keyword + " D", GetResource(keyword)));
+                Diagnostic(RudeEditKind.Renamed, keyword + " D", GetResource(keyword, "C")));
         }
 
         [Fact]
@@ -1357,7 +1357,7 @@ public class A3 : System.Attribute { }
                 "Delete [x = 1]@14");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "class D", FeaturesResources.class_));
+                Diagnostic(RudeEditKind.Renamed, "class D", GetResource("class", "C")));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54886")]
@@ -1373,7 +1373,7 @@ public class A3 : System.Attribute { }
 
             // TODO: expected: Replace edit of D
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "class D", FeaturesResources.class_));
+                Diagnostic(RudeEditKind.Renamed, "class D", GetResource("class", "C")));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54886")]
@@ -1394,7 +1394,7 @@ public class A3 : System.Attribute { }
 
             // TODO: expected: Replace edit of D
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "class D", FeaturesResources.class_));
+                Diagnostic(RudeEditKind.Renamed, "class D", GetResource("class", "C")));
         }
 
         [Fact]
@@ -2890,7 +2890,7 @@ class C
                 "Update [record C { }]@0 -> [record D { }]@0");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "record D", CSharpFeaturesResources.record_));
+                Diagnostic(RudeEditKind.Renamed, "record D", GetResource("record", "C")));
         }
 
         [Fact]
@@ -3165,10 +3165,10 @@ protected virtual bool PrintMembers(System.Text.StringBuilder sb) => false;
         }
 
         [Theory]
-        [InlineData("Equals", "public virtual bool Equals(C rhs) => true;", "Equals(C other)", "other")]
-        [InlineData("PrintMembers", "protected virtual bool PrintMembers(System.Text.StringBuilder sb) => true;", "PrintMembers(StringBuilder builder)", "builder")]
-        [InlineData("Deconstruct", "public void Deconstruct(out int Y) { Y = 1; }", "Deconstruct(out int X)", "X")]
-        [InlineData(".ctor", "protected C(C other) {}", "C(C original)", "original")]
+        [InlineData("Equals", "public virtual bool Equals(C rhs) => true;", "Equals(C rhs)", "rhs")]
+        [InlineData("PrintMembers", "protected virtual bool PrintMembers(System.Text.StringBuilder sb) => true;", "PrintMembers(StringBuilder sb)", "sb")]
+        [InlineData("Deconstruct", "public void Deconstruct(out int Y) { Y = 1; }", "Deconstruct(out int Y)", "Y")]
+        [InlineData(".ctor", "protected C(C other) {}", "C(C other)", "other")]
         public void Record_Method_Delete_ReplacingSynthesizedWithCustom_ParameterNameChanges(string methodName, string methodImpl, string methodDisplay, string parameterDisplay)
         {
             var src1 = "record C(int X) { " + methodImpl + " }";
@@ -3540,7 +3540,7 @@ record C(int X)
 
             // synthesized setter is writable in non-readonly struct
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessorKindUpdate, "record struct C", GetResource("property setter", "X.init")));
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "record struct C"));
         }
 
         [Fact]
@@ -3718,7 +3718,7 @@ record C(int X)
                 capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int P", GetResource("property")) },
+                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int P", GetResource("auto-property")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -3848,7 +3848,7 @@ record C(int X)
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessorKindUpdate, "set", GetResource("property setter")));
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "set"));
         }
 
         [Fact]
@@ -4081,7 +4081,7 @@ record C(int X)
                 capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "public int P", GetResource("property")) },
+                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "public int P", GetResource("auto-property")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -4280,7 +4280,7 @@ record C(int X)
                 "Update [enum Color { Red = 1, Blue = 2, }]@0 -> [enum Colors { Red = 1, Blue = 2, }]@0");
 
             edits.VerifySemanticDiagnostics(
-                 Diagnostic(RudeEditKind.Renamed, "enum Colors", FeaturesResources.enum_));
+                 Diagnostic(RudeEditKind.Renamed, "enum Colors", GetResource("enum", "Color")));
         }
 
         [Fact]
@@ -4522,7 +4522,7 @@ record C(int X)
                 "Update [Red]@13 -> [Orange]@13");
 
             edits.VerifySemanticDiagnostics(
-                 Diagnostic(RudeEditKind.Renamed, "Orange", FeaturesResources.enum_value));
+                 Diagnostic(RudeEditKind.Renamed, "Orange", GetResource("enum value", "Red")));
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/754916")]
@@ -4712,7 +4712,7 @@ record C(int X)
                 "Update [public delegate void D();]@0 -> [public delegate void Z();]@0");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "public delegate void Z()", FeaturesResources.delegate_));
+                Diagnostic(RudeEditKind.Renamed, "public delegate void Z()", GetResource("delegate", "D")));
         }
 
         [Fact]
@@ -4822,7 +4822,7 @@ record C(int X)
                 "Update [int a]@22 -> [int b]@22");
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", GetResource("parameter", "int b")) },
+                new[] { Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "int b", GetResource("parameter")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
 
             edits.VerifySemantics(
@@ -4846,7 +4846,7 @@ record C(int X)
                 "Update [int a]@22 -> [byte a]@22");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "byte a", GetResource("parameter", "byte a")));
+                Diagnostic(RudeEditKind.TypeUpdate, "byte a", GetResource("parameter")));
         }
 
         [Fact]
@@ -4872,7 +4872,7 @@ record C(int X)
                 capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int a", GetResource("parameter", "int a")) },
+                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int a", GetResource("parameter")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -4933,7 +4933,7 @@ record C(int X)
                 "Update [T]@22 -> [S]@22");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "S", FeaturesResources.type_parameter));
+                Diagnostic(RudeEditKind.Renamed, "S", GetResource("type parameter", "T")));
         }
 
         [Fact]
@@ -5102,7 +5102,7 @@ record C(int X)
                 "Update [int b]@22 -> [in int b]@22");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "in int b", GetResource("parameter", "in int b")));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "in int b", GetResource("parameter")));
         }
 
         [Fact]
@@ -5824,7 +5824,7 @@ class D<T>
                     DocumentResults(
                         diagnostics: new[]
                         {
-                            Diagnostic(RudeEditKind.InitializerUpdate, "int x = 2", GetResource("parameter", "int x"))
+                            Diagnostic(RudeEditKind.InitializerUpdate, "int x = 2", GetResource("parameter"))
                         }),
 
                     DocumentResults()
@@ -8651,7 +8651,7 @@ class C
                 $"Update [{modifier} void goo() {{ }}]@16 -> [{modifier} void boo() {{ }}]@16");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, $"{modifier} void boo()", FeaturesResources.method));
+                Diagnostic(RudeEditKind.Renamed, $"{modifier} void boo()", GetResource("method", "goo()")));
         }
 
         [Fact]
@@ -9249,25 +9249,34 @@ class C : I, J
         [Fact]
         public void MethodUpdate_ExplicitlyImplemented2()
         {
+            var interfaces = @"
+interface I { void Goo(); }
+interface J { void Goo(); }
+";
+
             var src1 = @"
 class C : I, J
 {
     void I.Goo() { Console.WriteLine(1); }
     void J.Goo() { Console.WriteLine(2); }
-}";
+}
+" + interfaces;
+
             var src2 = @"
 class C : I, J
 {
     void Goo() { Console.WriteLine(1); }
     void J.Goo() { Console.WriteLine(2); }
-}";
+}
+" + interfaces;
+
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyEdits(
                 "Update [void I.Goo() { Console.WriteLine(1); }]@25 -> [void Goo() { Console.WriteLine(1); }]@25");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "void Goo()", FeaturesResources.method));
+                Diagnostic(RudeEditKind.Renamed, "void Goo()", GetResource("method", "I.Goo()")));
         }
 
         [Fact]
@@ -9302,7 +9311,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.method));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc char[16]", FeaturesResources.method));
         }
 
         [Fact]
@@ -9336,7 +9345,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.method));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc char[16]", FeaturesResources.method));
         }
 
         [Fact]
@@ -10520,7 +10529,7 @@ class C
                 new[]
                 {
                     Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "int x", GetResource("parameter")),
-                    Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "int x", GetResource("property"))
+                    Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "int x", GetResource("auto-property"))
                 },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
@@ -11988,7 +11997,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[2]", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -12012,7 +12021,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[1]", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -12463,7 +12472,7 @@ partial class C
                     DocumentResults(
                         diagnostics: new[]
                         {
-                            Diagnostic(RudeEditKind.StackAllocUpdate, "partial class C", GetResource("constructor"))
+                            Diagnostic(RudeEditKind.StackAllocUpdate, "partial class C", GetResource("constructor", "C()"))
                         }),
                 });
         }
@@ -14558,7 +14567,7 @@ public class C
             edits.VerifySemanticDiagnostics(
                 new[]
                 {
-                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int a", GetResource("property")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int a", GetResource("auto-property")),
                     Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "class C<T>", GetResource("constructor", "C()")),
                 },
                 capabilities: EditAndContinueCapabilities.Baseline);
@@ -14583,7 +14592,7 @@ public class C
                 "Update [a = 1]@21 -> [a = 2]@21");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -14607,7 +14616,7 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("constructor")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[1]", GetResource("constructor")));
         }
 
         [Fact]
@@ -14631,7 +14640,7 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                 Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor")));
+                 Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor", "C()")));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37172")]
@@ -14657,8 +14666,8 @@ public class C
             // Note: One edit is for the initializer and the other for implicit constructor.
             // We don't attempt to avoid duplicates reported for different memebers.
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("auto-property")),
-                Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[20]", GetResource("auto-property")),
+                Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor", "C()")));
         }
 
         [Fact]
@@ -14673,7 +14682,7 @@ public class C
             // We don't attempt to avoid duplicates reported for different memebers.
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.StackAllocUpdate, "int a", GetResource("auto-property")),
-                Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "class C", GetResource("constructor", "C()")));
         }
 
         [Fact]
@@ -14685,7 +14694,7 @@ public class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("auto-property")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", GetResource("auto-property")));
         }
 
         [Fact]
@@ -14698,7 +14707,7 @@ public class C
 
             // TODO (tomat): diagnostic should point to the property initializer
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", FeaturesResources.constructor));
         }
 
         [Fact]
@@ -14722,7 +14731,7 @@ public class C
 
             // TODO (tomat): diagnostic should point to the property initializer
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[10]", FeaturesResources.constructor));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37172")]
@@ -15844,7 +15853,7 @@ partial class C
                 "Update [a = 0]@14 -> [b = 0]@14");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "b = 0", FeaturesResources.field));
+                Diagnostic(RudeEditKind.Renamed, "b = 0", GetResource("field", "a")));
         }
 
         [Fact]
@@ -15859,7 +15868,7 @@ partial class C
                 "Update [Action a;]@10 -> [event Action a;]@10");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.FieldKindUpdate, "event Action a", FeaturesResources.event_));
+                Diagnostic(RudeEditKind.FieldKindUpdate, "event Action a", GetResource("field")));
         }
 
         [Theory]
@@ -15886,7 +15895,7 @@ partial class C
             edits.VerifyEdits("Update [" + oldModifiers + "int F = 0;]@10 -> [" + newModifiers + "int F = 0;]@10");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "int F = 0", FeaturesResources.field));
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "int F = 0", GetResource(oldModifiers.Contains("const") ? "const field" : "field")));
         }
 
         [Fact]
@@ -17121,7 +17130,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "int J.P", FeaturesResources.property_));
+                Diagnostic(RudeEditKind.Renamed, "int J.P", GetResource("property", "I.P")));
         }
 
         [Fact]
@@ -17376,7 +17385,7 @@ class C
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "char P", FeaturesResources.property_) },
+                new[] { Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "char P", GetResource("auto-property")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -17420,7 +17429,7 @@ class C
                 capabilities: EditAndContinueCapabilities.ChangeCustomAttributes);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int P", FeaturesResources.property_) },
+                new[] { Diagnostic(RudeEditKind.ChangingAttributesNotSupportedByRuntime, "int P", GetResource("auto-property")) },
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
         }
 
@@ -17862,7 +17871,7 @@ class C
 
             // not allowed since it changes the backing field readonly-ness and the signature of the setter (modreq)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessorKindUpdate, "init", CSharpFeaturesResources.property_setter));
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "init"));
         }
 
         [Fact]
@@ -17878,7 +17887,7 @@ class C
 
             // not allowed since it changes the backing field readonly-ness and the signature of the setter (modreq)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessorKindUpdate, "set", CSharpFeaturesResources.property_setter));
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "set"));
         }
 
         [Fact]
@@ -17930,7 +17939,7 @@ class C
             edits.VerifyEdits("Update [get;]@18 -> [set;]@18");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.AccessorKindUpdate, "set", CSharpFeaturesResources.property_setter));
+                Diagnostic(RudeEditKind.AccessorKindUpdate, "set"));
         }
 
         [Fact]
@@ -18055,7 +18064,7 @@ class C
             edits.VerifySemanticDiagnostics(
                 new[]
                 {
-                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int P", GetResource("property")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int P", GetResource("auto-property")),
                     Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "int P", GetResource("property getter"))
                 },
                 capabilities: EditAndContinueCapabilities.Baseline);
@@ -18098,7 +18107,7 @@ class C
                 capabilities: EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType);
 
             edits.VerifySemanticDiagnostics(
-                new[] { Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "ref readonly int P", FeaturesResources.property_) },
+                new[] { Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "ref readonly int P", GetResource("auto-property")) },
                 capabilities: EditAndContinueCapabilities.Baseline);
         }
 
@@ -18713,7 +18722,7 @@ class C(int A, int B)
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "int J.this[int a]", CSharpFeaturesResources.indexer));
+                Diagnostic(RudeEditKind.Renamed, "int J.this[int a]", GetResource("indexer", "I.this[int a]")));
         }
 
         [Fact]
@@ -20625,7 +20634,7 @@ class C { static void M(string a) { } }
                 "Update [A]@8 -> [B]@8");
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter));
+                Diagnostic(RudeEditKind.Renamed, "B", GetResource("type parameter", "A")));
         }
 
         [Fact]
@@ -20657,7 +20666,7 @@ class C { static void M(string a) { } }
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter),
-                Diagnostic(RudeEditKind.Renamed, "C", FeaturesResources.type_parameter));
+                Diagnostic(RudeEditKind.Renamed, "C", GetResource("type parameter", "A")));
         }
 
         [Fact]
@@ -21121,7 +21130,7 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("top-level code")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[2]", GetResource("top-level code")));
         }
 
         [Fact]
@@ -21133,7 +21142,7 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("top-level code")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")));
         }
 
         [Fact]
@@ -21145,7 +21154,7 @@ Console.WriteLine(""Hello"");
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", GetResource("top-level code")));
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc int[3]", GetResource("top-level code")));
         }
 
         [Fact]

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -781,7 +781,7 @@ End Module
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifySemanticDiagnostics(active,
                 Diagnostic(RudeEditKind.Delete, Nothing, GetResource("Module", "Module1")),
-                Diagnostic(RudeEditKind.DeleteActiveStatement, Nothing, GetResource("method", "Main()")))
+                Diagnostic(RudeEditKind.DeleteActiveStatement, Nothing, GetResource("method", "Module1.Main()")))
         End Sub
 #End Region
 
@@ -2068,7 +2068,7 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1", GetResource("field")))
         End Sub
 
         <Fact>
@@ -2113,8 +2113,8 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1, b As Integer = 2", FeaturesResources.const_field),
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1, b As Integer = 2", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1, b As Integer = 2", GetResource("field")),
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Private Const a As Integer = 1, b As Integer = 2", GetResource("field")))
         End Sub
 
         <Fact>
@@ -4434,7 +4434,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ComplexQueryExpression, "Join", FeaturesResources.method))
+                Diagnostic(RudeEditKind.ComplexQueryExpression, "Join y In ys On       F()        Equals G()", FeaturesResources.method))
         End Sub
 
         <Fact>
@@ -4479,7 +4479,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ComplexQueryExpression, "Join", GetResource("Lambda")))
+                Diagnostic(RudeEditKind.ComplexQueryExpression, "Join y In ys On       F()        Equals G()", GetResource("Lambda")))
         End Sub
 #End Region
 
@@ -4631,7 +4631,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Function(b)", VBFeaturesResources.Lambda))
+                Diagnostic(RudeEditKind.ChangingLambdaReturnType, "Function(b)", GetResource("Lambda")),
+                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Function(b)", GetResource("Lambda")))
         End Sub
 
         <Fact>
@@ -4659,7 +4660,8 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Function(b)", VBFeaturesResources.Lambda))
+                Diagnostic(RudeEditKind.ChangingLambdaReturnType, "Function(b)", GetResource("Lambda")),
+                Diagnostic(RudeEditKind.ActiveStatementLambdaRemoved, "Function(b)", GetResource("Lambda")))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/EditingTestBase.vb
@@ -77,23 +77,29 @@ End Namespace
         End Function
 
         Public Shared Function TryGetResource(keyword As String) As String
-            Select Case keyword
-                Case "Enum"
+            Select Case keyword.ToLowerInvariant()
+                Case "enum"
                     Return FeaturesResources.enum_
-                Case "Class"
+                Case "enum value"
+                    Return FeaturesResources.enum_value
+                Case "class"
                     Return FeaturesResources.class_
-                Case "Structure"
+                Case "structure"
                     Return VBFeaturesResources.structure_
-                Case "Module"
+                Case "module"
                     Return VBFeaturesResources.module_
-                Case "Interface"
+                Case "interface"
                     Return FeaturesResources.interface_
-                Case "Delegate"
+                Case "delegate"
                     Return FeaturesResources.delegate_
-                Case "Lambda"
+                Case "lambda"
                     Return VBFeaturesResources.Lambda
+                Case "const field"
+                    Return FeaturesResources.const_field
                 Case "field"
                     Return FeaturesResources.field
+                Case "auto-property"
+                    Return FeaturesResources.auto_property
                 Case "property"
                     Return FeaturesResources.property_
                 Case "method"
@@ -106,7 +112,7 @@ End Namespace
                     Return FeaturesResources.parameter
                 Case "type parameter"
                     Return FeaturesResources.type_parameter
-                Case "WithEvents field"
+                Case "withevents field"
                     Return VBFeaturesResources.WithEvents_field
                 Case Else
                     Return Nothing

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -725,7 +725,7 @@ End Class
             edits.VerifyEdits("Update [" & keyword & " C]@0 -> [" & keyword & " c]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, keyword & " c", GetResource(keyword)))
+                Diagnostic(RudeEditKind.Renamed, keyword & " c", GetResource(keyword, "C")))
         End Sub
 
         <Fact>
@@ -739,7 +739,7 @@ End Class
                 "Update [Class C]@0 -> [Class D]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Class D", FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Renamed, "Class D", GetResource("Class", "C")))
         End Sub
 
         <Fact>
@@ -757,7 +757,7 @@ End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Class D", FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Renamed, "Class D", GetResource("Class", "C")))
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54886")>
@@ -775,7 +775,7 @@ End Class"
 
             ' TODO: expected: Replace edit of D
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Class D", FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Renamed, "Class D", GetResource("Class", "C")))
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/54886")>
@@ -796,7 +796,7 @@ End Class"
 
             ' TODO: expected: Replace edit of D
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Class D", FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Renamed, "Class D", GetResource("Class", "C")))
         End Sub
 
         <Fact>
@@ -880,7 +880,7 @@ End Class"
                 "Update [Interface C]@0 -> [Interface D]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Interface D", FeaturesResources.interface_))
+                Diagnostic(RudeEditKind.Renamed, "Interface D", GetResource("interface", "C")))
         End Sub
 
         <Fact>
@@ -889,7 +889,7 @@ End Class"
             Dim src2 = "Structure D : End Structure"
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifyEdits("Update [Structure C]@0 -> [Structure D]@0")
-            edits.VerifySemanticDiagnostics(Diagnostic(RudeEditKind.Renamed, "Structure D", VBFeaturesResources.structure_))
+            edits.VerifySemanticDiagnostics(Diagnostic(RudeEditKind.Renamed, "Structure D", GetResource("structure", "C")))
         End Sub
 
         <Fact>
@@ -902,7 +902,7 @@ End Class"
                 "Update [Class LongerName]@0 -> [Class LongerMame]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Class LongerMame", FeaturesResources.class_))
+                Diagnostic(RudeEditKind.Renamed, "Class LongerMame", GetResource("class", "LongerName")))
         End Sub
 
         <Fact>
@@ -2063,7 +2063,7 @@ End Class
                 "Update [Enum Color]@0 -> [Enum Colors]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Enum Colors", FeaturesResources.enum_))
+                Diagnostic(RudeEditKind.Renamed, "Enum Colors", GetResource("enum", "Color")))
         End Sub
 
         <Fact>
@@ -2305,7 +2305,7 @@ End Class
                 "Update [Red]@13 -> [Orange]@13")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Orange", FeaturesResources.enum_value))
+                Diagnostic(RudeEditKind.Renamed, "Orange", GetResource("enum value", "Red")))
         End Sub
 
         <Fact>
@@ -2362,7 +2362,7 @@ End Class
                 "Update [Public Delegate Sub D()]@0 -> [Public Delegate Sub Z()]@0")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Public Delegate Sub Z()", FeaturesResources.delegate_))
+                Diagnostic(RudeEditKind.Renamed, "Public Delegate Sub Z()", GetResource("delegate", "D")))
         End Sub
 
         <Fact>
@@ -2466,7 +2466,7 @@ End Class
                 "Delete [a]@27")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "Public Delegate Function D()", DeletedSymbolDisplay(FeaturesResources.parameter, "a As Integer")))
+                Diagnostic(RudeEditKind.Delete, "Public Delegate Function D()", GetResource("parameter", "a As Integer")))
         End Sub
 
         <Fact>
@@ -2479,7 +2479,7 @@ End Class
                 "Update [a]@27 -> [b]@27")
 
             edits.VerifySemanticDiagnostics(
-                {Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "Public Delegate Function D(b As Integer)", DeletedSymbolDisplay(FeaturesResources.parameter, "a As Integer"))},
+                {Diagnostic(RudeEditKind.RenamingNotSupportedByRuntime, "b", GetResource("parameter"))},
                 capabilities:=EditAndContinueCapabilities.Baseline)
 
             edits.VerifySemantics(
@@ -2502,7 +2502,7 @@ End Class
                 "Update [a As Integer]@27 -> [a As Byte]@27")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "Public Delegate Function D(a As Byte)", DeletedSymbolDisplay(FeaturesResources.parameter, "a As Integer")))
+                Diagnostic(RudeEditKind.TypeUpdate, "a As Byte", GetResource("parameter")))
         End Sub
 
         <Fact>
@@ -2572,7 +2572,7 @@ End Class
                 "Update [T]@30 -> [S]@30")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "S", FeaturesResources.type_parameter))
+                Diagnostic(RudeEditKind.Renamed, "S", GetResource("type parameter", "T")))
         End Sub
 
         <Fact>
@@ -4948,7 +4948,7 @@ End Class"
                 "Update [Sub Goo]@15 -> [Sub Bar]@15")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "Sub Bar", FeaturesResources.method))
+                Diagnostic(RudeEditKind.Renamed, "Sub Bar", GetResource("method", "Goo()")))
         End Sub
 
         <Fact>
@@ -5897,7 +5897,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Public Sub New()", FeaturesResources.constructor))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Public Sub New()", GetResource("shared constructor")))
         End Sub
 
         <Fact>
@@ -7163,7 +7163,8 @@ End Class
                 "Update [" & oldModifiers & "Dim F As Integer = 0]@10 -> [" & newModifiers & "Dim F As Integer = 0]@10")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "Dim F As Integer = 0", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, newModifiers + "Dim F As Integer = 0",
+                           GetResource(If(oldModifiers.Contains("Const"), "const field", "field"))))
         End Sub
 
         <Fact>
@@ -7176,7 +7177,7 @@ End Class
                 "Update [a]@14 -> [b]@14")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "b", FeaturesResources.field))
+                Diagnostic(RudeEditKind.Renamed, "b", GetResource("field", "a")))
         End Sub
 
         <Fact(Skip:="https://github.com/dotnet/roslyn/issues/51373"), WorkItem("https://github.com/dotnet/roslyn/issues/51373")>
@@ -7490,7 +7491,7 @@ End Class
                 "Update [Dim a As WE]@10 -> [WithEvents a As WE]@10")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "WithEvents a As WE", VBFeaturesResources.WithEvents_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "WithEvents a As WE", GetResource("field")))
         End Sub
 
         <Fact>
@@ -7503,7 +7504,7 @@ End Class
                 "Update [WithEvents a As WE]@10 -> [Dim a As WE]@10")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim a As WE", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim a As WE", GetResource("WithEvents field")))
         End Sub
 
         <Fact>
@@ -7599,8 +7600,8 @@ End Structure
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.InsertIntoStruct, "Private Event d As System.Action", FeaturesResources.event_, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "b", FeaturesResources.field, VBFeaturesResources.structure_),
-                Diagnostic(RudeEditKind.InsertIntoStruct, "c", FeaturesResources.field, VBFeaturesResources.structure_))
+                Diagnostic(RudeEditKind.InsertIntoStruct, "b As Integer", FeaturesResources.field, VBFeaturesResources.structure_),
+                Diagnostic(RudeEditKind.InsertIntoStruct, "c As Integer", FeaturesResources.field, VBFeaturesResources.structure_))
         End Sub
 
         <Fact>
@@ -7665,9 +7666,9 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7695,9 +7696,9 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c", FeaturesResources.field, FeaturesResources.class_),
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "c As Integer", FeaturesResources.field, FeaturesResources.class_),
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "d As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7729,7 +7730,7 @@ End Class
 
             ' TODO: We don't compare the ordering currently. We could allow this edit if the ordering is preserved.
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "b As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -7759,7 +7760,7 @@ End Class
 
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "a", FeaturesResources.field, FeaturesResources.class_))
+                Diagnostic(RudeEditKind.InsertIntoClassWithLayout, "a As Integer", FeaturesResources.field, FeaturesResources.class_))
         End Sub
 
         <Fact>
@@ -9163,7 +9164,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 {
-                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Property a", GetResource("property")),
+                    Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Property a", GetResource("auto-property")),
                     Diagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, "Class C(Of T)", GetResource("constructor", "New()"))
                 },
                 capabilities:=EditAndContinueCapabilities.Baseline)
@@ -9627,7 +9628,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim x As Integer = 0", FeaturesResources.field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Dim x As Integer = 0", GetResource("const field")))
         End Sub
 
         <Fact>
@@ -9637,7 +9638,7 @@ End Class
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Const x = 0", FeaturesResources.const_field))
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Const x = 0", GetResource("field")))
         End Sub
 
         <Fact>
@@ -11477,7 +11478,7 @@ End Class
                 "Update [A]@27 -> [B]@27")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter))
+                Diagnostic(RudeEditKind.Renamed, "B", GetResource("type parameter", "A")))
         End Sub
 
         <Fact>
@@ -11505,7 +11506,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter),
-                Diagnostic(RudeEditKind.Renamed, "C", FeaturesResources.type_parameter))
+                Diagnostic(RudeEditKind.Renamed, "C", GetResource("type parameter", "A")))
         End Sub
 #End Region
 
@@ -11577,7 +11578,7 @@ End Class
                 "Update [A]@11 -> [B]@11")
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "B", FeaturesResources.type_parameter))
+                Diagnostic(RudeEditKind.Renamed, "B", GetResource("type parameter", "A")))
         End Sub
 
         <Fact>
@@ -11605,7 +11606,7 @@ End Class
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.Move, "B", FeaturesResources.type_parameter),
-                Diagnostic(RudeEditKind.Renamed, "C", FeaturesResources.type_parameter))
+                Diagnostic(RudeEditKind.Renamed, "C", GetResource("type parameter", "A")))
         End Sub
 #End Region
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -983,9 +983,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 || ((BaseTypeDeclarationSyntax)syntaxRefs.Single().GetSyntax()).Modifiers.Any(SyntaxKind.PartialKeyword);
         }
 
-        protected override SyntaxNode GetSymbolDeclarationSyntax(ISymbol symbol, Func<ImmutableArray<SyntaxReference>, SyntaxReference> selector, CancellationToken cancellationToken)
+        protected override SyntaxNode? GetSymbolDeclarationSyntax(ISymbol symbol, Func<ImmutableArray<SyntaxReference>, SyntaxReference?> selector, CancellationToken cancellationToken)
         {
-            var syntax = selector(symbol.DeclaringSyntaxReferences).GetSyntax(cancellationToken);
+            var syntax = selector(symbol.DeclaringSyntaxReferences)?.GetSyntax(cancellationToken);
 
             // Use the parameter list to represent primary constructor declaration.
             return symbol.Kind == SymbolKind.Method && syntax is TypeDeclarationSyntax { ParameterList: { } parameterList } ? parameterList : syntax;
@@ -1817,6 +1817,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 MethodKind.Destructor => CSharpFeaturesResources.destructor,
                 MethodKind.Conversion => CSharpFeaturesResources.conversion_operator,
                 MethodKind.LocalFunction => FeaturesResources.local_function,
+                MethodKind.LambdaMethod => CSharpFeaturesResources.lambda,
+                MethodKind.Ordinary when symbol.Name == WellKnownMemberNames.TopLevelStatementsEntryPointMethodName => CSharpFeaturesResources.top_level_code,
                 _ => base.GetDisplayName(symbol)
             };
 
@@ -2553,7 +2555,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         internal override bool IsStateMachineMethod(SyntaxNode declaration)
             => SyntaxUtilities.IsAsyncDeclaration(declaration) || SyntaxUtilities.IsIterator(declaration);
 
-        internal override void ReportStateMachineSuspensionPointRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode)
+        internal override void ReportStateMachineSuspensionPointRudeEdits(DiagnosticContext diagnosticContext, SyntaxNode oldNode, SyntaxNode newNode)
         {
             if (newNode.IsKind(SyntaxKind.AwaitExpression) && oldNode.IsKind(SyntaxKind.AwaitExpression))
             {
@@ -2564,79 +2566,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 if (!SyntaxFactory.AreEquivalent(oldContainingStatementPart, newContainingStatementPart) &&
                     !HasNoSpilledState(newNode, newContainingStatementPart))
                 {
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.AwaitStatementUpdate, newContainingStatementPart.Span));
+                    diagnosticContext.Report(RudeEditKind.AwaitStatementUpdate, newContainingStatementPart.Span);
                 }
             }
-        }
-
-        internal override void ReportStateMachineSuspensionPointDeletedRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode deletedSuspensionPoint)
-        {
-            // Handle deletion of await keyword from await foreach statement.
-            if (deletedSuspensionPoint is CommonForEachStatementSyntax deletedForeachStatement &&
-                match.Matches.TryGetValue(deletedSuspensionPoint, out var newForEachStatement) &&
-                newForEachStatement is CommonForEachStatementSyntax &&
-                deletedForeachStatement.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.ChangingFromAsynchronousToSynchronous,
-                    GetDiagnosticSpan(newForEachStatement, EditKind.Update),
-                    newForEachStatement,
-                    new[] { GetDisplayName(newForEachStatement, EditKind.Update) }));
-
-                return;
-            }
-
-            // Handle deletion of await keyword from await using declaration.
-            if (deletedSuspensionPoint.IsKind(SyntaxKind.VariableDeclarator) &&
-                match.Matches.TryGetValue(deletedSuspensionPoint.Parent!.Parent!, out var newLocalDeclaration) &&
-                !((LocalDeclarationStatementSyntax)newLocalDeclaration).AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                diagnostics.Add(new RudeEditDiagnostic(
-                        RudeEditKind.ChangingFromAsynchronousToSynchronous,
-                        GetDiagnosticSpan(newLocalDeclaration, EditKind.Update),
-                        newLocalDeclaration,
-                        new[] { GetDisplayName(newLocalDeclaration, EditKind.Update) }));
-
-                return;
-            }
-
-            base.ReportStateMachineSuspensionPointDeletedRudeEdit(diagnostics, match, deletedSuspensionPoint);
-        }
-
-        internal override void ReportStateMachineSuspensionPointInsertedRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode insertedSuspensionPoint, bool aroundActiveStatement)
-        {
-            // Handle addition of await keyword to foreach statement.
-            if (insertedSuspensionPoint is CommonForEachStatementSyntax insertedForEachStatement &&
-                match.ReverseMatches.TryGetValue(insertedSuspensionPoint, out var oldNode) &&
-                oldNode is CommonForEachStatementSyntax oldForEachStatement &&
-                !oldForEachStatement.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.Insert,
-                    insertedForEachStatement.AwaitKeyword.Span,
-                    insertedForEachStatement,
-                    new[] { insertedForEachStatement.AwaitKeyword.ToString() }));
-
-                return;
-            }
-
-            // Handle addition of using keyword to using declaration.
-            if (insertedSuspensionPoint.IsKind(SyntaxKind.VariableDeclarator) &&
-                match.ReverseMatches.TryGetValue(insertedSuspensionPoint.Parent!.Parent!, out var oldLocalDeclaration) &&
-                !((LocalDeclarationStatementSyntax)oldLocalDeclaration).AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                var newLocalDeclaration = (LocalDeclarationStatementSyntax)insertedSuspensionPoint!.Parent!.Parent!;
-
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.Insert,
-                    newLocalDeclaration.AwaitKeyword.Span,
-                    newLocalDeclaration,
-                    new[] { newLocalDeclaration.AwaitKeyword.ToString() }));
-
-                return;
-            }
-
-            base.ReportStateMachineSuspensionPointInsertedRudeEdit(diagnostics, match, insertedSuspensionPoint, aroundActiveStatement);
         }
 
         private static SyntaxNode FindContainingStatementPart(SyntaxNode node)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -5007,7 +5007,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
 
                 var newDiagnosticSymbol = newSymbol;
-                
                 if (newDiagnosticSymbol == null)
                 {
                     Debug.Assert(oldSymbol != null);
@@ -6288,7 +6287,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected abstract SyntaxNode? GetSymbolDeclarationSyntax(ISymbol symbol, Func<ImmutableArray<SyntaxReference>, SyntaxReference?> selector, CancellationToken cancellationToken);
 
         protected SyntaxNode GetSymbolDeclarationSyntax(ISymbol symbol, CancellationToken cancellationToken)
-            => GetSymbolDeclarationSyntax(symbol, selector: System.Linq.ImmutableArrayExtensions.First, cancellationToken);
+            => GetSymbolDeclarationSyntax(symbol, selector: System.Linq.ImmutableArrayExtensions.First, cancellationToken)!;
 
         protected abstract ISymbol? GetDeclaredSymbol(SemanticModel model, SyntaxNode declaration, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -230,28 +230,28 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         // display names:
 
-        internal string GetDisplayKindAndName(ISymbol symbol, string? displayName = null, bool fullyQualify = false)
+        internal string GetDisplayKindAndName(ISymbol symbol, string? displayKind = null, bool fullyQualify = false)
         {
-            displayName ??= GetDisplayName(symbol);
+            displayKind ??= GetDisplayKind(symbol);
             var format = fullyQualify ? s_fullyQualifiedMemberDisplayFormat : s_unqualifiedMemberDisplayFormat;
 
             return (symbol is IParameterSymbol { ContainingType: not { TypeKind: TypeKind.Delegate } })
                 ? string.Format(
                     FeaturesResources.symbol_kind_and_name_of_member_kind_and_name,
-                    displayName,
+                    displayKind,
                     symbol.Name,
-                    GetDisplayName(symbol.ContainingSymbol),
+                    GetDisplayKind(symbol.ContainingSymbol),
                     symbol.ContainingSymbol.ToDisplayString(format))
                 : string.Format(
                     FeaturesResources.member_kind_and_name,
-                    displayName,
+                    displayKind,
                     symbol.ToDisplayString(format));
         }
 
         internal string GetDisplayName(SyntaxNode node, EditKind editKind = EditKind.Update)
           => TryGetDisplayName(node, editKind) ?? throw ExceptionUtilities.UnexpectedValue(node.GetType().Name);
 
-        internal string GetDisplayName(ISymbol symbol)
+        internal string GetDisplayKind(ISymbol symbol)
             => symbol.Kind switch
             {
                 SymbolKind.Event => FeaturesResources.event_,
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             };
 
         internal virtual string GetDisplayName(IPropertySymbol symbol)
-            => FeaturesResources.property_;
+            => symbol.IsAutoProperty() ? FeaturesResources.auto_property : FeaturesResources.property_;
 
         internal virtual string GetDisplayName(INamedTypeSymbol symbol)
             => symbol.TypeKind switch
@@ -342,34 +342,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal abstract bool HasUnsupportedOperation(IEnumerable<SyntaxNode> newNodes, [NotNullWhen(true)] out SyntaxNode? unsupportedNode, out RudeEditKind rudeEdit);
 
-        private bool ReportUnsupportedOperations(ArrayBuilder<RudeEditDiagnostic> diagnostics, DeclarationBody newBody, SyntaxNode newDeclaration, SyntaxNode? diagnosticNode = null)
+        private bool ReportUnsupportedOperations(in DiagnosticContext diagnosticContext, DeclarationBody body, CancellationToken cancellationToken)
         {
-            if (HasUnsupportedOperation(newBody.GetDescendantNodes(IsNotLambda), out var unsupportedNode, out var rudeEdit))
+            if (HasUnsupportedOperation(body.GetDescendantNodes(IsNotLambda), out var unsupportedNode, out var rudeEdit))
             {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    rudeEdit,
-                    GetDiagnosticSpan(diagnosticNode ?? unsupportedNode, EditKind.Update),
-                    newDeclaration,
-                    arguments: new[] { GetDisplayName(newDeclaration, EditKind.Update) }));
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool ReportUnsupportedConstructorOperations(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newConstructor, DeclarationBody newBody, SyntaxTree newSyntaxTree, CancellationToken cancellationToken)
-        {
-            if (HasUnsupportedOperation(newBody.GetDescendantNodes(IsNotLambda), out var unsupportedNode, out var rudeEdit))
-            {
-                var diagnosticNode = GetSymbolDeclarationSyntax(newConstructor.IsImplicitlyDeclared ? newConstructor.ContainingType : newConstructor, cancellationToken);
-
-                diagnostics.Add(new RudeEditDiagnostic(
-                    rudeEdit,
-                    GetDiagnosticSpan((unsupportedNode.SyntaxTree == newSyntaxTree) ? unsupportedNode : diagnosticNode, EditKind.Update),
-                    diagnosticNode,
-                    arguments: new[] { GetDisplayName(newConstructor) }));
-
+                diagnosticContext.Report(rudeEdit, unsupportedNode, cancellationToken);
                 return true;
             }
 
@@ -386,7 +363,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             bool isNonLeaf);
 
         internal abstract void ReportInsertedMemberSymbolRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol newSymbol, SyntaxNode newNode, bool insertingIntoExistingContainingType);
-        internal abstract void ReportStateMachineSuspensionPointRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode);
+        internal abstract void ReportStateMachineSuspensionPointRudeEdits(DiagnosticContext diagnosticContext, SyntaxNode oldNode, SyntaxNode newNode);
 
         internal abstract Func<SyntaxNode, bool> IsLambda { get; }
         internal abstract Func<SyntaxNode, bool> IsNotLambda { get; }
@@ -897,6 +874,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Debug.Assert(newActiveStatements.Count == newExceptionRegions.Count);
             Debug.Assert(oldMemberBody != null || newMemberBody != null);
 
+            var diagnosticContext = CreateDiagnosticContext(diagnostics, oldMember, newMember, newDeclaration, newModel);
+
             syntaxMap = null;
             var activeStatementIndices = oldMemberBody?.GetOverlappingActiveStatements(oldActiveStatements) ?? Array.Empty<int>();
 
@@ -986,10 +965,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 var oldStateMachineInfo = oldMemberBody?.GetStateMachineInfo() ?? StateMachineInfo.None;
                 var newStateMachineInfo = newMemberBody?.GetStateMachineInfo() ?? StateMachineInfo.None;
-                ReportStateMachineBodyUpdateRudeEdits(bodyMap, oldStateMachineInfo, newDeclaration, newStateMachineInfo, hasActiveStatement: activeNodesInBody.Length != 0, diagnostics);
+
+                ReportStateMachineBodyUpdateRudeEdits(diagnosticContext, bodyMap, oldStateMachineInfo, newStateMachineInfo, hasActiveStatement: activeNodesInBody.Length != 0, cancellationToken);
 
                 ReportMemberOrLambdaBodyUpdateRudeEdits(
-                    diagnostics,
+                    diagnosticContext,
                     oldModel,
                     oldDeclaration,
                     oldMember,
@@ -1001,7 +981,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     newMemberBody,
                     capabilities,
                     oldStateMachineInfo,
-                    newStateMachineInfo);
+                    newStateMachineInfo,
+                    cancellationToken);
 
                 ReportLambdaAndClosureRudeEdits(
                     oldModel,
@@ -1437,12 +1418,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
              : BidirectionalMap<SyntaxNode>.Empty;
 
         private void ReportStateMachineBodyUpdateRudeEdits(
+            in DiagnosticContext diagnosticContext,
             BidirectionalMap<SyntaxNode> match,
             StateMachineInfo oldStateMachineInfo,
-            SyntaxNode newDeclaration,
             StateMachineInfo newStateMachineInfo,
             bool hasActiveStatement,
-            ArrayBuilder<RudeEditDiagnostic> diagnostics)
+            CancellationToken cancellationToken)
         {
             // Consider following cases:
             // 1) The new method contains yields/awaits but the old doesn't.
@@ -1455,7 +1436,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 foreach (var (oldNode, newNode) in match.Forward)
                 {
-                    ReportStateMachineSuspensionPointRudeEdits(diagnostics, oldNode, newNode);
+                    ReportStateMachineSuspensionPointRudeEdits(diagnosticContext, oldNode, newNode);
                 }
             }
 
@@ -1464,48 +1445,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // since the debugger does not support remapping active statements to a different method.
             if (hasActiveStatement && oldStateMachineInfo.IsStateMachine != newStateMachineInfo.IsStateMachine)
             {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement,
-                    GetDiagnosticSpan(newDeclaration, EditKind.Update)));
+                diagnosticContext.Report(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, cancellationToken, arguments: Array.Empty<string>());
             }
 
             // report removing async as rude:
             if (oldStateMachineInfo.IsAsync && !newStateMachineInfo.IsAsync)
             {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.ChangingFromAsynchronousToSynchronous,
-                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
-                    newDeclaration,
-                    new[] { GetDisplayName(newDeclaration) }));
+                diagnosticContext.Report(RudeEditKind.ChangingFromAsynchronousToSynchronous, cancellationToken);
             }
 
             // VB supports iterator lambdas/methods without yields
             if (oldStateMachineInfo.IsIterator && !newStateMachineInfo.IsIterator)
             {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.ModifiersUpdate,
-                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
-                    newDeclaration,
-                    new[] { GetDisplayName(newDeclaration) }));
+                diagnosticContext.Report(RudeEditKind.ModifiersUpdate, cancellationToken);
             }
-        }
-
-        internal virtual void ReportStateMachineSuspensionPointDeletedRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode deletedSuspensionPoint)
-        {
-            diagnostics.Add(new RudeEditDiagnostic(
-                RudeEditKind.Delete,
-                GetDeletedNodeDiagnosticSpan(match.Matches, deletedSuspensionPoint),
-                deletedSuspensionPoint,
-                new[] { GetSuspensionPointDisplayName(deletedSuspensionPoint, EditKind.Delete) }));
-        }
-
-        internal virtual void ReportStateMachineSuspensionPointInsertedRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode insertedSuspensionPoint, bool aroundActiveStatement)
-        {
-            diagnostics.Add(new RudeEditDiagnostic(
-                aroundActiveStatement ? RudeEditKind.InsertAroundActiveStatement : RudeEditKind.Insert,
-                GetDiagnosticSpan(insertedSuspensionPoint, EditKind.Insert),
-                insertedSuspensionPoint,
-                new[] { GetSuspensionPointDisplayName(insertedSuspensionPoint, EditKind.Insert) }));
         }
 
         private static List<KeyValuePair<SyntaxNode, SyntaxNode>>? GetMatchingActiveNodes(IEnumerable<ActiveNode> activeNodes)
@@ -2444,6 +2397,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 {
                                     // pick the first declaration in the new file that contains the namespace change:
                                     var newTypeDeclaration = GetSymbolDeclarationSyntax(newSymbol, refs => refs.First(r => r.SyntaxTree == edit.NewNode!.SyntaxTree), cancellationToken);
+                                    Debug.Assert(newTypeDeclaration != null);
 
                                     diagnostics.Add(new RudeEditDiagnostic(
                                         RudeEditKind.ChangingNamespace,
@@ -2453,7 +2407,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 }
                                 else
                                 {
-                                    ReportUpdateRudeEdit(diagnostics, RudeEditKind.Move, edit.NewNode!);
+                                    CreateDiagnosticContext(diagnostics, oldSymbol, newSymbol, edit.NewNode, newModel).
+                                        Report(RudeEditKind.Move, cancellationToken);
                                 }
                             }
 
@@ -2478,6 +2433,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         SemanticEditKind editKind;
 
                         var (oldDeclaration, newDeclaration) = GetSymbolDeclarationNodes(oldSymbol, newSymbol, edit.OldNode, edit.NewNode);
+
+                        var diagnosticContext = CreateDiagnosticContext(diagnostics, oldSymbol, newSymbol, edit.NewNode, newModel);
 
                         // The syntax change implies an update of the associated symbol but the old/new symbol does not actually exist.
                         // Treat the edit as Insert/Delete. This may happen e.g. when all C# global statements are removed, the first one is added or they are moved to another file.
@@ -2520,7 +2477,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                         }
                                         else
                                         {
-                                            ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, newContainingType, newDeclaration, cancellationToken);
+                                            CreateDiagnosticContext(diagnostics, oldContainingType, newContainingType, newDeclaration, newModel).
+                                                Report(RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, cancellationToken);
                                         }
                                     }
 
@@ -2528,30 +2486,27 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 }
                             }
 
-                            var oldType = oldSymbol as INamedTypeSymbol;
-                            var newType = newSymbol as INamedTypeSymbol;
-
                             // Deleting a reloadable type is a rude edit, reported the same as for non-reloadable.
                             // Adding a reloadable type is a standard type addition (TODO: unless added to a reloadable type?).
                             // Making reloadable attribute non-reloadable results in a new version of the type that is
                             // not reloadable but does not update the old version in-place.
-                            if (syntacticEditKind != EditKind.Delete && oldType != null && newType != null && IsReloadable(oldType))
+                            if (syntacticEditKind != EditKind.Delete && oldSymbol is INamedTypeSymbol oldType && newSymbol is INamedTypeSymbol newType && IsReloadable(oldType))
                             {
                                 if (symbol == newType || processedSymbols.Add(newType))
                                 {
                                     if (oldType.Name != newType.Name)
                                     {
                                         // https://github.com/dotnet/roslyn/issues/54886
-                                        ReportUpdateRudeEdit(diagnostics, RudeEditKind.Renamed, newType, newDeclaration, cancellationToken);
+                                        diagnosticContext.Report(RudeEditKind.Renamed, cancellationToken);
                                     }
                                     else if (oldType.Arity != newType.Arity)
                                     {
                                         // https://github.com/dotnet/roslyn/issues/54881
-                                        ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingTypeParameters, newType, newDeclaration, cancellationToken);
+                                        diagnosticContext.Report(RudeEditKind.ChangingTypeParameters, cancellationToken);
                                     }
                                     else if (!capabilities.Grant(EditAndContinueCapabilities.NewTypeDefinition))
                                     {
-                                        ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, newType, newDeclaration, cancellationToken);
+                                        diagnosticContext.Report(RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, cancellationToken);
                                     }
                                     else
                                     {
@@ -2789,7 +2744,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                         {
                                             if (!ParameterTypesEquivalent(oldDelegateInvoke.Parameters, newDelegateInvoke.Parameters, exact: false))
                                             {
-                                                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingParameterTypes, newSymbol, newDeclaration, cancellationToken);
+                                                diagnosticContext.Report(RudeEditKind.ChangingParameterTypes, cancellationToken);
                                             }
                                         }
 
@@ -2798,7 +2753,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                             Contract.ThrowIfNull(oldDeclaration);
 
                                             // Handles cases when a data member explicit declaration is moved, which may change the type layout
-                                            ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, newDeclaration, newModel);
+                                            ReportTypeLayoutUpdateRudeEdits(diagnosticContext);
 
                                             var oldBody = TryGetDeclarationBody(oldDeclaration, oldSymbol);
                                             var newBody = TryGetDeclarationBody(newDeclaration, newSymbol);
@@ -2837,7 +2792,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                             {
                                                 if (isDeclarationWithInitializer)
                                                 {
-                                                    AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                                                    AnalyzeSymbolUpdate(diagnosticContext, editScript.Match, capabilities, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
                                                 }
 
                                                 DeferConstructorEdit(oldSymbol.ContainingType, newContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic,
@@ -2919,7 +2874,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                         // Report rude edits for changes to data member changes of a type with an explicit layout.
                                         // We disallow moving a data member of a partial type with explicit layout even when it actually does not change the layout.
                                         // We could compare the exact order of the members but the scenario is unlikely to occur.
-                                        ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, newDeclaration, newModel);
+                                        ReportTypeLayoutUpdateRudeEdits(diagnosticContext);
 
                                         // If a property or field is inserted into a record the synthesized members may change
                                         // (PrintMembers print all properties and fields, Equals and GHC compare all data members, etc.)
@@ -3032,7 +2987,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     {
                                         if (isDeclarationWithInitializer)
                                         {
-                                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                                            AnalyzeSymbolUpdate(diagnosticContext, editScript.Match, capabilities, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
                                         }
 
                                         DeferConstructorEdit(oldSymbol.ContainingType, newSymbol.ContainingType, newDeclaration, syntaxMap, newSymbol.IsStatic,
@@ -3143,7 +3098,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                             if (newActiveStatementSpan.HasValue)
                             {
-                                ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newModel, RudeEditKind.DeleteActiveStatement, cancellationToken);
+                                diagnosticContext.Report(RudeEditKind.DeleteActiveStatement, cancellationToken);
                             }
                         }
 
@@ -3153,7 +3108,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         {
                             Contract.ThrowIfNull(oldSymbol);
 
-                            AnalyzeSymbolUpdate(oldSymbol, newSymbol, edit.NewNode, newModel, editScript.Match, capabilities, diagnostics, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
+                            AnalyzeSymbolUpdate(diagnosticContext, editScript.Match, capabilities, semanticEdits, syntaxMap, processedSymbols, cancellationToken);
 
                             if (newSymbol is INamedTypeSymbol or IFieldSymbol or IParameterSymbol or ITypeParameterSymbol)
                             {
@@ -3177,7 +3132,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 // For reordering of parameters we need to report insert and delete edits, but we also need to account for
                                 // renames if the runtime doesn't support it. We track this with a syntax node that we can use to report
                                 // the rude edit.
-                                IParameterSymbol? renamedParameter = null;
+                                var renamedParameterOrdinal = -1;
                                 for (var i = 0; i < oldMethod.Parameters.Length; i++)
                                 {
                                     var rudeEditKind = RudeEditKind.None;
@@ -3186,13 +3141,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     AnalyzeParameterType(oldMethod.Parameters[i], newMethod.Parameters[i], capabilities, ref rudeEditKind, ref unused, ref hasParameterTypeChange);
 
                                     createDeleteAndInsertEdits |= hasParameterTypeChange;
-                                    renamedParameter ??= oldMethod.Parameters[i].Name != newMethod.Parameters[i].Name ? newMethod.Parameters[i] : null;
+
+                                    if (renamedParameterOrdinal == -1 && oldMethod.Parameters[i].Name != newMethod.Parameters[i].Name)
+                                    {
+                                        renamedParameterOrdinal = i;
+                                    }
                                 }
 
-                                if (!createDeleteAndInsertEdits && renamedParameter is not null && !capabilities.Grant(EditAndContinueCapabilities.UpdateParameters))
+                                if (!createDeleteAndInsertEdits && renamedParameterOrdinal >= 0 && !capabilities.Grant(EditAndContinueCapabilities.UpdateParameters))
                                 {
-                                    processedSymbols.Add(renamedParameter);
-                                    ReportUpdateRudeEdit(diagnostics, RudeEditKind.RenamingNotSupportedByRuntime, renamedParameter, GetRudeEditDiagnosticNode(renamedParameter, cancellationToken), cancellationToken);
+                                    var newRenamedParameter = newMethod.Parameters[renamedParameterOrdinal];
+                                    var oldRenamedParameter = oldMethod.Parameters[renamedParameterOrdinal];
+                                    processedSymbols.Add(newRenamedParameter);
+
+                                    CreateDiagnosticContext(diagnostics, oldRenamedParameter, newRenamedParameter, newNode: null, newModel).
+                                        Report(RudeEditKind.RenamingNotSupportedByRuntime, cancellationToken);
                                     continue;
                                 }
                             }
@@ -3284,7 +3247,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 }
                                 else
                                 {
-                                    ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, newContainingType, newDeclaration, cancellationToken);
+                                    CreateDiagnosticContext(diagnostics, oldContainingType, newContainingType, newDeclaration, newModel)
+                                        .Report(RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime, cancellationToken);
                                 }
                             }
 
@@ -3308,7 +3272,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                         syntaxMap = isActiveMember ? CreateSyntaxMapForEquivalentNodes(oldBody, newBody) : null;
 
-                        ReportUnsupportedOperations(diagnostics, newBody, newDeclaration);
+                        var diagnosticContext = CreateDiagnosticContext(diagnostics, oldSymbol, newSymbol, newDeclaration, newModel);
+                        ReportUnsupportedOperations(diagnosticContext, newBody, cancellationToken);
 
                         var isConstructorWithMemberInitializers = IsConstructorWithMemberInitializers(newSymbol, cancellationToken);
                         var isDeclarationWithInitializer = IsDeclarationWithInitializer(newDeclaration);
@@ -3328,7 +3293,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         // updating generic methods and types
                         if (InGenericContext(oldSymbol) && !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
                         {
-                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, diagnosticSpan, newEditNode, new[] { GetDisplayName(newEditNode) }));
+                            diagnosticContext.Report(RudeEditKind.UpdatingGenericNotSupportedByRuntime, cancellationToken, diagnosticSpan);
                             continue;
                         }
 
@@ -3961,7 +3926,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         private void ReportMemberOrLambdaBodyUpdateRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
+            in DiagnosticContext diagnosticContext,
             SemanticModel? oldModel,
             SyntaxNode oldDeclaration,
             ISymbol oldMember,
@@ -3973,17 +3938,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             DeclarationBody? newBody,
             EditAndContinueCapabilitiesGrantor capabilities,
             StateMachineInfo oldStateMachineInfo,
-            StateMachineInfo newStateMachineInfo)
+            StateMachineInfo newStateMachineInfo,
+            CancellationToken cancellationToken)
         {
             // Report rude edit if an unsupported operations is found in the new or old body. 
             // Only report for the new body if both bodies have unsupported operations.
-            _ = newBody != null && ReportUnsupportedOperations(diagnostics, newBody, newDeclaration) ||
-                oldBody != null && ReportUnsupportedOperations(diagnostics, oldBody, newDeclaration, diagnosticNode: newDeclaration);
+            _ = newBody != null && ReportUnsupportedOperations(diagnosticContext, newBody, cancellationToken) ||
+                oldBody != null && ReportUnsupportedOperations(diagnosticContext, oldBody, cancellationToken);
 
             if (oldStateMachineInfo.IsStateMachine)
             {
                 Contract.ThrowIfNull(oldModel);
-                ReportMissingStateMachineAttribute(oldModel.Compilation, oldStateMachineInfo, newDeclaration, diagnostics);
+                ReportMissingStateMachineAttribute(diagnosticContext, oldModel.Compilation, oldStateMachineInfo, cancellationToken);
             }
 
             if (!oldStateMachineInfo.IsStateMachine &&
@@ -3993,14 +3959,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // Adding a state machine, either for async or iterator, will require creating a new helper class
                 // so is a rude edit if the runtime doesn't support it
                 var rudeEdit = newStateMachineInfo.IsAsync ? RudeEditKind.MakeMethodAsyncNotSupportedByRuntime : RudeEditKind.MakeMethodIteratorNotSupportedByRuntime;
-                diagnostics.Add(new RudeEditDiagnostic(rudeEdit, GetDiagnosticSpan(newDeclaration, EditKind.Update)));
+                diagnosticContext.Report(rudeEdit, cancellationToken, arguments: Array.Empty<string>());
             }
 
             if (oldStateMachineInfo.IsStateMachine && newStateMachineInfo.IsStateMachine)
             {
                 if (!capabilities.Grant(EditAndContinueCapabilities.AddInstanceFieldToExistingType))
                 {
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, GetDiagnosticSpan(newDeclaration, EditKind.Update)));
+                    diagnosticContext.Report(RudeEditKind.UpdatingStateMachineMethodNotSupportedByRuntime, cancellationToken, arguments: Array.Empty<string>());
                 }
 
                 if ((InGenericContext(oldMember) ||
@@ -4009,17 +3975,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                      newMemberBody != null && IsLambda(newDeclaration) && InGenericLocalContext(newDeclaration, newMemberBody.RootNodes)) &&
                     !capabilities.Grant(EditAndContinueCapabilities.GenericAddFieldToExistingType))
                 {
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, GetDiagnosticSpan(newDeclaration, EditKind.Update), newDeclaration, new[] { GetDisplayName(newDeclaration) }));
+                    diagnosticContext.Report(RudeEditKind.UpdatingGenericNotSupportedByRuntime, cancellationToken);
                 }
             }
         }
 
         private void ReportUpdatedSymbolDeclarationRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
-            ISymbol oldSymbol,
-            ISymbol newSymbol,
-            SyntaxNode? newNode,
-            SemanticModel newModel,
+            in DiagnosticContext diagnosticContext,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasGeneratedAttributeChange,
             out bool hasGeneratedReturnTypeAttributeChange,
@@ -4029,6 +3991,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             CancellationToken cancellationToken)
         {
             var rudeEdit = RudeEditKind.None;
+            var oldSymbol = diagnosticContext.RequiredOldSymbol;
+            var newSymbol = diagnosticContext.RequiredNewSymbol;
 
             hasGeneratedAttributeChange = false;
             hasGeneratedReturnTypeAttributeChange = false;
@@ -4212,8 +4176,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     }
                 }
 
-                // VB implements clause
-                if (!oldMethod.ExplicitInterfaceImplementations.SequenceEqual(newMethod.ExplicitInterfaceImplementations, SymbolsEquivalent))
+                // VB implements clause (the method name is the same, but interface implementations differ)
+                if (oldMethod.Name == newMethod.Name &&
+                    !oldMethod.ExplicitInterfaceImplementations.SequenceEqual(newMethod.ExplicitInterfaceImplementations, SymbolsEquivalent))
                 {
                     rudeEdit = RudeEditKind.ImplementsClauseUpdate;
                 }
@@ -4327,7 +4292,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             if (rudeEdit != RudeEditKind.None)
             {
-                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
+                diagnosticContext.Report(rudeEdit, cancellationToken);
             }
         }
 
@@ -4525,13 +4490,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             => parameter is { Ordinal: 0, ContainingSymbol: IMethodSymbol { IsExtensionMethod: true } };
 
         private void AnalyzeSymbolUpdate(
-            ISymbol oldSymbol,
-            ISymbol newSymbol,
-            SyntaxNode? newNode,
-            SemanticModel newModel,
+            in DiagnosticContext diagnosticContext,
             Match<SyntaxNode> topMatch,
             EditAndContinueCapabilitiesGrantor capabilities,
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
             ArrayBuilder<SemanticEditInfo> semanticEdits,
             Func<SyntaxNode, SyntaxNode?>? syntaxMap,
             HashSet<ISymbol> processedSymbols,
@@ -4540,11 +4501,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // TODO: fails in VB on delegate parameter https://github.com/dotnet/roslyn/issues/53337
             // Contract.ThrowIfFalse(newSymbol.IsImplicitlyDeclared == newDeclaration is null);
 
-            ReportCustomAttributeRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newModel, capabilities, out var hasAttributeChange, out var hasReturnTypeAttributeChange, cancellationToken);
+            ReportCustomAttributeRudeEdits(diagnosticContext, capabilities, out var hasAttributeChange, out var hasReturnTypeAttributeChange, cancellationToken);
 
-            ReportUpdatedSymbolDeclarationRudeEdits(diagnostics, oldSymbol, newSymbol, newNode, newModel, capabilities, out var hasGeneratedAttributeChange, out var hasGeneratedReturnTypeAttributeChange, out var hasParameterRename, out var hasParameterTypeChange, out var hasReturnTypeChange, cancellationToken);
+            ReportUpdatedSymbolDeclarationRudeEdits(diagnosticContext, capabilities, out var hasGeneratedAttributeChange, out var hasGeneratedReturnTypeAttributeChange, out var hasParameterRename, out var hasParameterTypeChange, out var hasReturnTypeChange, cancellationToken);
             hasAttributeChange |= hasGeneratedAttributeChange;
             hasReturnTypeAttributeChange |= hasGeneratedReturnTypeAttributeChange;
+
+            var oldSymbol = diagnosticContext.RequiredOldSymbol;
+            var newSymbol = diagnosticContext.RequiredNewSymbol;
 
             if (hasParameterRename || hasParameterTypeChange)
             {
@@ -4558,7 +4522,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return;
                 }
 
-                AddParameterUpdateSemanticEdit(semanticEdits, (IParameterSymbol)oldSymbol, (IParameterSymbol)newSymbol, newModel.Compilation, syntaxMap, reportDeleteAndInsertEdits: hasParameterTypeChange, processedSymbols, cancellationToken);
+                AddParameterUpdateSemanticEdit(semanticEdits, (IParameterSymbol)oldSymbol, (IParameterSymbol)newSymbol, diagnosticContext.NewModel.Compilation, syntaxMap, reportDeleteAndInsertEdits: hasParameterTypeChange, processedSymbols, cancellationToken);
             }
             else if (hasReturnTypeChange)
             {
@@ -4567,7 +4531,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
             else if (hasAttributeChange || hasReturnTypeAttributeChange)
             {
-                AddCustomAttributeSemanticEdits(semanticEdits, oldSymbol, newSymbol, newModel.Compilation, topMatch, syntaxMap, processedSymbols, hasAttributeChange, hasReturnTypeAttributeChange, cancellationToken);
+                AddCustomAttributeSemanticEdits(semanticEdits, oldSymbol, newSymbol, diagnosticContext.NewModel.Compilation, topMatch, syntaxMap, processedSymbols, hasAttributeChange, hasReturnTypeAttributeChange, cancellationToken);
             }
         }
 
@@ -4687,42 +4651,37 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         private void ReportCustomAttributeRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
-            ISymbol oldSymbol,
-            ISymbol newSymbol,
-            SyntaxNode? newNode,
-            SemanticModel newModel,
+            in DiagnosticContext diagnosticContext,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasAttributeChange,
             out bool hasReturnTypeAttributeChange,
             CancellationToken cancellationToken)
         {
+            var oldSymbol = diagnosticContext.RequiredOldSymbol;
+            var newSymbol = diagnosticContext.RequiredNewSymbol;
+
             // This is the only case we care about whether to issue an edit or not, because this is the only case where types have their attributes checked
             // and types are the only things that would otherwise not have edits reported.
-            hasAttributeChange = ReportCustomAttributeRudeEdits(diagnostics, oldSymbol.GetAttributes(), newSymbol.GetAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
+            hasAttributeChange = ReportCustomAttributeRudeEdits(diagnosticContext, oldSymbol.GetAttributes(), newSymbol.GetAttributes(), capabilities, cancellationToken);
 
             hasReturnTypeAttributeChange = false;
 
             if (oldSymbol is IMethodSymbol oldMethod &&
                 newSymbol is IMethodSymbol newMethod)
             {
-                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldMethod.GetReturnTypeAttributes(), newMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
+                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnosticContext, oldMethod.GetReturnTypeAttributes(), newMethod.GetReturnTypeAttributes(), capabilities, cancellationToken);
             }
             else if (oldSymbol is INamedTypeSymbol { DelegateInvokeMethod: not null and var oldInvokeMethod } &&
                      newSymbol is INamedTypeSymbol { DelegateInvokeMethod: not null and var newInvokeMethod })
             {
-                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnostics, oldInvokeMethod.GetReturnTypeAttributes(), newInvokeMethod.GetReturnTypeAttributes(), oldSymbol, newSymbol, newNode, newModel, capabilities, cancellationToken);
+                hasReturnTypeAttributeChange |= ReportCustomAttributeRudeEdits(diagnosticContext, oldInvokeMethod.GetReturnTypeAttributes(), newInvokeMethod.GetReturnTypeAttributes(), capabilities, cancellationToken);
             }
         }
 
         private bool ReportCustomAttributeRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
+            in DiagnosticContext diagnosticContext,
             ImmutableArray<AttributeData>? oldAttributes,
             ImmutableArray<AttributeData> newAttributes,
-            ISymbol oldSymbol,
-            ISymbol newSymbol,
-            SyntaxNode? newNode,
-            SemanticModel newModel,
             EditAndContinueCapabilitiesGrantor capabilities,
             CancellationToken cancellationToken)
         {
@@ -4742,15 +4701,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // If the runtime doesn't support changing attributes we don't need to check anything else
             if (!capabilities.Grant(EditAndContinueCapabilities.ChangeCustomAttributes))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingAttributesNotSupportedByRuntime, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
+                diagnosticContext.Report(RudeEditKind.ChangingAttributesNotSupportedByRuntime, cancellationToken);
                 return false;
             }
+
+            var oldSymbol = diagnosticContext.RequiredOldSymbol;
 
             // Updating type parameter attributes is currently not supported.
             if (oldSymbol is ITypeParameterSymbol)
             {
                 var rudeEdit = oldSymbol.ContainingSymbol.Kind == SymbolKind.Method ? RudeEditKind.GenericMethodUpdate : RudeEditKind.GenericTypeUpdate;
-                ReportUpdateRudeEdit(diagnostics, rudeEdit, oldSymbol, newSymbol, newNode, newModel, cancellationToken);
+                diagnosticContext.Report(rudeEdit, cancellationToken);
                 return false;
             }
 
@@ -4759,12 +4720,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 if (IsNonCustomAttribute(attributeData))
                 {
-                    var node = newNode ?? GetRudeEditDiagnosticNode(newSymbol, cancellationToken);
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ChangingNonCustomAttribute, GetDiagnosticSpan(node, EditKind.Update), node, new[]
+                    diagnosticContext.Report(RudeEditKind.ChangingNonCustomAttribute, cancellationToken, arguments: new[]
                     {
                         attributeData.AttributeClass!.Name,
-                        GetDisplayName(newSymbol)
-                    }));
+                        GetDisplayKind(diagnosticContext.RequiredNewSymbol)
+                    });
 
                     return false;
                 }
@@ -4778,11 +4738,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         ContainingNamespace.ContainingNamespace.ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true
                     })
                 {
-                    var node = newNode ?? GetRudeEditDiagnosticNode(newSymbol, cancellationToken);
-                    diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.ChangingAttribute, GetDiagnosticSpan(node, EditKind.Update), node, new[]
+                    diagnosticContext.Report(RudeEditKind.ChangingAttribute, cancellationToken, arguments: new[]
                     {
                         attributeData.AttributeClass.Name,
-                    }));
+                    });
 
                     return false;
                 }
@@ -5010,157 +4969,223 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
-        private void ReportDeletedMemberRudeEdit(
+        internal readonly struct DiagnosticContext(
+            AbstractEditAndContinueAnalyzer analyzer,
             ArrayBuilder<RudeEditDiagnostic> diagnostics,
-            ISymbol oldSymbol,
-            SemanticModel newModel,
-            RudeEditKind rudeEditKind,
-            CancellationToken cancellationToken)
+            ISymbol? oldSymbol,
+            ISymbol? newSymbol,
+            SyntaxNode? newNode,
+            SemanticModel newModel)
         {
-            var newNode = GetDeleteRudeEditDiagnosticNode(oldSymbol, newModel, cancellationToken);
+            public SemanticModel NewModel => newModel;
 
-            diagnostics.Add(new RudeEditDiagnostic(
-                rudeEditKind,
-                GetDiagnosticSpan(newNode, EditKind.Delete),
-                arguments: new[] { GetDisplayKindAndName(oldSymbol, fullyQualify: false) }));
-        }
-
-        private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, SyntaxNode newNode)
-        {
-            diagnostics.Add(new RudeEditDiagnostic(
-                rudeEdit,
-                GetDiagnosticSpan(newNode, EditKind.Update),
-                newNode,
-                new[] { GetDisplayName(newNode) }));
-        }
-
-        private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, ISymbol newSymbol, SyntaxNode? newNode, CancellationToken cancellationToken)
-        {
-            var node = newNode ?? GetRudeEditDiagnosticNode(newSymbol, cancellationToken);
-            var span = GetDiagnosticSpan(node, (rudeEdit == RudeEditKind.ChangeImplicitMainReturnType) ? EditKind.Delete : EditKind.Update);
-
-            var arguments = rudeEdit switch
+            public ISymbol RequiredOldSymbol
             {
-                RudeEditKind.TypeKindUpdate or
-                RudeEditKind.ChangeImplicitMainReturnType or
-                RudeEditKind.GenericMethodUpdate or
-                RudeEditKind.GenericTypeUpdate
-                    => Array.Empty<string>(),
-
-                RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime
-                    => new[] { CreateNewOnMetadataUpdateAttributeName },
-
-                _ => new[]
+                get
                 {
-                    // Include member name if it is implicitly declared, otherwise it might not be obvious which member is being referred to.
-                    // TODO: newSymbol.ContainingSymbol.IsImplicitlyDeclared should not be needed https://github.com/dotnet/roslyn/issues/68510
-                    newSymbol.IsImplicitlyDeclared || newSymbol.ContainingSymbol is { IsImplicitlyDeclared: true, Kind: not SymbolKind.Namespace }
-                        ? GetDisplayKindAndName(newSymbol, fullyQualify: false)
-                        : GetDisplayName(newSymbol)
+                    Contract.ThrowIfNull(oldSymbol);
+                    return oldSymbol;
                 }
-            };
-
-            diagnostics.Add(new RudeEditDiagnostic(rudeEdit, span, node, arguments));
-        }
-
-        private void ReportUpdateRudeEdit(ArrayBuilder<RudeEditDiagnostic> diagnostics, RudeEditKind rudeEdit, ISymbol oldSymbol, ISymbol newSymbol, SyntaxNode? newNode, SemanticModel newModel, CancellationToken cancellationToken)
-        {
-            if (newSymbol.IsImplicitlyDeclared && rudeEdit != RudeEditKind.GenericTypeUpdate)
-            {
-                ReportDeletedMemberRudeEdit(diagnostics, oldSymbol, newModel, rudeEdit, cancellationToken);
             }
-            else
-            {
-                ReportUpdateRudeEdit(diagnostics, rudeEdit, newSymbol, newNode, cancellationToken);
-            }
-        }
 
-        private SyntaxNode GetRudeEditDiagnosticNode(ISymbol symbol, CancellationToken cancellationToken)
-        {
-            var container = symbol;
-            while (container != null)
+            public ISymbol RequiredNewSymbol
             {
-                // TODO: only one condition should be sufficient https://github.com/dotnet/roslyn/issues/68510
-                if (container.DeclaringSyntaxReferences.Length > 0 && !container.IsImplicitlyDeclared)
+                get
                 {
-                    return GetSymbolDeclarationSyntax(container, cancellationToken);
+                    Contract.ThrowIfNull(newSymbol);
+                    return newSymbol;
+                }
+            }
+
+            private SyntaxNode GetDiagnosticNode(out int distance, CancellationToken cancellationToken)
+            {
+                distance = 0;
+
+                if (newNode != null)
+                {
+                    return newNode;
                 }
 
-                container = container.ContainingSymbol;
-            }
-
-            throw ExceptionUtilities.Unreachable();
-        }
-
-        private SyntaxNode GetDeleteRudeEditDiagnosticNode(ISymbol oldSymbol, SemanticModel newModel, CancellationToken cancellationToken)
-        {
-            var oldContainer = oldSymbol.ContainingSymbol;
-            while (oldContainer != null)
-            {
-                var containerKey = SymbolKey.Create(oldContainer, cancellationToken);
-                var newContainer = containerKey.Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
-                if (newContainer != null)
+                var newDiagnosticSymbol = newSymbol;
+                
+                if (newDiagnosticSymbol == null)
                 {
-                    return GetRudeEditDiagnosticNode(newContainer, cancellationToken);
+                    Debug.Assert(oldSymbol != null);
+                    newDiagnosticSymbol = TryGetNewContainer(oldSymbol, ref distance, cancellationToken);
                 }
 
-                oldContainer = oldContainer.ContainingSymbol;
+                while (newDiagnosticSymbol != null)
+                {
+                    // TODO: condition !newDiagnosticSymbol.IsImplicitlyDeclared should not be needed https://github.com/dotnet/roslyn/issues/68510
+                    if (newDiagnosticSymbol.DeclaringSyntaxReferences.Length > 0 && !newDiagnosticSymbol.IsImplicitlyDeclared)
+                    {
+                        var newTree = newModel.SyntaxTree;
+                        var node = analyzer.GetSymbolDeclarationSyntax(newDiagnosticSymbol, syntaxRefs => syntaxRefs.FirstOrDefault(r => r.SyntaxTree == newTree), cancellationToken);
+                        if (node != null)
+                        {
+                            return node;
+                        }
+                    }
+
+                    if (newDiagnosticSymbol.Kind is not (SymbolKind.Parameter or SymbolKind.TypeParameter))
+                    {
+                        distance++;
+                    }
+
+                    newDiagnosticSymbol = newDiagnosticSymbol.ContainingSymbol;
+                }
+
+                return newModel.SyntaxTree.GetRoot(cancellationToken);
             }
 
-            return newModel.SyntaxTree.GetRoot(cancellationToken);
+            private ISymbol? TryGetNewContainer(ISymbol oldSymbol, ref int distance, CancellationToken cancellationToken)
+            {
+                var oldContainer = oldSymbol.ContainingSymbol;
+
+                if (oldSymbol.Kind is not (SymbolKind.Parameter or SymbolKind.TypeParameter))
+                {
+                    distance++;
+                }
+
+                while (oldContainer != null)
+                {
+                    var containerKey = SymbolKey.Create(oldContainer, cancellationToken);
+                    var newContainer = containerKey.Resolve(newModel.Compilation, ignoreAssemblyKey: true, cancellationToken).Symbol;
+                    if (newContainer != null)
+                    {
+                        return newContainer;
+                    }
+
+                    oldContainer = oldContainer.ContainingSymbol;
+                    distance++;
+                }
+
+                return null;
+            }
+
+            public void Report(RudeEditKind kind, TextSpan span)
+                => diagnostics.Add(new RudeEditDiagnostic(kind, span));
+
+            /// <summary>
+            /// Reports rude edit in the context of newDeclaration.
+            /// 
+            /// If <paramref name="locationNode"/> is in the same syntax tree as newDeclaration its span will be used for the location of the diagnostic, otherwise the diagnostic will be reported on the newDeclaration.
+            /// If <paramref name="arguments"/> is given it is used for the diagnostic arguments, otherwise the display name of the newDeclaration is passed as the single argument.
+            /// 
+            /// The rude edit will be associated with the syntax kind of newDeclaration in telemetry.
+            /// </summary>
+            public void Report(RudeEditKind kind, SyntaxNode locationNode, CancellationToken cancellationToken, string?[]? arguments = null)
+                => Report(
+                    kind,
+                    cancellationToken,
+                    span: (locationNode.SyntaxTree == newModel.SyntaxTree) ?
+                        locationNode.Span : analyzer.GetDiagnosticSpan(GetDiagnosticNode(out var distance, cancellationToken), distance > 0 ? EditKind.Delete : EditKind.Update),
+                    arguments);
+
+            /// <summary>
+            /// Reports rude edit in the context of newDeclaration.
+            /// 
+            /// If <paramref name="span"/> is given it will be used for the location of the diagnostic, otherwise the diagnostic will be reported on the newDeclaration.
+            /// If <paramref name="arguments"/> is given it is used for the diagnostic arguments, otherwise the display name of the newDeclaration is passed as the single argument.
+            /// 
+            /// The rude edit will be associated with the syntax kind of newDeclaration in telemetry.
+            /// </summary>
+            public void Report(RudeEditKind kind, CancellationToken cancellationToken, TextSpan? span = null, string?[]? arguments = null)
+            {
+                var node = GetDiagnosticNode(out var distance, cancellationToken);
+
+                diagnostics.Add(new RudeEditDiagnostic(
+                    kind,
+                    span ?? analyzer.GetDiagnosticSpan(node, (distance > 0 || kind == RudeEditKind.ChangeImplicitMainReturnType) ? EditKind.Delete : EditKind.Update),
+                    node,
+                    arguments ?? kind switch
+                    {
+                        RudeEditKind.TypeKindUpdate or
+                        RudeEditKind.ChangeImplicitMainReturnType or
+                        RudeEditKind.GenericMethodUpdate or
+                        RudeEditKind.GenericTypeUpdate or
+                        RudeEditKind.SwitchBetweenLambdaAndLocalFunction or
+                        RudeEditKind.AccessorKindUpdate
+                            => Array.Empty<string>(),
+
+                        RudeEditKind.ChangingReloadableTypeNotSupportedByRuntime
+                            => new[] { CreateNewOnMetadataUpdateAttributeName },
+
+                        RudeEditKind.Renamed
+                            => new[] { analyzer.GetDisplayKindAndName(oldSymbol!, fullyQualify: false) },
+
+                        _ => new[]
+                        {
+                            // Use name of oldSymbol, in case the symbol we are refering to has been renamed:
+                            ((oldSymbol ?? newSymbol) is not { } symbol)
+                                ? analyzer.GetDisplayName(node)
+                                // Include member name if it is deleted or implicitly declared, otherwise it might not be obvious which member is being referred to.
+                                : distance > 0
+                                    ? analyzer.GetDisplayKindAndName(symbol, fullyQualify: distance > 1)
+                                    : analyzer.GetDisplayKind(symbol)
+                        }
+                    }));
+            }
+
+            public void ReportTypeLayoutUpdateRudeEdits()
+            {
+                Debug.Assert(newSymbol != null);
+                Debug.Assert(newNode != null);
+
+                var intoStruct = newSymbol.ContainingType.TypeKind == TypeKind.Struct;
+
+                diagnostics.Add(new RudeEditDiagnostic(
+                    intoStruct ? RudeEditKind.InsertIntoStruct : RudeEditKind.InsertIntoClassWithLayout,
+                    newNode.Span,
+                    newNode,
+                    new[]
+                    {
+                        analyzer.GetDisplayName(newNode, EditKind.Insert),
+                        analyzer.GetDisplayName(analyzer.TryGetContainingTypeDeclaration(newNode)!, EditKind.Update)
+                    }));
+            }
+
+            public DiagnosticContext WithSymbols(ISymbol oldSymbol, ISymbol newSymbol)
+                => new(analyzer, diagnostics, oldSymbol, newSymbol, newNode, newModel);
         }
+
+        private DiagnosticContext CreateDiagnosticContext(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol? oldSymbol, ISymbol? newSymbol, SyntaxNode? newNode, SemanticModel newModel)
+            => new(this, diagnostics, oldSymbol, newSymbol, newNode, newModel);
 
         #region Type Layout Update Validation 
 
-        internal void ReportTypeLayoutUpdateRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
-            ISymbol newSymbol,
-            SyntaxNode newSyntax,
-            SemanticModel newModel)
+        internal static void ReportTypeLayoutUpdateRudeEdits(in DiagnosticContext diagnosticContext)
         {
+            var newSymbol = diagnosticContext.RequiredNewSymbol;
+
             switch (newSymbol.Kind)
             {
                 case SymbolKind.Field:
-                    if (HasExplicitOrSequentialLayout(newSymbol.ContainingType, newModel))
+                    if (HasExplicitOrSequentialLayout(newSymbol.ContainingType, diagnosticContext.NewModel))
                     {
-                        ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, newSyntax);
+                        diagnosticContext.ReportTypeLayoutUpdateRudeEdits();
                     }
 
                     break;
 
                 case SymbolKind.Property:
                     if (newSymbol.IsAutoProperty() &&
-                        HasExplicitOrSequentialLayout(newSymbol.ContainingType, newModel))
+                        HasExplicitOrSequentialLayout(newSymbol.ContainingType, diagnosticContext.NewModel))
                     {
-                        ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, newSyntax);
+                        diagnosticContext.ReportTypeLayoutUpdateRudeEdits();
                     }
 
                     break;
 
                 case SymbolKind.Event:
                     if (HasBackingField((IEventSymbol)newSymbol) &&
-                        HasExplicitOrSequentialLayout(newSymbol.ContainingType, newModel))
+                        HasExplicitOrSequentialLayout(newSymbol.ContainingType, diagnosticContext.NewModel))
                     {
-                        ReportTypeLayoutUpdateRudeEdits(diagnostics, newSymbol, newSyntax);
+                        diagnosticContext.ReportTypeLayoutUpdateRudeEdits();
                     }
 
                     break;
             }
-        }
-
-        private void ReportTypeLayoutUpdateRudeEdits(ArrayBuilder<RudeEditDiagnostic> diagnostics, ISymbol symbol, SyntaxNode syntax)
-        {
-            var intoStruct = symbol.ContainingType.TypeKind == TypeKind.Struct;
-
-            diagnostics.Add(new RudeEditDiagnostic(
-                intoStruct ? RudeEditKind.InsertIntoStruct : RudeEditKind.InsertIntoClassWithLayout,
-                syntax.Span,
-                syntax,
-                new[]
-                {
-                    GetDisplayName(syntax, EditKind.Insert),
-                    GetDisplayName(TryGetContainingTypeDeclaration(syntax)!, EditKind.Update)
-                }));
         }
 
         private static bool HasBackingField(IEventSymbol @event)
@@ -5388,9 +5413,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         // If the declaration represents a primary constructor the body will be null.
                         if (newDeclaration.SyntaxTree == newSyntaxTree)
                         {
+                            var diagnosticContext = CreateDiagnosticContext(diagnostics, oldCtor, newCtor, newDeclaration, newModel);
+
                             unsupportedOperationReported |=
-                                TryGetDeclarationBody(newDeclaration, newCtor) is { } newBody && ReportUnsupportedOperations(diagnostics, newBody, newDeclaration) ||
-                                oldDeclaration != null && TryGetDeclarationBody(oldDeclaration, oldCtor) is { } oldBody && ReportUnsupportedOperations(diagnostics, oldBody, oldDeclaration, diagnosticNode: newDeclaration);
+                                TryGetDeclarationBody(newDeclaration, newCtor) is { } newBody && ReportUnsupportedOperations(diagnosticContext, newBody, cancellationToken) ||
+                                oldDeclaration != null && TryGetDeclarationBody(oldDeclaration, oldCtor) is { } oldBody && ReportUnsupportedOperations(diagnosticContext, oldBody, cancellationToken);
                         }
                     }
                     else
@@ -5411,13 +5438,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (oldCtor != null)
                     {
-                        AnalyzeSymbolUpdate(oldCtor, newCtor, newDeclaration, newModel, topMatch, capabilities, diagnostics, semanticEdits, syntaxMapToUse, processedSymbols, cancellationToken);
+                        var diagnosticContext = CreateDiagnosticContext(diagnostics, oldCtor, newCtor, newDeclaration, newModel);
+                        AnalyzeSymbolUpdate(diagnosticContext, topMatch, capabilities, semanticEdits, syntaxMapToUse, processedSymbols, cancellationToken);
 
                         // We don't need to check initializers of the new type since any change that would
                         // add stackalloc or other disallowed syntax would already be reported as rude edit.
                         unsupportedOperationReported |= AnyMemberInitializerBody(
                             oldType,
-                            body => ReportUnsupportedConstructorOperations(diagnostics, newCtor, body, newModel.SyntaxTree, cancellationToken),
+                            body => ReportUnsupportedOperations(diagnosticContext, body, cancellationToken),
                             isStatic,
                             cancellationToken);
 
@@ -5551,11 +5579,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             if (matchedLambdas != null)
             {
+                var anySignatureErrors = false;
+                var hasUnmatchedLambdas = false;
                 foreach (var (oldLambdaBody, newLambdaInfo) in matchedLambdas)
                 {
                     var newLambdaBody = newLambdaInfo.NewBody;
                     if (newLambdaBody == null)
                     {
+                        hasUnmatchedLambdas = true;
                         continue;
                     }
 
@@ -5565,9 +5596,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     var oldLambda = oldLambdaBody.GetLambda();
                     var newLambda = newLambdaBody.GetLambda();
 
+                    Debug.Assert(IsNestedFunction(newLambda) == IsNestedFunction(oldLambda));
+                    var isNestedFunction = IsNestedFunction(newLambda);
+
+                    var oldLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(oldModel, oldLambda, cancellationToken) : null;
+                    var newLambdaSymbol = isNestedFunction ? GetLambdaExpressionSymbol(newModel, newLambda, cancellationToken) : null;
+
+                    var diagnosticContext = CreateDiagnosticContext(diagnostics, oldLambdaSymbol, newLambdaSymbol, newLambda, newModel);
+
                     var oldStateMachineInfo = oldLambdaBody.GetStateMachineInfo();
                     var newStateMachineInfo = newLambdaBody.GetStateMachineInfo();
-                    ReportStateMachineBodyUpdateRudeEdits(lambdaBodyMatch.Value, oldStateMachineInfo, newLambda, newStateMachineInfo, newLambdaInfo.HasActiveStatement, diagnostics);
+
+                    ReportStateMachineBodyUpdateRudeEdits(diagnosticContext, lambdaBodyMatch.Value, oldStateMachineInfo, newStateMachineInfo, newLambdaInfo.HasActiveStatement, cancellationToken);
 
                     // When the delta IL of the containing method is emitted lambdas declared in it are also emitted.
                     // If the runtime does not support changing IL of the method (e.g. method containing stackalloc)
@@ -5578,7 +5618,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     if (!oldLambdaBody.IsSyntaxEquivalentTo(newLambdaBody))
                     {
                         ReportMemberOrLambdaBodyUpdateRudeEdits(
-                            diagnostics,
+                            diagnosticContext,
                             oldModel,
                             oldLambda,
                             oldMember,
@@ -5590,28 +5630,29 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             newLambdaBody,
                             capabilities,
                             oldStateMachineInfo,
-                            newStateMachineInfo);
+                            newStateMachineInfo,
+                            cancellationToken);
 
                         if ((IsGenericLocalFunction(oldLambda) || IsGenericLocalFunction(newLambda)) &&
                             !capabilities.Grant(EditAndContinueCapabilities.GenericUpdateMethod))
                         {
-                            diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.UpdatingGenericNotSupportedByRuntime, GetDiagnosticSpan(newLambda, EditKind.Update), newLambda, new[] { GetDisplayName(newLambda) }));
+                            diagnosticContext.Report(RudeEditKind.UpdatingGenericNotSupportedByRuntime, cancellationToken);
                         }
+                    }
+
+                    // query signatures are analyzed separately:
+                    if (isNestedFunction)
+                    {
+                        ReportLambdaSignatureRudeEdits(diagnosticContext, oldLambda, newLambda, capabilities, out var hasErrors, cancellationToken);
+                        anySignatureErrors |= hasErrors;
                     }
                 }
 
-                var anySignatureErrors = false;
-                foreach (var (oldLambdaBody, newLambdaInfo) in matchedLambdas)
+                // Any unmatched lambdas would have contained an active statement and a rude edit would be reported in syntax analysis phase.
+                // Skip the rest of lambda and closure analysis if such lambdas are present.
+                if (hasUnmatchedLambdas)
                 {
-                    // Any unmatched lambdas would have contained an active statement and a rude edit would be reported in syntax analysis phase.
-                    // Skip the rest of lambda and closure analysis if such lambdas are present.
-                    if (newLambdaInfo.Match == null || newLambdaInfo.NewBody == null)
-                    {
-                        return;
-                    }
-
-                    ReportLambdaSignatureRudeEdits(diagnostics, oldModel, oldLambdaBody, newModel, newLambdaInfo.NewBody, capabilities, out var hasErrors, cancellationToken);
-                    anySignatureErrors |= hasErrors;
+                    return;
                 }
 
                 ArrayBuilder<SyntaxNode>? lazyNewErroneousClauses = null;
@@ -6244,7 +6285,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Returns node that represents a declaration of the symbol.
         /// </summary>
-        protected abstract SyntaxNode GetSymbolDeclarationSyntax(ISymbol symbol, Func<ImmutableArray<SyntaxReference>, SyntaxReference> selector, CancellationToken cancellationToken);
+        protected abstract SyntaxNode? GetSymbolDeclarationSyntax(ISymbol symbol, Func<ImmutableArray<SyntaxReference>, SyntaxReference?> selector, CancellationToken cancellationToken);
 
         protected SyntaxNode GetSymbolDeclarationSyntax(ISymbol symbol, CancellationToken cancellationToken)
             => GetSymbolDeclarationSyntax(symbol, selector: System.Linq.ImmutableArrayExtensions.First, cancellationToken);
@@ -6644,52 +6685,42 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         private void ReportLambdaSignatureRudeEdits(
-            ArrayBuilder<RudeEditDiagnostic> diagnostics,
-            SemanticModel oldModel,
-            LambdaBody oldLambdaBody,
-            SemanticModel newModel,
-            LambdaBody newLambdaBody,
+            DiagnosticContext diagnosticContext,
+            SyntaxNode oldLambda,
+            SyntaxNode newLambda,
             EditAndContinueCapabilitiesGrantor capabilities,
             out bool hasSignatureErrors,
             CancellationToken cancellationToken)
         {
             hasSignatureErrors = false;
 
-            var newLambda = newLambdaBody.GetLambda();
-            var oldLambda = oldLambdaBody.GetLambda();
-
-            Debug.Assert(IsNestedFunction(newLambda) == IsNestedFunction(oldLambda));
-
-            // queries are analyzed separately
-            if (!IsNestedFunction(newLambda))
-            {
-                return;
-            }
+            Debug.Assert(IsNestedFunction(newLambda));
+            Debug.Assert(IsNestedFunction(oldLambda));
 
             if (IsLocalFunction(oldLambda) != IsLocalFunction(newLambda))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.SwitchBetweenLambdaAndLocalFunction, newLambda);
+                diagnosticContext.Report(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, cancellationToken);
                 hasSignatureErrors = true;
                 return;
             }
 
-            var oldLambdaSymbol = GetLambdaExpressionSymbol(oldModel, oldLambda, cancellationToken);
-            var newLambdaSymbol = GetLambdaExpressionSymbol(newModel, newLambda, cancellationToken);
+            var oldLambdaSymbol = (IMethodSymbol)diagnosticContext.RequiredOldSymbol;
+            var newLambdaSymbol = (IMethodSymbol)diagnosticContext.RequiredNewSymbol;
 
             // signature validation:
             if (!ParameterTypesEquivalent(oldLambdaSymbol.Parameters, newLambdaSymbol.Parameters, exact: false))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingLambdaParameters, newLambda);
+                diagnosticContext.Report(RudeEditKind.ChangingLambdaParameters, cancellationToken);
                 hasSignatureErrors = true;
             }
             else if (!ReturnTypesEquivalent(oldLambdaSymbol, newLambdaSymbol, exact: false))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingLambdaReturnType, newLambda);
+                diagnosticContext.Report(RudeEditKind.ChangingLambdaReturnType, cancellationToken);
                 hasSignatureErrors = true;
             }
             else if (!TypeParametersEquivalent(oldLambdaSymbol.TypeParameters, newLambdaSymbol.TypeParameters, exact: false))
             {
-                ReportUpdateRudeEdit(diagnostics, RudeEditKind.ChangingTypeParameters, newLambda);
+                diagnosticContext.Report(RudeEditKind.ChangingTypeParameters, cancellationToken);
                 hasSignatureErrors = true;
             }
 
@@ -6700,16 +6731,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // custom attributes
 
-            ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol, newLambdaSymbol, newLambda, newModel, capabilities, out _, out _, cancellationToken);
+            ReportCustomAttributeRudeEdits(diagnosticContext, capabilities, out _, out _, cancellationToken);
 
             for (var i = 0; i < oldLambdaSymbol.Parameters.Length; i++)
             {
-                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.Parameters[i], newLambdaSymbol.Parameters[i], newLambda, newModel, capabilities, out _, out _, cancellationToken);
+                ReportCustomAttributeRudeEdits(diagnosticContext.WithSymbols(oldLambdaSymbol.Parameters[i], newLambdaSymbol.Parameters[i]), capabilities, out _, out _, cancellationToken);
             }
 
             for (var i = 0; i < oldLambdaSymbol.TypeParameters.Length; i++)
             {
-                ReportCustomAttributeRudeEdits(diagnostics, oldLambdaSymbol.TypeParameters[i], newLambdaSymbol.TypeParameters[i], newLambda, newModel, capabilities, out _, out _, cancellationToken);
+                ReportCustomAttributeRudeEdits(diagnosticContext.WithSymbols(oldLambdaSymbol.TypeParameters[i], newLambdaSymbol.TypeParameters[i]), capabilities, out _, out _, cancellationToken);
             }
         }
 
@@ -6752,11 +6783,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         #region State Machines
 
-        private void ReportMissingStateMachineAttribute(
+        private static void ReportMissingStateMachineAttribute(
+            in DiagnosticContext diagnosticContext,
             Compilation oldCompilation,
             StateMachineInfo kinds,
-            SyntaxNode newDeclaration,
-            ArrayBuilder<RudeEditDiagnostic> diagnostics)
+            CancellationToken cancellationToken)
         {
             var stateMachineAttributeQualifiedName = kinds switch
             {
@@ -6778,11 +6809,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // since the attribute has been long defined in the BCL.
             if (oldCompilation.GetTypeByMetadataName(stateMachineAttributeQualifiedName) == null)
             {
-                diagnostics.Add(new RudeEditDiagnostic(
-                    RudeEditKind.UpdatingStateMachineMethodMissingAttribute,
-                    GetDiagnosticSpan(newDeclaration, EditKind.Update),
-                    newDeclaration,
-                    new[] { stateMachineAttributeQualifiedName }));
+                diagnosticContext.Report(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, cancellationToken, arguments: new[] { stateMachineAttributeQualifiedName });
             }
         }
 


### PR DESCRIPTION
Extract rude edit reporting logic to `DiagnosticContext` and unify across multiple places in the analyzer.

Fixes https://github.com/dotnet/roslyn/issues/54758