### PR TITLE
Semantic snippets - make `foreach` snippet work with `await` and async enumerables

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -372,29 +372,36 @@ static void Main(string[] args)
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit, sourceCodeKind: SourceCodeKind.Script);
         }
 
-        [WpfFact]
-        public async Task InsertInlineForEachSnippetForCorrectTypeTest()
+        [WpfTheory]
+        [InlineData("List<int>")]
+        [InlineData("int[]")]
+        [InlineData("IEnumerable<int>")]
+        [InlineData("ArrayList")]
+        [InlineData("IEnumerable")]
+        public async Task InsertInlineForEachSnippetForCorrectTypeTest(string collectionType)
         {
-            var markupBeforeCommit = """
+            var markupBeforeCommit = $$"""
                 using System.Collections.Generic;
+                using System.Collections;
 
                 class C
                 {
-                    void M(List<int> list)
+                    void M({{collectionType}} enumerable)
                     {
-                        list.$$
+                        enumerable.$$
                     }
                 }
                 """;
 
-            var expectedCodeAfterCommit = """
+            var expectedCodeAfterCommit = $$"""
                 using System.Collections.Generic;
+                using System.Collections;
                 
                 class C
                 {
-                    void M(List<int> list)
+                    void M({{collectionType}} enumerable)
                     {
-                        foreach (var item in list)
+                        foreach (var item in enumerable)
                         {
                             $$
                         }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -14,6 +14,130 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     {
         protected override string ItemToCommit => "foreach";
 
+        private const string IAsyncEnumerable = """
+            namespace System
+            {
+                public interface IAsyncDisposable
+                {
+                    System.Threading.Tasks.ValueTask DisposeAsync();
+                }
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                using System.Threading.Tasks;
+
+                public sealed class AsyncMethodBuilderAttribute : Attribute
+                {
+                    public AsyncMethodBuilderAttribute(Type builderType) { }
+                    public Type BuilderType { get; }
+                }
+
+                public struct AsyncValueTaskMethodBuilder
+                {
+                    public ValueTask Task => default;
+
+                    public static AsyncValueTaskMethodBuilder Create() => default;
+                    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+                        where TAwaiter : INotifyCompletion
+                        where TStateMachine : IAsyncStateMachine {}
+
+                    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+                        where TAwaiter : ICriticalNotifyCompletion
+                        where TStateMachine : IAsyncStateMachine {}
+                    public void SetException(Exception exception) {}
+                    public void SetResult() {}
+                    public void SetStateMachine(IAsyncStateMachine stateMachine) {}
+                    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine {}
+                }
+
+                public readonly struct ValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
+                {
+                    public bool IsCompleted => default;
+
+                    public void GetResult() { }
+                    public void OnCompleted(Action continuation) { }
+                    public void UnsafeOnCompleted(Action continuation) { }
+                }
+
+                public readonly struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion, INotifyCompletion
+                {
+                    public bool IsCompleted => default;
+                    public TResult GetResult() => default;
+                    public void OnCompleted(Action continuation) { }
+                    public void UnsafeOnCompleted(Action continuation) { }
+                }
+            }
+
+            namespace System.Threading.Tasks
+            {
+                using System.Runtime.CompilerServices;
+
+                [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder))]
+                public readonly struct ValueTask : IEquatable<ValueTask>
+                {
+                    public ValueTask(Task task) {}
+                    public ValueTask(IValueTaskSource source, short token) {}
+
+                    public bool IsCompleted => default;
+                    public bool IsCompletedSuccessfully => default;
+                    public bool IsFaulted => default;
+                    public bool IsCanceled => default;
+
+                    public Task AsTask() => default;
+                    public ConfiguredValueTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) => default;
+                    public override bool Equals(object obj) => default;
+                    public bool Equals(ValueTask other) => default;
+                    public ValueTaskAwaiter GetAwaiter() => default;
+                    public override int GetHashCode() => default;
+                    public ValueTask Preserve() => default;
+
+                    public static bool operator ==(ValueTask left, ValueTask right) => default;
+                    public static bool operator !=(ValueTask left, ValueTask right) => default;
+                }
+
+                [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder<>))]
+                public readonly struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
+                {
+                    public ValueTask(TResult result) {}
+                    public ValueTask(Task<TResult> task) {}
+                    public ValueTask(IValueTaskSource<TResult> source, short token) {}
+
+                    public bool IsFaulted => default;
+                    public bool IsCompletedSuccessfully => default;
+                    public bool IsCompleted => default;
+                    public bool IsCanceled => default;
+                    public TResult Result => default;
+
+                    public Task<TResult> AsTask() => default;
+                    public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) => default;
+
+                    public bool Equals(ValueTask<TResult> other) => default;
+                    public override bool Equals(object obj) => default;
+                    public ValueTaskAwaiter<TResult> GetAwaiter() => default;
+                    public override int GetHashCode() => default;
+                    public ValueTask<TResult> Preserve() => default;
+                    public override string ToString() => default;
+                    public static bool operator ==(ValueTask<TResult> left, ValueTask<TResult> right) => default;
+                    public static bool operator !=(ValueTask<TResult> left, ValueTask<TResult> right) => default;
+                }
+            }
+
+            namespace System.Collections.Generic
+            {
+                public interface IAsyncEnumerable<out T>
+                {
+                    IAsyncEnumerator<T> GetAsyncEnumerator();
+                }
+
+                public interface IAsyncEnumerator<out T> : IAsyncDisposable
+                {
+                    System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
+                    T Current { get; }
+                }
+            }
+            """;
+
         [WpfFact]
         public async Task InsertForEachSnippetInMethodTest()
         {
@@ -425,6 +549,142 @@ static void Main(string[] args)
                     $$
                 }
                 """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("")]
