### PR TITLE
Visit foreach await info in error scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -10149,6 +10149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If we're in this scenario, there was a binding error, and we should suppress any further warnings.
                 Debug.Assert(node.HasErrors);
                 VisitRvalue(node.Expression);
+                Visit(node.AwaitOpt);
                 return;
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69539.

<details>
<summary>
The assert was:
</summary>

```
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.5+1caef2f33e (64-bit .NET 7.0.10)
[xUnit.net 00:00:06.20]   Starting:    Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests
[xUnit.net 00:00:07.02]     Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.ForEach_26 [FAIL]
[xUnit.net 00:00:07.02]       System.InvalidOperationException : Did not find Microsoft.CodeAnalysis.CSharp.BoundAwaitableValuePlaceholder `` in the map.
[xUnit.net 00:00:07.02]       Stack Trace:
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\Test\Core\ThrowingTraceListener.cs(26,0): at Microsoft.CodeAnalysis.ThrowingTraceListener.Fail(String message, String detailMessage)
[xUnit.net 00:00:07.02]            at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
[xUnit.net 00:00:07.02]            at System.Diagnostics.Debug.Fail(String message, String detailMessage)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(69,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.VerifyExpression(BoundExpression expression, Boolean overrideSkippedExpression)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(76,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.VisitExpressionWithoutStackGuard(BoundExpression node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeVisitors.cs(212,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeVisitor.VisitExpressionWithStackGuard(Int32& recursionDepth, BoundExpression node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(91,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(9846,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeWalker.VisitAwaitableInfo(BoundAwaitableInfo node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(2123,0): at Microsoft.CodeAnalysis.CSharp.BoundAwaitableInfo.Accept(BoundTreeVisitor visitor)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeVisitors.cs(151,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeVisitor.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(93,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(136,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.VisitForEachStatement(BoundForEachStatement node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(3967,0): at Microsoft.CodeAnalysis.CSharp.BoundForEachStatement.Accept(BoundTreeVisitor visitor)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeVisitors.cs(151,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeVisitor.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(93,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeWalker.cs(22,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeWalker.VisitList[T](ImmutableArray`1 list)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(9934,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeWalker.VisitBlock(BoundBlock node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(3220,0): at Microsoft.CodeAnalysis.CSharp.BoundBlock.Accept(BoundTreeVisitor visitor)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeVisitors.cs(151,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeVisitor.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(93,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(10635,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeWalker.VisitNonConstructorMethodBody(BoundNonConstructorMethodBody node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs(8591,0): at Microsoft.CodeAnalysis.CSharp.BoundNonConstructorMethodBody.Accept(BoundTreeVisitor visitor)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\BoundTree\BoundTreeVisitors.cs(151,0): at Microsoft.CodeAnalysis.CSharp.BoundTreeVisitor.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(93,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Visit(BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.DebugVerifier.cs(39,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.DebugVerifier.Verify(ImmutableDictionary`2 analyzedNullabilityMap, SnapshotManager snapshotManagerOpt, BoundNode node)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.cs(1500,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.AnalyzeWithSemanticInfo(CSharpCompilation compilation, Symbol symbol, BoundNode node, Binder binder, VariableState initialState, DiagnosticBag diagnostics, Boolean createSnapshots, Boolean requiresAnalysis)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\FlowAnalysis\NullableWalker.cs(1453,0): at Microsoft.CodeAnalysis.CSharp.NullableWalker.AnalyzeAndRewrite(CSharpCompilation compilation, Symbol symbol, BoundNode node, Binder binder, VariableState initialState, DiagnosticBag diagnostics, Boolean createSnapshots, SnapshotManager& snapshotManager, ImmutableDictionary`2& remappedSymbols)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(1852,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.BindMethodBody(MethodSymbol method, TypeCompilationState compilationState, BindingDiagnosticBag diagnostics, Boolean includeInitializersInBody, BoundNode initializersBody, Boolean reportNullableDiagnostics, ImportChain& importChain, Boolean& originalBodyNested, Boolean& prependedDefaultValueTypeConstructorInitializer, InitialState& forSemanticModel)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(1061,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethod(MethodSymbol methodSymbol, Int32 methodOrdinal, ProcessedFieldInitializers& processedInitializers, SynthesizedSubmissionFields previousSubmissionFields, TypeCompilationState compilationState)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(527,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileNamedType(NamedTypeSymbol containingType)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(429,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.<>c__DisplayClass25_0.<CompileNamedTypeAsync>b__0()
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\Core\Portable\InternalUtilities\UICultureUtilities.cs(139,0): at Roslyn.Utilities.UICultureUtilities.<>c__DisplayClass5_0.<WithCurrentUICulture>b__0()
[xUnit.net 00:00:07.02]            at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
[xUnit.net 00:00:07.02]         --- End of stack trace from previous location ---
[xUnit.net 00:00:07.02]            at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
[xUnit.net 00:00:07.02]            at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
[xUnit.net 00:00:07.02]         --- End of stack trace from previous location ---
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(328,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.WaitForWorkers()
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compiler\MethodCompiler.cs(160,0): at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethodBodies(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, Boolean emittingPdb, Boolean hasDeclarationErrors, Boolean emitMethodBodies, BindingDiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2935,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnosticsForAllMethodBodies(BindingDiagnosticBag diagnostics, Boolean doLowering, CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2907,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnosticsWithoutFiltering(CompilationStage stage, Boolean includeEarlierStages, BindingDiagnosticBag builder, CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2818,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CompilationStage stage, Boolean includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2809,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CompilationStage stage, Boolean includeEarlierStages, CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2803,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CancellationToken cancellationToken)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\Test\Core\Diagnostics\DiagnosticExtensions.cs(108,0): at Microsoft.CodeAnalysis.DiagnosticExtensions.VerifyDiagnostics[TCompilation](TCompilation c, DiagnosticDescription[] expected)
[xUnit.net 00:00:07.02]         C:\Users\janjones\Code\roslyn\src\Compilers\CSharp\Test\Semantic\Semantics\NullableReferenceTypesTests.cs(87614,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics.NullableReferenceTypesTests.ForEach_26()
[xUnit.net 00:00:07.02]            at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
[xUnit.net 00:00:07.02]            at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
[xUnit.net 00:00:07.03]   Finished:    Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests
```

</details>