### PR TITLE
Support creating binlogs for the language server's design time builds

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace
+{
+    internal static class LanguageServerProjectSystemOptionsStorage
+    {
+        private static readonly OptionGroup s_optionGroup = new(name: "projects", description: "");
+
+        /// <summary>
+        /// A folder to log binlogs to when running design-time builds.
+        /// </summary>
+        public static readonly Option2<string?> BinaryLogPath = new Option2<string?>("dotnet_binary_log_path", defaultValue: null, s_optionGroup);
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.ImplementType;
 using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.QuickInfo;
@@ -58,6 +59,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             SolutionCrawlerOptionsStorage.CompilerDiagnosticsScopeOption,
             // Code lens options
             LspOptionsStorage.LspEnableReferencesCodeLens,
-            LspOptionsStorage.LspEnableTestsCodeLens);
+            LspOptionsStorage.LspEnableTestsCodeLens,
+            // Project system
+            LanguageServerProjectSystemOptionsStorage.BinaryLogPath);
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -143,7 +143,8 @@ public class A { }";
                 "background_analysis.dotnet_analyzer_diagnostics_scope",
                 "background_analysis.dotnet_compiler_diagnostics_scope",
                 "code_lens.dotnet_enable_references_code_lens",
-                "code_lens.dotnet_enable_tests_code_lens"
+                "code_lens.dotnet_enable_tests_code_lens",
+                "projects.dotnet_binary_log_path"
             }.OrderBy(name => name);
 
             Assert.Equal(expectedNames, actualNames);
@@ -266,6 +267,10 @@ public class A { }";
                 {
                     var defaultValue = (int)option.DefaultValue!;
                     return defaultValue + 1;
+                }
+                else if (type == typeof(string))
+                {
+                    return Guid.NewGuid().ToString();
                 }
                 else if (type.IsEnum)
                 {

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -225,6 +225,7 @@ public class VisualStudioOptionStorageTests
             "dotnet_remove_unnecessary_suppression_exclusions",                             // Doesn't have VS UI. TODO: https://github.com/dotnet/roslyn/issues/66062
             "dotnet_style_operator_placement_when_wrapping",                                // Doesn't have VS UI. TODO: https://github.com/dotnet/roslyn/issues/66062
             "dotnet_style_prefer_foreach_explicit_cast_in_source",                          // For a small customer segment, doesn't warrant VS UI.
+            "dotnet_binary_log_path",                                                       // VSCode only option for the VS Code project system; does not apply to VS
             "dotnet_lsp_using_devkit",                                                      // VSCode internal only option.  Does not need any UI.
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.

--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -168,7 +168,11 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             {
                 Loggers = _msbuildLogger is null
                     ? (new MSB.Framework.ILogger[] { _batchBuildLogger })
-                    : (new MSB.Framework.ILogger[] { _batchBuildLogger, _msbuildLogger })
+                    : (new MSB.Framework.ILogger[] { _batchBuildLogger, _msbuildLogger }),
+
+                // If we have an additional logger and it's diagnostic, then we need to opt into task inputs globally, or otherwise
+                // it won't get any log events. This logic matches https://github.com/dotnet/msbuild/blob/fa6710d2720dcf1230a732a8858ffe71bcdbe110/src/Build/Instance/ProjectInstance.cs#L2365-L2371
+                LogTaskInputs = _msbuildLogger is not null && _msbuildLogger.Verbosity == LoggerVerbosity.Diagnostic
             };
 
             MSB.Execution.BuildManager.DefaultBuildManager.BeginBuild(buildParameters);


### PR DESCRIPTION
This allows you to configure a directory where we will write binlogs for any design time builds. This is only needed when debugging project system issues, but when you need this, you really need this.