+        [InlineData("async ")]
+        public async Task InsertForEachSnippetAfterSingleAwaitKeywordInMethodBodyTest(string asyncKeyword)
+        {
+            var markupBeforeCommit = $$"""
+                class C
+                {
+                    {{asyncKeyword}}void M()
+                    {
+                        await $$
+                    }
+                }
+                """ + IAsyncEnumerable;
+
+            var expectedCodeAfterCommit = $$"""
+                class C
+                {
+                    {{asyncKeyword}}void M()
+                    {
+                        await foreach (var item in collection)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """ + IAsyncEnumerable;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task InsertForEachSnippetAfterSingleAwaitKeywordInGlobalStatementTest()
+        {
+            var markupBeforeCommit = """
+                await $$
+
+                """ + IAsyncEnumerable;
+
+            var expectedCodeAfterCommit = """
+                await foreach (var item in collection)
+                {
+                    $$
+                }
+
+                """ + IAsyncEnumerable;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task NoForEachStatementAfterAwaitKeywordWhenWontResultInStatementTest()
+        {
+            var markupBeforeCommit = """
+                var result = await $$
+                """ + IAsyncEnumerable;
+
+            await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("")]
+        [InlineData("async ")]
+        public async Task PreferAsyncEnumerableVariableInScopeForAwaitForEachTest(string asyncKeyword)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    {{asyncKeyword}}void M()
+                    {
+                        IEnumerable<int> enumerable;
+                        IAsyncEnumerable<int> asyncEnumerable;
+
+                        await $$
+                    }
+                }
+                """ + IAsyncEnumerable;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    {{asyncKeyword}}void M()
+                    {
+                        IEnumerable<int> enumerable;
+                        IAsyncEnumerable<int> asyncEnumerable;
+                
+                        await foreach (var item in asyncEnumerable)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """ + IAsyncEnumerable;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfTheory]
+        [InlineData("")]
+        [InlineData("async ")]
+        public async Task InsertAwaitForEachSnippetForPostfixAsyncEnumerableTest(string asyncKeyword)
+        {
+            var markupBeforeCommit = $$"""
+                using System.Collections.Generic;
+
+                class C
+                {
+                    {{asyncKeyword}}void M(IAsyncEnumerable<int> asyncEnumerable)
+                    {
+                        asyncEnumerable.$$
+                    }
+                }
+                """ + IAsyncEnumerable;
+
+            var expectedCodeAfterCommit = $$"""
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    {{asyncKeyword}}void M(IAsyncEnumerable<int> asyncEnumerable)
+                    {
+                        await foreach (var item in asyncEnumerable)
+                        {
+                            $$
+                        }
+                    }
+                }
+                """ + IAsyncEnumerable;
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }

