### PR TITLE
Include CodeLens on remaining types and members

### DIFF
--- a/src/Features/CSharp/Portable/CodeLens/CSharpCodeLensMemberFinder.cs
+++ b/src/Features/CSharp/Portable/CodeLens/CSharpCodeLensMemberFinder.cs
@@ -55,6 +55,7 @@ internal sealed class CSharpCodeLensMemberFinder : ICodeLensMemberFinder
         public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
         {
             _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
+            base.VisitEnumDeclaration(node);
         }
 
         public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
@@ -82,6 +83,42 @@ internal sealed class CSharpCodeLensMemberFinder : ICodeLensMemberFinder
         {
             _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
             base.VisitRecordDeclaration(node);
+        }
+
+        public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+        {
+            _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
+        }
+
+        public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
+        {
+            _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            foreach (var variable in node.Declaration.Variables)
+            {
+                _memberBuilder.Add(new CodeLensMember(variable, variable.Identifier.Span));
+            }
+        }
+
+        public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+        {
+            foreach (var variable in node.Declaration.Variables)
+            {
+                _memberBuilder.Add(new CodeLensMember(variable, variable.Identifier.Span));
+            }
+        }
+
+        public override void VisitEventDeclaration(EventDeclarationSyntax node)
+        {
+            _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
+        }
+
+        public override void VisitDestructorDeclaration(DestructorDeclarationSyntax node)
+        {
+            _memberBuilder.Add(new CodeLensMember(node, node.Identifier.Span));
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeLens;
 using Newtonsoft.Json;
 using Roslyn.Test.Utilities;
-using StreamJsonRpc;
 using Xunit;
 using Xunit.Abstractions;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -135,12 +134,155 @@ public class CSharpCodeLensTests : AbstractCodeLensTests
     }
 
     [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEnumMemberDeclarationAsync(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"enum A
+{
+    {|codeLens:One|}
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestPropertyDeclarationAsync(bool lspMutatingWorkspace)
     {
         var markup =
 @"class A
 {
     public int {|codeLens:I|} { get; set; }
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEventDeclarationAsync(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public event System.EventHandler {|codeLens:I|} { add { } remove { } }
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEventFieldDeclaration1Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public event System.EventHandler {|codeLens:I|};
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEventFieldDeclaration2Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public event System.EventHandler {|codeLens:I|}, I2;
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEventFieldDeclaration3Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public event System.EventHandler I, {|codeLens:I2|};
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration1Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public int {|codeLens:I|};
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration2Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public int {|codeLens:I|}, I2;
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration3Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public int I, {|codeLens:I2|};
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestConstantDeclaration1Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public const int {|codeLens:I|} = 0;
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestConstantDeclaration2Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public const int {|codeLens:I|} = 0, I2 = 0;
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestConstantDeclaration3Async(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    public const int I = 0, {|codeLens:I2|} = 0;
 }";
         await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
         await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
@@ -172,12 +314,37 @@ public class CSharpCodeLensTests : AbstractCodeLensTests
     }
 
     [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestDelegateDeclarationAsync(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"delegate void {|codeLens:A|}();";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestConstructorDeclarationAsync(bool lspMutatingWorkspace)
     {
         var markup =
 @"class A
 {
     public {|codeLens:A|}()
+    {
+    }
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace, CapabilitiesWithVSExtensions);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestDestructorDeclarationAsync(bool lspMutatingWorkspace)
+    {
+        var markup =
+@"class A
+{
+    ~{|codeLens:A|}()
     {
     }
 }";

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/VisualBasicCodeLensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeLens/VisualBasicCodeLensTests.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeLens;
 
@@ -89,6 +86,90 @@ End Enum";
     }
 
     [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEnumMemberDeclarationAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Enum A
+    {|codeLens:One|}
+End Enum";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration1Async(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public {|codeLens:One|} As Integer
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration2Async(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public {|codeLens:One|}, Two As Integer
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration3Async(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public One, {|codeLens:Two|} As Integer
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration4Async(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public {|codeLens:One|} As Integer, Two As Integer
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestFieldDeclaration5Async(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public One As Integer, {|codeLens:Two|} As Integer
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestEventDeclarationAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Public Event {|codeLens:One|} As System.EventHandler
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestPropertyDeclarationAsync(bool mutatingLspWorkspace)
     {
         var markup =
@@ -112,12 +193,36 @@ End Class";
     }
 
     [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestDelegateSubDeclarationAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Delegate Sub {|codeLens:M|}()
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestFunctionDeclarationAsync(bool mutatingLspWorkspace)
     {
         var markup =
 @"Class A
     Function {|codeLens:M|}()
     End Function
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestDelegateFunctionDeclarationAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Delegate Function {|codeLens:M|}() As Integer
 End Class";
         await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
         await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
@@ -139,6 +244,19 @@ End Structure";
         var markup =
 @"Class A
     Sub {|codeLens:New|}()
+    End Sub
+End Class";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);
+        await VerifyCodeLensAsync(testLspServer, expectedNumberOfReferences: 0);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69583")]
+    public async Task TestDestructorDeclarationAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"Class A
+    Protected Overrides Sub {|codeLens:Finalize|}()
     End Sub
 End Class";
         await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup, mutatingLspWorkspace);

--- a/src/Features/VisualBasic/Portable/CodeLens/VisualBasicCodeLensMemberFinder.vb
+++ b/src/Features/VisualBasic/Portable/CodeLens/VisualBasicCodeLensMemberFinder.vb
@@ -52,6 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeLens
 
             Public Overrides Sub VisitEnumStatement(node As EnumStatementSyntax)
                 _memberBuilder.Add(New CodeLensMember(node, node.Identifier.Span))
+                MyBase.VisitEnumStatement(node)
             End Sub
 
             Public Overrides Sub VisitPropertyStatement(node As PropertyStatementSyntax)
@@ -74,6 +75,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeLens
             Public Overrides Sub VisitModuleStatement(node As ModuleStatementSyntax)
                 _memberBuilder.Add(New CodeLensMember(node, node.Identifier.Span))
                 MyBase.VisitModuleStatement(node)
+            End Sub
+
+            Public Overrides Sub VisitDelegateStatement(node As DelegateStatementSyntax)
+                _memberBuilder.Add(New CodeLensMember(node, node.Identifier.Span))
+            End Sub
+
+            Public Overrides Sub VisitEnumMemberDeclaration(node As EnumMemberDeclarationSyntax)
+                _memberBuilder.Add(New CodeLensMember(node, node.Identifier.Span))
+            End Sub
+
+            Public Overrides Sub VisitFieldDeclaration(node As FieldDeclarationSyntax)
+                For Each variable In node.Declarators
+                    For Each name In variable.Names
+                        _memberBuilder.Add(New CodeLensMember(name, name.Identifier.Span))
+                    Next
+                Next
+            End Sub
+
+            Public Overrides Sub VisitEventStatement(node As EventStatementSyntax)
+                _memberBuilder.Add(New CodeLensMember(node, node.Identifier.Span))
             End Sub
         End Class
     End Class


### PR DESCRIPTION
Support the following items in the LSP implementation of CodeLens:

* C#
    * Delegates
    * Enum members
    * Fields
    * Events (both full form and field form)
    * Destructors
* Visual Basic
    * Delegates
    * Enum members
    * Fields
    * Events

Fixes #69583