### PR TITLE
Move helpers for 'use collection expression'.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -2,26 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
+
+using static UseCollectionExpressionHelpers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer
     : AbstractCSharpUseCollectionExpressionDiagnosticAnalyzer
 {
-    private const string CreateName = nameof(ImmutableArray.Create);
-    private const string CreateRangeName = nameof(ImmutableArray.CreateRange);
-
     public const string UnwrapArgument = nameof(UnwrapArgument);
 
     private static readonly ImmutableDictionary<string, string?> s_unwrapArgumentProperties =
@@ -42,9 +36,7 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
     private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
     {
         var semanticModel = context.SemanticModel;
-        var compilation = semanticModel.Compilation;
         var syntaxTree = semanticModel.SyntaxTree;
-        var invocationExpression = (InvocationExpressionSyntax)context.Node;
         var cancellationToken = context.CancellationToken;
 
         // no point in analyzing if the option is off.
@@ -52,65 +44,20 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
         if (!option.Value)
             return;
 
-        // Looking for `XXX.Create(...)`
-        if (invocationExpression.Expression is not MemberAccessExpressionSyntax
-            {
-                RawKind: (int)SyntaxKind.SimpleMemberAccessExpression,
-                Name.Identifier.Value: CreateName or CreateRangeName,
-            } memberAccessExpression)
-        {
+        var invocationExpression = (InvocationExpressionSyntax)context.Node;
+        if (!IsCollectionFactoryCreate(semanticModel, invocationExpression, out var memberAccess, out var unwrapArgument, cancellationToken))
             return;
-        }
-
-        var createMethod = semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol as IMethodSymbol;
-        if (createMethod is not { IsStatic: true })
-            return;
-
-        var factoryType = semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol as INamedTypeSymbol;
-        if (factoryType is null)
-            return;
-
-        // The pattern is a type like `ImmutableArray` (non-generic), returning an instance of `ImmutableArray<T>`.  The
-        // actual collection type (`ImmutableArray<T>`) has to have a `[CollectionBuilder(...)]` attribute on it that
-        // then points at the factory type.
-        var collectionBuilderAttribute = compilation.CollectionBuilderAttribute()!;
-        var collectionBuilderAttributeData = createMethod.ReturnType.OriginalDefinition
-            .GetAttributes()
-            .FirstOrDefault(a => collectionBuilderAttribute.Equals(a.AttributeClass));
-        if (collectionBuilderAttributeData?.ConstructorArguments is not [{ Value: ITypeSymbol collectionBuilderType }, { Value: CreateName }])
-            return;
-
-        if (!factoryType.OriginalDefinition.Equals(collectionBuilderType.OriginalDefinition))
-            return;
-
-        // Ok, this is type that has a collection-builder option available.  We can switch over if the current method
-        // we're calling has one of the following signatures:
-        //
-        //  `Create()`.  Trivial case, can be replaced with `[]`.
-        //  `Create(T), Create(T, T), Create(T, T, T)` etc.
-        //  `Create(params T[])` (passing as individual elements, or an array with an initializer)
-        //  `Create(ReadOnlySpan<T>)` (passing as a stack-alloc with an initializer)
-        //  `Create(IEnumerable<T>)` (passing as something with an initializer.
-        if (!IsCompatibleSignatureAndArguments(
-                compilation, invocationExpression, createMethod.OriginalDefinition,
-                out var unwrapArgument, cancellationToken))
-        {
-            return;
-        }
 
         // Make sure we can actually use a collection expression in place of the full invocation.
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, invocationExpression, skipVerificationForReplacedNode: true, cancellationToken))
-        {
+        if (!CanReplaceWithCollectionExpression(semanticModel, invocationExpression, skipVerificationForReplacedNode: true, cancellationToken))
             return;
-        }
 
         var locations = ImmutableArray.Create(invocationExpression.GetLocation());
         var properties = unwrapArgument ? s_unwrapArgumentProperties : null;
 
         context.ReportDiagnostic(DiagnosticHelper.Create(
             Descriptor,
-            memberAccessExpression.Name.Identifier.GetLocation(),
+            memberAccess.Name.Identifier.GetLocation(),
             option.Notification.Severity,
             additionalLocations: locations,
             properties));
