### PR TITLE
Add analyzer/fixer to suggest changing code like `ImmutableArray.Create(1, 2, 3)` to `[1, 2, 3]`

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -83,6 +83,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CollectionExpressionMatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\CSharpUseCollectionInitializerAnalyzer.cs" />

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -91,7 +91,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
         ReportArrayCreationDiagnostics(context, syntaxTree, option, arrayCreationExpression);
     }
 
-    public static ImmutableArray<CollectionExpressionMatch> TryGetMatches(
+    public static ImmutableArray<CollectionExpressionMatch<StatementSyntax>> TryGetMatches(
         SemanticModel semanticModel,
         ArrayCreationExpressionSyntax expression,
         CancellationToken cancellationToken)

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -196,7 +196,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
                 } enumerableType] && enumerableType.OriginalDefinition.Equals(compilation.IEnumerableOfTType()))
             {
                 if (arguments[0].Expression
-                        is ArrayCreationExpressionSyntax
+                        is ArrayCreationExpressionSyntax { Initializer: not null }
                         or ImplicitArrayCreationExpressionSyntax
                         or ObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: 0, Initializer.RawKind: (int)SyntaxKind.CollectionInitializerExpression }
                         or ImplicitObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: 0, Initializer.RawKind: (int)SyntaxKind.CollectionInitializerExpression })
@@ -223,7 +223,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
                 if (arguments.Count >= 2)
                     return true;
 
-                if (arguments is [{ Expression: ArrayCreationExpressionSyntax or ImplicitArrayCreationExpressionSyntax }])
+                if (arguments is [{ Expression: ArrayCreationExpressionSyntax { Initializer: not null } or ImplicitArrayCreationExpressionSyntax }])
                 {
                     unwrapArgument = true;
                     return true;
@@ -239,17 +239,20 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
 
             if (arguments.Count == 1 &&
                 compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes) &&
-                originalCreateMethod.Parameters is [INamedTypeSymbol
-                {
-                    Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                    TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
-                } spanType])
+                originalCreateMethod.Parameters is [
+                    {
+                        Type: INamedTypeSymbol
+                        {
+                            Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                            TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+                        } spanType
+                    }])
             {
                 if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
                     spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
                 {
                     if (arguments[0].Expression
-                            is StackAllocArrayCreationExpressionSyntax
+                            is StackAllocArrayCreationExpressionSyntax { Initializer: not null }
                             or ImplicitStackAllocArrayCreationExpressionSyntax)
                     {
                         unwrapArgument = true;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer
+    : AbstractBuiltInCodeStyleDiagnosticAnalyzer
+{
+    public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+        => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+    private static readonly DiagnosticDescriptor s_descriptor = CreateDescriptorWithId(
+        IDEDiagnosticIds.UseCollectionExpressionForCreateDiagnosticId,
+        EnforceOnBuildValues.UseCollectionExpressionForCreate,
+        new LocalizableResourceString(nameof(AnalyzersResources.Simplify_collection_initialization), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+        new LocalizableResourceString(nameof(AnalyzersResources.Collection_initialization_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+        isUnnecessary: false);
+
+    private static readonly DiagnosticDescriptor s_unnecessaryCodeDescriptor = CreateDescriptorWithId(
+        IDEDiagnosticIds.UseCollectionExpressionForCreateDiagnosticId,
+        EnforceOnBuildValues.UseCollectionExpressionForCreate,
+        new LocalizableResourceString(nameof(AnalyzersResources.Simplify_collection_initialization), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+        new LocalizableResourceString(nameof(AnalyzersResources.Collection_initialization_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+        isUnnecessary: true);
+
+    public CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer()
+        : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
+                .Add(s_descriptor, CodeStyleOptions2.PreferCollectionExpression)
+                .Add(s_unnecessaryCodeDescriptor, CodeStyleOptions2.PreferCollectionExpression))
+    {
+    }
+
+    protected override void InitializeWorker(AnalysisContext context)
+        => context.RegisterCompilationStartAction(context =>
+        {
+            var compilation = context.Compilation;
+            if (!compilation.LanguageVersion().SupportsCollectionExpressions())
+                return;
+
+            // Runtime needs to support inline arrays in order for this to be ok.  Otherwise compiler has no good way to
+            // emit these collection expressions.
+            //
+            // TODO: add this check once the SDK test system supports referencing .Net 8.
+            //
+            // if (!compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes))
+            //    return;
+
+            // We wrap the SyntaxNodeAction within a CodeBlockStartAction, which allows us to
+            // get callbacks for object creation expression nodes, but analyze nodes across the entire code block
+            // and eventually report fading diagnostics with location outside this node.
+            // Without the containing CodeBlockStartAction, our reported diagnostic would be classified
+            // as a non-local diagnostic and would not participate in lightbulb for computing code fixes.
+            context.RegisterCodeBlockStartAction<SyntaxKind>(context =>
+            {
+                context.RegisterSyntaxNodeAction(
+                    context => AnalyzeExplicitCreateExpression(context),
+                    SyntaxKind.CreateArrayCreationExpression);
+                context.RegisterSyntaxNodeAction(
+                    context => AnalyzeImplicitCreateExpression(context),
+                    SyntaxKind.ImplicitCreateArrayCreationExpression);
+            });
+        });
+
+    private static void AnalyzeImplicitCreateExpression(SyntaxNodeAnalysisContext context)
+    {
+        var semanticModel = context.SemanticModel;
+        var syntaxTree = semanticModel.SyntaxTree;
+        var expression = (ImplicitCreateArrayCreationExpressionSyntax)context.Node;
+        var cancellationToken = context.CancellationToken;
+
+        // no point in analyzing if the option is off.
+        var option = context.GetAnalyzerOptions().PreferCollectionExpression;
+        if (!option.Value)
+            return;
+
+        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
+                semanticModel, expression, skipVerificationForReplacedNode: true, cancellationToken))
+        {
+            return;
+        }
+
+        var locations = ImmutableArray.Create(expression.GetLocation());
+        context.ReportDiagnostic(DiagnosticHelper.Create(
+            s_descriptor,
+            expression.GetFirstToken().GetLocation(),
+            option.Notification.Severity,
+            additionalLocations: locations,
+            properties: null));
+
+        var additionalUnnecessaryLocations = ImmutableArray.Create(
+            syntaxTree.GetLocation(TextSpan.FromBounds(
+                expression.SpanStart,
+                expression.CloseBracketToken.Span.End)));
+
+        context.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
+            s_unnecessaryCodeDescriptor,
+            additionalUnnecessaryLocations[0],
+            ReportDiagnostic.Default,
+            additionalLocations: locations,
+            additionalUnnecessaryLocations: additionalUnnecessaryLocations));
+    }
+
+    private static void AnalyzeExplicitCreateExpression(SyntaxNodeAnalysisContext context)
+    {
+        var semanticModel = context.SemanticModel;
+        var syntaxTree = semanticModel.SyntaxTree;
+        var expression = (CreateArrayCreationExpressionSyntax)context.Node;
+        var cancellationToken = context.CancellationToken;
+
+        // no point in analyzing if the option is off.
+        var option = context.GetAnalyzerOptions().PreferCollectionExpression;
+        if (!option.Value)
+            return;
+
+        var matches = TryGetMatches(semanticModel, expression, cancellationToken);
+        if (matches.IsDefault)
+            return;
+
+        var locations = ImmutableArray.Create(expression.GetLocation());
+        context.ReportDiagnostic(DiagnosticHelper.Create(
+            s_descriptor,
+            expression.GetFirstToken().GetLocation(),
+            option.Notification.Severity,
+            additionalLocations: locations,
+            properties: null));
+
+        var additionalUnnecessaryLocations = ImmutableArray.Create(
+            syntaxTree.GetLocation(TextSpan.FromBounds(
+                expression.SpanStart,
+                expression.Type.Span.End)));
+
+        context.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
+            s_unnecessaryCodeDescriptor,
+            additionalUnnecessaryLocations[0],
+            ReportDiagnostic.Default,
+            additionalLocations: locations,
+            additionalUnnecessaryLocations: additionalUnnecessaryLocations));
+    }
+
+    public static ImmutableArray<CollectionExpressionMatch> TryGetMatches(
+        SemanticModel semanticModel,
+        CreateArrayCreationExpressionSyntax expression,
+        CancellationToken cancellationToken)
+    {
+        return UseCollectionExpressionHelpers.TryGetMatches(
+            semanticModel,
+            expression,
+            static e => e.Type,
+            static e => e.Initializer,
+            cancellationToken);
+    }
+}

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -10,7 +13,9 @@ using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
@@ -18,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer
     : AbstractBuiltInCodeStyleDiagnosticAnalyzer
 {
+    private const string CreateName = "Create";
+
     public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
         => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
@@ -49,13 +56,9 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             if (!compilation.LanguageVersion().SupportsCollectionExpressions())
                 return;
 
-            // Runtime needs to support inline arrays in order for this to be ok.  Otherwise compiler has no good way to
-            // emit these collection expressions.
-            //
-            // TODO: add this check once the SDK test system supports referencing .Net 8.
-            //
-            // if (!compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes))
-            //    return;
+            var collectionBuilderAttribute = compilation.CollectionBuilderAttribute();
+            if (collectionBuilderAttribute is null)
+                return;
 
             // We wrap the SyntaxNodeAction within a CodeBlockStartAction, which allows us to
             // get callbacks for object creation expression nodes, but analyze nodes across the entire code block
@@ -65,19 +68,18 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             context.RegisterCodeBlockStartAction<SyntaxKind>(context =>
             {
                 context.RegisterSyntaxNodeAction(
-                    context => AnalyzeExplicitCreateExpression(context),
-                    SyntaxKind.CreateArrayCreationExpression);
-                context.RegisterSyntaxNodeAction(
-                    context => AnalyzeImplicitCreateExpression(context),
-                    SyntaxKind.ImplicitCreateArrayCreationExpression);
+                    context => AnalyzeInvocationExpression(context, collectionBuilderAttribute),
+                    SyntaxKind.InvocationExpression);
             });
         });
 
-    private static void AnalyzeImplicitCreateExpression(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeInvocationExpression(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol collectionBuilderAttribute)
     {
         var semanticModel = context.SemanticModel;
         var syntaxTree = semanticModel.SyntaxTree;
-        var expression = (ImplicitCreateArrayCreationExpressionSyntax)context.Node;
+        var invocationExpression = (InvocationExpressionSyntax)context.Node;
         var cancellationToken = context.CancellationToken;
 
         // no point in analyzing if the option is off.
@@ -85,24 +87,67 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
         if (!option.Value)
             return;
 
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, expression, skipVerificationForReplacedNode: true, cancellationToken))
+        // Looking for `XXX.Create(...)`
+        if (invocationExpression.Expression is not MemberAccessExpressionSyntax
+            {
+                RawKind: (int)SyntaxKind.SimpleMemberAccessExpression,
+                Name.Identifier.Value: CreateName,
+            } memberAccessExpression)
         {
             return;
         }
 
