### PR TITLE
Pull out syntax helpers used in 'create collection initializer/collection' into utility types

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -87,6 +87,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\CSharpUseCollectionExpressionForStackAllocDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionExpression\UseCollectionExpressionHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\CSharpUpdateExpressionSyntaxHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\CSharpUseCollectionInitializerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs" />

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUpdateExpressionSyntaxHelper.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.UseCollectionInitializer;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
+
+internal sealed class CSharpUpdateExpressionSyntaxHelper : IUpdateExpressionSyntaxHelper<ExpressionSyntax, StatementSyntax>
+{
+    public static readonly CSharpUpdateExpressionSyntaxHelper Instance = new();
+
+    public void GetPartsOfForeachStatement(
+        StatementSyntax statement,
+        out SyntaxToken identifier,
+        out ExpressionSyntax expression,
+        out IEnumerable<StatementSyntax> statements)
+    {
+        var foreachStatement = (ForEachStatementSyntax)statement;
+        identifier = foreachStatement.Identifier;
+        expression = foreachStatement.Expression;
+        statements = ExtractEmbeddedStatements(foreachStatement.Statement);
+    }
+
+    public void GetPartsOfIfStatement(
+        StatementSyntax statement,
+        out ExpressionSyntax condition,
+        out IEnumerable<StatementSyntax> whenTrueStatements,
+        out IEnumerable<StatementSyntax>? whenFalseStatements)
+    {
+        var ifStatement = (IfStatementSyntax)statement;
+        condition = ifStatement.Condition;
+        whenTrueStatements = ExtractEmbeddedStatements(ifStatement.Statement);
+        whenFalseStatements = ifStatement.Else != null ? ExtractEmbeddedStatements(ifStatement.Else.Statement) : null;
+    }
+
+    private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)
+        => embeddedStatement is BlockSyntax block ? block.Statements : SpecializedCollections.SingletonEnumerable(embeddedStatement);
+}

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 
@@ -16,11 +14,12 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
     MemberAccessExpressionSyntax,
     InvocationExpressionSyntax,
     ExpressionStatementSyntax,
-    ForEachStatementSyntax,
-    IfStatementSyntax,
     VariableDeclaratorSyntax,
     CSharpUseCollectionInitializerAnalyzer>
 {
+    protected override IUpdateExpressionSyntaxHelper<ExpressionSyntax, StatementSyntax> SyntaxHelper
+        => CSharpUpdateExpressionSyntaxHelper.Instance;
+
     protected override bool IsComplexElementInitializer(SyntaxNode expression)
         => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);
 
@@ -34,29 +33,4 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             Expressions.Count: > 0,
         };
     }
-
-    protected override void GetPartsOfForeachStatement(
-        ForEachStatementSyntax statement,
-        out SyntaxToken identifier,
-        out ExpressionSyntax expression,
-        out IEnumerable<StatementSyntax> statements)
-    {
-        identifier = statement.Identifier;
-        expression = statement.Expression;
-        statements = ExtractEmbeddedStatements(statement.Statement);
-    }
-
-    protected override void GetPartsOfIfStatement(
-        IfStatementSyntax statement,
-        out ExpressionSyntax condition,
-        out IEnumerable<StatementSyntax> whenTrueStatements,
-        out IEnumerable<StatementSyntax>? whenFalseStatements)
-    {
-        condition = statement.Condition;
-        whenTrueStatements = ExtractEmbeddedStatements(statement.Statement);
-        whenFalseStatements = statement.Else != null ? ExtractEmbeddedStatements(statement.Else.Statement) : null;
-    }
-
-    private static IEnumerable<StatementSyntax> ExtractEmbeddedStatements(StatementSyntax embeddedStatement)
-        => embeddedStatement is BlockSyntax block ? block.Statements : SpecializedCollections.SingletonEnumerable(embeddedStatement);
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -24,8 +24,6 @@ internal sealed class CSharpUseCollectionInitializerDiagnosticAnalyzer :
         MemberAccessExpressionSyntax,
         InvocationExpressionSyntax,
         ExpressionStatementSyntax,
-        ForEachStatementSyntax,
-        IfStatementSyntax,
         VariableDeclaratorSyntax,
         CSharpUseCollectionInitializerAnalyzer>
 {

--- a/src/Analyzers/Core/Analyzers/Analyzers.projitems
+++ b/src/Analyzers/Core/Analyzers/Analyzers.projitems
@@ -83,6 +83,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractObjectCreationExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractUseCollectionInitializerDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\AbstractUseCollectionInitializerAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\IUpdateExpressionSyntaxHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\UseCollectionInitializerHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\UseCompoundAssignmentUtilities.cs" />

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -38,8 +38,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         TMemberAccessExpressionSyntax,
         TInvocationExpressionSyntax,
         TExpressionStatementSyntax,
-        TForeachStatementSyntax,
-        TIfStatementSyntax,
         TVariableDeclaratorSyntax,
         TAnalyzer>
         : AbstractBuiltInCodeStyleDiagnosticAnalyzer
@@ -50,8 +48,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         where TMemberAccessExpressionSyntax : TExpressionSyntax
         where TInvocationExpressionSyntax : TExpressionSyntax
         where TExpressionStatementSyntax : TStatementSyntax
-        where TForeachStatementSyntax : TStatementSyntax
-        where TIfStatementSyntax : TStatementSyntax
         where TVariableDeclaratorSyntax : SyntaxNode
         where TAnalyzer : AbstractUseCollectionInitializerAnalyzer<
             TExpressionSyntax,
@@ -60,8 +56,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             TMemberAccessExpressionSyntax,
             TInvocationExpressionSyntax,
             TExpressionStatementSyntax,
-            TForeachStatementSyntax,
-            TIfStatementSyntax,
             TVariableDeclaratorSyntax,
             TAnalyzer>, new()
     {
@@ -266,7 +260,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                             properties));
                     }
                 }