@@ -128,116 +75,5 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
             additionalLocations: locations,
             additionalUnnecessaryLocations: additionalUnnecessaryLocations,
             properties));
-    }
-
-    private static bool IsCompatibleSignatureAndArguments(
-        Compilation compilation,
-        InvocationExpressionSyntax invocationExpression,
-        IMethodSymbol originalCreateMethod,
-        out bool unwrapArgument,
-        CancellationToken cancellationToken)
-    {
-        unwrapArgument = false;
-
-        var arguments = invocationExpression.ArgumentList.Arguments;
-
-        // Don't bother offering if any of the arguments are named.  It's unlikely for this to occur in practice, and it
-        // means we do not have to worry about order of operations.
-        if (arguments.Any(static a => a.NameColon != null))
-            return false;
-
-        if (originalCreateMethod.Name is CreateRangeName)
-        {
-            // If we have `CreateRange<T>(IEnumerable<T> values)` this is legal if we have an array, or no-arg object creation.
-            if (originalCreateMethod.Parameters is [
-                {
-                    Type: INamedTypeSymbol
-                    {
-                        Name: nameof(IEnumerable<int>),
-                        TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
-                    } enumerableType
-                }] && enumerableType.OriginalDefinition.Equals(compilation.IEnumerableOfTType()))
-            {
-                var argExpression = arguments[0].Expression;
-                if (argExpression
-                        is ArrayCreationExpressionSyntax { Initializer: not null }
-                        or ImplicitArrayCreationExpressionSyntax)
-                {
-                    unwrapArgument = true;
-                    return true;
-                }
-
-                if (argExpression is ObjectCreationExpressionSyntax objectCreation)
-                {
-                    // Can't have any arguments, as we cannot preserve them once we grab out all the elements.
-                    if (objectCreation.ArgumentList != null && objectCreation.ArgumentList.Arguments.Count > 0)
-                        return false;
-
-                    // If it's got an initializer, it has to be a collection initializer (or an empty object initializer);
-                    if (objectCreation.Initializer.IsKind(SyntaxKind.ObjectCreationExpression) && objectCreation.Initializer.Expressions.Count > 0)
-                        return false;
-
-                    unwrapArgument = true;
-                    return true;
-                }
-            }
-        }
-        else if (originalCreateMethod.Name is CreateName)
-        {
-            // `XXX.Create()` can be converted to `[]`
-            if (originalCreateMethod.Parameters.Length == 0)
-                return arguments.Count == 0;
-
-            // If we have `Create<T>(T)`, `Create<T>(T, T)` etc., then this is convertible.
-            if (originalCreateMethod.Parameters.All(static p => p.Type is ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }))
-                return arguments.Count == originalCreateMethod.Parameters.Length;
-
-            // If we have `Create<T>(params T[])` this is legal if there are multiple arguments.  Or a single argument that
-            // is an array literal.
-            if (originalCreateMethod.Parameters is [{ IsParams: true, Type: IArrayTypeSymbol { ElementType: ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } } }])
-            {
-                if (arguments.Count >= 2)
-                    return true;
-
-                if (arguments is [{ Expression: ArrayCreationExpressionSyntax { Initializer: not null } or ImplicitArrayCreationExpressionSyntax }])
-                {
-                    unwrapArgument = true;
-                    return true;
-                }
-
-                return false;
-            }
-
-            // If we have `Create<T>(ReadOnlySpan<T> values)` this is legal if a stack-alloc expression is passed along.
-            //
-            // Runtime needs to support inline arrays in order for this to be ok.  Otherwise compiler will change the
-            // stack alloc to a heap alloc, which could be very bad for user perf.
-
-            if (arguments.Count == 1 &&
-                compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes) &&
-                originalCreateMethod.Parameters is [
-                    {
-                        Type: INamedTypeSymbol
-                        {
-                            Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                            TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
-                        } spanType
-                    }])
-            {
-                if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
-                    spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
-                {
-                    if (arguments[0].Expression
-                            is StackAllocArrayCreationExpressionSyntax { Initializer: not null }
-                            or ImplicitStackAllocArrayCreationExpressionSyntax)
-                    {
-                        unwrapArgument = true;
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
+
+using static UseCollectionExpressionHelpers;
 
 /// <summary>
 /// Analyzer/fixer that looks for code of the form <c>X.Empty&lt;T&gt;()</c> or <c>X&lt;T&gt;.Empty</c> and offers to
@@ -18,8 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
 internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer
     : AbstractCSharpUseCollectionExpressionDiagnosticAnalyzer
 {
-    private const string EmptyName = nameof(Array.Empty);
-
     public CSharpUseCollectionExpressionForEmptyDiagnosticAnalyzer()
         : base(IDEDiagnosticIds.UseCollectionExpressionForEmptyDiagnosticId,
                EnforceOnBuildValues.UseCollectionExpressionForEmpty)
@@ -32,8 +30,6 @@ internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAna
     private void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
     {
         var semanticModel = context.SemanticModel;
-        var syntaxTree = semanticModel.SyntaxTree;
-        var memberAccess = (MemberAccessExpressionSyntax)context.Node;
         var cancellationToken = context.CancellationToken;
 
         // no point in analyzing if the option is off.
@@ -41,15 +37,18 @@ internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAna
         if (!option.Value)
             return;
 
-        // X.Empty<T>() or X<T>.Empty
+        var memberAccess = (MemberAccessExpressionSyntax)context.Node;
 
         var nodeToReplace =
-            IsEmptyProperty() ? memberAccess :
-            IsEmptyMethodCall() ? (ExpressionSyntax)memberAccess.GetRequiredParent() : null;
+            IsCollectionEmptyAccess(semanticModel, memberAccess, cancellationToken)
+                ? memberAccess
+                : memberAccess.Parent is InvocationExpressionSyntax invocation && IsCollectionEmptyAccess(semanticModel, invocation, cancellationToken)
+                    ? (ExpressionSyntax)invocation
+                    : null;
         if (nodeToReplace is null)
             return;
 
-        if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(semanticModel, nodeToReplace, skipVerificationForReplacedNode: true, cancellationToken))
+        if (!CanReplaceWithCollectionExpression(semanticModel, nodeToReplace, skipVerificationForReplacedNode: true, cancellationToken))
             return;
 
         context.ReportDiagnostic(DiagnosticHelper.Create(
@@ -60,89 +59,5 @@ internal sealed partial class CSharpUseCollectionExpressionForEmptyDiagnosticAna
             properties: null));
 
         return;
-
-        // X<T>.Empty
-        bool IsEmptyProperty()
-        {
-            if (!IsPossiblyDottedGenericName(memberAccess.Expression))
-                return false;
-
-            if (memberAccess.Name is not IdentifierNameSyntax { Identifier.ValueText: EmptyName })
-                return false;
-
-            var expressionSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol;
-            if (expressionSymbol is not INamedTypeSymbol)
-                return false;
-
-            var emptySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol;
-            if (emptySymbol is not { IsStatic: true })
-                return false;
-
-            if (emptySymbol is not IFieldSymbol and not IPropertySymbol)
-                return false;
-
-            return true;
-        }
-
-        // X.Empty<T>()
-        bool IsEmptyMethodCall()
-        {
-            if (memberAccess is not
-                {
-                    Parent: InvocationExpressionSyntax { ArgumentList.Arguments.Count: 0 },
-                    Name: GenericNameSyntax
-                    {
-                        TypeArgumentList.Arguments.Count: 1,
-                        Identifier.ValueText: EmptyName,
-                    },
-                })
-            {
-                return false;
-            }
-
-            if (!IsPossiblyDottedName(memberAccess.Expression))
-                return false;
-
-            var expressionSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol;
-            if (expressionSymbol is not INamedTypeSymbol)
-                return false;
-
-            var emptySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol;
-            if (emptySymbol is not { IsStatic: true })
-                return false;
-
-            if (emptySymbol is not IMethodSymbol)
-                return false;
-
-            return true;
-        }
-
-        static bool IsPossiblyDottedGenericName(ExpressionSyntax expression)
-        {
-            if (expression is GenericNameSyntax)
-                return true;
-
-            if (expression is MemberAccessExpressionSyntax { Expression: ExpressionSyntax childName, Name: GenericNameSyntax } &&
-                IsPossiblyDottedName(childName))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        static bool IsPossiblyDottedName(ExpressionSyntax name)
-        {
-            if (name is IdentifierNameSyntax)
-                return true;
-
-            if (name is MemberAccessExpressionSyntax { Expression: ExpressionSyntax childName, Name: IdentifierNameSyntax } &&
-                IsPossiblyDottedName(childName))
-            {
-                return true;
-            }
-
-            return false;
-        }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -594,13 +594,13 @@ internal static class UseCollectionExpressionHelpers
                 if (arguments.Count == 1 &&
                     compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes) &&
                     originalCreateMethod.Parameters is [
+                    {
+                        Type: INamedTypeSymbol
                         {
-                            Type: INamedTypeSymbol
-                            {
-                                Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                                TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
-                            } spanType
-                        }])
+                            Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                            TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+                        } spanType
+                    }])
                 {
                     if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
                         spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -453,5 +455,299 @@ internal static class UseCollectionExpressionHelpers
         }
 
         return matches.ToImmutable();
+    }
+
+    public static bool IsCollectionFactoryCreate(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocationExpression,
+        [NotNullWhen(true)] out MemberAccessExpressionSyntax? memberAccess,
+        out bool unwrapArgument,
+        CancellationToken cancellationToken)
+    {
+        const string CreateName = nameof(ImmutableArray.Create);
+        const string CreateRangeName = nameof(ImmutableArray.CreateRange);
+        unwrapArgument = false;
+        memberAccess = null;
+        // Looking for `XXX.Create(...)`
+        if (invocationExpression.Expression is not MemberAccessExpressionSyntax
+            {
+                RawKind: (int)SyntaxKind.SimpleMemberAccessExpression,
+                Name.Identifier.Value: CreateName or CreateRangeName,
+            } memberAccessExpression)
+        {
+            return false;
+        }
+        memberAccess = memberAccessExpression;
+        var createMethod = semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol as IMethodSymbol;
+        if (createMethod is not { IsStatic: true })
+            return false;
+        var factoryType = semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol as INamedTypeSymbol;
+        if (factoryType is null)
+            return false;
+        var compilation = semanticModel.Compilation;
+        // The pattern is a type like `ImmutableArray` (non-generic), returning an instance of `ImmutableArray<T>`.  The
+        // actual collection type (`ImmutableArray<T>`) has to have a `[CollectionBuilder(...)]` attribute on it that
+        // then points at the factory type.
+        var collectionBuilderAttribute = compilation.CollectionBuilderAttribute()!;
+        var collectionBuilderAttributeData = createMethod.ReturnType.OriginalDefinition
+            .GetAttributes()
+            .FirstOrDefault(a => collectionBuilderAttribute.Equals(a.AttributeClass));
+        if (collectionBuilderAttributeData?.ConstructorArguments is not [{ Value: ITypeSymbol collectionBuilderType }, { Value: CreateName }])
+            return false;
+
+        if (!factoryType.OriginalDefinition.Equals(collectionBuilderType.OriginalDefinition))
+            return false;
+
+        // Ok, this is type that has a collection-builder option available.  We can switch over if the current method
+        // we're calling has one of the following signatures:
+        //
+        //  `Create()`.  Trivial case, can be replaced with `[]`.
+        //  `Create(T), Create(T, T), Create(T, T, T)` etc.
+        //  `Create(params T[])` (passing as individual elements, or an array with an initializer)
+        //  `Create(ReadOnlySpan<T>)` (passing as a stack-alloc with an initializer)
+        //  `Create(IEnumerable<T>)` (passing as something with an initializer.
+        if (!IsCompatibleSignatureAndArguments(createMethod.OriginalDefinition, out unwrapArgument))
+            return false;
+
+        return true;
+
+        bool IsCompatibleSignatureAndArguments(
+            IMethodSymbol originalCreateMethod,
+            out bool unwrapArgument)
+        {
+            unwrapArgument = false;
+
+            var arguments = invocationExpression.ArgumentList.Arguments;
+
+            // Don't bother offering if any of the arguments are named.  It's unlikely for this to occur in practice, and it
+            // means we do not have to worry about order of operations.
+            if (arguments.Any(static a => a.NameColon != null))
+                return false;
+
+            if (originalCreateMethod.Name is CreateRangeName)
+            {
+                // If we have `CreateRange<T>(IEnumerable<T> values)` this is legal if we have an array, or no-arg object creation.
+                if (originalCreateMethod.Parameters is [
+                    {
+                        Type: INamedTypeSymbol
+                        {
+                            Name: nameof(IEnumerable<int>),
+                            TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+                        } enumerableType
+                    }] && enumerableType.OriginalDefinition.Equals(compilation.IEnumerableOfTType()))
+                {
+                    var argExpression = arguments[0].Expression;
+                    if (argExpression
+                            is ArrayCreationExpressionSyntax { Initializer: not null }
+                            or ImplicitArrayCreationExpressionSyntax)
+                    {
+                        unwrapArgument = true;
+                        return true;
+                    }
+
+                    if (argExpression is ObjectCreationExpressionSyntax objectCreation)
+                    {
+                        // Can't have any arguments, as we cannot preserve them once we grab out all the elements.
+                        if (objectCreation.ArgumentList != null && objectCreation.ArgumentList.Arguments.Count > 0)
+                            return false;
+
+                        // If it's got an initializer, it has to be a collection initializer (or an empty object initializer);
+                        if (objectCreation.Initializer.IsKind(SyntaxKind.ObjectCreationExpression) && objectCreation.Initializer.Expressions.Count > 0)
+                            return false;
+
+                        unwrapArgument = true;
+                        return true;
+                    }
+                }
+            }
+            else if (originalCreateMethod.Name is CreateName)
+            {
+                // `XXX.Create()` can be converted to `[]`
+                if (originalCreateMethod.Parameters.Length == 0)
+                    return arguments.Count == 0;
+
+                // If we have `Create<T>(T)`, `Create<T>(T, T)` etc., then this is convertible.
+                if (originalCreateMethod.Parameters.All(static p => p.Type is ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }))
+                    return arguments.Count == originalCreateMethod.Parameters.Length;
+
+                // If we have `Create<T>(params T[])` this is legal if there are multiple arguments.  Or a single argument that
+                // is an array literal.
+                if (originalCreateMethod.Parameters is [{ IsParams: true, Type: IArrayTypeSymbol { ElementType: ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } } }])
+                {
+                    if (arguments.Count >= 2)
+                        return true;
+
+                    if (arguments is [{ Expression: ArrayCreationExpressionSyntax { Initializer: not null } or ImplicitArrayCreationExpressionSyntax }])
+                    {
+                        unwrapArgument = true;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                // If we have `Create<T>(ReadOnlySpan<T> values)` this is legal if a stack-alloc expression is passed along.
+                //
+                // Runtime needs to support inline arrays in order for this to be ok.  Otherwise compiler will change the
+                // stack alloc to a heap alloc, which could be very bad for user perf.
+
+                if (arguments.Count == 1 &&
+                    compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes) &&
+                    originalCreateMethod.Parameters is [
+                        {
+                            Type: INamedTypeSymbol
+                            {
+                                Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                                TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+                            } spanType
+                        }])
+                {
+                    if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
+                        spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))
+                    {
+                        if (arguments[0].Expression
+                                is StackAllocArrayCreationExpressionSyntax { Initializer: not null }
+                                or ImplicitStackAllocArrayCreationExpressionSyntax)
+                        {
+                            unwrapArgument = true;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static bool IsCollectionEmptyAccess(
+        SemanticModel semanticModel,
+        ExpressionSyntax expression,
+        CancellationToken cancellationToken)
+    {
+        const string EmptyName = nameof(Array.Empty);
+
+        if (expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            // X<T>.Empty
+            return IsEmptyProperty(memberAccess);
+        }
+        else if (expression is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax innerMemberAccess } invocation)
+        {
+            // X.Empty<T>()
+            return IsEmptyMethodCall(invocation, innerMemberAccess);
+        }
+        else
+        {
+            return false;
+        }
+
+        // X<T>.Empty
+        bool IsEmptyProperty(MemberAccessExpressionSyntax memberAccess)
+        {
+            if (!IsPossiblyDottedGenericName(memberAccess.Expression))
+                return false;
+
+            if (memberAccess.Name is not IdentifierNameSyntax { Identifier.ValueText: EmptyName })
+                return false;
+
+            var expressionSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol;
+            if (expressionSymbol is not INamedTypeSymbol)
+                return false;
+
+            var emptySymbol = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol;
+            if (emptySymbol is not { IsStatic: true })
+                return false;
+
+            if (emptySymbol is not IFieldSymbol and not IPropertySymbol)
+                return false;
+
+            return true;
+        }
+
+        // X.Empty<T>()
+        bool IsEmptyMethodCall(InvocationExpressionSyntax invocation, MemberAccessExpressionSyntax memberAccess)
+        {
+            if (invocation.ArgumentList.Arguments.Count != 0)
+                return false;
+
+            if (memberAccess.Name is not GenericNameSyntax
+                {
+                    TypeArgumentList.Arguments.Count: 1,
+                    Identifier.ValueText: EmptyName,
+                })
+            {
+                return false;
+            }
+
+            if (!IsPossiblyDottedName(memberAccess.Expression))
+                return false;
+
+            var expressionSymbol = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol;
+            if (expressionSymbol is not INamedTypeSymbol)
+                return false;
+
+            var emptySymbol = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol;
+            if (emptySymbol is not { IsStatic: true })
+                return false;
+
+            if (emptySymbol is not IMethodSymbol)
+                return false;
+
+            return true;
+        }
+
+        static bool IsPossiblyDottedGenericName(ExpressionSyntax expression)
+        {
+            if (expression is GenericNameSyntax)
+                return true;
+
+            if (expression is MemberAccessExpressionSyntax { Expression: ExpressionSyntax childName, Name: GenericNameSyntax } &&
+                IsPossiblyDottedName(childName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool IsPossiblyDottedName(ExpressionSyntax name)
+        {
+            if (name is IdentifierNameSyntax)
+                return true;
+
+            if (name is MemberAccessExpressionSyntax { Expression: ExpressionSyntax childName, Name: IdentifierNameSyntax } &&
+                IsPossiblyDottedName(childName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public static SeparatedSyntaxList<ArgumentSyntax> GetArguments(InvocationExpressionSyntax invocationExpression, bool unwrapArgument)
+    {
+        var arguments = invocationExpression.ArgumentList.Arguments;
+        // If we're not unwrapping a singular argument expression, then just pass back all the explicit argument
+        // expressions the user wrote out.
+        if (!unwrapArgument)
+            return arguments;
+        Contract.ThrowIfTrue(arguments.Count != 1);
+        var expression = arguments.Single().Expression;
+        var initializer = expression switch
+        {
+            ImplicitArrayCreationExpressionSyntax implicitArray => implicitArray.Initializer,
+            ImplicitStackAllocArrayCreationExpressionSyntax implicitStackAlloc => implicitStackAlloc.Initializer,
+            ArrayCreationExpressionSyntax arrayCreation => arrayCreation.Initializer,
+            StackAllocArrayCreationExpressionSyntax stackAllocCreation => stackAllocCreation.Initializer,
+            ImplicitObjectCreationExpressionSyntax implicitObjectCreation => implicitObjectCreation.Initializer,
+            ObjectCreationExpressionSyntax objectCreation => objectCreation.Initializer,
+            _ => throw ExceptionUtilities.Unreachable(),
+        };
+        return initializer is null
+            ? default
+            : SeparatedList<ArgumentSyntax>(initializer.Expressions.GetWithSeparators().Select(
+                nodeOrToken => nodeOrToken.IsToken ? nodeOrToken : Argument((ExpressionSyntax)nodeOrToken.AsNode()!)));
     }
 }

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             {
                 // Look for a call to Add or AddRange
                 if (this.State.TryAnalyzeAddInvocation(
-                        expressionStatement,
+                        (TExpressionSyntax)this.SyntaxFacts.GetExpressionOfExpressionStatement(expressionStatement),
                         requiredArgumentName: null,
                         forCollectionExpression: false,
                         cancellationToken,


### PR DESCRIPTION
These helpers are useful for the next upcoming analyzer/fixer, which finds things of the form `ImmutableArray.Create(1, 2, 3).Add(x).Concat(other).ToArray()` (and similar expressions) and offers to conver to `[1, 2, 3, x, .. other)]`