-        var locations = ImmutableArray.Create(expression.GetLocation());
+        var createMethod = semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol as IMethodSymbol;
+        if (createMethod is not { IsStatic: true })
+            return;
+
+        var factoryType = semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol as INamedTypeSymbol;
+        if (factoryType is null)
+            return;
+
+        // The pattern is a type like `ImmutableArray` (non-generic), returning an instance of `ImmutableArray<T>`.  The
+        // actual collection type (`ImmutableArray<T>`) has to have a `[CollectionBuilder(...)]` attribute on it that
+        // then points at the factory type.
+        var collectionBuilderAttributeData = createMethod.ReturnType.OriginalDefinition
+            .GetAttributes()
+            .FirstOrDefault(a => collectionBuilderAttribute.Equals(a.AttributeClass));
+        if (collectionBuilderAttributeData?.ConstructorArguments is not [{ Value: ITypeSymbol collectionBuilderType }, { Value: CreateName }])
+            return;
+
+        if (!factoryType.OriginalDefinition.Equals(collectionBuilderType.OriginalDefinition))
+            return;
+
+        // Ok, this is type that has a collection-builder option available.  We can switch over if the current method
+        // we're calling has one of the following signatures:
+        //
+        //  `Create()`.  Trivial case, can be replaced with `[]`.
+        //  `Create(T), Create(T, T), Create(T, T, T)` etc.
+        //  `Create(params T[])` (passing as individual elements, or an array with an initializer)
+        //  `Create(ReadOnlySpan<T>)` (passing as a stack-alloc with an initializer)
+        //  `Create(IEnumerable<T>)` (passing as something with an initializer.
+        if (!IsCompatibleSignatureAndArguments(semanticModel.Compilation, invocationExpression, createMethod.OriginalDefinition, cancellationToken))
+            return;
+
+        // Make sure we can actually use a collection expression in place of the full invocation.
+        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
+                semanticModel, invocationExpression, skipVerificationForReplacedNode: true, cancellationToken))
+        {
+            return;
+        }
+
+        var locations = ImmutableArray.Create(invocationExpression.GetLocation());
         context.ReportDiagnostic(DiagnosticHelper.Create(
             s_descriptor,
-            expression.GetFirstToken().GetLocation(),
+            memberAccessExpression.Name.Identifier.GetLocation(),
             option.Notification.Severity,
             additionalLocations: locations,
             properties: null));
 
         var additionalUnnecessaryLocations = ImmutableArray.Create(
             syntaxTree.GetLocation(TextSpan.FromBounds(
-                expression.SpanStart,
-                expression.CloseBracketToken.Span.End)));
+                invocationExpression.SpanStart,
+                invocationExpression.ArgumentList.OpenParenToken.Span.End)),
+            invocationExpression.ArgumentList.CloseParenToken.GetLocation());
 
         context.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
             s_unnecessaryCodeDescriptor,
@@ -112,53 +157,74 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             additionalUnnecessaryLocations: additionalUnnecessaryLocations));
     }
 
-    private static void AnalyzeExplicitCreateExpression(SyntaxNodeAnalysisContext context)
-    {
-        var semanticModel = context.SemanticModel;
-        var syntaxTree = semanticModel.SyntaxTree;
-        var expression = (CreateArrayCreationExpressionSyntax)context.Node;
-        var cancellationToken = context.CancellationToken;
-
-        // no point in analyzing if the option is off.
-        var option = context.GetAnalyzerOptions().PreferCollectionExpression;
-        if (!option.Value)
-            return;
-
-        var matches = TryGetMatches(semanticModel, expression, cancellationToken);
-        if (matches.IsDefault)
-            return;
-
-        var locations = ImmutableArray.Create(expression.GetLocation());
-        context.ReportDiagnostic(DiagnosticHelper.Create(
-            s_descriptor,
-            expression.GetFirstToken().GetLocation(),
-            option.Notification.Severity,
-            additionalLocations: locations,
-            properties: null));
-
-        var additionalUnnecessaryLocations = ImmutableArray.Create(
-            syntaxTree.GetLocation(TextSpan.FromBounds(
-                expression.SpanStart,
-                expression.Type.Span.End)));
-
-        context.ReportDiagnostic(DiagnosticHelper.CreateWithLocationTags(
-            s_unnecessaryCodeDescriptor,
-            additionalUnnecessaryLocations[0],
-            ReportDiagnostic.Default,
-            additionalLocations: locations,
-            additionalUnnecessaryLocations: additionalUnnecessaryLocations));
-    }
-
-    public static ImmutableArray<CollectionExpressionMatch> TryGetMatches(
-        SemanticModel semanticModel,
-        CreateArrayCreationExpressionSyntax expression,
+    private static bool IsCompatibleSignatureAndArguments(
+        Compilation compilation,
+        InvocationExpressionSyntax invocationExpression,
+        IMethodSymbol originalCreateMethod,
         CancellationToken cancellationToken)
     {
-        return UseCollectionExpressionHelpers.TryGetMatches(
-            semanticModel,
-            expression,
-            static e => e.Type,
-            static e => e.Initializer,
-            cancellationToken);
+        // `XXX.Create()` can always be converted to `[]`
+        if (originalCreateMethod.Parameters.Length == 0)
+            return true;
+
+        var arguments = invocationExpression.ArgumentList.Arguments;
+
+        // Don't bother offering if any of the arguments are named.  It's unlikely for this to occur in practice, and it
+        // means we do not have to worry about order of operations.
+        if (arguments.Any(static a => a.NameColon != null))
+            return false;
+
+        // If we have `Create<T>(T)`, `Create<T>(T, T)` etc., then this is convertible.
+        if (originalCreateMethod.Parameters.All(static p => p.Type is ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }))
+            return true;
+
+        // If we have `Create<T>(params T[])` this is legal if there are multiple arguments.  Or a single argument that
+        // is an array literal.
+        if (originalCreateMethod.Parameters is [{ IsParams: true, Type: IArrayTypeSymbol { ElementType: ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } } }])
+        {
+            if (arguments.Count >= 2)
+                return true;
+
+            if (arguments is [{ Expression: ArrayCreationExpressionSyntax or ImplicitArrayCreationExpressionSyntax])
+                return true;
+
+            return false;
+        }
+
+        // If we have `Create<T>(ReadOnlySpan<T> values)` this is legal if a stack-alloc expression is passed along.
+        if (arguments.Count == 1 &&
+            originalCreateMethod.Parameters is [INamedTypeSymbol
+            {
+                Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+            } spanType])
+        {
+            if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
+                spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
+            {
+                if (arguments[0].Expression is StackAllocArrayCreationExpressionSyntax or ImplicitStackAllocArrayCreationExpressionSyntax)
+                    return true;
+            }
+        }
+
+        // If we have `Create<T>(IEnumerable<T> values)` this is legal if we have an array, or no-arg object creation.
+        if (arguments.Count == 1 &&
+            originalCreateMethod.Parameters is [INamedTypeSymbol
+            {
+                Name: nameof(IEnumerable<int>),
+                TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+            } enumerableType] && enumerableType.OriginalDefinition.Equals(compilation.IEnumerableOfTType()))
+        {
+            if (arguments[0].Expression
+                    is ArrayCreationExpressionSyntax
+                    or ImplicitArrayCreationExpressionSyntax
+                    or ObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: 0 }
+                    or ImplicitObjectCreationExpressionSyntax {  ArgumentList.Arguments.Count: 0 })
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs
@@ -146,7 +146,7 @@ internal sealed partial class CSharpUseCollectionExpressionForStackAllocDiagnost
             additionalUnnecessaryLocations: additionalUnnecessaryLocations));
     }
 
-    public static ImmutableArray<CollectionExpressionMatch> TryGetMatches(
+    public static ImmutableArray<CollectionExpressionMatch<StatementSyntax>> TryGetMatches(
         SemanticModel semanticModel,
         StackAllocArrayCreationExpressionSyntax expression,
         CancellationToken cancellationToken)

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CollectionExpressionMatch.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 
 /// <inheritdoc cref="Match{TStatementSyntax}"/>
-internal readonly record struct CollectionExpressionMatch(
-    StatementSyntax Statement,
-    bool UseSpread);
+internal readonly record struct CollectionExpressionMatch<TMatchNode>(
+    TMatchNode Node,
+    bool UseSpread) where TMatchNode : SyntaxNode;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -296,7 +296,7 @@ internal static class UseCollectionExpressionHelpers
         return false;
     }
 
-    public static ImmutableArray<CollectionExpressionMatch> TryGetMatches<TArrayCreationExpressionSyntax>(
+    public static ImmutableArray<CollectionExpressionMatch<StatementSyntax>> TryGetMatches<TArrayCreationExpressionSyntax>(
         SemanticModel semanticModel,
         TArrayCreationExpressionSyntax expression,
         Func<TArrayCreationExpressionSyntax, TypeSyntax> getType,
@@ -310,7 +310,7 @@ internal static class UseCollectionExpressionHelpers
         if (getType(expression) is not ArrayTypeSyntax { RankSpecifiers: [{ Sizes: [var size] }, ..] })
             return default;
 
-        using var _ = ArrayBuilder<CollectionExpressionMatch>.GetInstance(out var matches);
+        using var _ = ArrayBuilder<CollectionExpressionMatch<StatementSyntax>>.GetInstance(out var matches);
 
         var initializer = getInitializer(expression);
         if (size is OmittedArraySizeExpressionSyntax)

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -77,6 +77,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UpdateProjectToAllowUnsafe\CSharpUpdateProjectToAllowUnsafeCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpgradeProject\CSharpUpgradeProjectCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpCollectionExpressionRewriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForCreateCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForEmptyCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForArrayCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForStackAllocCodeFixProvider.cs" />

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -578,8 +578,9 @@ internal static class CSharpCollectionExpressionRewriter
 
         string GetIndentationStringForPosition(int position)
         {
-            var tokenLine = document.Text.Lines.GetLineFromPosition(position);
-            var indentation = position - tokenLine.Start;
+            var lineContainingPosition = document.Text.Lines.GetLineFromPosition(position);
+            var lineText = lineContainingPosition.ToString();
+            var indentation = lineText.ConvertTabToSpace(formattingOptions.TabSize, initialColumn: 0, endPosition: position - lineContainingPosition.Start);
             return indentation.CreateIndentationString(formattingOptions.UseTabs, formattingOptions.TabSize);
         }
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -406,7 +406,6 @@ internal static class CSharpCollectionExpressionRewriter
             }
             else if (node is ExpressionSyntax expression)
             {
-                // expression.GetAncestor<StatementSyntax>()
                 return CreateCollectionElement(match, IndentExpression(parentStatement: null, expression, preferredIndentation));
             }
             else

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -406,6 +406,7 @@ internal static class CSharpCollectionExpressionRewriter
             }
             else if (node is ExpressionSyntax expression)
             {
+                // expression.GetAncestor<StatementSyntax>()
                 return CreateCollectionElement(match, IndentExpression(parentStatement: null, expression, preferredIndentation));
             }
             else

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpCollectionExpressionRewriter.cs
@@ -580,10 +580,7 @@ internal static class CSharpCollectionExpressionRewriter
         {
             var tokenLine = document.Text.Lines.GetLineFromPosition(position);
             var indentation = position - tokenLine.Start;
-            var indentationString = new IndentationResult(indentation, offset: 0).GetIndentationString(
-                document.Text, indentationOptions);
-
-            return indentationString;
+            return indentation.CreateIndentationString(formattingOptions.UseTabs, formattingOptions.TabSize);
         }
 
         bool MakeMultiLineCollectionExpression()

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForArrayCodeFixProvider.cs
@@ -95,7 +95,7 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider
 
             editor.ReplaceNode(arrayCreationExpression, collectionExpression);
             foreach (var match in matches)
-                editor.RemoveNode(match.Statement);
+                editor.RemoveNode(match.Node);
         }
 
         return;
@@ -103,13 +103,13 @@ internal partial class CSharpUseCollectionExpressionForArrayCodeFixProvider
         static bool IsOnSingleLine(SourceText sourceText, SyntaxNode node)
             => sourceText.AreOnSameLine(node.GetFirstToken(), node.GetLastToken());
 
