### PR TITLE
Implement ref switch expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -109,6 +109,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     leftPlaceholder: null, leftConversion: null, finalPlaceholder: null, finalConversion: null, LookupResultKind.NotAVariable, CreateErrorType(), hasErrors: true);
             }
 
+            if (left.Kind == BoundKind.UnconvertedSwitchExpression)
+            {
+                var switchExpression = (BoundUnconvertedSwitchExpression)left;
+                var switchExpressionDiagnostics = diagnostics;
+                if (!switchExpression.IsRef)
+                {
+                    Error(diagnostics, ErrorCode.ERR_RequiresRefReturningSwitchExpression, node.OperatorToken);
+                    // Ignore further binding errors, potentially including unavailable conversions
+                    switchExpressionDiagnostics = BindingDiagnosticBag.Discarded;
+                }
+
+                left = this.ConvertSwitchExpression(switchExpression, destination: left.Type, null, switchExpressionDiagnostics);
+            }
+
             // A compound operator, say, x |= y, is bound as x = (X)( ((T)x) | ((T)y) ). We must determine
             // the binary operator kind, the type conversions from each side to the types expected by
             // the operator, and the type conversion from the return type of the operand to the left hand side.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1941,7 +1941,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    return expression;
+                    return ConvertIdentityRefExpression(expression, targetType, diagnostics, ref useSiteInfo);
                 }
             }
             else if (!conversion.IsValid ||
@@ -1963,6 +1963,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return CreateConversion(expression.Syntax, expression, conversion, isCast: false, conversionGroupOpt: null, targetType, diagnostics);
+        }
+
+        private BoundExpression ConvertIdentityRefExpression(BoundExpression expression, TypeSymbol destination, BindingDiagnosticBag diagnostics, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            switch (expression.Kind)
+            {
+                case BoundKind.UnconvertedSwitchExpression:
+                    var switchExpression = (BoundUnconvertedSwitchExpression)expression;
+                    //var conversion = this.Conversions.ClassifyConversionFromExpression(expression, destination, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
+                    return ConvertSwitchExpression(switchExpression, destination, null, diagnostics);
+
+                default:
+                    return expression;
+            }
         }
 
 #nullable enable

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1971,7 +1971,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case BoundKind.UnconvertedSwitchExpression:
                     var switchExpression = (BoundUnconvertedSwitchExpression)expression;
-                    //var conversion = this.Conversions.ClassifyConversionFromExpression(expression, destination, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
                     return ConvertSwitchExpression(switchExpression, destination, null, diagnostics);
 
                 default:

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -396,6 +396,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Expression);
             using var _ = new PatternInput(this, GetValEscape(node.Expression, _localScopeDepth));
             this.VisitList(node.SwitchArms);
+            if (node.IsRef)
+            {
+                this.ValidateRefSwitchExpression(node.Syntax, node.SwitchArms, this._diagnostics);
+            }
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionArmBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionArmBinder.cs
@@ -43,9 +43,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? whenClause = node.WhenClause != null
                 ? armBinder.BindBooleanExpression(node.WhenClause.Condition, diagnostics)
                 : null;
-            BoundExpression armResult = armBinder.BindValue(node.Expression, diagnostics, BindValueKind.RValue);
+
+            var bindValueKind = BindValueKind.RValue;
+            var unwrappedExpression = node.Expression.CheckAndUnwrapRefExpression(diagnostics, out var refKind);
+
+            if (refKind is not RefKind.None)
+            {
+                var refExpression = node.Expression as RefExpressionSyntax;
+                Debug.Assert(refExpression is not null);
+                var refKeywordLocation = Location.Create(node.SyntaxTree, refExpression!.RefKeyword.Span);
+                MessageID.IDS_FeatureRefInSwitchExpressionArm.CheckFeatureAvailability(diagnostics, node, refKeywordLocation);
+
+                bindValueKind |= BindValueKind.RefersToLocation;
+            }
+
+            BoundExpression armResult = armBinder.BindValue(unwrappedExpression, diagnostics, bindValueKind);
+            // TODO: Get whether the underlying expression is readonly
+
             var label = new GeneratedLabelSymbol("arm");
-            return new BoundSwitchExpressionArm(node, locals, pattern, whenClause, armResult, label, hasErrors | pattern.HasErrors);
+            return new BoundSwitchExpressionArm(node, locals, pattern, whenClause, armResult, label, refKind, hasErrors | pattern.HasErrors);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1480,6 +1480,7 @@
     <Field Name="ReachabilityDecisionDag" Type="BoundDecisionDag" Null="disallow" SkipInVisitor="true"/>
     <Field Name="DefaultLabel" Type="LabelSymbol?"/>
     <Field Name="ReportedNotExhaustive" Type="bool"/>
+    <Field Name="RefKind" Type="RefKind" />
   </AbstractNode>
   <Node Name="BoundSwitchExpressionArm" Base="BoundNode">
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
@@ -1487,6 +1488,7 @@
     <Field Name="WhenClause" Type="BoundExpression?"/>
     <Field Name="Value" Type="BoundExpression" Null="disallow"/>
     <Field Name="Label" Type="LabelSymbol" Null="disallow"/>
