### PR TITLE
Remove use of Environment.CurrentDirectory

### DIFF
--- a/src/Compilers/Core/Portable/BannedSymbols.CompilerLibraries.txt
+++ b/src/Compilers/Core/Portable/BannedSymbols.CompilerLibraries.txt
@@ -1,1 +1,2 @@
 M:System.IO.Path.GetTempPath(); Cannot be used safely in APIs or compiler server as underlying environment variables can change during build.
+P:System.Environment.CurrentDirectory; Cannot be used safely in APIs or compiler server as underlying environment variables can change during build.

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -747,9 +747,6 @@
     <value>The hintName '{0}' contains an invalid segment '{1}' at position {2}.</value>
     <comment>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</comment>
   </data>
-  <data name="HintNameNotWithinCurrentDirectory" xml:space="preserve">
-    <value>The hintName '{0}' is not within the current directory.</value>
-  </data>
   <data name="MethodSymbolExpected" xml:space="preserve">
     <value>Method symbol expected</value>
   </data>

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis
     internal sealed class AdditionalSourcesCollection
     {
         private readonly ArrayBuilder<GeneratedSourceText> _sourcesAdded;
-
         private readonly string _fileExtension;
 
         private const StringComparison _hintNameComparison = StringComparison.OrdinalIgnoreCase;
@@ -82,11 +81,6 @@ namespace Microsoft.CodeAnalysis
             if (source.Encoding is null)
             {
                 throw new ArgumentException(string.Format(CodeAnalysisResources.SourceTextRequiresEncoding, hintName), nameof(source));
-            }
-
-            if (Path.IsPathRooted(hintName) || !Path.GetFullPath(hintName).StartsWith(Environment.CurrentDirectory, _hintNameComparison))
-            {
-                throw new ArgumentException(string.Format(CodeAnalysisResources.HintNameNotWithinCurrentDirectory, hintName), nameof(hintName));
             }
 
             _sourcesAdded.Add(new GeneratedSourceText(hintName, source));

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -89,11 +89,6 @@
         <target state="translated">HintName {0} obsahuje neplatný segment {1} na pozici {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">HintName {0} není v aktuálním adresáři.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">{0} hintName přidaného zdrojového souboru musí být v rámci generátoru jedinečná.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -89,11 +89,6 @@
         <target state="translated">Der hintName „{0}“ enthält ein ungültiges Segment „{1}“ an Position {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">Der hintName „{0}“ befindet sich nicht im aktuellen Verzeichnis.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">Der hintName "{0}" der hinzugefügten Quelldatei muss innerhalb eines Generators eindeutig sein.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -89,11 +89,6 @@
         <target state="translated">HintName '{0}' contiene un segmento no válido '{1}' en la posición {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">El valor de hintName '{0}' no está dentro del directorio actual.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">El elemento hintName "{0}"del archivo de código fuente agregado debe ser único dentro de un generador.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -89,11 +89,6 @@
         <target state="translated">Le hintName '{0}' contient un segment non valide '{1}' à la position {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">Le '{0}' hintName ne se trouve pas dans le répertoire actif.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">Le hintName « {0} »du fichier source ajouté doit être unique dans un générateur.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -89,11 +89,6 @@
         <target state="translated">L'elemento hintName '{0}' contiene un segmento non valido '{1}' alla posizione {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">L'elemento '{0}' hintName non si trova nella directory corrente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">L'elemento hintName '{0}' del file di origine aggiunto deve essere univoco all'interno di un generatore.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -89,11 +89,6 @@
         <target state="translated">hintName '{0}' の位置 {2} に無効なセグメント '{1}' が含まれています。</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">hintName '{0}' が現在のディレクトリ内にありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">追加されたソース ファイルの hintName '{0}' は、ジェネレーター内で一意である必要があります。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -89,11 +89,6 @@
         <target state="translated">hintName '{0}'의 위치 {2}에 잘못된 세그먼트 '{1}'이(가) 있습니다.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">hintName '{0}'이(가) 현재 디렉터리에 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">추가된 원본 파일의 hintName ‘{0}’은(는) 생성기 내에서 고유해야 합니다.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -89,11 +89,6 @@
         <target state="translated">Element hintName '{0}' zawiera nieprawidłowy segment '{1}' na pozycji {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">Nazwa wskazówki '{0}' nie znajduje się w bieżącym katalogu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">Element hintName „{0}” dodanego pliku źródłowego musi być unikatowy w generatorze.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -89,11 +89,6 @@
         <target state="translated">O hintName "{0}" contém um segmento inválido "{1}" na posição {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">O hintName "{0}" não está dentro do diretório atual.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">O hintName '{0}' do arquivo de origem adicionado precisa ser exclusivo em um gerador.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -89,11 +89,6 @@
         <target state="translated">HintName "{0}" содержит недопустимый сегмент "{1}" в позиции {2}.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">HintName "{0}" находится вне текущего каталога.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">HintName "{0}" добавленного исходного файла должно быть уникальным в пределах генератора.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -89,11 +89,6 @@
         <target state="translated">HintName '{0}', {2} konumunda geçersiz bir '{1}' segmenti içeriyor.</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">HintName '{0}' geçerli dizinde değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">Eklenen kaynak dosyanın '{0}' hintName'i bir oluşturucu içinde benzersiz olmalıdır.</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -89,11 +89,6 @@
         <target state="translated">hintName“{0}”的段“{1}”(位于位置“{2}”)无效。</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">hintName“{0}”不在当前目录中。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">添加的源文件的 hintName“{0}”在生成器中必须唯一。</target>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -89,11 +89,6 @@
         <target state="translated">hintName '{0}' 的位置 {2} 包含無效的字元 '{1}'。</target>
         <note>{0}: the provided hintname. {1}: the invalid segment, {2} the position it occurred at</note>
       </trans-unit>
-      <trans-unit id="HintNameNotWithinCurrentDirectory">
-        <source>The hintName '{0}' is not within the current directory.</source>
-        <target state="translated">hintName '{0}' 不在目前的目錄內。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="HintNameUniquePerGenerator">
         <source>The hintName '{0}' of the added source file must be unique within a generator.</source>
         <target state="translated">新增來源檔案的 hintName '{0}' 在產生器中必須是唯一的。</target>


### PR DESCRIPTION
The compiler should not make use of `Environment.CurrentDirectory` in the libraries layer. That layer cannot depend on anything environment related because doing so would break cases like VBCSCompiler which needs to be environment agnostic.

The one use was in `AdditionalSourcesCollection` to verify that the provided hint name was within the current working directory. After some thought I decided the best course was to remove this restriction. The ratoinale is once you actually thread through the current directory you find that it must be added to the `Compilation`. Effectively everything that hosts a `Compilation` must provide a working directory and that goes against the goals of `Compilation` which seeks to be agnostic to working directories.

Think allowing customers to specify the full paths was the lesser evil here.

closes #69516