-        ImmutableArray<CollectionExpressionMatch> GetMatches(SemanticModel semanticModel, ExpressionSyntax expression)
+        ImmutableArray<CollectionExpressionMatch<StatementSyntax>> GetMatches(SemanticModel semanticModel, ExpressionSyntax expression)
             => expression switch
             {
                 // if we have `new[] { ... }` we have no subsequent matches to add to the collection. All values come
                 // from within the initializer.
                 ImplicitArrayCreationExpressionSyntax
-                    => ImmutableArray<CollectionExpressionMatch>.Empty,
+                    => ImmutableArray<CollectionExpressionMatch<StatementSyntax>>.Empty,
 
                 // we have `stackalloc T[...] ...;` defer to analyzer to find the items that follow that may need to
                 // be added to the collection expression.

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
@@ -14,8 +14,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
@@ -46,10 +46,11 @@ internal partial class CSharpUseCollectionExpressionForCreateCodeFixProvider
         var unwrapArgument = properties.ContainsKey(CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.UnwrapArgument);
 
         // We want to replace `XXX.Create(...)` with the new collection expression.  To do this, we go through the
-        // following steps.  First, we replace `XXX.Create(...)` with `new()` (an empty object creation expression). We
-        // then call into our helper which replaces expressions with collection expressions.  The reason for the dummy
-        // object creation expression is that it serves as an actual node the rewriting code can attach an initializer
-        // to, by which it can figure out appropriate wrapping and indentation for the collection expression elements.
+        // following steps.  First, we replace `XXX.Create(a, b, c)` with `new(a, b, c)` (an dummy object creation
+        // expression). We then call into our helper which replaces expressions with collection expressions.  The reason
+        // for the dummy object creation expression is that it serves as an actual node the rewriting code can attach an
+        // initializer to, by which it can figure out appropriate wrapping and indentation for the collection expression
+        // elements.
 
         var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
@@ -77,7 +78,7 @@ internal partial class CSharpUseCollectionExpressionForCreateCodeFixProvider
         var collectionExpression = await CSharpCollectionExpressionRewriter.CreateCollectionExpressionAsync(
             newSemanticDocument.Document,
             fallbackOptions,
-            dummyObjectAnnotation,
+            dummyObjectCreation,
             expressions.SelectAsArray(static e => new CollectionExpressionMatch<ExpressionSyntax>(e, UseSpread: false)),
             static o => o.Initializer,
             static (o, i) => o.WithInitializer(i),

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForCreateCodeFixProvider.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
+
+using static SyntaxFactory;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseCollectionExpressionForCreate), Shared]
+internal partial class CSharpUseCollectionExpressionForCreateCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public CSharpUseCollectionExpressionForCreateCodeFixProvider()
+    {
+    }
+
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(IDEDiagnosticIds.UseCollectionExpressionForCreateDiagnosticId);
+
+    protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
+        => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        RegisterCodeFix(context, CSharpCodeFixesResources.Use_collection_expression, IDEDiagnosticIds.UseCollectionExpressionForCreateDiagnosticId);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task FixAllAsync(
+        Document document,
+        ImmutableArray<Diagnostic> diagnostics,
+        SyntaxEditor editor,
+        CodeActionOptionsProvider fallbackOptions,
+        CancellationToken cancellationToken)
+    {
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var diagnostic in diagnostics.OrderByDescending(d => d.Location.SourceSpan.Start))
+        {
+            var expression = diagnostic.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken);
+            editor.ReplaceNode(
+                expression,
+                (current, _) => EmptyCollection.WithTriviaFrom(current));
+        }
+
+        return;
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionExpression/CSharpUseCollectionExpressionForStackAllocCodeFixProvider.cs
@@ -69,17 +69,17 @@ internal partial class CSharpUseCollectionExpressionForStackAllocCodeFixProvider
         editor.ReplaceNode(stackAllocExpression, collectionExpression);
 
         foreach (var match in matches)
-            editor.RemoveNode(match.Statement);
+            editor.RemoveNode(match.Node);
 
         return;
 
-        ImmutableArray<CollectionExpressionMatch> GetMatches()
+        ImmutableArray<CollectionExpressionMatch<StatementSyntax>> GetMatches()
             => stackAllocExpression switch
             {
                 // if we have `stackalloc[] { ... }` we have no subsequent matches to add to the collection. All values come
                 // from within the initializer.
                 ImplicitStackAllocArrayCreationExpressionSyntax
-                    => ImmutableArray<CollectionExpressionMatch>.Empty,
+                    => ImmutableArray<CollectionExpressionMatch<StatementSyntax>>.Empty,
 
                 // we have `stackalloc T[...] ...;` defer to analyzer to find the items that follow that may need to
                 // be added to the collection expression.

--- a/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider_CollectionExpression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
                 document,
                 fallbackOptions,
                 objectCreation,
-                matches.SelectAsArray(m => new CollectionExpressionMatch(m.Statement, m.UseSpread)),
+                matches.SelectAsArray(m => new CollectionExpressionMatch<StatementSyntax>(m.Statement, m.UseSpread)),
                 static objectCreation => objectCreation.Initializer,
                 static (objectCreation, initializer) => objectCreation.WithInitializer(initializer),
                 cancellationToken);