--- a/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpForEachLoopSnippetProvider.cs
@@ -31,6 +31,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
         }
 
+        protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
+            var syntaxContext = document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
+            var targetToken = syntaxContext.TargetToken;
+
+            // Allow `foreach` snippet after `await` as expression statement
+            // So `await $$` is a valid position, but `var result = await $$` is not
+            // The second check if for case when completions are invoked after `await` in non-async context. In such cases parser treats `await` as identifier
+            if (targetToken is { RawKind: (int)SyntaxKind.AwaitKeyword, Parent: ExpressionSyntax { Parent: ExpressionStatementSyntax } } ||
+                targetToken is { RawKind: (int)SyntaxKind.IdentifierToken, ValueText: "await", Parent: IdentifierNameSyntax { Parent: ExpressionStatementSyntax } })
+            {
+                return true;
+            }
+
+            return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
+        }
+
         protected override SyntaxNode GenerateStatement(SyntaxGenerator generator, SyntaxContext syntaxContext, SyntaxNode? inlineExpression)
         {
             var semanticModel = syntaxContext.SemanticModel;
@@ -41,8 +59,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             if (collectionIdentifier is null)
             {
+                var isAsync = syntaxContext.TargetToken is { RawKind: (int)SyntaxKind.AwaitKeyword } or { RawKind: (int)SyntaxKind.IdentifierToken, ValueText: "await" };
                 var enumerationSymbol = semanticModel.LookupSymbols(position).FirstOrDefault(symbol => symbol.GetSymbolType() is { } symbolType &&
-                    symbolType.CanBeEnumerated() &&
+                    (isAsync ? symbolType.CanBeAsynchronouslyEnumerated(semanticModel.Compilation) : symbolType.CanBeEnumerated()) &&
                     symbol.Kind is SymbolKind.Local or SymbolKind.Field or SymbolKind.Parameter or SymbolKind.Property);
                 collectionIdentifier = enumerationSymbol is null
                     ? SyntaxFactory.IdentifierName("collection")
@@ -52,7 +71,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var itemString = NameGenerator.GenerateUniqueName(
                 "item", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
 
-            return SyntaxFactory.ForEachStatement(varIdentifier, itemString, collectionIdentifier.WithoutLeadingTrivia(), SyntaxFactory.Block()).NormalizeWhitespace();
+            ForEachStatementSyntax forEachStatement;
+
+            if (inlineExpression is not null &&
+                semanticModel.GetTypeInfo(inlineExpression).Type!.CanBeAsynchronouslyEnumerated(semanticModel.Compilation))
+            {
+                forEachStatement = SyntaxFactory.ForEachStatement(
+                    SyntaxFactory.Token(SyntaxKind.AwaitKeyword),
+                    SyntaxFactory.Token(SyntaxKind.ForEachKeyword),
+                    SyntaxFactory.Token(SyntaxKind.OpenParenToken),
+                    varIdentifier,
+                    SyntaxFactory.Identifier(itemString),
+                    SyntaxFactory.Token(SyntaxKind.InKeyword),
+                    collectionIdentifier.WithoutLeadingTrivia(),
+                    SyntaxFactory.Token(SyntaxKind.CloseParenToken),
+                    SyntaxFactory.Block());
+            }
+            else
+            {
+                forEachStatement = SyntaxFactory.ForEachStatement(
+                    varIdentifier,
+                    itemString,
+                    collectionIdentifier.WithoutLeadingTrivia(),
+                    SyntaxFactory.Block());
+            }
+
+            return forEachStatement.NormalizeWhitespace();
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConditionalBlockSnippetProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
     {
         protected abstract SyntaxNode GetCondition(SyntaxNode node);
 
-        protected override bool IsValidAccessingType(ITypeSymbol type)
+        protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
             => type.SpecialType == SpecialType.System_Boolean;
 
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForEachLoopSnippetProvider.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         public override string Description => FeaturesResources.foreach_loop;
 
-        protected override bool IsValidAccessingType(ITypeSymbol type)
-            => type.CanBeEnumerated();
+        protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
+            => type.CanBeEnumerated() || type.CanBeAsynchronouslyEnumerated(compilation);
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)
         {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractForLoopSnippetProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
     internal abstract class AbstractForLoopSnippetProvider : AbstractInlineStatementSnippetProvider
     {
-        protected override bool IsValidAccessingType(ITypeSymbol type)
+        protected override bool IsValidAccessingType(ITypeSymbol type, Compilation compilation)
             => type.IsIntegralType() || type.IsNativeIntegerType;
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractInlineStatementSnippetProvider.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         /// Tells if accessing type of a member access expression is valid for that snippet
         /// </summary>
         /// <param name="type">Type of right-hand side of a member access expression</param>
-        protected abstract bool IsValidAccessingType(ITypeSymbol type);
+        /// <param name="compilation">Current compilation instance</param>
+        protected abstract bool IsValidAccessingType(ITypeSymbol type, Compilation compilation);
 
         /// <summary>
         /// Generate statement node
@@ -38,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
         /// </summary>
         protected bool ConstructedFromInlineExpression { get; private set; }
 
-        protected sealed override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
             var syntaxContext = document.GetRequiredLanguageService<ISyntaxContextService>().CreateContext(document, semanticModel, position, cancellationToken);
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
                 var accessingType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
 
                 if (accessingType is not null)
-                    return IsValidAccessingType(accessingType);
+                    return IsValidAccessingType(accessingType, semanticModel.Compilation);
             }
 
             return await base.IsValidSnippetLocationAsync(document, position, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -236,5 +236,31 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool CanBeEnumerated(this ITypeSymbol type)
             => type.AllInterfaces.Any(s => s.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T or SpecialType.System_Collections_IEnumerable);
 
+        public static bool CanBeAsynchronouslyEnumerated(this ITypeSymbol type, Compilation compilation)
+        {
+            var asyncEnumerableType = compilation.IAsyncEnumerableOfTType();
+
+            if (asyncEnumerableType is null)
+            {
+                return false;
+            }
+
+            // Type itself is an IAsyncEnumerable<SomeType>
+            if (type.TypeKind == TypeKind.Interface &&
+                type.OriginalDefinition.Equals(asyncEnumerableType, SymbolEqualityComparer.Default))
+            {
+                return true;
+            }
+
+            foreach (var @interface in type.AllInterfaces)
+            {
+                if (@interface.OriginalDefinition.Equals(asyncEnumerableType, SymbolEqualityComparer.Default))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -234,7 +234,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static bool CanBeEnumerated(this ITypeSymbol type)
-            => type.AllInterfaces.Any(s => s.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T or SpecialType.System_Collections_IEnumerable);
+        {
+            // Type itself is IEnumerable/IEnumerable<SomeType>
+            if (type.OriginalDefinition is { SpecialType: SpecialType.System_Collections_Generic_IEnumerable_T or SpecialType.System_Collections_IEnumerable })
+            {
+                return true;
+            }
+
+            return type.AllInterfaces.Any(s => s.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T or SpecialType.System_Collections_IEnumerable);
+        }
 
         public static bool CanBeAsynchronouslyEnumerated(this ITypeSymbol type, Compilation compilation)
         {


### PR DESCRIPTION
- Suggest `foreach` snippet after single `await` keyword
- In such case snippet prefers `IAsyncEnumerable<T>` variables in current scope
- Also suggest snippet in postfix completions for `IAsyncEnumerable<T>`
- In such case snippet generates `await foreach` statement

While working on async enumerables I noticed that there is a bug, that prevents postfix completion of `foreach` for `IEnumerable` type (yes, non-generic one). So I fixed it in the second commit and added more test cases for valid collection types

@akhera99 for review