### PR TITLE
Collection expressions: overload resolution

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2542,17 +2542,13 @@ outerDefault:
                 switch (t1.IsRefLikeType, t2.IsRefLikeType)
                 {
                     case (false, true):
-                        if (Conversions.ClassifyImplicitConversionFromType(e2.Type, e1.Type, ref useSiteInfo).IsImplicit)
-                        {
-                            return BetterResult.Right;
-                        }
-                        break;
+                        return Conversions.ClassifyImplicitConversionFromType(e2.Type, e1.Type, ref useSiteInfo).IsImplicit ?
+                            BetterResult.Right :
+                            BetterResult.Neither;
                     case (true, false):
-                        if (Conversions.ClassifyImplicitConversionFromType(e1.Type, e2.Type, ref useSiteInfo).IsImplicit)
-                        {
-                            return BetterResult.Left;
-                        }
-                        break;
+                        return Conversions.ClassifyImplicitConversionFromType(e1.Type, e2.Type, ref useSiteInfo).IsImplicit ?
+                            BetterResult.Left :
+                            BetterResult.Neither;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2531,6 +2531,31 @@ outerDefault:
             if (!conv2.IsConditionalExpression && conv1.IsConditionalExpression)
                 return BetterResult.Right;
 
+            // C1 and C2 are collection expression conversions and the following hold:
+            // - T1 is a ref struct type with iteration type E1, and T2 is a non- ref struct type with iteration type E2, and
+            // - E1 is implicitly convertible to E2
+            if (conv1.Kind == ConversionKind.CollectionExpression &&
+                conv2.Kind == ConversionKind.CollectionExpression &&
+                _binder.TryGetCollectionIterationType((Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)node.Syntax, t1, out TypeWithAnnotations e1) &&
+                _binder.TryGetCollectionIterationType((Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax)node.Syntax, t2, out TypeWithAnnotations e2))
+            {
+                switch (t1.IsRefLikeType, t2.IsRefLikeType)
+                {
+                    case (false, true):
+                        if (Conversions.ClassifyImplicitConversionFromType(e2.Type, e1.Type, ref useSiteInfo).IsImplicit)
+                        {
+                            return BetterResult.Right;
+                        }
+                        break;
+                    case (true, false):
+                        if (Conversions.ClassifyImplicitConversionFromType(e1.Type, e2.Type, ref useSiteInfo).IsImplicit)
+                        {
+                            return BetterResult.Left;
+                        }
+                        break;
+                }
+            }
+
             // - T1 is a better conversion target than T2 and either C1 and C2 are both conditional expression
             //   conversions or neither is a conditional expression conversion.
             return BetterConversionTarget(node, t1, conv1, t2, conv2, ref useSiteInfo, out okToDowngradeToNeither);


### PR DESCRIPTION
Add *better conversion from expression* rule for *collection expression conversions* ([proposal](https://github.com/dotnet/csharplang/pull/7477)).

Relates to test plan https://github.com/dotnet/roslyn/issues/66418