--- a/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
@@ -98,6 +98,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForIfNullStatementCheckTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForNullableTernaryConditionalCheckTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\UseCoalesceExpressionForTernaryConditionalCheckTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionForCreateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionForStackAllocTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionForArrayTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionForEmptyTests.cs" />

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -26,12 +26,15 @@ public class UseCollectionExpressionForCreateTests
         await new VerifyCS.Test
         {
             TestCode = """
+                using System.Collections.Immutable;
+
                 class C
                 {
-                    int[] i = { 1, 2, 3 };
+                    ImmutableArray<int> i = ImmutableArray.Create(1, 2, 3);
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp11,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
 
@@ -41,15 +44,19 @@ public class UseCollectionExpressionForCreateTests
         await new VerifyCS.Test
         {
             TestCode = """
+                using System.Collections.Immutable;
+
                 class C
                 {
-                    int[] i = [|{|] 1, 2, 3 };
+                    ImmutableArray<int> i = [|ImmutableArray.[|Create|](|]1, 2, 3);
                 }
                 """,
             FixedCode = """
+                using System.Collections.Immutable;
+
                 class C
                 {
-                    int[] i = [1, 2, 3];
+                    ImmutableArray<int> i = [1, 2, 3];
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -57,2589 +64,2615 @@ public class UseCollectionExpressionForCreateTests
     }
 
     [Fact]
-    public async Task TestSingleLine_TrailingComma()
+    public async Task TestInCSharp12_Net80()
     {
         await new VerifyCS.Test
         {
             TestCode = """
+                using System.Collections.Immutable;
+
                 class C
                 {
-                    int[] i = [|{|] 1, 2, 3, };
+                    ImmutableArray<int> i = [|ImmutableArray.[|Create|](|]1, 2, 3);
                 }
                 """,
             FixedCode = """
+                using System.Collections.Immutable;
+
                 class C
                 {
-                    int[] i = [1, 2, 3,];
+                    ImmutableArray<int> i = [1, 2, 3];
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
 
-    [Fact]
-    public async Task TestSingleLine_Trivia()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = /*x*/ [|{|] /*y*/ 1, 2, 3 /*z*/ } /*w*/;
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = /*x*/ [/*y*/ 1, 2, 3 /*z*/] /*w*/;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestSingleLine_TrailingComma()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|] 1, 2, 3, };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [1, 2, 3,];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestMultiLine()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|]
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestSingleLine_Trivia()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = /*x*/ [|{|] /*y*/ 1, 2, 3 /*z*/ } /*w*/;
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = /*x*/ [/*y*/ 1, 2, 3 /*z*/] /*w*/;
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestMultiLine_TrailingComma()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|]
-                        1, 2, 3,
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                        1, 2, 3,
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestMultiLine()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|]
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestEmpty1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|]};
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestMultiLine_TrailingComma()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|]
+    //                    1, 2, 3,
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                    1, 2, 3,
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestEmpty2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|] };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestEmpty1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|]};
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotWithIncompatibleExplicitArrays()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = new string[] { "" };
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestEmpty2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|] };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleExplicitArrays1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = [|[|new|] object[]|] { "" };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    object[] i = [""];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotWithIncompatibleExplicitArrays()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = new string[] { "" };
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleExplicitArrays2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = [|[|new|] object[]|]
-                    {
-                        ""
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    object[] i =
-                    [
-                        ""
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleExplicitArrays1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = [|[|new|] object[]|] { "" };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                object[] i = [""];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleExplicitArrays_Empty()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = [|[|new|] object[]|] { };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    object[] i = [];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleExplicitArrays2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = [|[|new|] object[]|]
+    //                {
+    //                    ""
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                object[] i =
+    //                [
+    //                    ""
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleExplicitArrays_TrailingComma()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = [|[|new|] object[]|] { "", };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    object[] i = ["",];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleExplicitArrays_Empty()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = [|[|new|] object[]|] { };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                object[] i = [];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithExplicitArray_ExplicitSize()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[] i = [|[|new|] string[1]|] { "" };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    string[] i = [""];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleExplicitArrays_TrailingComma()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = [|[|new|] object[]|] { "", };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                object[] i = ["",];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[,] i = new string[1, 1];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithExplicitArray_ExplicitSize()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[] i = [|[|new|] string[1]|] { "" };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                string[] i = [""];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[,] i = new string[1, 1] { { "" } };
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[,] i = new string[1, 1];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithExplicitArray_MultiDimensionalArray_ImplicitSizes1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[,] i = new string[,] { { "" } };
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[,] i = new string[1, 1] { { "" } };
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotWithIncompatibleImplicitArrays()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    object[] i = new[] { "" };
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithExplicitArray_MultiDimensionalArray_ImplicitSizes1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[,] i = new string[,] { { "" } };
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleImplicitArrays1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[] i = [|[|new|][]|] { "" };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    string[] i = [""];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotWithIncompatibleImplicitArrays()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                object[] i = new[] { "" };
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleImplicitArrays2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[] i = [|[|new|][]|]
-                    {
-                        ""
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    string[] i =
-                    [
-                        ""
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleImplicitArrays1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[] i = [|[|new|][]|] { "" };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                string[] i = [""];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestMissingOnEmptyImplicitArray()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[] i = {|CS0826:{|CS0029:new[] { }|}|};
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleImplicitArrays2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[] i = [|[|new|][]|]
+    //                {
+    //                    ""
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                string[] i =
+    //                [
+    //                    ""
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestWithCompatibleImplicitArrays_TrailingComma()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    string[] i = [|[|new|][]|] { "", };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    string[] i = ["",];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestMissingOnEmptyImplicitArray()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[] i = {|CS0826:{|CS0029:new[] { }|}|};
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Theory, CombinatorialData]
-    public async Task TestNotWithVar_ExplicitArrayType(
-         [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = $$"""
-                class C
-                {
-                    void M()
-                    {
-                        {{type}} i = new string[] { "" };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestWithCompatibleImplicitArrays_TrailingComma()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                string[] i = [|[|new|][]|] { "", };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                string[] i = ["",];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Theory, CombinatorialData]
-    public async Task TestNotWithVar_ExplicitArrayType2(
-        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = $$"""
-                class C
-                {
-                    void M()
-                    {
-                        {{type}} i = (new string[] { "" });
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Theory, CombinatorialData]
+    //public async Task TestNotWithVar_ExplicitArrayType(
+    //     [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = $$"""
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    {{type}} i = new string[] { "" };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Theory, CombinatorialData]
-    public async Task TestNotWithVar_ImplicitArrayType(
-        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = $$"""
-                class C
-                {
-                    void M()
-                    {
-                        {{type}} i = new[] { "" };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Theory, CombinatorialData]
+    //public async Task TestNotWithVar_ExplicitArrayType2(
+    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = $$"""
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    {{type}} i = (new string[] { "" });
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Theory, CombinatorialData]
-    public async Task TestNotWithVar_ImplicitArrayType2(
-        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = $$"""
-                class C
-                {
-                    void M()
-                    {
-                        {{type}} i = (new[] { "" });
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Theory, CombinatorialData]
+    //public async Task TestNotWithVar_ImplicitArrayType(
+    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = $$"""
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    {{type}} i = new[] { "" };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotWithExtension()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
+    //[Theory, CombinatorialData]
+    //public async Task TestNotWithVar_ImplicitArrayType2(
+    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = $$"""
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    {{type}} i = (new[] { "" });
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-                class C
-                {
-                    void M()
-                    {
-                        var i = new int[] { 1 }.AsSpan();
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotWithExtension()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
 
-    [Fact]
-    public async Task TestTargetTypedToField()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int[] X = [|[|new|] int[]|] { 1 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    private int[] X = [1];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    var i = new int[] { 1 }.AsSpan();
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //        ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedToProperty()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int[] X { get; } = [|[|new|] int[]|] { 1 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    private int[] X { get; } = [1];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedToField()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                private int[] X = [|[|new|] int[]|] { 1 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                private int[] X = [1];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedToComplexCast()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M()
-                    {
-                        var c = (int[])[|[|new|] int[]|] { 1 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M()
-                    {
-                        var c = (int[])[1];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedToProperty()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                private int[] X { get; } = [|[|new|] int[]|] { 1 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                private int[] X { get; } = [1];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotTargetTypedWithIdentifierCast()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using IntArray = int[];
+    //[Fact]
+    //public async Task TestTargetTypedToComplexCast()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    var c = (int[])[|[|new|] int[]|] { 1 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    var c = (int[])[1];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-                class C
-                {
-                    void M()
-                    {
-                        var c = (IntArray)new int[] { 1 };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotTargetTypedWithIdentifierCast()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using IntArray = int[];
 
-    [Fact]
-    public async Task TestTargetTypedInConditional1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var c = true ? [|[|new|] int[]|] { 1 } : x;
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var c = true ? [1] : x;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    var c = (IntArray)new int[] { 1 };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInConditional2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var c = true ? x : [|[|new|] int[]|] { 1 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var c = true ? x : [1];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInConditional1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var c = true ? [|[|new|] int[]|] { 1 } : x;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var c = true ? [1] : x;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInConditional3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        int[] c = true ? null : [|[|new|] int[]|] { 1 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        int[] c = true ? null : [1];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInConditional2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var c = true ? x : [|[|new|] int[]|] { 1 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var c = true ? x : [1];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotTargetTypedInConditional4()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var c = true ? null : new int[] { 1 };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInConditional3()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    int[] c = true ? null : [|[|new|] int[]|] { 1 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    int[] c = true ? null : [1];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInSwitchExpressionArm1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = b switch { true => x, false => [|[|new|] int[]|] { 1 } };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = b switch { true => x, false => [1] };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotTargetTypedInConditional4()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var c = true ? null : new int[] { 1 };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInSwitchExpressionArm2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = b switch { false => [|[|new|] int[]|] { 1 }, true => x };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = b switch { false => [1], true => x };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInSwitchExpressionArm1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = b switch { true => x, false => [|[|new|] int[]|] { 1 } };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = b switch { true => x, false => [1] };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInSwitchExpressionArm3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        int[] c = b switch { false => [|[|new|] int[]|] { 1 }, true => null };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        int[] c = b switch { false => [1], true => null };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInSwitchExpressionArm2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = b switch { false => [|[|new|] int[]|] { 1 }, true => x };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = b switch { false => [1], true => x };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotTargetTypedInSwitchExpressionArm4()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = b switch { false => new int[] { 1 }, true => null };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInSwitchExpressionArm3()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    int[] c = b switch { false => [|[|new|] int[]|] { 1 }, true => null };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    int[] c = b switch { false => [1], true => null };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNotTargetTypedInitializer1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new int[,] { { 1, 2, 3 } };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotTargetTypedInSwitchExpressionArm4()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = b switch { false => new int[] { 1 }, true => null };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInitializer2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new[] { [|[|new|][]|] { 1, 2, 3 }, x };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new[] { [1, 2, 3], x };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotTargetTypedInitializer1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new int[,] { { 1, 2, 3 } };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInitializer3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new[] { x, [|[|new|][]|] { 1, 2, 3 } };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new[] { x, [1, 2, 3] };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInitializer2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new[] { [|[|new|][]|] { 1, 2, 3 }, x };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new[] { [1, 2, 3], x };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInitializer4()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        var c = new[] { new[] { 1, 2, 3 } };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInitializer3()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new[] { x, [|[|new|][]|] { 1, 2, 3 } };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new[] { x, [1, 2, 3] };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedInitializer5()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        int[][] c = [|[|new|][]|] { new[] { 1, 2, 3 } };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x, bool b)
-                    {
-                        int[][] c = [new[] { 1, 2, 3 }];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedInitializer4()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    var c = new[] { new[] { 1, 2, 3 } };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedArgument1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M()
-                    {
-                        X([|[|new|] int[]|] { 1, 2, 3 });
-                    }
+    //[Fact]
+    //public async Task TestTargetTypedInitializer5()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    int[][] c = [|[|new|][]|] { new[] { 1, 2, 3 } };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x, bool b)
+    //                {
+    //                    int[][] c = [new[] { 1, 2, 3 }];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-                    void X(int[] x) { }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M()
-                    {
-                        X([1, 2, 3]);
-                    }
+    //[Fact]
+    //public async Task TestTargetTypedArgument1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    X([|[|new|] int[]|] { 1, 2, 3 });
+    //                }
 
-                    void X(int[] x) { }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //                void X(int[] x) { }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    X([1, 2, 3]);
+    //                }
 
-    [Fact]
-    public async Task TestNotTargetTypedArgument2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System.Collections.Generic;
-                class C
-                {
-                    void M()
-                    {
-                        X(new int[] { 1, 2, 3 });
-                    }
+    //                void X(int[] x) { }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-                    void X(int[] x) { }
-                    void X(List<int> x) { }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestNotTargetTypedArgument2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System.Collections.Generic;
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    X(new int[] { 1, 2, 3 });
+    //                }
 
-    [Fact]
-    public async Task TestTargetTypedAttributeArgument1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                [X([|[|new|] int[]|] { 1, 2, 3 })]
-                class C
-                {
-                }
+    //                void X(int[] x) { }
+    //                void X(List<int> x) { }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-                public class XAttribute : System.Attribute
-                {
-                    public XAttribute(int[] values) { }
-                }
-                """,
-            FixedCode = """
-                [X([1, 2, 3])]
-                class C
-                {
-                }
+    //[Fact]
+    //public async Task TestTargetTypedAttributeArgument1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            [X([|[|new|] int[]|] { 1, 2, 3 })]
+    //            class C
+    //            {
+    //            }
+
+    //            public class XAttribute : System.Attribute
+    //            {
+    //                public XAttribute(int[] values) { }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            [X([1, 2, 3])]
+    //            class C
+    //            {
+    //            }
                 
-                public class XAttribute : System.Attribute
-                {
-                    public XAttribute(int[] values) { }
-                }
-                """,
-            FixedState =
-                {
-                    // THis will tart working once https://github.com/dotnet/roslyn/issues/69133 is fixed.
-                    ExpectedDiagnostics =
-                    {
-                        // /0/Test0.cs(1,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
-                        DiagnosticResult.CompilerError("CS0182").WithSpan(1, 4, 1, 13),
-                    }
-                },
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            public class XAttribute : System.Attribute
+    //            {
+    //                public XAttribute(int[] values) { }
+    //            }
+    //            """,
+    //        FixedState =
+    //            {
+    //                // THis will tart working once https://github.com/dotnet/roslyn/issues/69133 is fixed.
+    //                ExpectedDiagnostics =
+    //                {
+    //                    // /0/Test0.cs(1,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+    //                    DiagnosticResult.CompilerError("CS0182").WithSpan(1, 4, 1, 13),
+    //                }
+    //            },
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestTargetTypedReturn1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] M()
-                    {
-                        return [|[|new|] int[]|] { 1, 2, 3 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] M()
-                    {
-                        return [1, 2, 3];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestTargetTypedReturn1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] M()
+    //                {
+    //                    return [|[|new|] int[]|] { 1, 2, 3 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] M()
+    //                {
+    //                    return [1, 2, 3];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestAssignment1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        x = [|[|new|] int[]|] { 1, 2, 3 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        x = [1, 2, 3];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //[Fact]
+    //public async Task TestAssignment1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    x = [|[|new|] int[]|] { 1, 2, 3 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    x = [1, 2, 3];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestAssignment2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    public int[] X;
+    //[Fact]
+    //public async Task TestAssignment2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                public int[] X;
 
-                    void M()
-                    {
-                        var v = new C
-                        {
-                            X = [|[|new|] int[]|] { 1, 2, 3 },
-                        };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    public int[] X;
+    //                void M()
+    //                {
+    //                    var v = new C
+    //                    {
+    //                        X = [|[|new|] int[]|] { 1, 2, 3 },
+    //                    };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                public int[] X;
                 
-                    void M()
-                    {
-                        var v = new C
-                        {
-                            X = [1, 2, 3],
-                        };
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestCoalesce1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var y = x ?? [|[|new|] int[]|] { 1, 2, 3 };
-                    }
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var y = x ?? [1, 2, 3];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithLinqLet()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-                using System.Linq;
-
-                class C
-                {
-                    void M(int[] x)
-                    {
-                        var y = from a in x
-                                let b = new int[] { 1, 2, 3 }
-                                select b;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|] 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|{|] 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|]
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting4()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|{|]
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting5()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|{|] 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting6()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|{|]
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting7()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|{|]
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting8()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-
-                        [|{|]
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting1_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|] int[]|] { 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting2_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|] int[]|] { 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting3_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|] int[]|] {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting4_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|] int[]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting5_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|] int[]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting6_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|] int[]|] {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting7_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|[|new|] int[]|]
-                        {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting8_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|[|new|] int[]|] {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting9_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|] int[]|] {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting10_Explicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-
-                    [|[|new|] int[]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting1_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|][]|] { 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting2_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|][]|] { 1, 2, 3 };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [1, 2, 3];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting3_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|][]|] {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting4_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|][]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting5_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|][]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting6_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                    [|[|new|][]|] {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting7_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|[|new|][]|]
-                        {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting8_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-                        [|[|new|][]|] {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-                        [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting9_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i = [|[|new|][]|] {
-                            1, 2, 3
-                        };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i = [
-                            1, 2, 3
-                        ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestInitializerFormatting10_Implicit()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    int[] i =
-
-                    [|[|new|][]|]
-                    {
-                        1, 2, 3
-                    };
-                }
-                """,
-            FixedCode = """
-                class C
-                {
-                    int[] i =
-
-                    [
-                        1, 2, 3
-                    ];
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_MultiLine1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [|[|new|] int[1]|];
-                        r[0] = 1 +
-                            2;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r =
-                        [
-                            1 +
-                                2,
-                        ];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_MultiLine2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [|[|new|] int[2]|];
-                        r[0] = 1 +
-                            2;
-                        r[1] = 3 +
-                            4;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r =
-                        [
-                            1 +
-                                2,
-                            3 +
-                                4,
-                        ];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ZeroSize()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        int[] r = [|[|new|] int[0]|];
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        int[] r = [];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_NotEnoughFollowingStatements()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        int[] r = new int[1];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_WrongFollowingStatement()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        int[] r = new int[1];
-                        return;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_NotLocalStatementInitializer()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M()
-                    {
-                        int[] r = Goo(new int[1]);
-                        r[0] = 1;
-                    }
-
-                    int[] Goo(int[] input) => default;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ExpressionStatementNotAssignment()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i)
-                    {
-                        int[] r = new int[1];
-                        i++;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_AssignmentNotElementAccess()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[1];
-                        i = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ElementAccessNotToIdentifier()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    static int[] array;
-
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[1];
-                        C.array[0] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_IdentifierNotEqualToVariableName()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    static int[] array;
-
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[1];
-                        array[0] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ArgumentNotConstant()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[1];
-                        r[i] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ConstantArgumentNotCorrect1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[1];
-                        r[1] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_ConstantArgumentNotCorrect2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[2];
-                        r[0] = i;
-                        r[0] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_OneElement()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [|[|new|] int[1]|];
-                        r[0] = i;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [i];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_OneElement_MultipleFollowingStatements()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [|[|new|] int[1]|];
-                        r[0] = i;
-                        r[0] = j;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [i];
-                        r[0] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [|[|new|] int[2]|];
-                        r[0] = i;
-                        r[1] = j;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = [i, j];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement2_Constant()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        const int v = 1;
-                        int[] r = [|[|new|] int[2]|];
-                        r[0] = i;
-                        r[v] = j;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        const int v = 1;
-                        int[] r = [i, j];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement2_SecondWrongIndex()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[] r = new int[2];
-                        r[0] = i;
-                        r[0] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement2_SecondNonConstant()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        var v = 1;
-                        int[] r = new int[2];
-                        r[0] = i;
-                        r[v] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement2_SecondWrongDestination()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    static int[] array;
-
-                    void M(int i, int j)
-                    {
-                        var v = 1;
-                        int[] r = new int[2];
-                        r[0] = i;
-                        array[1] = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement_TwoDimensional1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [|[|new|] int[2][]|];
-                        r[0] = null;
-                        r[1] = null;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [null, null];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNoInitializer_TwoElement_TwoDimensional2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [|[|new|] int[2][]|];
-                        r[0] = [|[|new|][]|] { 1 };
-                        r[1] = [|[|new|] int[]|] { 2 };
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [new[] { 1 }, new int[] { 2 }];
-                    }
-                }
-                """,
-            BatchFixedCode = """
-                using System;
+    //                void M()
+    //                {
+    //                    var v = new C
+    //                    {
+    //                        X = [1, 2, 3],
+    //                    };
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestCoalesce1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var y = x ?? [|[|new|] int[]|] { 1, 2, 3 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var y = x ?? [1, 2, 3];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNotWithLinqLet()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+    //            using System.Linq;
+
+    //            class C
+    //            {
+    //                void M(int[] x)
+    //                {
+    //                    var y = from a in x
+    //                            let b = new int[] { 1, 2, 3 }
+    //                            select b;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|] 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|{|] 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting3()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|]
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting4()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|{|]
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting5()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|{|] 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting6()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|{|]
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting7()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|{|]
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting8()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                    [|{|]
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting1_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|] int[]|] { 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting2_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|] int[]|] { 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting3_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|] int[]|] {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting4_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|] int[]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting5_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|] int[]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting6_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|] int[]|] {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting7_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|[|new|] int[]|]
+    //                    {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting8_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|[|new|] int[]|] {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting9_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|] int[]|] {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting10_Explicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                [|[|new|] int[]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting1_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|][]|] { 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting2_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|][]|] { 1, 2, 3 };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [1, 2, 3];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting3_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|][]|] {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting4_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|][]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting5_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|][]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting6_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [|[|new|][]|] {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting7_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|[|new|][]|]
+    //                    {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting8_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [|[|new|][]|] {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+    //                    [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting9_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i = [|[|new|][]|] {
+    //                        1, 2, 3
+    //                    };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i = [
+    //                        1, 2, 3
+    //                    ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestInitializerFormatting10_Implicit()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                [|[|new|][]|]
+    //                {
+    //                    1, 2, 3
+    //                };
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            class C
+    //            {
+    //                int[] i =
+
+    //                [
+    //                    1, 2, 3
+    //                ];
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_MultiLine1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [|[|new|] int[1]|];
+    //                    r[0] = 1 +
+    //                        2;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r =
+    //                    [
+    //                        1 +
+    //                            2,
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_MultiLine2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [|[|new|] int[2]|];
+    //                    r[0] = 1 +
+    //                        2;
+    //                    r[1] = 3 +
+    //                        4;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r =
+    //                    [
+    //                        1 +
+    //                            2,
+    //                        3 +
+    //                            4,
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ZeroSize()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    int[] r = [|[|new|] int[0]|];
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    int[] r = [];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_NotEnoughFollowingStatements()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    int[] r = new int[1];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_WrongFollowingStatement()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    int[] r = new int[1];
+    //                    return;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_NotLocalStatementInitializer()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M()
+    //                {
+    //                    int[] r = Goo(new int[1]);
+    //                    r[0] = 1;
+    //                }
+
+    //                int[] Goo(int[] input) => default;
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ExpressionStatementNotAssignment()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i)
+    //                {
+    //                    int[] r = new int[1];
+    //                    i++;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_AssignmentNotElementAccess()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[1];
+    //                    i = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ElementAccessNotToIdentifier()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                static int[] array;
+
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[1];
+    //                    C.array[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_IdentifierNotEqualToVariableName()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                static int[] array;
+
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[1];
+    //                    array[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ArgumentNotConstant()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[1];
+    //                    r[i] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ConstantArgumentNotCorrect1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[1];
+    //                    r[1] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_ConstantArgumentNotCorrect2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[2];
+    //                    r[0] = i;
+    //                    r[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_OneElement()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [|[|new|] int[1]|];
+    //                    r[0] = i;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [i];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_OneElement_MultipleFollowingStatements()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [|[|new|] int[1]|];
+    //                    r[0] = i;
+    //                    r[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [i];
+    //                    r[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [|[|new|] int[2]|];
+    //                    r[0] = i;
+    //                    r[1] = j;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = [i, j];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement2_Constant()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    const int v = 1;
+    //                    int[] r = [|[|new|] int[2]|];
+    //                    r[0] = i;
+    //                    r[v] = j;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    const int v = 1;
+    //                    int[] r = [i, j];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement2_SecondWrongIndex()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[] r = new int[2];
+    //                    r[0] = i;
+    //                    r[0] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement2_SecondNonConstant()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    var v = 1;
+    //                    int[] r = new int[2];
+    //                    r[0] = i;
+    //                    r[v] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement2_SecondWrongDestination()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                static int[] array;
+
+    //                void M(int i, int j)
+    //                {
+    //                    var v = 1;
+    //                    int[] r = new int[2];
+    //                    r[0] = i;
+    //                    array[1] = j;
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement_TwoDimensional1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [|[|new|] int[2][]|];
+    //                    r[0] = null;
+    //                    r[1] = null;
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [null, null];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
+
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement_TwoDimensional2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [|[|new|] int[2][]|];
+    //                    r[0] = [|[|new|][]|] { 1 };
+    //                    r[1] = [|[|new|] int[]|] { 2 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [new[] { 1 }, new int[] { 2 }];
+    //                }
+    //            }
+    //            """,
+    //        BatchFixedCode = """
+    //            using System;
                 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [[1], [2]];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [[1], [2]];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia1()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [|[|new|] int[2][]|];
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [|[|new|] int[2][]|];
 