+    <Field Name="RefKind" Type="RefKind"/>
   </Node>
 
   <Node Name="BoundUnconvertedSwitchExpression" Base="BoundSwitchExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundSwitchExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundSwitchExpression.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class BoundSwitchExpression
     {
+        public bool IsRef => RefKind is not RefKind.None;
+
         public BoundDecisionDag GetDecisionDagForLowering(CSharpCompilation compilation, out LabelSymbol? defaultLabel)
         {
             defaultLabel = this.DefaultLabel;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundSwitchExpressionArm.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundSwitchExpressionArm.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class BoundSwitchExpressionArm
+    {
+        public bool IsRef => RefKind is not RefKind.None;
+    }
+}

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7796,4 +7796,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureRefInSwitchExpressionArm" xml:space="preserve">
     <value>ref in switch expression arms</value>
   </data>
+  <data name="ERR_MismatchedRefEscapeInSwitchExpression" xml:space="preserve">
+    <value>The branches of the ref switch expression refer to variables with incompatible declaration scopes</value>
+  </data>
+  <data name="WRN_MismatchedRefEscapeInSwitchExpression" xml:space="preserve">
+    <value>The branches of the ref switch expression refer to variables with incompatible declaration scopes</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7793,4 +7793,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_UseDefViolationRefField_Title" xml:space="preserve">
     <value>Ref field should be ref-assigned before use.</value>
   </data>
+  <data name="IDS_FeatureRefInSwitchExpressionArm" xml:space="preserve">
+    <value>ref in switch expression arms</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7802,4 +7802,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_MismatchedRefEscapeInSwitchExpression" xml:space="preserve">
     <value>The branches of the ref switch expression refer to variables with incompatible declaration scopes</value>
   </data>
+  <data name="ERR_RequiresRefReturningSwitchExpression" xml:space="preserve">
+    <value>The switch expression in the left side of a compound assignment must return a by-ref expression</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2271,6 +2271,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion
 
+        #region diagnostics introduced for C# Next
+
+        ERR_MismatchedRefEscapeInSwitchExpression = 9300,
+        WRN_MismatchedRefEscapeInSwitchExpression = 9301,
+
+        #endregion
+
         // Note: you will need to do the following after adding warnings:
         //  1) Re-generate compiler code (eng\generate-compiler-code.cmd).
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2275,6 +2275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_MismatchedRefEscapeInSwitchExpression = 9300,
         WRN_MismatchedRefEscapeInSwitchExpression = 9301,
+        ERR_RequiresRefReturningSwitchExpression = 9302,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -276,6 +276,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureInlineArrays = MessageBase + 12836,
         IDS_FeatureCollectionExpressions = MessageBase + 12837,
         IDS_FeatureRefReadonlyParameters = MessageBase + 12838,
+
+        IDS_FeatureRefInSwitchExpressionArm = MessageBase + 12860,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -456,8 +458,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // PREFER reporting diagnostics in binding when diagnostics do not affect the shape of the syntax tree
 
                 // C# preview features.
-                //case MessageID.IDS_NewFeature:
-                //    return LanguageVersion.Preview;
+                case MessageID.IDS_FeatureRefInSwitchExpressionArm: // syntax check
+                    return LanguageVersion.Preview;
 
                 // C# 12.0 features.
                 case MessageID.IDS_FeatureLambdaOptionalParameters: // semantic check

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -3198,6 +3198,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void VisitConditionalOperand(TLocalState state, BoundExpression operand, bool isByRef)
         {
             SetState(state);
+            VisitPotentialByRefExpression(operand, isByRef);
+        }
+
+        protected void VisitPotentialByRefExpression(BoundExpression operand, bool isByRef)
+        {
             if (isByRef)
             {
                 VisitLvalue(operand);
@@ -3206,7 +3211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                Visit(operand);
+                VisitRvalue(operand);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -608,6 +608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         VisitLvalue(access);
                         break;
                     }
+
                 default:
                     VisitRvalue(node);
                     break;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     SetState(StateWhenTrue);
                 }
 
-                VisitRvalue(arm.Value);
+                VisitPotentialByRefExpression(arm.Value, arm.IsRef);
                 Join(ref endState, ref this.State);
             }
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -4772,7 +4772,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal abstract partial class BoundSwitchExpression : BoundExpression
     {
-        protected BoundSwitchExpression(BoundKind kind, SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, TypeSymbol? type, bool hasErrors = false)
+        protected BoundSwitchExpression(BoundKind kind, SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, RefKind refKind, TypeSymbol? type, bool hasErrors = false)
             : base(kind, syntax, type, hasErrors)
         {
 
@@ -4785,6 +4785,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ReachabilityDecisionDag = reachabilityDecisionDag;
             this.DefaultLabel = defaultLabel;
             this.ReportedNotExhaustive = reportedNotExhaustive;
+            this.RefKind = refKind;
         }
 
         public BoundExpression Expression { get; }
@@ -4792,11 +4793,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundDecisionDag ReachabilityDecisionDag { get; }
         public LabelSymbol? DefaultLabel { get; }
         public bool ReportedNotExhaustive { get; }
+        public RefKind RefKind { get; }
     }
 
     internal sealed partial class BoundSwitchExpressionArm : BoundNode
     {
-        public BoundSwitchExpressionArm(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundPattern pattern, BoundExpression? whenClause, BoundExpression value, LabelSymbol label, bool hasErrors = false)
+        public BoundSwitchExpressionArm(SyntaxNode syntax, ImmutableArray<LocalSymbol> locals, BoundPattern pattern, BoundExpression? whenClause, BoundExpression value, LabelSymbol label, RefKind refKind, bool hasErrors = false)
             : base(BoundKind.SwitchExpressionArm, syntax, hasErrors || pattern.HasErrors() || whenClause.HasErrors() || value.HasErrors())
         {
 
@@ -4810,6 +4812,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.WhenClause = whenClause;
             this.Value = value;
             this.Label = label;
+            this.RefKind = refKind;
         }
 
         public ImmutableArray<LocalSymbol> Locals { get; }
@@ -4817,15 +4820,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression? WhenClause { get; }
         public BoundExpression Value { get; }
         public LabelSymbol Label { get; }
+        public RefKind RefKind { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitSwitchExpressionArm(this);
 
-        public BoundSwitchExpressionArm Update(ImmutableArray<LocalSymbol> locals, BoundPattern pattern, BoundExpression? whenClause, BoundExpression value, LabelSymbol label)
+        public BoundSwitchExpressionArm Update(ImmutableArray<LocalSymbol> locals, BoundPattern pattern, BoundExpression? whenClause, BoundExpression value, LabelSymbol label, RefKind refKind)
         {
-            if (locals != this.Locals || pattern != this.Pattern || whenClause != this.WhenClause || value != this.Value || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
+            if (locals != this.Locals || pattern != this.Pattern || whenClause != this.WhenClause || value != this.Value || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || refKind != this.RefKind)
             {
-                var result = new BoundSwitchExpressionArm(this.Syntax, locals, pattern, whenClause, value, label, this.HasErrors);
+                var result = new BoundSwitchExpressionArm(this.Syntax, locals, pattern, whenClause, value, label, refKind, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -4835,8 +4839,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundUnconvertedSwitchExpression : BoundSwitchExpression
     {
-        public BoundUnconvertedSwitchExpression(SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, TypeSymbol? type, bool hasErrors = false)
-            : base(BoundKind.UnconvertedSwitchExpression, syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, type, hasErrors || expression.HasErrors() || switchArms.HasErrors() || reachabilityDecisionDag.HasErrors())
+        public BoundUnconvertedSwitchExpression(SyntaxNode syntax, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, RefKind refKind, TypeSymbol? type, bool hasErrors = false)
+            : base(BoundKind.UnconvertedSwitchExpression, syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, refKind, type, hasErrors || expression.HasErrors() || switchArms.HasErrors() || reachabilityDecisionDag.HasErrors())
         {
 
             RoslynDebug.Assert(expression is object, "Field 'expression' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
@@ -4849,11 +4853,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUnconvertedSwitchExpression(this);
 
-        public BoundUnconvertedSwitchExpression Update(BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, TypeSymbol? type)
+        public BoundUnconvertedSwitchExpression Update(BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, RefKind refKind, TypeSymbol? type)
         {
-            if (expression != this.Expression || switchArms != this.SwitchArms || reachabilityDecisionDag != this.ReachabilityDecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(defaultLabel, this.DefaultLabel) || reportedNotExhaustive != this.ReportedNotExhaustive || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (expression != this.Expression || switchArms != this.SwitchArms || reachabilityDecisionDag != this.ReachabilityDecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(defaultLabel, this.DefaultLabel) || reportedNotExhaustive != this.ReportedNotExhaustive || refKind != this.RefKind || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundUnconvertedSwitchExpression(this.Syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, type, this.HasErrors);
+                var result = new BoundUnconvertedSwitchExpression(this.Syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, refKind, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -4863,8 +4867,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundConvertedSwitchExpression : BoundSwitchExpression
     {
-        public BoundConvertedSwitchExpression(SyntaxNode syntax, TypeSymbol? naturalTypeOpt, bool wasTargetTyped, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, TypeSymbol type, bool hasErrors = false)
-            : base(BoundKind.ConvertedSwitchExpression, syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, type, hasErrors || expression.HasErrors() || switchArms.HasErrors() || reachabilityDecisionDag.HasErrors())
+        public BoundConvertedSwitchExpression(SyntaxNode syntax, TypeSymbol? naturalTypeOpt, bool wasTargetTyped, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, RefKind refKind, TypeSymbol type, bool hasErrors = false)
+            : base(BoundKind.ConvertedSwitchExpression, syntax, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, refKind, type, hasErrors || expression.HasErrors() || switchArms.HasErrors() || reachabilityDecisionDag.HasErrors())
         {
 
             RoslynDebug.Assert(expression is object, "Field 'expression' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
@@ -4883,11 +4887,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitConvertedSwitchExpression(this);
 
-        public BoundConvertedSwitchExpression Update(TypeSymbol? naturalTypeOpt, bool wasTargetTyped, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, TypeSymbol type)
+        public BoundConvertedSwitchExpression Update(TypeSymbol? naturalTypeOpt, bool wasTargetTyped, BoundExpression expression, ImmutableArray<BoundSwitchExpressionArm> switchArms, BoundDecisionDag reachabilityDecisionDag, LabelSymbol? defaultLabel, bool reportedNotExhaustive, RefKind refKind, TypeSymbol type)
         {
-            if (!TypeSymbol.Equals(naturalTypeOpt, this.NaturalTypeOpt, TypeCompareKind.ConsiderEverything) || wasTargetTyped != this.WasTargetTyped || expression != this.Expression || switchArms != this.SwitchArms || reachabilityDecisionDag != this.ReachabilityDecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(defaultLabel, this.DefaultLabel) || reportedNotExhaustive != this.ReportedNotExhaustive || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (!TypeSymbol.Equals(naturalTypeOpt, this.NaturalTypeOpt, TypeCompareKind.ConsiderEverything) || wasTargetTyped != this.WasTargetTyped || expression != this.Expression || switchArms != this.SwitchArms || reachabilityDecisionDag != this.ReachabilityDecisionDag || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(defaultLabel, this.DefaultLabel) || reportedNotExhaustive != this.ReportedNotExhaustive || refKind != this.RefKind || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundConvertedSwitchExpression(this.Syntax, naturalTypeOpt, wasTargetTyped, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, type, this.HasErrors);
+                var result = new BoundConvertedSwitchExpression(this.Syntax, naturalTypeOpt, wasTargetTyped, expression, switchArms, reachabilityDecisionDag, defaultLabel, reportedNotExhaustive, refKind, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11367,7 +11371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(node.Locals, pattern, whenClause, value, node.Label);
+            return node.Update(node.Locals, pattern, whenClause, value, node.Label, node.RefKind);
         }
         public override BoundNode? VisitUnconvertedSwitchExpression(BoundUnconvertedSwitchExpression node)
         {
@@ -11375,7 +11379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
+            return node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, type);
         }
         public override BoundNode? VisitConvertedSwitchExpression(BoundConvertedSwitchExpression node)
         {
@@ -11384,7 +11388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag reachabilityDecisionDag = node.ReachabilityDecisionDag;
             TypeSymbol? naturalTypeOpt = this.VisitType(node.NaturalTypeOpt);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
+            return node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, type);
         }
         public override BoundNode? VisitDecisionDag(BoundDecisionDag node)
         {
@@ -13438,7 +13442,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
             BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(locals, pattern, whenClause, value, node.Label);
+            return node.Update(locals, pattern, whenClause, value, node.Label, node.RefKind);
         }
 
         public override BoundNode? VisitUnconvertedSwitchExpression(BoundUnconvertedSwitchExpression node)
@@ -13450,12 +13454,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, infoAndType.Type);
+                updatedNode = node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.Type);
+                updatedNode = node.Update(expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, node.Type);
             }
             return updatedNode;
         }
@@ -13470,12 +13474,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, infoAndType.Type!);
+                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.Type);
+                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, reachabilityDecisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.RefKind, node.Type);
             }
             return updatedNode;
         }
@@ -15879,6 +15883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("whenClause", null, new TreeDumperNode[] { Visit(node.WhenClause, null) }),
             new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
             new TreeDumperNode("label", node.Label, null),
+            new TreeDumperNode("refKind", node.RefKind, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
@@ -15889,6 +15894,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("reachabilityDecisionDag", null, new TreeDumperNode[] { Visit(node.ReachabilityDecisionDag, null) }),
             new TreeDumperNode("defaultLabel", node.DefaultLabel, null),
             new TreeDumperNode("reportedNotExhaustive", node.ReportedNotExhaustive, null),
+            new TreeDumperNode("refKind", node.RefKind, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
@@ -15903,6 +15909,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("reachabilityDecisionDag", null, new TreeDumperNode[] { Visit(node.ReachabilityDecisionDag, null) }),
             new TreeDumperNode("defaultLabel", node.DefaultLabel, null),
             new TreeDumperNode("reportedNotExhaustive", node.ReportedNotExhaustive, null),
+            new TreeDumperNode("refKind", node.RefKind, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -334,6 +334,7 @@
                 case ErrorCode.WRN_TargetDifferentRefness:
                 case ErrorCode.WRN_RefReadonlyParameterDefaultValue:
                 case ErrorCode.WRN_UseDefViolationRefField:
+                case ErrorCode.WRN_MismatchedRefEscapeInSwitchExpression:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -990,6 +990,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // this[int], Slice(int, int), Substring(int, int)
                     return false;
 
+                case BoundKind.ConvertedSwitchExpression:
+                    return ((BoundConvertedSwitchExpression)expr).IsRef;
+
                 case BoundKind.ListPatternReceiverPlaceholder:
                 case BoundKind.SlicePatternReceiverPlaceholder:
                 case BoundKind.SlicePatternRangePlaceholder:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -990,6 +990,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // this[int], Slice(int, int), Substring(int, int)
                     return false;
 
+                case BoundKind.UnconvertedSwitchExpression:
+                    throw ExceptionUtilities.UnexpectedValue(expr.Kind);
+
                 case BoundKind.ConvertedSwitchExpression:
                     return ((BoundConvertedSwitchExpression)expr).IsRef;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -699,6 +699,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(((BoundConditionalOperator)originalLHS).IsRef);
                     break;
 
+                case BoundKind.ConvertedSwitchExpression:
+                    Debug.Assert(((BoundSwitchExpression)originalLHS).IsRef);
+                    break;
+
                 case BoundKind.AssignmentOperator:
                     Debug.Assert(((BoundAssignmentOperator)originalLHS).IsRef);
                     break;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     this.CurrentToken.Kind == SyntaxKind.ColonToken
                         ? this.EatTokenAsKind(SyntaxKind.EqualsGreaterThanToken)
                         : this.EatToken(SyntaxKind.EqualsGreaterThanToken),
-                    ParseExpressionCore());
+                    ParsePossibleRefExpression());
 
                 // If we're not making progress, abort
                 if (switchExpressionCase.Width == 0 && this.CurrentToken.Kind != SyntaxKind.CommaToken)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">pole ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Žádná přetížená metoda {0} neodpovídá ukazateli na funkci {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Neočekávané klíčové slovo record. Měli jste na mysli record struct nebo record class?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Převádí se skupina metod na nedelegující typ.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Typy a aliasy nemůžou mít název required.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">{0}: Cílový modul runtime nepodporuje v přepisech kovariantní typy. Typ musí být {2}, aby odpovídal přepsanému členu {1}.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Typen und Aliase können nicht als "erforderlich" bezeichnet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">{0}: Die Zielruntime unterstützt keine covarianten Typen in Überschreibungen. Der Typ muss "{2}" sein, um dem überschriebenen Member "{1}" zu entsprechen.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Keine Überladung für "{0}" stimmt mit dem Funktionszeiger "{1}" überein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Unerwartetes Schlüsselwort „Datensatz“. Meinten Sie „Datensatzstruktur“ oder „Datensatzklasse“?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Die Methodengruppe wird in einen Nichtdelegattyp konvertiert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">Referenzfelder</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Ninguna sobrecarga correspondiente a "{0}" coincide con el puntero de función "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Palabra clave \"record\" inesperada. ¿Quería decir \"record struct\" o \"record class\"?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Convirtiendo grupo de métodos a tipo no delegado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">campos de referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Los tipos y alias no se pueden denominar 'required'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">"{0}": el entorno de ejecución de destino no admite los tipos de covariante en las invalidaciones. El tipo debe ser "{2}" para que coincida con el miembro "{1}" invalidado.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Aucune surcharge pour '{0}' ne correspond au pointeur de fonction '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Mot clé 'record' inattendu. Vouliez-vous dire « struct d’enregistrement » ou « classe d’enregistrement » ?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Conversion d’un groupe de méthodes en type non-délégué</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Les types et alias ne peuvent pas être nommés « required ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}' : le runtime cible ne prend pas en charge les types covariants dans les substitutions. Le type doit être '{2}' pour correspondre au membre substitué '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">champs ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">I tipi e gli alias non possono essere denominati 'obbligatori'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': il runtime di destinazione non supporta tipi covarianti negli override. Il tipo deve essere '{2}' in modo da corrispondere al membro '{1}' di cui è stato eseguito l'override</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">campi ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Nessun overload per '{0}' corrisponde al puntatore a funzione '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Parola chiave 'record' imprevista. Si intendeva 'struct record' o 'classe record'?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Conversione del gruppo di metodi in un tipo non delegato</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">型とエイリアスに 'required' という名前を付けることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': ターゲットのランタイムはオーバーライドで covariant 型をサポートしていません。型は、オーバーライドされるメンバー '{1}' と一致する '{2}' にする必要があります</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">ref フィールド</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">関数ポインター '{1}' に一致する '{0}' のオーバーロードはありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">予期しないキーワード 'record' です。'record struct' または 'record class' のつもりでしたか?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">メソッド グループを非デリゲート型に変換しています</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">유형 및 별칭은 '필수'로 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': 대상 런타임이 재정의에서 공변(covariant) 형식을 지원하지 않습니다. 재정의된 멤버 '{1}'과(와) 일치하려면 '{2}' 형식이어야 합니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">함수 포인터 '{1}'과(와) 일치하는 '{0}'에 대한 오버로드가 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">예기치 않은 'record' 키워드가 있습니다. 'record struct' 또는 'record class'를 사용할까요?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">메소드 그룹을 비 위임 유형으로 변환</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">참조 필드</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">pola referencyjne</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Typy i aliasy nie mogą mieć nazwy „required”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">„{0}”: docelowe środowisko uruchomieniowe nie obsługuje typów kowariantnych w przesłonięciach. Typem musi być „{2}”, aby zachować zgodność z przesłoniętą składową „{1}”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Żadne z przeciążeń dla elementu „{0}” nie pasuje do wskaźnika funkcji „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Nieoczekiwane słowo kluczowe „record”. Czy chodziło o „record struct” lub „record class”?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Konwertowanie grupy metod na typ inny niż delegowany</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Nenhuma sobrecarga de '{0}' corresponde ao ponteiro de função '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Palavra-chave inesperada “record”. Você quis dizer “record struct” or “record class”?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Convertendo grupo de método em tipo não delegado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Tipos e pseudônimos não podem ser nomeados 'requeridos'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': o runtime de destino não dá suporte a tipos covariantes em substituições. O tipo precisa ser '{2}' para corresponder ao membro substituído '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">campos ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">У типов и псевдонимов не может быть имя "required".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">"{0}": целевая среда выполнения не поддерживает ковариантные типы в переопределениях. Для сопоставления переопределенного элемента "{1}" необходимо использовать тип "{2}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">поля ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">Нет перегруженного метода для "{0}", который соответствует указателю на функцию "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Непредвиденное ключевое слово \"record\". Возможно, вы имели в виду \"record struct\" или \"record class\"?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Преобразование группы методов в незаменямый тип</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">Türler ve diğer adlar 'gerekli' olarak adlandırılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': Hedef çalışma zamanı, geçersiz kılmalarda birlikte değişken türleri desteklemiyor. Tür, geçersiz kılınan '{1}' üyesiyle eşleşmek için '{2}' olmalıdır</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">'{0}' için aşırı yüklemelerin hiçbiri '{1}' işlev işaretçisiyle eşleşmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">Beklenmeyen 'record' anahtar sözcüğü. 'record struct' veya 'record class' mi demek istediniz?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">Yöntem grubunu temsilci olmayan türe dönüştürme</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">başvuru alanları</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">类型和别名不能命名为 “required”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">“{0}”: 目标运行时不支持替代中的协变类型。类型必须为“{2}”才能匹配替代成员“{1}”</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">ref 字段</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">“{0}”没有与函数指针“{1}”匹配的重载</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">意外的关键字 \"record\"。你的意思是 \"record struct\" 还是 \"record class\"?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">将方法组转换为非委托类型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1237,6 +1237,11 @@
         <target state="translated">'{0}' 沒有任何多載符合函式指標 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
         <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
         <target state="translated">未預期的關鍵字 'record'。您是指 'record struct' 或 'record class'?</target>
@@ -2655,6 +2660,11 @@
       <trans-unit id="WRN_MethGrpToNonDel_Title">
         <source>Converting method group to non-delegate type</source>
         <target state="translated">將方法群組轉換為非委派類型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MismatchedRefEscapeInSwitchExpression">
+        <source>The branches of the ref switch expression refer to variables with incompatible declaration scopes</source>
+        <target state="new">The branches of the ref switch expression refer to variables with incompatible declaration scopes</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_MismatchedRefEscapeInTernary">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1722,6 +1722,11 @@
         <target state="translated">類型和別名不能命名為 'required'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_RequiresRefReturningSwitchExpression">
+        <source>The switch expression in the left side of a compound assignment must return a by-ref expression</source>
+        <target state="new">The switch expression in the left side of a compound assignment must return a by-ref expression</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportCovariantPropertiesOfClasses">
         <source>'{0}': Target runtime doesn't support covariant types in overrides. Type must be '{2}' to match overridden member '{1}'</source>
         <target state="translated">'{0}': 在覆寫中，目標執行階段不支援 Covariant 類型。類型必須是 '{2}'，才符合覆寫的成員 '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2222,6 +2222,11 @@
         <target state="translated">ref 欄位</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefInSwitchExpressionArm">
+        <source>ref in switch expression arms</source>
+        <target state="new">ref in switch expression arms</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReadonlyParameters">
         <source>ref readonly parameters</source>
         <target state="new">ref readonly parameters</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -5351,41 +5351,52 @@ void M(out int x) => throw null;
             const string expressionIL =
                 """
                 {
-                  // Code size       64 (0x40)
-                  .maxstack  1
-                  .locals init (int& V_0)
-                  // sequence point: direction sw ...     }
-                  IL_0000:  ldarg.1
-                  IL_0001:  switch    (
-                        IL_0018,
-                        IL_0021,
-                        IL_002a,
-                        IL_0033)
-                  IL_0016:  br.s       IL_003c
-                  IL_0018:  ldarg.0
-                  IL_0019:  ldflda     "int C.northField"
-                  IL_001e:  stloc.0
-                  IL_001f:  br.s       IL_003e
-                  IL_0021:  ldarg.0
-                  IL_0022:  ldflda     "int C.southField"
-                  IL_0027:  stloc.0
-                  IL_0028:  br.s       IL_003e
-                  IL_002a:  ldarg.0
-                  IL_002b:  ldflda     "int C.eastField"
-                  IL_0030:  stloc.0
-                  IL_0031:  br.s       IL_003e
-                  IL_0033:  ldarg.0
-                  IL_0034:  ldflda     "int C.westField"
-                  IL_0039:  stloc.0
-                  IL_003a:  br.s       IL_003e
-                  IL_003c:  ldnull
-                  IL_003d:  throw
-                  IL_003e:  ldloc.0
-                  IL_003f:  ret
+                  // Code size       72 (0x48)
+                  .maxstack  3
+                  .locals init (int& V_0,
+                                int& V_1)
+                  // sequence point: {
+                  IL_0000:  nop
+                  // sequence point: direction sw ...   } += value
+                  IL_0001:  ldarg.1
+                  IL_0002:  switch    (
+                        IL_0019,
+                        IL_0022,
+                        IL_002b,
+                        IL_0034)
+                  IL_0017:  br.s       IL_003d
+                  IL_0019:  ldarg.0
+                  IL_001a:  ldflda     "int C.NorthField"
+                  IL_001f:  stloc.0
+                  IL_0020:  br.s       IL_003f
+                  IL_0022:  ldarg.0
+                  IL_0023:  ldflda     "int C.SouthField"
+                  IL_0028:  stloc.0
+                  IL_0029:  br.s       IL_003f
+                  IL_002b:  ldarg.0
+                  IL_002c:  ldflda     "int C.EastField"
+                  IL_0031:  stloc.0
+                  IL_0032:  br.s       IL_003f
+                  IL_0034:  ldarg.0
+                  IL_0035:  ldflda     "int C.WestField"
+                  IL_003a:  stloc.0
+                  IL_003b:  br.s       IL_003f
+                  IL_003d:  ldnull
+                  IL_003e:  throw
+                  IL_003f:  ldloc.0
+                  IL_0040:  stloc.1
+                  IL_0041:  ldloc.1
+                  IL_0042:  ldloc.1
+                  IL_0043:  ldind.i4
+                  IL_0044:  ldarg.2
+                  IL_0045:  add
+                  IL_0046:  stind.i4
+                  // sequence point: }
+                  IL_0047:  ret
                 }
                 """;
 
-            verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
+            verifier.VerifyMethodBody("C.IncrementDirectionField", expressionIL);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -5247,41 +5247,46 @@ void M(out int x) => throw null;
             const string expressionIL =
                 """
                 {
-                  // Code size       64 (0x40)
-                  .maxstack  1
+                  // Code size       67 (0x43)
+                  .maxstack  2
                   .locals init (int& V_0)
-                  // sequence point: direction sw ...     }
-                  IL_0000:  ldarg.1
-                  IL_0001:  switch    (
-                        IL_0018,
-                        IL_0021,
-                        IL_002a,
-                        IL_0033)
-                  IL_0016:  br.s       IL_003c
-                  IL_0018:  ldarg.0
-                  IL_0019:  ldflda     "int C.northField"
-                  IL_001e:  stloc.0
-                  IL_001f:  br.s       IL_003e
-                  IL_0021:  ldarg.0
-                  IL_0022:  ldflda     "int C.southField"
-                  IL_0027:  stloc.0
-                  IL_0028:  br.s       IL_003e
-                  IL_002a:  ldarg.0
-                  IL_002b:  ldflda     "int C.eastField"
-                  IL_0030:  stloc.0
-                  IL_0031:  br.s       IL_003e
-                  IL_0033:  ldarg.0
-                  IL_0034:  ldflda     "int C.westField"
-                  IL_0039:  stloc.0
-                  IL_003a:  br.s       IL_003e
-                  IL_003c:  ldnull
-                  IL_003d:  throw
-                  IL_003e:  ldloc.0
-                  IL_003f:  ret
+                  // sequence point: {
+                  IL_0000:  nop
+                  // sequence point: direction sw ...    } = value
+                  IL_0001:  ldarg.1
+                  IL_0002:  switch    (
+                        IL_0019,
+                        IL_0022,
+                        IL_002b,
+                        IL_0034)
+                  IL_0017:  br.s       IL_003d
+                  IL_0019:  ldarg.0
+                  IL_001a:  ldflda     "int C.NorthField"
+                  IL_001f:  stloc.0
+                  IL_0020:  br.s       IL_003f
+                  IL_0022:  ldarg.0
+                  IL_0023:  ldflda     "int C.SouthField"
+                  IL_0028:  stloc.0
+                  IL_0029:  br.s       IL_003f
+                  IL_002b:  ldarg.0
+                  IL_002c:  ldflda     "int C.EastField"
+                  IL_0031:  stloc.0
+                  IL_0032:  br.s       IL_003f
+                  IL_0034:  ldarg.0
+                  IL_0035:  ldflda     "int C.WestField"
+                  IL_003a:  stloc.0
+                  IL_003b:  br.s       IL_003f
+                  IL_003d:  ldnull
+                  IL_003e:  throw
+                  IL_003f:  ldloc.0
+                  IL_0040:  ldarg.2
+                  IL_0041:  stind.i4
+                  // sequence point: }
+                  IL_0042:  ret
                 }
                 """;
 
-            verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
+            verifier.VerifyMethodBody("C.SetDirectionField", expressionIL);
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -4908,24 +4908,30 @@ void M(out int x) => throw null;
             }
         }
 
-        [Fact]
-        public void RefSwitchStatement()
+        #region Ref switch statements
+
+        [Theory]
+        [InlineData("North")]
+        [InlineData("South")]
+        [InlineData("East")]
+        [InlineData("West")]
+        public void RefSwitchStatement_DirectReturnMethod(string direction)
         {
-            const string source =
-                """
+            string source =
+                $$"""
                 public class C
                 {
-                    int northField;
-                    int southField;
-                    int eastField;
-                    int westField;
+                    public int NorthField;
+                    public int SouthField;
+                    public int EastField;
+                    public int WestField;
 
                     public ref int GetDirectionField(Direction direction) => ref direction switch
                     {
-                        Direction.North => ref northField,
-                        Direction.South => ref southField,
-                        Direction.East => ref eastField,
-                        Direction.West => ref westField,
+                        Direction.North => ref NorthField,
+                        Direction.South => ref SouthField,
+                        Direction.East => ref EastField,
+                        Direction.West => ref WestField,
                         _ => throw null!,
                     };
 
@@ -4934,13 +4940,13 @@ void M(out int x) => throw null;
                         switch (direction)
                         {
                             case Direction.North:
-                                return ref northField;
+                                return ref NorthField;
                             case Direction.South:
-                                return ref southField;
+                                return ref SouthField;
                             case Direction.East:
-                                return ref eastField;
+                                return ref EastField;
                             case Direction.West:
-                                return ref westField;
+                                return ref WestField;
                             default:
                                 throw null!;
                         }
@@ -4962,10 +4968,10 @@ void M(out int x) => throw null;
                         const int otherValue = 3412;
 
                         var c = new C();
-                        ref var directionFieldNorth = ref c.GetDirectionField(Direction.North);
-                        directionFieldNorth = otherValue;
-                        ref var directionFieldNorth1 = ref c.GetDirectionField(Direction.North);
-                        System.Console.Write($"{directionFieldNorth1 is otherValue} {directionFieldNorth} {directionFieldNorth1}");
+                        ref var directionField = ref c.GetDirectionField(Direction.{{direction}});
+                        directionField = otherValue;
+                        ref var directionField1 = ref c.GetDirectionField(Direction.{{direction}});
+                        System.Console.Write($"{directionField1 is otherValue} {directionField} {directionField1}");
                     }
                 }
                 """;
@@ -5000,24 +5006,24 @@ void M(out int x) => throw null;
                         IL_002f,
                         IL_0038)
                   IL_001b:  br.s       IL_0041
-                  // sequence point: return ref northField;
+                  // sequence point: return ref NorthField;
                   IL_001d:  ldarg.0
-                  IL_001e:  ldflda     "int C.northField"
+                  IL_001e:  ldflda     "int C.NorthField"
                   IL_0023:  stloc.2
                   IL_0024:  br.s       IL_0043
-                  // sequence point: return ref southField;
+                  // sequence point: return ref SouthField;
                   IL_0026:  ldarg.0
-                  IL_0027:  ldflda     "int C.southField"
+                  IL_0027:  ldflda     "int C.SouthField"
                   IL_002c:  stloc.2
                   IL_002d:  br.s       IL_0043
-                  // sequence point: return ref eastField;
+                  // sequence point: return ref EastField;
                   IL_002f:  ldarg.0
-                  IL_0030:  ldflda     "int C.eastField"
+                  IL_0030:  ldflda     "int C.EastField"
                   IL_0035:  stloc.2
                   IL_0036:  br.s       IL_0043
-                  // sequence point: return ref westField;
+                  // sequence point: return ref WestField;
                   IL_0038:  ldarg.0
-                  IL_0039:  ldflda     "int C.westField"
+                  IL_0039:  ldflda     "int C.WestField"
                   IL_003e:  stloc.2
                   IL_003f:  br.s       IL_0043
                   // sequence point: throw null!;
@@ -5028,6 +5034,215 @@ void M(out int x) => throw null;
                   IL_0044:  ret
                 }
                 """;
+
+            const string expressionIL =
+                """
+                {
+                  // Code size       64 (0x40)
+                  .maxstack  1
+                  .locals init (int& V_0)
+                  // sequence point: direction sw ...     }
+                  IL_0000:  ldarg.1
+                  IL_0001:  switch    (
+                        IL_0018,
+                        IL_0021,
+                        IL_002a,
+                        IL_0033)
+                  IL_0016:  br.s       IL_003c
+                  IL_0018:  ldarg.0
+                  IL_0019:  ldflda     "int C.NorthField"
+                  IL_001e:  stloc.0
+                  IL_001f:  br.s       IL_003e
+                  IL_0021:  ldarg.0
+                  IL_0022:  ldflda     "int C.SouthField"
+                  IL_0027:  stloc.0
+                  IL_0028:  br.s       IL_003e
+                  IL_002a:  ldarg.0
+                  IL_002b:  ldflda     "int C.EastField"
+                  IL_0030:  stloc.0
+                  IL_0031:  br.s       IL_003e
+                  IL_0033:  ldarg.0
+                  IL_0034:  ldflda     "int C.WestField"
+                  IL_0039:  stloc.0
+                  IL_003a:  br.s       IL_003e
+                  IL_003c:  ldnull
+                  IL_003d:  throw
+                  IL_003e:  ldloc.0
+                  IL_003f:  ret
+                }
+                """;
+
+            verifier.VerifyMethodBody("C.GetDirectionField_Target", targetIL);
+            verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
+        }
+
+        [Theory]
+        [InlineData("North")]
+        [InlineData("South")]
+        [InlineData("East")]
+        [InlineData("West")]
+        public void RefSwitchStatement_LocalRefVariable(string direction)
+        {
+            string source =
+                $$"""
+                public class C
+                {
+                    public int NorthField;
+                    public int SouthField;
+                    public int EastField;
+                    public int WestField;
+                
+                    public ref int GetDirectionField(Direction direction)
+                    {
+                        ref int directionVar = ref direction switch
+                        {
+                            Direction.North => ref NorthField,
+                            Direction.South => ref SouthField,
+                            Direction.East => ref EastField,
+                            Direction.West => ref WestField,
+                            _ => throw null!,
+                        };
+
+                        return ref directionVar;
+                    }
+                }
+                
+                public enum Direction
+                {
+                    North,
+                    South,
+                    East,
+                    West,
+                }
+
+                public class Program
+                {
+                    static void Main()
+                    {
+                        const int otherValue = 3412;
+
+                        var c = new C();
+                        ref var directionField = ref c.GetDirectionField(Direction.{{direction}});
+                        directionField = otherValue;
+                        ref var directionField1 = ref c.GetDirectionField(Direction.{{direction}});
+                        System.Console.Write($"{directionField1 is otherValue} {directionField} {directionField1}");
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics();
+
+            // Skipped verification because of method returning by ref int
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "True 3412 3412");
+
+            const string expressionIL =
+                """
+                {
+                  // Code size       71 (0x47)
+                  .maxstack  1
+                  .locals init (int& V_0, //directionVar
+                                int& V_1,
+                                int& V_2)
+                  // sequence point: {
+                  IL_0000:  nop
+                  // sequence point: ref int dire ...         };
+                  IL_0001:  ldarg.1
+                  IL_0002:  switch    (
+                        IL_0019,
+                        IL_0022,
+                        IL_002b,
+                        IL_0034)
+                  IL_0017:  br.s       IL_003d
+                  IL_0019:  ldarg.0
+                  IL_001a:  ldflda     "int C.NorthField"
+                  IL_001f:  stloc.1
+                  IL_0020:  br.s       IL_003f
+                  IL_0022:  ldarg.0
+                  IL_0023:  ldflda     "int C.SouthField"
+                  IL_0028:  stloc.1
+                  IL_0029:  br.s       IL_003f
+                  IL_002b:  ldarg.0
+                  IL_002c:  ldflda     "int C.EastField"
+                  IL_0031:  stloc.1
+                  IL_0032:  br.s       IL_003f
+                  IL_0034:  ldarg.0
+                  IL_0035:  ldflda     "int C.WestField"
+                  IL_003a:  stloc.1
+                  IL_003b:  br.s       IL_003f
+                  IL_003d:  ldnull
+                  IL_003e:  throw
+                  IL_003f:  ldloc.1
+                  IL_0040:  stloc.0
+                  // sequence point: return ref directionVar;
+                  IL_0041:  ldloc.0
+                  IL_0042:  stloc.2
+                  IL_0043:  br.s       IL_0045
+                  // sequence point: }
+                  IL_0045:  ldloc.2
+                  IL_0046:  ret
+                }
+                """;
+
+            verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
+        }
+
+        [Theory]
+        [InlineData("North")]
+        [InlineData("South")]
+        [InlineData("East")]
+        [InlineData("West")]
+        public void RefSwitchStatement_DirectAssignment(string direction)
+        {
+            string source =
+                $$"""
+                public class C
+                {
+                    public int NorthField;
+                    public int SouthField;
+                    public int EastField;
+                    public int WestField;
+
+                    public void SetDirectionField(Direction direction, int value)
+                    {
+                        direction switch
+                        {
+                            Direction.North => ref NorthField,
+                            Direction.South => ref SouthField,
+                            Direction.East => ref EastField,
+                            Direction.West => ref WestField,
+                            _ => throw null!,
+                        } = value;
+                    }
+                }
+                
+                public enum Direction
+                {
+                    North,
+                    South,
+                    East,
+                    West,
+                }
+
+                public class Program
+                {
+                    static void Main()
+                    {
+                        const int otherValue = 3412;
+
+                        var c = new C();
+                        c.SetDirectionField(Direction.{{direction}}, otherValue);
+                        var value = c.{{direction}}Field;
+                        System.Console.Write($"{value is otherValue} {value}");
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics();
+
+            // Skipped verification because of method returning by ref int
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "True 3412");
 
             const string expressionIL =
                 """
@@ -5066,8 +5281,108 @@ void M(out int x) => throw null;
                 }
                 """;
 
-            verifier.VerifyMethodBody("C.GetDirectionField_Target", targetIL);
             verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
         }
+
+        [Theory]
+        [InlineData("North")]
+        [InlineData("South")]
+        [InlineData("East")]
+        [InlineData("West")]
+        public void RefSwitchStatement_DirectCompoundAssignment(string direction)
+        {
+            string source =
+                $$"""
+                public class C
+                {
+                    public int NorthField = 5;
+                    public int SouthField = 6;
+                    public int EastField = 10;
+                    public int WestField = 12;
+
+                    public void IncrementDirectionField(Direction direction, int value)
+                    {
+                        direction switch
+                        {
+                            Direction.North => ref NorthField,
+                            Direction.South => ref SouthField,
+                            Direction.East => ref EastField,
+                            Direction.West => ref WestField,
+                            _ => throw null!,
+                        } += value;
+                    }
+                }
+                
+                public enum Direction
+                {
+                    North,
+                    South,
+                    East,
+                    West,
+                }
+
+                public class Program
+                {
+                    static void Main()
+                    {
+                        const int otherValue = 3412;
+
+                        var c = new C();
+                        var oldValue = c.{{direction}}Field;
+                        c.IncrementDirectionField(Direction.{{direction}}, otherValue);
+                        var expectedValue = oldValue + otherValue;
+                        var value = c.{{direction}}Field;
+                        System.Console.Write(value == expectedValue);
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics();
+
+            // Skipped verification because of method returning by ref int
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "True");
+
+            const string expressionIL =
+                """
+                {
+                  // Code size       64 (0x40)
+                  .maxstack  1
+                  .locals init (int& V_0)
+                  // sequence point: direction sw ...     }
+                  IL_0000:  ldarg.1
+                  IL_0001:  switch    (
+                        IL_0018,
+                        IL_0021,
+                        IL_002a,
+                        IL_0033)
+                  IL_0016:  br.s       IL_003c
+                  IL_0018:  ldarg.0
+                  IL_0019:  ldflda     "int C.northField"
+                  IL_001e:  stloc.0
+                  IL_001f:  br.s       IL_003e
+                  IL_0021:  ldarg.0
+                  IL_0022:  ldflda     "int C.southField"
+                  IL_0027:  stloc.0
+                  IL_0028:  br.s       IL_003e
+                  IL_002a:  ldarg.0
+                  IL_002b:  ldflda     "int C.eastField"
+                  IL_0030:  stloc.0
+                  IL_0031:  br.s       IL_003e
+                  IL_0033:  ldarg.0
+                  IL_0034:  ldflda     "int C.westField"
+                  IL_0039:  stloc.0
+                  IL_003a:  br.s       IL_003e
+                  IL_003c:  ldnull
+                  IL_003d:  throw
+                  IL_003e:  ldloc.0
+                  IL_003f:  ret
+                }
+                """;
+
+            verifier.VerifyMethodBody("C.GetDirectionField", expressionIL);
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SwitchExpressionParsingTests.cs
@@ -2515,4 +2515,114 @@ public class SwitchExpressionParsingTests : ParsingTests
         }
         EOF();
     }
+
+    [Fact]
+    public void RefSwitchExpression_01()
+    {
+        const string source =
+            """
+            ref int a = ref axis switch
+            {
+                Axis.X => ref x,
+                Axis.Y => ref y,
+            };
+            """;
+
+        UsingStatement(source);
+
+        N(SyntaxKind.LocalDeclarationStatement);
+        {
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.RefType);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                    N(SyntaxKind.EqualsValueClause);
+                    {
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.RefExpression);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.SwitchExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "axis");
+                                }
+                                N(SyntaxKind.SwitchKeyword);
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.SwitchExpressionArm);
+                                {
+                                    N(SyntaxKind.ConstantPattern);
+                                    {
+                                        N(SyntaxKind.SimpleMemberAccessExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Axis");
+                                            }
+                                            N(SyntaxKind.DotToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "X");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.RefExpression);
+                                    {
+                                        N(SyntaxKind.RefKeyword);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "x");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.SwitchExpressionArm);
+                                {
+                                    N(SyntaxKind.ConstantPattern);
+                                    {
+                                        N(SyntaxKind.SimpleMemberAccessExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Axis");
+                                            }
+                                            N(SyntaxKind.DotToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Y");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.RefExpression);
+                                    {
+                                        N(SyntaxKind.RefKeyword);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "y");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
 }

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -220,6 +220,11 @@ namespace Microsoft.CodeAnalysis
         LocalStoreTracker = 36,
 
         /// <summary>
+        /// Temp created for the result of a switch expression returning by ref.
+        /// </summary>
+        SwitchExpressionRef = 37,
+
+        /// <summary>
         /// All values have to be less than or equal to <see cref="MaxValidValueForLocalVariableSerializedToDebugInformation"/> 
         /// (<see cref="EditAndContinueMethodDebugInformation"/>)
         /// </summary>


### PR DESCRIPTION
This draft PR is approved by @CyrusNajmabadi in offline conversations.

The feature's spec is dotnet/csharplang#7352

Currently handled cases:
- [x] Syntax parsing
- [x] Variable assignment
- [x] Direct return in method body
- [x] Direct assignment to the ref
- [x] Direct compound assignment to the ref
- [x] Ref and value escaping based on scope