### PR TITLE
Cache substituted base type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -39,6 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private TypeMap _lazyMap;
         private ImmutableArray<TypeParameterSymbol> _lazyTypeParameters;
 
+        private NamedTypeSymbol _lazyBaseType = ErrorTypeSymbol.UnknownResultType;
+
         // computed on demand
         private int _hashCode;
 
@@ -148,8 +150,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _unbound ? ImmutableArray<NamedTypeSymbol>.Empty : Map.SubstituteNamedTypes(OriginalDefinition.GetDeclaredInterfaces(basesBeingResolved));
         }
-
-        private NamedTypeSymbol _lazyBaseType = ErrorTypeSymbol.UnknownResultType;
 
         internal sealed override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         {

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
 {
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
         /// is a consistent stack size for them to execute in. 
         /// </summary>
         /// <param name="action"></param>
-        private static void RunInThread(Action action)
+        private static void RunInThread(Action action, TimeSpan? timeout = null)
         {
             Exception exception = null;
             var thread = new System.Threading.Thread(() =>
@@ -43,7 +44,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
             }, 0);
 
             thread.Start();
-            thread.Join();
+            if (timeout is { } t && !Debugger.IsAttached)
+            {
+                if (!thread.Join(t))
+                {
+                    throw new TimeoutException(t.ToString());
+                }
+            }
+            else
+            {
+                thread.Join();
+            }
 
             if (exception is object)
             {
@@ -233,6 +244,83 @@ public class Test
                     CompileAndVerify(compilation, expectedOutput: "Pass", verify: Verification.Skipped);
                 });
             }
+        }
+
+        [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/69515")]
+        public void GenericInheritanceCascade_CSharp(bool reverse, bool concurrent)
+        {
+            const int number = 17;
+
+            /*
+                class C0<T>;
+                class C1<T> : C0<T>;
+                class C2<T> : C1<T>;
+                ...
+            */
+            var declarations = new string[number];
+            declarations[0] = "class C0<T0> { }";
+            for (int i = 1; i < number; i++)
+            {
+                declarations[i] = $$"""class C{{i}}<T{{i}}> : C{{i - 1}}<T{{i}}> { }""";
+            }
+
+            if (reverse)
+            {
+                Array.Reverse(declarations);
+            }
+
+            var source = string.Join(Environment.NewLine, declarations);
+            var options = TestOptions.DebugDll.WithConcurrentBuild(concurrent);
+
+            RunInThread(() =>
+            {
+                CompileAndVerify(source, options: options).VerifyDiagnostics();
+            }, timeout: TimeSpan.FromSeconds(10));
+        }
+
+        [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/69515")]
+        public void GenericInheritanceCascade_VisualBasic(bool reverse, bool concurrent)
+        {
+            const int number = 17;
+
+            /*
+                Class C0(Of T)
+                End Class
+                Class C1(Of T)
+                    Inherits C0(Of T)
+                End Class
+                Class C2(Of T)
+                    Inherits C1(Of T)
+                End Class
+                ...
+            */
+            var declarations = new string[number];
+            declarations[0] = """
+                Class C0(Of T0)
+                End Class
+                """;
+            for (int i = 1; i < number; i++)
+            {
+                declarations[i] = $"""
+                    Class C{i}(Of T{i})
+                        Inherits C{i - 1}(Of T{i})
+                    End Class
+                    """;
+            }
+
+            if (reverse)
+            {
+                Array.Reverse(declarations);
+            }
+
+            var source = string.Join(Environment.NewLine, declarations);
+            var options = new VisualBasic.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithConcurrentBuild(concurrent);
+
+            RunInThread(() =>
+            {
+                CreateVisualBasicCompilation(source, compilationOptions: options).VerifyDiagnostics();
+            }, timeout: TimeSpan.FromSeconds(10));
         }
 
         [ConditionalFact(typeof(WindowsOrLinuxOnly), typeof(NoIOperationValidation))]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69515.

The regression was introduced by https://github.com/dotnet/roslyn/commit/727569fa3fec7b370f55897adc18ef7001818b2f which adds recursive checking of base types. But those base types of generic types were substituted over and over again. VB doesn't have that problem, it seems to cache them, so I've done a similar thing in C#.