-                        // Leading
-                        r[0] = [|[|new|][]|] { 1 }; // Trailing
-                        r[1] = [|[|new|] int[]|] { 2 };
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
+    //                    // Leading
+    //                    r[0] = [|[|new|][]|] { 1 }; // Trailing
+    //                    r[1] = [|[|new|] int[]|] { 2 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            // Leading
-                            new[] { 1 }, // Trailing
-                            new int[] { 2 },
-                        ];
-                    }
-                }
-                """,
-            BatchFixedCode = """
-                using System;
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r =
+    //                    [
+    //                        // Leading
+    //                        new[] { 1 }, // Trailing
+    //                        new int[] { 2 },
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        BatchFixedCode = """
+    //            using System;
                 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            // Leading
-                            [1], // Trailing
-                            [2],
-                        ];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r =
+    //                    [
+    //                        // Leading
+    //                        [1], // Trailing
+    //                        [2],
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 
-    [Fact]
-    public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
+    //[Fact]
+    //public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia2()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [|[|new|] int[2][]|];
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r = [|[|new|] int[2][]|];
 
-                        r[0] = [|[|new|][]|]
-                        {
-                            // Leading
-                            1 // Trailing
-                        };
-                        r[1] = [|[|new|] int[]|] { 2 };
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
+    //                    r[0] = [|[|new|][]|]
+    //                    {
+    //                        // Leading
+    //                        1 // Trailing
+    //                    };
+    //                    r[1] = [|[|new|] int[]|] { 2 };
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            new[]
-                            {
-                                // Leading
-                                1 // Trailing
-                            },
-                            new int[] { 2 },
-                        ];
-                    }
-                }
-                """,
-            BatchFixedCode = """
-                using System;
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r =
+    //                    [
+    //                        new[]
+    //                        {
+    //                            // Leading
+    //                            1 // Trailing
+    //                        },
+    //                        new int[] { 2 },
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        BatchFixedCode = """
+    //            using System;
                 
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            [
-                                // Leading
-                                1 // Trailing
-                            ],
-                            [2],
-                        ];
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
+    //            class C
+    //            {
+    //                void M(int i, int j)
+    //                {
+    //                    int[][] r =
+    //                    [
+    //                        [
+    //                            // Leading
+    //                            1 // Trailing
+    //                        ],
+    //                        [2],
+    //                    ];
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //    }.RunAsync();
+    //}
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -54,6 +51,11 @@ public class UseCollectionExpressionForCreateTests
         {
             public System.Collections.Generic.IEnumerator<T> GetEnumerator() => default;
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => default;
+        }
+        
+        [System.Runtime.CompilerServices.CollectionBuilder(typeof(MyCollection), "Create")]
+        interface IMyCollection<T> : System.Collections.Generic.IEnumerable<T>
+        {
         }
         """;
 
@@ -410,2616 +412,410 @@ public class UseCollectionExpressionForCreateTests
         }.RunAsync();
     }
 
-    //[Fact]
-    //public async Task TestInCSharp12_Net80()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System.Collections.Immutable;
-
-    //            class C
-    //            {
-    //                MyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3);
-    //            }
-    //            """ + s_collectionBuilderApi + s_basicCollectionApi,
-    //        FixedCode = """
-    //            using System.Collections.Immutable;
-
-    //            class C
-    //            {
-    //                MyCollection<int> i = [1, 2, 3];
-    //            }
-    //            """ + s_collectionBuilderApi + s_basicCollectionApi,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //        ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestSingleLine_TrailingComma()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|] 1, 2, 3, };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [1, 2, 3,];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestSingleLine_Trivia()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = /*x*/ [|{|] /*y*/ 1, 2, 3 /*z*/ } /*w*/;
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = /*x*/ [/*y*/ 1, 2, 3 /*z*/] /*w*/;
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestMultiLine()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|]
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestMultiLine_TrailingComma()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|]
-    //                    1, 2, 3,
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                    1, 2, 3,
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestEmpty1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|]};
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestEmpty2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|] };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotWithIncompatibleExplicitArrays()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = new string[] { "" };
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleExplicitArrays1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = [|[|new|] object[]|] { "" };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                object[] i = [""];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleExplicitArrays2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = [|[|new|] object[]|]
-    //                {
-    //                    ""
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                object[] i =
-    //                [
-    //                    ""
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleExplicitArrays_Empty()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = [|[|new|] object[]|] { };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                object[] i = [];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleExplicitArrays_TrailingComma()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = [|[|new|] object[]|] { "", };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                object[] i = ["",];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithExplicitArray_ExplicitSize()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[] i = [|[|new|] string[1]|] { "" };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                string[] i = [""];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[,] i = new string[1, 1];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[,] i = new string[1, 1] { { "" } };
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithExplicitArray_MultiDimensionalArray_ImplicitSizes1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[,] i = new string[,] { { "" } };
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotWithIncompatibleImplicitArrays()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                object[] i = new[] { "" };
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleImplicitArrays1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[] i = [|[|new|][]|] { "" };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                string[] i = [""];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleImplicitArrays2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[] i = [|[|new|][]|]
-    //                {
-    //                    ""
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                string[] i =
-    //                [
-    //                    ""
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestMissingOnEmptyImplicitArray()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[] i = {|CS0826:{|CS0029:new[] { }|}|};
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestWithCompatibleImplicitArrays_TrailingComma()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                string[] i = [|[|new|][]|] { "", };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                string[] i = ["",];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Theory, CombinatorialData]
-    //public async Task TestNotWithVar_ExplicitArrayType(
-    //     [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = $$"""
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    {{type}} i = new string[] { "" };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Theory, CombinatorialData]
-    //public async Task TestNotWithVar_ExplicitArrayType2(
-    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = $$"""
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    {{type}} i = (new string[] { "" });
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Theory, CombinatorialData]
-    //public async Task TestNotWithVar_ImplicitArrayType(
-    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = $$"""
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    {{type}} i = new[] { "" };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Theory, CombinatorialData]
-    //public async Task TestNotWithVar_ImplicitArrayType2(
-    //    [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = $$"""
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    {{type}} i = (new[] { "" });
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotWithExtension()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    var i = new int[] { 1 }.AsSpan();
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //        ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedToField()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                private int[] X = [|[|new|] int[]|] { 1 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                private int[] X = [1];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedToProperty()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                private int[] X { get; } = [|[|new|] int[]|] { 1 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                private int[] X { get; } = [1];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedToComplexCast()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    var c = (int[])[|[|new|] int[]|] { 1 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    var c = (int[])[1];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotTargetTypedWithIdentifierCast()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using IntArray = int[];
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    var c = (IntArray)new int[] { 1 };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInConditional1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var c = true ? [|[|new|] int[]|] { 1 } : x;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var c = true ? [1] : x;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInConditional2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var c = true ? x : [|[|new|] int[]|] { 1 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var c = true ? x : [1];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInConditional3()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    int[] c = true ? null : [|[|new|] int[]|] { 1 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    int[] c = true ? null : [1];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotTargetTypedInConditional4()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var c = true ? null : new int[] { 1 };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInSwitchExpressionArm1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = b switch { true => x, false => [|[|new|] int[]|] { 1 } };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = b switch { true => x, false => [1] };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInSwitchExpressionArm2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = b switch { false => [|[|new|] int[]|] { 1 }, true => x };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = b switch { false => [1], true => x };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInSwitchExpressionArm3()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    int[] c = b switch { false => [|[|new|] int[]|] { 1 }, true => null };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    int[] c = b switch { false => [1], true => null };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotTargetTypedInSwitchExpressionArm4()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = b switch { false => new int[] { 1 }, true => null };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotTargetTypedInitializer1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new int[,] { { 1, 2, 3 } };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInitializer2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new[] { [|[|new|][]|] { 1, 2, 3 }, x };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new[] { [1, 2, 3], x };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInitializer3()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new[] { x, [|[|new|][]|] { 1, 2, 3 } };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new[] { x, [1, 2, 3] };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInitializer4()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    var c = new[] { new[] { 1, 2, 3 } };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedInitializer5()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    int[][] c = [|[|new|][]|] { new[] { 1, 2, 3 } };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x, bool b)
-    //                {
-    //                    int[][] c = [new[] { 1, 2, 3 }];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedArgument1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    X([|[|new|] int[]|] { 1, 2, 3 });
-    //                }
-
-    //                void X(int[] x) { }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    X([1, 2, 3]);
-    //                }
-
-    //                void X(int[] x) { }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotTargetTypedArgument2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System.Collections.Generic;
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    X(new int[] { 1, 2, 3 });
-    //                }
-
-    //                void X(int[] x) { }
-    //                void X(List<int> x) { }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedAttributeArgument1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            [X([|[|new|] int[]|] { 1, 2, 3 })]
-    //            class C
-    //            {
-    //            }
-
-    //            public class XAttribute : System.Attribute
-    //            {
-    //                public XAttribute(int[] values) { }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            [X([1, 2, 3])]
-    //            class C
-    //            {
-    //            }
-
-    //            public class XAttribute : System.Attribute
-    //            {
-    //                public XAttribute(int[] values) { }
-    //            }
-    //            """,
-    //        FixedState =
-    //            {
-    //                // THis will tart working once https://github.com/dotnet/roslyn/issues/69133 is fixed.
-    //                ExpectedDiagnostics =
-    //                {
-    //                    // /0/Test0.cs(1,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
-    //                    DiagnosticResult.CompilerError("CS0182").WithSpan(1, 4, 1, 13),
-    //                }
-    //            },
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestTargetTypedReturn1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] M()
-    //                {
-    //                    return [|[|new|] int[]|] { 1, 2, 3 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] M()
-    //                {
-    //                    return [1, 2, 3];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestAssignment1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    x = [|[|new|] int[]|] { 1, 2, 3 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    x = [1, 2, 3];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestAssignment2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                public int[] X;
-
-    //                void M()
-    //                {
-    //                    var v = new C
-    //                    {
-    //                        X = [|[|new|] int[]|] { 1, 2, 3 },
-    //                    };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                public int[] X;
-
-    //                void M()
-    //                {
-    //                    var v = new C
-    //                    {
-    //                        X = [1, 2, 3],
-    //                    };
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestCoalesce1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var y = x ?? [|[|new|] int[]|] { 1, 2, 3 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var y = x ?? [1, 2, 3];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNotWithLinqLet()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-    //            using System.Linq;
-
-    //            class C
-    //            {
-    //                void M(int[] x)
-    //                {
-    //                    var y = from a in x
-    //                            let b = new int[] { 1, 2, 3 }
-    //                            select b;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|] 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|{|] 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting3()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|]
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting4()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|{|]
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting5()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|{|] 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting6()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|{|]
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting7()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|{|]
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting8()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                    [|{|]
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting1_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|] int[]|] { 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting2_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|] int[]|] { 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting3_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|] int[]|] {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting4_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|] int[]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting5_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|] int[]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting6_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|] int[]|] {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting7_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|[|new|] int[]|]
-    //                    {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting8_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|[|new|] int[]|] {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting9_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|] int[]|] {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting10_Explicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                [|[|new|] int[]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting1_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|][]|] { 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting2_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|][]|] { 1, 2, 3 };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [1, 2, 3];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting3_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|][]|] {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting4_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|][]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting5_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|][]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting6_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [|[|new|][]|] {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting7_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|[|new|][]|]
-    //                    {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting8_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [|[|new|][]|] {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-    //                    [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting9_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i = [|[|new|][]|] {
-    //                        1, 2, 3
-    //                    };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i = [
-    //                        1, 2, 3
-    //                    ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestInitializerFormatting10_Implicit()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                [|[|new|][]|]
-    //                {
-    //                    1, 2, 3
-    //                };
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            class C
-    //            {
-    //                int[] i =
-
-    //                [
-    //                    1, 2, 3
-    //                ];
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_MultiLine1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [|[|new|] int[1]|];
-    //                    r[0] = 1 +
-    //                        2;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r =
-    //                    [
-    //                        1 +
-    //                            2,
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_MultiLine2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [|[|new|] int[2]|];
-    //                    r[0] = 1 +
-    //                        2;
-    //                    r[1] = 3 +
-    //                        4;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r =
-    //                    [
-    //                        1 +
-    //                            2,
-    //                        3 +
-    //                            4,
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ZeroSize()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    int[] r = [|[|new|] int[0]|];
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    int[] r = [];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_NotEnoughFollowingStatements()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    int[] r = new int[1];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_WrongFollowingStatement()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    int[] r = new int[1];
-    //                    return;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_NotLocalStatementInitializer()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M()
-    //                {
-    //                    int[] r = Goo(new int[1]);
-    //                    r[0] = 1;
-    //                }
-
-    //                int[] Goo(int[] input) => default;
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ExpressionStatementNotAssignment()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i)
-    //                {
-    //                    int[] r = new int[1];
-    //                    i++;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_AssignmentNotElementAccess()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[1];
-    //                    i = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ElementAccessNotToIdentifier()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                static int[] array;
-
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[1];
-    //                    C.array[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_IdentifierNotEqualToVariableName()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                static int[] array;
-
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[1];
-    //                    array[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ArgumentNotConstant()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[1];
-    //                    r[i] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ConstantArgumentNotCorrect1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[1];
-    //                    r[1] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_ConstantArgumentNotCorrect2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[2];
-    //                    r[0] = i;
-    //                    r[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_OneElement()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [|[|new|] int[1]|];
-    //                    r[0] = i;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [i];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_OneElement_MultipleFollowingStatements()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [|[|new|] int[1]|];
-    //                    r[0] = i;
-    //                    r[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [i];
-    //                    r[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [|[|new|] int[2]|];
-    //                    r[0] = i;
-    //                    r[1] = j;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = [i, j];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement2_Constant()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    const int v = 1;
-    //                    int[] r = [|[|new|] int[2]|];
-    //                    r[0] = i;
-    //                    r[v] = j;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    const int v = 1;
-    //                    int[] r = [i, j];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement2_SecondWrongIndex()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[] r = new int[2];
-    //                    r[0] = i;
-    //                    r[0] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement2_SecondNonConstant()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    var v = 1;
-    //                    int[] r = new int[2];
-    //                    r[0] = i;
-    //                    r[v] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement2_SecondWrongDestination()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                static int[] array;
-
-    //                void M(int i, int j)
-    //                {
-    //                    var v = 1;
-    //                    int[] r = new int[2];
-    //                    r[0] = i;
-    //                    array[1] = j;
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement_TwoDimensional1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [|[|new|] int[2][]|];
-    //                    r[0] = null;
-    //                    r[1] = null;
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [null, null];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement_TwoDimensional2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [|[|new|] int[2][]|];
-    //                    r[0] = [|[|new|][]|] { 1 };
-    //                    r[1] = [|[|new|] int[]|] { 2 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [new[] { 1 }, new int[] { 2 }];
-    //                }
-    //            }
-    //            """,
-    //        BatchFixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [[1], [2]];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia1()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [|[|new|] int[2][]|];
-
-    //                    // Leading
-    //                    r[0] = [|[|new|][]|] { 1 }; // Trailing
-    //                    r[1] = [|[|new|] int[]|] { 2 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r =
-    //                    [
-    //                        // Leading
-    //                        new[] { 1 }, // Trailing
-    //                        new int[] { 2 },
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        BatchFixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r =
-    //                    [
-    //                        // Leading
-    //                        [1], // Trailing
-    //                        [2],
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
-
-    //[Fact]
-    //public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia2()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r = [|[|new|] int[2][]|];
-
-    //                    r[0] = [|[|new|][]|]
-    //                    {
-    //                        // Leading
-    //                        1 // Trailing
-    //                    };
-    //                    r[1] = [|[|new|] int[]|] { 2 };
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r =
-    //                    [
-    //                        new[]
-    //                        {
-    //                            // Leading
-    //                            1 // Trailing
-    //                        },
-    //                        new int[] { 2 },
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        BatchFixedCode = """
-    //            using System;
-
-    //            class C
-    //            {
-    //                void M(int i, int j)
-    //                {
-    //                    int[][] r =
-    //                    [
-    //                        [
-    //                            // Leading
-    //                            1 // Trailing
-    //                        ],
-    //                        [2],
-    //                    ];
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //    }.RunAsync();
-    //}
+    [Fact]
+    public async Task TestCreateRange_Null()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange<int>(null);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_ComputedExpression()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange(GetValues());
+
+                    static IEnumerable<int> GetValues() => default;
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_ExplicitArray1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange(new int [5]);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_ExplicitArray2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new int[] { });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_ExplicitArray3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new int[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_ImplicitArray1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithArgument()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange(new List<int>(capacity: 0));
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithArgument2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange(new List<int>(capacity: 0) { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithoutArgument()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new List<int>());
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithInitializer1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new List<int> { });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithInitializer2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new List<int>() { });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithInitializer3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new List<int> { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewObjectWithInitializer4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|CreateRange|](|]new List<int> { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCreateRange_NewImplicitObject()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    MyCollection<int> i = MyCollection.CreateRange<int>({|CS0144:new() { }|]);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInterfaceDestination()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    IMyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                class C
+                {
+                    IMyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTrivia1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = /*leading*/ [|MyCollection.[|Create|](|]1) /*trailing*/;
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = /*leading*/ [1] /*trailing*;
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultiLine1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1 +
+                        2);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i =
+                    [
+                        1 +
+                            2,
+                    ];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultiLine2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1 +
+                        2,
+                        3 +
+                            4);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i =
+                    [
+                        1 +
+                            2,
+                        3 +
+                            4,
+                    ];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -98,6 +98,318 @@ public class UseCollectionExpressionForCreateTests
         }.RunAsync();
     }
 
+    [Fact]
+    public async Task TestEmpty()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|]<int>(|]);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestOneElement()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTwoElements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1, 2);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestThreeElements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestFourElements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3, 4);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3, 4];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestParamsWithMultipleElements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3, 4, 5);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3, 4, 5];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestParamsWithExplicitArrayArgument1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = MyCollection.Create(new int[5]);
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestParamsWithExplicitArrayArgument2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]new int[] { });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestParamsWithExplicitArrayArgument3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]new int[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestParamsWithImplicitArrayArgument1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|](|]new[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReadOnlySpan_ExplicitStackAlloc_Net70()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = MyCollection.Create<int>(stackalloc int[] { 1 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReadOnlySpan_ImplicitStackAlloc_Net70()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = MyCollection.Create<int>(stackalloc[] { 1 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReadOnlySpan_ExplicitStackAlloc_Net80_1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|]<int>(|]stackalloc int[] { });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReadOnlySpan_ExplicitStackAlloc_Net80_2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|]<int>(|]stackalloc int[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReadOnlySpan_ImplicitStackAlloc_Net80_1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    MyCollection<int> i = [|MyCollection.[|Create|]<int>(|]stackalloc[] { 1, 2, 3 });
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            FixedCode = """
+                class C
+                {
+                    MyCollection<int> i = [1, 2, 3];
+                }
+                """ + s_collectionBuilderApi + s_basicCollectionApi,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
     //[Fact]
     //public async Task TestInCSharp12_Net80()
     //{
@@ -1103,7 +1415,7 @@ public class UseCollectionExpressionForCreateTests
     //            class C
     //            {
     //            }
-                
+
     //            public class XAttribute : System.Attribute
     //            {
     //                public XAttribute(int[] values) { }
@@ -1199,7 +1511,7 @@ public class UseCollectionExpressionForCreateTests
     //            class C
     //            {
     //                public int[] X;
-                
+
     //                void M()
     //                {
     //                    var v = new C
@@ -2578,7 +2890,7 @@ public class UseCollectionExpressionForCreateTests
     //            """,
     //        BatchFixedCode = """
     //            using System;