-                else if (match is TForeachStatementSyntax)
+                else if (syntaxFacts.IsForEachStatement(match))
                 {
                     // For a `foreach (var x in expr) ...` statement, fade out the parts before and after `expr`.
 

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/IUpdateExpressionSyntaxHelper.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/IUpdateExpressionSyntaxHelper.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.UseCollectionInitializer;
+
+internal interface IUpdateExpressionSyntaxHelper<
+    TExpressionSyntax,
+    TStatementSyntax>
+    where TExpressionSyntax : SyntaxNode
+    where TStatementSyntax : SyntaxNode
+{
+    void GetPartsOfForeachStatement(TStatementSyntax statement, out SyntaxToken identifier, out TExpressionSyntax expression, out IEnumerable<TStatementSyntax> statements);
+    void GetPartsOfIfStatement(TStatementSyntax statement, out TExpressionSyntax condition, out IEnumerable<TStatementSyntax> whenTrueStatements, out IEnumerable<TStatementSyntax>? whenFalseStatements);
+}

--- a/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -46,8 +46,6 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             TMemberAccessExpressionSyntax,
             TInvocationExpressionSyntax,
             TExpressionStatementSyntax,
-            TForeachStatementSyntax,
-            TIfStatementSyntax,
             TVariableDeclaratorSyntax,
             TAnalyzer>, new()
     {

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -14,20 +14,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             MemberAccessExpressionSyntax,
             InvocationExpressionSyntax,
             ExpressionStatementSyntax,
-            ForEachStatementSyntax,
-            IfStatementSyntax,
             VariableDeclaratorSyntax,
             VisualBasicCollectionInitializerAnalyzer)
 
-        Protected Overrides Sub GetPartsOfForeachStatement(statement As ForEachStatementSyntax, ByRef identifier As SyntaxToken, ByRef expression As ExpressionSyntax, ByRef statements As IEnumerable(Of StatementSyntax))
-            ' Only called for collection expressions, which VB does not support
-            Throw ExceptionUtilities.Unreachable()
-        End Sub
-
-        Protected Overrides Sub GetPartsOfIfStatement(statement As IfStatementSyntax, ByRef condition As ExpressionSyntax, ByRef whenTrueStatements As IEnumerable(Of StatementSyntax), ByRef whenFalseStatements As IEnumerable(Of StatementSyntax))
-            ' Only called for collection expressions, which VB does not support
-            Throw ExceptionUtilities.Unreachable()
-        End Sub
+        Protected Overrides ReadOnly Property SyntaxHelper As IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax) =
+            VisualBasicUpdateExpressionSyntaxHelper.Instance
 
         Protected Overrides Function IsComplexElementInitializer(expression As SyntaxNode) As Boolean
             ' Only called for collection expressions, which VB does not support

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUpdateExpressionSyntaxHelper.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUpdateExpressionSyntaxHelper.vb
@@ -1,0 +1,24 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.UseCollectionInitializer
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
+    Friend NotInheritable Class VisualBasicUpdateExpressionSyntaxHelper
+        Implements IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax)
+
+        Public Shared ReadOnly Instance As New VisualBasicUpdateExpressionSyntaxHelper()
+
+        Public Sub GetPartsOfForeachStatement(statement As StatementSyntax, ByRef identifier As SyntaxToken, ByRef expression As ExpressionSyntax, ByRef statements As IEnumerable(Of StatementSyntax)) Implements IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax).GetPartsOfForeachStatement
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
+        End Sub
+
+        Public Sub GetPartsOfIfStatement(statement As StatementSyntax, ByRef condition As ExpressionSyntax, ByRef whenTrueStatements As IEnumerable(Of StatementSyntax), ByRef whenFalseStatements As IEnumerable(Of StatementSyntax)) Implements IUpdateExpressionSyntaxHelper(Of ExpressionSyntax, StatementSyntax).GetPartsOfIfStatement
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
+        End Sub
+    End Class
+End Namespace

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb
@@ -20,8 +20,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             MemberAccessExpressionSyntax,
             InvocationExpressionSyntax,
             ExpressionStatementSyntax,
-            ForEachStatementSyntax,
-            IfStatementSyntax,
             VariableDeclaratorSyntax,
             VisualBasicCollectionInitializerAnalyzer)
 

--- a/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
+++ b/src/Analyzers/VisualBasic/Analyzers/VisualBasicAnalyzers.projitems
@@ -49,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForTernaryConditionalCheckDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCoalesceExpression\VisualBasicUseCoalesceExpressionForNullableTernaryConditionalCheckDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicCollectionInitializerAnalyzer.vb" />
+    <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicUpdateExpressionSyntaxHelper.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\Utilities.vb" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb" />


### PR DESCRIPTION
This helps https://github.com/dotnet/roslyn/pull/69500, where we want to use the same helpers for a different feature.