### PR TITLE
Fix regression for suppressed diagnostics in Suggestion diagnostics tagger

### DIFF
--- a/src/EditorFeatures/CSharpTest/SuggestionTags/SuggestionTagProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SuggestionTags/SuggestionTagProducerTests.cs
@@ -25,18 +25,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SuggestionTags
     [Trait(Traits.Feature, Traits.Features.SuggestionTags), Trait(Traits.Feature, Traits.Features.Tagging)]
     public class SuggestionTagProducerTests
     {
-        [WpfFact]
-        public async Task SuggestionTagTest1()
+        [WpfTheory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1869759")]
+        public async Task SuggestionTagTest1(bool isSuppressed)
         {
+            var pragmaText = isSuppressed ? $@"#pragma warning disable {IDEDiagnosticIds.UseObjectInitializerDiagnosticId}
+" : string.Empty;
             var (spans, selection) = await GetTagSpansAndSelectionAsync(
-@"class C {
+pragmaText + @"class C {
     void M() {
         var v = [|ne|]w X();
         v.Y = 1;
     }
 }");
-            Assert.Equal(1, spans.Length);
-            Assert.Equal(selection, spans.Single().Span.Span.ToTextSpan());
+            if (isSuppressed)
+            {
+                Assert.Empty(spans);
+            }
+            else
+            {
+                Assert.Equal(1, spans.Length);
+                Assert.Equal(selection, spans.Single().Span.Span.ToTextSpan());
+            }
         }
 
         private static async Task<(ImmutableArray<ITagSpan<IErrorTag>> spans, TextSpan selection)> GetTagSpansAndSelectionAsync(string content)

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
@@ -104,6 +104,9 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
             {
                 var requestedSpan = documentSpanToTag.SnapshotSpan;
 
+                // NOTE: We pass 'includeSuppressedDiagnostics: true' to ensure that IDE0079 (unnecessary suppressions)
+                // are flagged and faded in the editor. IDE0079 analyzer requires all source suppressed diagnostics to
+                // be provided to it to function correctly.
                 var diagnostics = await _analyzerService.GetDiagnosticsForSpanAsync(
                     document,
                     requestedSpan.Span.ToTextSpan(),
@@ -113,7 +116,7 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
 
                 foreach (var diagnosticData in diagnostics)
                 {
-                    if (_callback.IncludeDiagnostic(diagnosticData))
+                    if (_callback.IncludeDiagnostic(diagnosticData) && !diagnosticData.IsSuppressed)
                     {
                         var diagnosticSpans = _callback.GetLocationsToTag(diagnosticData)
                             .Select(loc => loc.UnmappedFileSpan.GetClampedTextSpan(sourceText).ToSnapshotSpan(snapshot));

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -10,15 +10,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.Utilities;
@@ -121,11 +118,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         }
 
         [WpfTheory]
-        [InlineData(DiagnosticKind.CompilerSyntax)]
-        [InlineData(DiagnosticKind.CompilerSemantic)]
-        [InlineData(DiagnosticKind.AnalyzerSyntax)]
-        [InlineData(DiagnosticKind.AnalyzerSemantic)]
-        internal async Task TestWithMockDiagnosticService_TaggerProviderCreatedBeforeInitialDiagnosticsReported(DiagnosticKind diagnosticKind)
+        [InlineData(DiagnosticKind.CompilerSyntax, false)]
+        [InlineData(DiagnosticKind.CompilerSemantic, false)]
+        [InlineData(DiagnosticKind.AnalyzerSyntax, false)]
+        [InlineData(DiagnosticKind.AnalyzerSemantic, false)]
+        // Test no tags for suppressed analyzer diagnostics. NOTE: Compiler errors cannot be suppressed.
+        [InlineData(DiagnosticKind.AnalyzerSyntax, true)]
+        [InlineData(DiagnosticKind.AnalyzerSemantic, true)]
+        internal async Task TestWithMockDiagnosticService_TaggerProviderCreatedBeforeInitialDiagnosticsReported(DiagnosticKind diagnosticKind, bool isSuppressed)
         {
             // This test produces diagnostics from a mock service so that we are disconnected from
             // all the asynchrony of the actual async analyzer engine.  If this fails, then the 
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             // Now product the first diagnostic and fire the events.
             var tree = await workspace.CurrentSolution.Projects.Single().Documents.Single().GetRequiredSyntaxTreeAsync(CancellationToken.None);
             var span = TextSpan.FromBounds(0, 5);
-            diagnosticService.CreateDiagnosticAndFireEvents(workspace, analyzerService, Location.Create(tree, span), diagnosticKind);
+            diagnosticService.CreateDiagnosticAndFireEvents(workspace, analyzerService, Location.Create(tree, span), diagnosticKind, isSuppressed);
 
             using var disposable = tagger as IDisposable;
             await listenerProvider.GetWaiter(FeatureAttribute.DiagnosticService).ExpeditedWaitAsync();
@@ -160,16 +160,26 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             var snapshot = firstDocument.GetTextBuffer().CurrentSnapshot;
             var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
-            Assert.Equal(1, spans.Count);
-            Assert.Equal(span.ToSpan(), spans[0].Span.Span);
+            if (isSuppressed)
+            {
+                Assert.Empty(spans);
+            }
+            else
+            {
+                Assert.Equal(1, spans.Count);
+                Assert.Equal(span.ToSpan(), spans[0].Span.Span);
+            }
         }
 
         [WpfTheory]
-        [InlineData(DiagnosticKind.CompilerSyntax)]
-        [InlineData(DiagnosticKind.CompilerSemantic)]
-        [InlineData(DiagnosticKind.AnalyzerSyntax)]
-        [InlineData(DiagnosticKind.AnalyzerSemantic)]
-        internal async Task TestWithMockDiagnosticService_TaggerProviderCreatedAfterInitialDiagnosticsReported(DiagnosticKind diagnosticKind)
+        [InlineData(DiagnosticKind.CompilerSyntax, false)]
+        [InlineData(DiagnosticKind.CompilerSemantic, false)]
+        [InlineData(DiagnosticKind.AnalyzerSyntax, false)]
+        [InlineData(DiagnosticKind.AnalyzerSemantic, false)]
+        // Test no tags for suppressed analyzer diagnostics. NOTE: Compiler errors cannot be suppressed.
+        [InlineData(DiagnosticKind.AnalyzerSyntax, true)]
+        [InlineData(DiagnosticKind.AnalyzerSemantic, true)]
+        internal async Task TestWithMockDiagnosticService_TaggerProviderCreatedAfterInitialDiagnosticsReported(DiagnosticKind diagnosticKind, bool isSuppressed)
         {
             // This test produces diagnostics from a mock service so that we are disconnected from
             // all the asynchrony of the actual async analyzer engine.  If this fails, then the 
@@ -191,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             // Create and fire the diagnostic events before the tagger is even made.
             var tree = await workspace.CurrentSolution.Projects.Single().Documents.Single().GetRequiredSyntaxTreeAsync(CancellationToken.None);
             var span = TextSpan.FromBounds(0, 5);
-            diagnosticService.CreateDiagnosticAndFireEvents(workspace, analyzerService, Location.Create(tree, span), diagnosticKind);
+            diagnosticService.CreateDiagnosticAndFireEvents(workspace, analyzerService, Location.Create(tree, span), diagnosticKind, isSuppressed);
 
             var firstDocument = workspace.Documents.First();
             var tagger = provider.CreateTagger<IErrorTag>(firstDocument.GetTextBuffer());
@@ -203,8 +213,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             var snapshot = firstDocument.GetTextBuffer().CurrentSnapshot;
             var spans = tagger.GetTags(snapshot.GetSnapshotSpanCollection()).ToList();
-            Assert.Equal(1, spans.Count);
-            Assert.Equal(span.ToSpan(), spans[0].Span.Span);
+            if (isSuppressed)
+            {
+                Assert.Empty(spans);
+            }
+            else
+            {
+                Assert.Equal(1, spans.Count);
+                Assert.Equal(span.ToSpan(), spans[0].Span.Span);
+            }
         }
 
         private class Analyzer : DiagnosticAnalyzer

--- a/src/EditorFeatures/Test/Diagnostics/MockDiagnosticService.cs
+++ b/src/EditorFeatures/Test/Diagnostics/MockDiagnosticService.cs
@@ -57,10 +57,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 : ImmutableArray.Create(new DiagnosticBucket(this, workspace, GetProjectId(workspace), GetDocumentId(workspace)));
         }
 
-        internal void CreateDiagnosticAndFireEvents(Workspace workspace, MockDiagnosticAnalyzerService analyzerService, Location location, DiagnosticKind diagnosticKind)
+        internal void CreateDiagnosticAndFireEvents(Workspace workspace, MockDiagnosticAnalyzerService analyzerService, Location location, DiagnosticKind diagnosticKind, bool isSuppressed)
         {
             var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
-            _diagnosticData = DiagnosticData.Create(Diagnostic.Create(DiagnosticId, "MockCategory", "MockMessage", DiagnosticSeverity.Error, DiagnosticSeverity.Error, isEnabledByDefault: true, warningLevel: 0,
+            _diagnosticData = DiagnosticData.Create(Diagnostic.Create(DiagnosticId, "MockCategory", "MockMessage", DiagnosticSeverity.Error, DiagnosticSeverity.Error, isEnabledByDefault: true, warningLevel: 0, isSuppressed: isSuppressed,
                 location: location),
                 document);
 


### PR DESCRIPTION
Fixes [AB#1869759](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1869759)

This regressed with #68287, which enabled IDE0079 for LSP clients.

## Testing

- I verified that the customer repro attached to the feedback ticket is fixed with this change.
- I verified that the `SuggestionTagTest1` failed with `isSuppressed = true` prior to the product change in this PR.
- I have also enhanced `DiagnosticSquiggleTaggerProvider` tests to validate the `isSuppressed = true` scenario, though those tests pass without the product change as that tagger provider already bailed out for suppressed diagnostics.