### PR TITLE
Fix reassigned-variable-underlining with primary constructors

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
@@ -1296,5 +1296,31 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ReassignedVariable
                 }
                 """);
         }
+
+        [Fact]
+        public async Task TestPrimaryConstructor5()
+        {
+            await TestAsync(
+                """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                        <Document>
+                partial class C(int [|p|])
+                {
+                }
+                        </Document>
+                        <Document>
+                partial class C
+                {
+                    void M()
+                    {
+                        [|p|] = 1;
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+                """);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ReassignedVariable;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -1232,6 +1229,70 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ReassignedVariable
                 {
                     public static T EnsureInitialized<T>([NotNull] ref T? [|target|]) where T : class
                         => Volatile.Read(ref [|target|]!);
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestPrimaryConstructor1()
+        {
+            await TestAsync(
+                """
+                class C(int [|p|])
+                {
+                    void M()
+                    {
+                        [|p|] = 1;
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestPrimaryConstructor2()
+        {
+            await TestAsync(
+                """
+                class C(int p)
+                {
+                    void M()
+                    {
+                        var v = new C(p: 1);
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestPrimaryConstructor3()
+        {
+            await TestAsync(
+                """
+                partial class C(int [|p|])
+                {
+                }
+
+                partial class C
+                {
+                    void M()
+                    {
+                        [|p|] = 1;
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestPrimaryConstructor4()
+        {
+            await TestAsync(
+                """
+                class B(int p)
+                {
+                }
+
+                partial class C(int [|p|]) : B([|p|] = 1)
+                {
                 }
                 """);
         }

--- a/src/EditorFeatures/TestUtilities/ReassignedVariable/AbstractReassignedVariableTests.cs
+++ b/src/EditorFeatures/TestUtilities/ReassignedVariable/AbstractReassignedVariableTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,26 +13,30 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReassignedVariable
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReassignedVariable;
+
+[UseExportProvider]
+public abstract class AbstractReassignedVariableTests
 {
-    [UseExportProvider]
-    public abstract class AbstractReassignedVariableTests
+    protected abstract TestWorkspace CreateWorkspace(string markup);
+
+    protected async Task TestAsync(string markup)
     {
-        protected abstract TestWorkspace CreateWorkspace(string markup);
+        using var workspace = CreateWorkspace(markup);
 
-        protected async Task TestAsync(string markup)
+        var project = workspace.CurrentSolution.Projects.Single();
+        var language = project.Language;
+        var documents = project.Documents.ToImmutableArray();
+
+        for (var i = 0; i < documents.Length; i++)
         {
-            using var workspace = CreateWorkspace(markup);
-
-            var project = workspace.CurrentSolution.Projects.Single();
-            var language = project.Language;
-            var document = project.Documents.Single();
+            var document = documents[i];
             var text = await document.GetTextAsync();
 
             var service = document.GetRequiredLanguageService<IReassignedVariableService>();
             var result = await service.GetLocationsAsync(document, new TextSpan(0, text.Length), CancellationToken.None);
 
-            var expectedSpans = workspace.Documents.Single().SelectedSpans.OrderBy(s => s.Start);
+            var expectedSpans = workspace.Documents[i].SelectedSpans.OrderBy(s => s.Start);
             var actualSpans = result.OrderBy(s => s.Start);
 
             Assert.Equal(expectedSpans, actualSpans);

--- a/src/Workspaces/Core/Portable/ReassignedVariable/AbstractReassignedVariableService.cs
+++ b/src/Workspaces/Core/Portable/ReassignedVariable/AbstractReassignedVariableService.cs
@@ -43,17 +43,20 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             using var _1 = PooledDictionary<ISymbol, bool>.GetInstance(out var symbolToIsReassigned);
             using var _2 = ArrayBuilder<TextSpan>.GetInstance(out var result);
             using var _3 = ArrayBuilder<SyntaxNode>.GetInstance(out var stack);
+            using var _4 = PooledDictionary<SyntaxTree, SemanticModel>.GetInstance(out var syntaxTreeToModel);
 
             // Walk through all the nodes in the provided span.  Directly analyze local or parameter declaration.  And
             // also analyze any identifiers which might be reference to locals or parameters.  Note that we might hit
             // locals/parameters without any references in the span, or references that don't have the declarations in 
             // the span
             stack.Add(root.FindNode(span));
+
+            var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var initialModel = GetSemanticModel(root.SyntaxTree);
 
             // Use a stack so we don't blow out the stack with recursion.
             while (stack.Count > 0)
@@ -63,7 +66,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
 
                 if (current.Span.IntersectsWith(span))
                 {
-                    ProcessNode(current);
+                    ProcessNode(initialModel, current);
 
                     foreach (var child in current.ChildNodesAndTokens())
                     {
@@ -76,26 +79,37 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
             result.RemoveDuplicates();
             return result.ToImmutable();
 
-            void ProcessNode(SyntaxNode node)
+            SemanticModel GetSemanticModel(SyntaxTree syntaxTree)
+            {
+                if (!syntaxTreeToModel.TryGetValue(syntaxTree, out var model))
+                {
+                    model = compilation.GetSemanticModel(syntaxTree);
+                    syntaxTreeToModel.Add(syntaxTree, model);
+                }
+
+                return model;
+            }
+
+            void ProcessNode(SemanticModel semanticModel, SyntaxNode node)
             {
                 switch (node)
                 {
                     case TIdentifierNameSyntax identifier:
-                        ProcessIdentifier(identifier);
+                        ProcessIdentifier(semanticModel, identifier);
                         break;
                     case TParameterSyntax parameter:
-                        ProcessParameter(parameter);
+                        ProcessParameter(semanticModel, parameter);
                         break;
                     case TVariableSyntax variable:
-                        ProcessVariable(variable);
+                        ProcessVariable(semanticModel, variable);
                         break;
                     case TSingleVariableDesignationSyntax designation:
-                        ProcessSingleVariableDesignation(designation);
+                        ProcessSingleVariableDesignation(semanticModel, designation);
                         break;
                 }
             }
 
-            void ProcessIdentifier(TIdentifierNameSyntax identifier)
+            void ProcessIdentifier(SemanticModel semanticModel, TIdentifierNameSyntax identifier)
             {
                 // Don't bother even looking at identifiers that aren't standalone (i.e. they're not on the left of some
                 // expression).  These could not refer to locals or fields.
@@ -103,32 +117,32 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
                     return;
 
                 var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
-                if (IsSymbolReassigned(symbol))
+                if (IsSymbolReassigned(semanticModel, symbol))
                     result.Add(identifier.Span);
             }
 
-            void ProcessParameter(TParameterSyntax parameterSyntax)
+            void ProcessParameter(SemanticModel semanticModel, TParameterSyntax parameterSyntax)
             {
                 var parameter = semanticModel.GetDeclaredSymbol(parameterSyntax, cancellationToken) as IParameterSymbol;
-                if (IsSymbolReassigned(parameter))
+                if (IsSymbolReassigned(semanticModel, parameter))
                     result.Add(syntaxFacts.GetIdentifierOfParameter(parameterSyntax).Span);
             }
 
-            void ProcessVariable(TVariableSyntax variable)
+            void ProcessVariable(SemanticModel semanticModel, TVariableSyntax variable)
             {
                 var local = semanticModel.GetDeclaredSymbol(variable, cancellationToken) as ILocalSymbol;
-                if (IsSymbolReassigned(local))
+                if (IsSymbolReassigned(semanticModel, local))
                     result.Add(GetIdentifierOfVariable(variable).Span);
             }
 
-            void ProcessSingleVariableDesignation(TSingleVariableDesignationSyntax designation)
+            void ProcessSingleVariableDesignation(SemanticModel semanticModel, TSingleVariableDesignationSyntax designation)
             {
                 var local = semanticModel.GetDeclaredSymbol(designation, cancellationToken) as ILocalSymbol;
-                if (IsSymbolReassigned(local))
+                if (IsSymbolReassigned(semanticModel, local))
                     result.Add(GetIdentifierOfSingleVariableDesignation(designation).Span);
             }
 
-            bool IsSymbolReassigned([NotNullWhen(true)] ISymbol? symbol)
+            bool IsSymbolReassigned(SemanticModel semanticModel, [NotNullWhen(true)] ISymbol? symbol)
             {
                 // Note: we don't need to test range variables, as they are never reassignable.
                 if (symbol is not IParameterSymbol and not ILocalSymbol)
@@ -136,18 +150,22 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
 
                 if (!symbolToIsReassigned.TryGetValue(symbol, out var reassignedResult))
                 {
-                    reassignedResult = symbol is IParameterSymbol parameter
-                        ? ComputeParameterIsAssigned(parameter)
-                        : ComputeLocalIsAssigned((ILocalSymbol)symbol);
+                    reassignedResult = symbol switch
+                    {
+                        IParameterSymbol parameter => ComputeParameterIsAssigned(semanticModel, parameter),
+                        ILocalSymbol local => ComputeLocalIsAssigned(semanticModel, local),
+                        _ => throw ExceptionUtilities.Unreachable(),
+                    };
+
                     symbolToIsReassigned[symbol] = reassignedResult;
                 }
 
                 return reassignedResult;
             }
 
-            bool ComputeParameterIsAssigned(IParameterSymbol parameter)
+            bool ComputeParameterIsAssigned(SemanticModel semanticModel, IParameterSymbol parameter)
             {
-                if (!TryGetParameterLocation(parameter, out var parameterLocation))
+                if (!TryGetParameterLocation(semanticModel, parameter, out var parameterLocation))
                     return false;
 
                 var methodOrProperty = parameter.ContainingSymbol;
@@ -167,18 +185,24 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
                     // A primary constructor parameter is analyzed across all parts of the type declaration it is
                     // created in.
                     var containingType = methodOrProperty.ContainingType;
-                    foreach (var syntaxReference in containingType.DeclaringSyntaxReferences)
+                    foreach (var group in containingType.DeclaringSyntaxReferences.GroupBy(r => r.SyntaxTree))
                     {
-                        var declaration = syntaxReference.GetSyntax(cancellationToken);
+                        var otherSemanticModel = GetSemanticModel(group.Key);
 
-                        // All parameters (except for 'out' parameters), come in definitely assigned.
-                        if (AnalyzePotentialMatches(
-                                parameter,
-                                parameterLocation,
-                                symbolIsDefinitelyAssigned: parameter.RefKind != RefKind.Out,
-                                declaration))
+                        foreach (var syntaxReference in group)
                         {
-                            return true;
+                            var declaration = syntaxReference.GetSyntax(cancellationToken);
+
+                            // All parameters (except for 'out' parameters), come in definitely assigned.
+                            if (AnalyzePotentialMatches(
+                                    otherSemanticModel,
+                                    parameter,
+                                    parameterLocation,
+                                    symbolIsDefinitelyAssigned: parameter.RefKind != RefKind.Out,
+                                    declaration))
+                            {
+                                return true;
+                            }
                         }
                     }
 
@@ -195,6 +219,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
 
                     // All parameters (except for 'out' parameters), come in definitely assigned.
                     return AnalyzePotentialMatches(
+                        semanticModel,
                         parameter,
                         parameterLocation,
                         symbolIsDefinitelyAssigned: parameter.RefKind != RefKind.Out,
@@ -202,7 +227,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
                 }
             }
 
-            bool TryGetParameterLocation(IParameterSymbol parameter, out TextSpan location)
+            bool TryGetParameterLocation(SemanticModel semanticModel, IParameterSymbol parameter, out TextSpan location)
             {
                 // Be resilient to cases where the parameter might have multiple locations.  This
                 // should not normally happen, but we want to be resilient in case it occurs in
@@ -228,7 +253,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
                 return false;
             }
 
-            bool ComputeLocalIsAssigned(ILocalSymbol local)
+            bool ComputeLocalIsAssigned(SemanticModel semanticModel, ILocalSymbol local)
             {
                 if (local.DeclaringSyntaxReferences.Length == 0)
                     return false;
@@ -245,6 +270,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
 
                 // A local is definitely assigned during analysis if it had an initializer.
                 return AnalyzePotentialMatches(
+                    semanticModel,
                     local,
                     localDeclaration.Span,
                     symbolIsDefinitelyAssigned: HasInitializer(localDeclaration),
@@ -252,6 +278,7 @@ namespace Microsoft.CodeAnalysis.ReassignedVariable
             }
 
             bool AnalyzePotentialMatches(
+                SemanticModel semanticModel,
                 ISymbol localOrParameter,
                 TextSpan localOrParameterDeclarationSpan,
                 bool symbolIsDefinitelyAssigned,


### PR DESCRIPTION
We weren't marking the parameter reassigned if the assignment was in a different partial part.