### PR TITLE
Reduce LOH allocations for SemanticToken classification in LSP

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -4,11 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             CancellationToken cancellationToken)
         {
             var classificationService = document.GetRequiredLanguageService<IClassificationService>();
-            using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var classifiedSpans);
+            using var _ = Classifier.GetPooledList(out var classifiedSpans);
 
             // We always return both syntactic and semantic classifications.  If there is a syntactic classifier running on the client
             // then the semantic token classifications will override them.
@@ -82,9 +82,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
         public static ClassifiedSpan[] ConvertMultiLineToSingleLineSpans(SourceText text, ClassifiedSpan[] classifiedSpans)
         {
-            using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var updatedClassifiedSpans);
+            using var _ = Classifier.GetPooledList(out var updatedClassifiedSpans);
 
-            for (var spanIndex = 0; spanIndex < classifiedSpans.Length; spanIndex++)
+            for (var spanIndex = 0; spanIndex < updatedClassifiedSpans.Count; spanIndex++)
             {
                 var span = classifiedSpans[spanIndex];
                 text.GetLinesAndOffsets(span.TextSpan, out var startLine, out var startOffset, out var endLine, out var endOffSet);
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             static void ConvertToSingleLineSpan(
                 SourceText text,
                 ClassifiedSpan[] originalClassifiedSpans,
-                ArrayBuilder<ClassifiedSpan> updatedClassifiedSpans,
+                SegmentedList<ClassifiedSpan> updatedClassifiedSpans,
                 ref int spanIndex,
                 string classificationType,
                 int startLine,

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
         {
             using var _ = Classifier.GetPooledList(out var updatedClassifiedSpans);
 
-            for (var spanIndex = 0; spanIndex < updatedClassifiedSpans.Count; spanIndex++)
+            for (var spanIndex = 0; spanIndex < classifiedSpans.Length; spanIndex++)
             {
                 var span = classifiedSpans[spanIndex];
                 text.GetLinesAndOffsets(span.TextSpan, out var startLine, out var startOffset, out var endLine, out var endOffSet);


### PR DESCRIPTION
LSP semantic classification classifies the whole document per call. This ends up with a large number of classifiedspans per call, enough so that the standard ArrayBuilder cache ends up throwing away it's values upon Free. Instead, use the Classifier's pooled list, as it doesn't have the size limit for it's cache.

This accounts for about 0.5% of LOH allocations in the devenv process in the customer profile that I'm looking at.