-                
+
     //            class C
     //            {
     //                void M(int i, int j)
@@ -2629,7 +2941,7 @@ public class UseCollectionExpressionForCreateTests
     //            """,
     //        BatchFixedCode = """
     //            using System;
-                
+
     //            class C
     //            {
     //                void M(int i, int j)
@@ -2691,7 +3003,7 @@ public class UseCollectionExpressionForCreateTests
     //            """,
     //        BatchFixedCode = """
     //            using System;
-                
+
     //            class C
     //            {
     //                void M(int i, int j)

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -748,7 +748,7 @@ public class UseCollectionExpressionForCreateTests
             FixedCode = """
                 class C
                 {
-                    MyCollection<int> i = /*leading*/ [1] /*trailing*;
+                    MyCollection<int> i = /*leading*/ [1] /*trailing*/;
                 }
                 """ + s_collectionBuilderApi + s_basicCollectionApi,
             LanguageVersion = LanguageVersion.CSharp12,

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -1,0 +1,2645 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
+using Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.UseCollectionExpression;
+
+using VerifyCS = CSharpCodeFixVerifier<
+    CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer,
+    CSharpUseCollectionExpressionForCreateCodeFixProvider>;
+
+[Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionExpression)]
+public class UseCollectionExpressionForCreateTests
+{
+    [Fact]
+    public async Task TestNotInCSharp11()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = { 1, 2, 3 };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp11,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInCSharp12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSingleLine_TrailingComma()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|] 1, 2, 3, };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3,];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSingleLine_Trivia()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = /*x*/ [|{|] /*y*/ 1, 2, 3 /*z*/ } /*w*/;
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = /*x*/ [/*y*/ 1, 2, 3 /*z*/] /*w*/;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultiLine()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultiLine_TrailingComma()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                        1, 2, 3,
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3,
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestEmpty1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]};
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestEmpty2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|] };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithIncompatibleExplicitArrays()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = new string[] { "" };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleExplicitArrays1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = [|[|new|] object[]|] { "" };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    object[] i = [""];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleExplicitArrays2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = [|[|new|] object[]|]
+                    {
+                        ""
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    object[] i =
+                    [
+                        ""
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleExplicitArrays_Empty()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = [|[|new|] object[]|] { };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    object[] i = [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleExplicitArrays_TrailingComma()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = [|[|new|] object[]|] { "", };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    object[] i = ["",];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExplicitArray_ExplicitSize()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[] i = [|[|new|] string[1]|] { "" };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    string[] i = [""];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[,] i = new string[1, 1];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExplicitArray_MultiDimensionalArray_ExplicitSizes2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[,] i = new string[1, 1] { { "" } };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExplicitArray_MultiDimensionalArray_ImplicitSizes1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[,] i = new string[,] { { "" } };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithIncompatibleImplicitArrays()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    object[] i = new[] { "" };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleImplicitArrays1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[] i = [|[|new|][]|] { "" };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    string[] i = [""];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleImplicitArrays2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[] i = [|[|new|][]|]
+                    {
+                        ""
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    string[] i =
+                    [
+                        ""
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMissingOnEmptyImplicitArray()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[] i = {|CS0826:{|CS0029:new[] { }|}|};
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithCompatibleImplicitArrays_TrailingComma()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    string[] i = [|[|new|][]|] { "", };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    string[] i = ["",];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestNotWithVar_ExplicitArrayType(
+         [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                class C
+                {
+                    void M()
+                    {
+                        {{type}} i = new string[] { "" };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestNotWithVar_ExplicitArrayType2(
+        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                class C
+                {
+                    void M()
+                    {
+                        {{type}} i = (new string[] { "" });
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestNotWithVar_ImplicitArrayType(
+        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                class C
+                {
+                    void M()
+                    {
+                        {{type}} i = new[] { "" };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestNotWithVar_ImplicitArrayType2(
+        [CombinatorialValues(new object[] { "var", "object", "dynamic" })] string type)
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                class C
+                {
+                    void M()
+                    {
+                        {{type}} i = (new[] { "" });
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithExtension()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        var i = new int[] { 1 }.AsSpan();
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedToField()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int[] X = [|[|new|] int[]|] { 1 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private int[] X = [1];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedToProperty()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int[] X { get; } = [|[|new|] int[]|] { 1 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private int[] X { get; } = [1];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedToComplexCast()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M()
+                    {
+                        var c = (int[])[|[|new|] int[]|] { 1 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M()
+                    {
+                        var c = (int[])[1];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotTargetTypedWithIdentifierCast()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using IntArray = int[];
+
+                class C
+                {
+                    void M()
+                    {
+                        var c = (IntArray)new int[] { 1 };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInConditional1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var c = true ? [|[|new|] int[]|] { 1 } : x;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var c = true ? [1] : x;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInConditional2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var c = true ? x : [|[|new|] int[]|] { 1 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var c = true ? x : [1];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInConditional3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        int[] c = true ? null : [|[|new|] int[]|] { 1 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        int[] c = true ? null : [1];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotTargetTypedInConditional4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var c = true ? null : new int[] { 1 };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInSwitchExpressionArm1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = b switch { true => x, false => [|[|new|] int[]|] { 1 } };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = b switch { true => x, false => [1] };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInSwitchExpressionArm2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = b switch { false => [|[|new|] int[]|] { 1 }, true => x };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = b switch { false => [1], true => x };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInSwitchExpressionArm3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        int[] c = b switch { false => [|[|new|] int[]|] { 1 }, true => null };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        int[] c = b switch { false => [1], true => null };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotTargetTypedInSwitchExpressionArm4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = b switch { false => new int[] { 1 }, true => null };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotTargetTypedInitializer1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new int[,] { { 1, 2, 3 } };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInitializer2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new[] { [|[|new|][]|] { 1, 2, 3 }, x };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new[] { [1, 2, 3], x };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInitializer3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new[] { x, [|[|new|][]|] { 1, 2, 3 } };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new[] { x, [1, 2, 3] };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInitializer4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        var c = new[] { new[] { 1, 2, 3 } };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedInitializer5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        int[][] c = [|[|new|][]|] { new[] { 1, 2, 3 } };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x, bool b)
+                    {
+                        int[][] c = [new[] { 1, 2, 3 }];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedArgument1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M()
+                    {
+                        X([|[|new|] int[]|] { 1, 2, 3 });
+                    }
+
+                    void X(int[] x) { }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M()
+                    {
+                        X([1, 2, 3]);
+                    }
+
+                    void X(int[] x) { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotTargetTypedArgument2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+                class C
+                {
+                    void M()
+                    {
+                        X(new int[] { 1, 2, 3 });
+                    }
+
+                    void X(int[] x) { }
+                    void X(List<int> x) { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedAttributeArgument1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                [X([|[|new|] int[]|] { 1, 2, 3 })]
+                class C
+                {
+                }
+
+                public class XAttribute : System.Attribute
+                {
+                    public XAttribute(int[] values) { }
+                }
+                """,
+            FixedCode = """
+                [X([1, 2, 3])]
+                class C
+                {
+                }
+                
+                public class XAttribute : System.Attribute
+                {
+                    public XAttribute(int[] values) { }
+                }
+                """,
+            FixedState =
+                {
+                    // THis will tart working once https://github.com/dotnet/roslyn/issues/69133 is fixed.
+                    ExpectedDiagnostics =
+                    {
+                        // /0/Test0.cs(1,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                        DiagnosticResult.CompilerError("CS0182").WithSpan(1, 4, 1, 13),
+                    }
+                },
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestTargetTypedReturn1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] M()
+                    {
+                        return [|[|new|] int[]|] { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] M()
+                    {
+                        return [1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestAssignment1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        x = [|[|new|] int[]|] { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        x = [1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestAssignment2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int[] X;
+
+                    void M()
+                    {
+                        var v = new C
+                        {
+                            X = [|[|new|] int[]|] { 1, 2, 3 },
+                        };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    public int[] X;
+                
+                    void M()
+                    {
+                        var v = new C
+                        {
+                            X = [1, 2, 3],
+                        };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestCoalesce1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var y = x ?? [|[|new|] int[]|] { 1, 2, 3 };
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var y = x ?? [1, 2, 3];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithLinqLet()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+
+                class C
+                {
+                    void M(int[] x)
+                    {
+                        var y = from a in x
+                                let b = new int[] { 1, 2, 3 }
+                                select b;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|{|]
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|{|] 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                        [|{|]
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting1_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|] int[]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|] int[]|]
+                        {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|] int[]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting9_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|] int[]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting10_Explicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                    [|[|new|] int[]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting1_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting2_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|] { 1, 2, 3 };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [1, 2, 3];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting3_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting4_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting5_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting6_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                    [|[|new|][]|] {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting7_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|][]|]
+                        {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting8_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+                        [|[|new|][]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+                        [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting9_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i = [|[|new|][]|] {
+                            1, 2, 3
+                        };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i = [
+                            1, 2, 3
+                        ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInitializerFormatting10_Implicit()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    int[] i =
+
+                    [|[|new|][]|]
+                    {
+                        1, 2, 3
+                    };
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    int[] i =
+
+                    [
+                        1, 2, 3
+                    ];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_MultiLine1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [|[|new|] int[1]|];
+                        r[0] = 1 +
+                            2;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r =
+                        [
+                            1 +
+                                2,
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_MultiLine2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [|[|new|] int[2]|];
+                        r[0] = 1 +
+                            2;
+                        r[1] = 3 +
+                            4;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r =
+                        [
+                            1 +
+                                2,
+                            3 +
+                                4,
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ZeroSize()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        int[] r = [|[|new|] int[0]|];
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        int[] r = [];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_NotEnoughFollowingStatements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        int[] r = new int[1];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_WrongFollowingStatement()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        int[] r = new int[1];
+                        return;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_NotLocalStatementInitializer()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        int[] r = Goo(new int[1]);
+                        r[0] = 1;
+                    }
+
+                    int[] Goo(int[] input) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ExpressionStatementNotAssignment()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i)
+                    {
+                        int[] r = new int[1];
+                        i++;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_AssignmentNotElementAccess()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[1];
+                        i = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ElementAccessNotToIdentifier()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    static int[] array;
+
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[1];
+                        C.array[0] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_IdentifierNotEqualToVariableName()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    static int[] array;
+
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[1];
+                        array[0] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ArgumentNotConstant()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[1];
+                        r[i] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ConstantArgumentNotCorrect1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[1];
+                        r[1] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_ConstantArgumentNotCorrect2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[2];
+                        r[0] = i;
+                        r[0] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_OneElement()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [|[|new|] int[1]|];
+                        r[0] = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [i];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_OneElement_MultipleFollowingStatements()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [|[|new|] int[1]|];
+                        r[0] = i;
+                        r[0] = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [i];
+                        r[0] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [|[|new|] int[2]|];
+                        r[0] = i;
+                        r[1] = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = [i, j];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement2_Constant()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        const int v = 1;
+                        int[] r = [|[|new|] int[2]|];
+                        r[0] = i;
+                        r[v] = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        const int v = 1;
+                        int[] r = [i, j];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement2_SecondWrongIndex()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[] r = new int[2];
+                        r[0] = i;
+                        r[0] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement2_SecondNonConstant()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        var v = 1;
+                        int[] r = new int[2];
+                        r[0] = i;
+                        r[v] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement2_SecondWrongDestination()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    static int[] array;
+
+                    void M(int i, int j)
+                    {
+                        var v = 1;
+                        int[] r = new int[2];
+                        r[0] = i;
+                        array[1] = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement_TwoDimensional1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [|[|new|] int[2][]|];
+                        r[0] = null;
+                        r[1] = null;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [null, null];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement_TwoDimensional2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [|[|new|] int[2][]|];
+                        r[0] = [|[|new|][]|] { 1 };
+                        r[1] = [|[|new|] int[]|] { 2 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [new[] { 1 }, new int[] { 2 }];
+                    }
+                }
+                """,
+            BatchFixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [[1], [2]];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [|[|new|] int[2][]|];
+
+                        // Leading
+                        r[0] = [|[|new|][]|] { 1 }; // Trailing
+                        r[1] = [|[|new|] int[]|] { 2 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r =
+                        [
+                            // Leading
+                            new[] { 1 }, // Trailing
+                            new int[] { 2 },
+                        ];
+                    }
+                }
+                """,
+            BatchFixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r =
+                        [
+                            // Leading
+                            [1], // Trailing
+                            [2],
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNoInitializer_TwoElement_TwoDimensional2_Trivia2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r = [|[|new|] int[2][]|];
+
+                        r[0] = [|[|new|][]|]
+                        {
+                            // Leading
+                            1 // Trailing
+                        };
+                        r[1] = [|[|new|] int[]|] { 2 };
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r =
+                        [
+                            new[]
+                            {
+                                // Leading
+                                1 // Trailing
+                            },
+                            new int[] { 2 },
+                        ];
+                    }
+                }
+                """,
+            BatchFixedCode = """
+                using System;
+                
+                class C
+                {
+                    void M(int i, int j)
+                    {
+                        int[][] r =
+                        [
+                            [
+                                // Leading
+                                1 // Trailing
+                            ],
+                            [2],
+                        ];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+}

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForCreateTests.cs
@@ -581,6 +581,8 @@ public class UseCollectionExpressionForCreateTests
                 }
                 """ + s_collectionBuilderApi + s_basicCollectionApi,
             FixedCode = """
+                using System.Collections.Generic;
+                
                 class C
                 {
                     MyCollection<int> i = [];
@@ -723,15 +725,8 @@ public class UseCollectionExpressionForCreateTests
 
                 class C
                 {
-                    IMyCollection<int> i = [|MyCollection.[|Create|](|]1, 2, 3);
-                }
-                """ + s_collectionBuilderApi + s_basicCollectionApi,
-            FixedCode = """
-                using System.Collections.Generic;
-
-                class C
-                {
-                    IMyCollection<int> i = [1, 2, 3];
+                    // Will start working once we allow reference conversions.
+                    IMyCollection<int> i = {|CS0266:MyCollection.Create(1, 2, 3)|};
                 }
                 """ + s_collectionBuilderApi + s_basicCollectionApi,
             LanguageVersion = LanguageVersion.CSharp12,

--- a/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
+++ b/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const EnforceOnBuild UseCollectionExpressionForArray = /*IDE0300*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseCollectionExpressionForEmpty = /*IDE0301*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild UseCollectionExpressionForStackAlloc = /*IDE0302*/ EnforceOnBuild.Recommended;
+        public const EnforceOnBuild UseCollectionExpressionForCreate = /*IDE0303*/ EnforceOnBuild.Recommended;
 
         /* EnforceOnBuild.WhenExplicitlyEnabled */
         public const EnforceOnBuild RemoveUnnecessaryCast = /*IDE0004*/ EnforceOnBuild.WhenExplicitlyEnabled; // TODO: Move to 'Recommended' OR 'HighlyRecommended' bucket once performance problems are addressed: https://github.com/dotnet/roslyn/issues/43304

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string UseCollectionExpressionForArrayDiagnosticId = "IDE0300";
         public const string UseCollectionExpressionForEmptyDiagnosticId = "IDE0301";
         public const string UseCollectionExpressionForStackAllocDiagnosticId = "IDE0302";
+        public const string UseCollectionExpressionForCreateDiagnosticId = "IDE0303";
 
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string UseCoalesceExpressionForNullableTernaryConditionalCheck = nameof(UseCoalesceExpressionForNullableTernaryConditionalCheck);
         public const string UseCoalesceExpressionForTernaryConditionalCheck = nameof(UseCoalesceExpressionForTernaryConditionalCheck);
         public const string UseCollectionExpressionForArray = nameof(UseCollectionExpressionForArray);
+        public const string UseCollectionExpressionForCreate = nameof(UseCollectionExpressionForCreate);
         public const string UseCollectionExpressionForEmpty = nameof(UseCollectionExpressionForEmpty);
         public const string UseCollectionExpressionForStackAlloc = nameof(UseCollectionExpressionForStackAlloc);
         public const string UseCollectionInitializer = nameof(UseCollectionInitializer);

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -563,8 +563,8 @@ namespace A
             var expectedNumberOfUnsupportedDiagnosticIds =
                 language switch
                 {
-                    LanguageNames.CSharp => 45,
-                    LanguageNames.VisualBasic => 82,
+                    LanguageNames.CSharp => 46,
+                    LanguageNames.VisualBasic => 83,
                     _ => throw ExceptionUtilities.UnexpectedValue(language),
                 };
 

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -473,6 +473,9 @@ dotnet_diagnostic.IDE0301.severity = %value%
 # IDE0302
 dotnet_diagnostic.IDE0302.severity = %value%
 
+# IDE0303
+dotnet_diagnostic.IDE0303.severity = %value%
+
 # IDE1005
 dotnet_diagnostic.IDE1005.severity = %value%
 
@@ -883,6 +886,7 @@ dotnet_diagnostic.JSON002.severity = %value%
                 ("IDE0300", "dotnet_style_prefer_collection_expression", "true"),
                 ("IDE0301", "dotnet_style_prefer_collection_expression", "true"),
                 ("IDE0302", "dotnet_style_prefer_collection_expression", "true"),
+                ("IDE0303", "dotnet_style_prefer_collection_expression", "true"),
                 ("IDE1005", "csharp_style_conditional_delegate_call", "true"),
                 ("IDE1006", null, null),
                 ("IDE1007", null, null),

--- a/src/Features/RulesMissingDocumentation.md
+++ b/src/Features/RulesMissingDocumentation.md
@@ -15,6 +15,7 @@ IDE0290 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-r
 IDE0300 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0300> | Simplify collection initialization |
 IDE0301 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0301> | Simplify collection initialization |
 IDE0302 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0302> | Simplify collection initialization |
+IDE0303 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0303> | Simplify collection initialization |
 IDE1007 |  |  |
 IDE2000 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000> | Avoid multiple blank lines |
 IDE2001 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001> | Embedded statements must be on their own line |

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
@@ -186,6 +186,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static INamedTypeSymbol? OnSerializedAttribute(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(OnSerializedAttribute).FullName!);
 
+        public static INamedTypeSymbol? CollectionBuilderAttribute(this Compilation compilation)
+            => compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.CollectionBuilderAttribute");
+
         public static INamedTypeSymbol? ComRegisterFunctionAttribute(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(ComRegisterFunctionAttribute).FullName!);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingExtensions.cs
@@ -102,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         public static SuppressOption RemoveFlag(this SuppressOption option, SuppressOption flag)
             => option & ~flag;
 
+
         public static string CreateIndentationString(this int desiredIndentation, bool useTab, int tabSize)
         {
             var numberOfTabs = 0;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ExpressionGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ExpressionGenerator.cs
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return GenerateExpression(generator, typedConstant.Type, typedConstant.Value, canUseFieldReference: true);
 
                 case TypedConstantKind.Type:
-                    return typedConstant.Value is ITypeSymbol
-                        ? SyntaxFactory.TypeOfExpression(((ITypeSymbol)typedConstant.Value).GenerateTypeSyntax())
+                    return typedConstant.Value is ITypeSymbol typeSymbol
+                        ? SyntaxFactory.TypeOfExpression(typeSymbol.GenerateTypeSyntax())
                         : GenerateNullLiteral();
 
                 case TypedConstantKind.Array:


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/issues/69132

Followup to https://github.com/dotnet/roslyn/pull/69452