### PR TITLE
Collection expression conversions: check elements are convertible

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -953,11 +953,22 @@ public class UseCollectionExpressionForArrayTests
                 {
                     void M(int[] x, bool b)
                     {
-                        int[][] c = [[1, 2, 3]];
+                        int[][] c = [new[] { 1, 2, 3 }];
                     }
                 }
                 """,
+            FixedState =
+            {
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(5,22): info IDE0300: Collection initialization can be simplified
+                    VerifyCS.Diagnostic().WithSpan(5, 22, 5, 25).WithSpan(5, 22, 5, 39).WithSeverity(DiagnosticSeverity.Info),
+                    // /0/Test0.cs(5,22): hidden IDE0300: Collection initialization can be simplified
+                    VerifyCS.Diagnostic().WithSpan(5, 22, 5, 27).WithSpan(5, 22, 5, 39).WithSpan(5, 22, 5, 27).WithSeverity(DiagnosticSeverity.Hidden),
+                }
+            },
             LanguageVersion = LanguageVersion.CSharp12,
+            CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne,
         }.RunAsync();
     }
 

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -953,7 +953,7 @@ public class UseCollectionExpressionForArrayTests
                 {
                     void M(int[] x, bool b)
                     {
-                        int[][] c = [new[] { 1, 2, 3 }];
+                        int[][] c = [[1, 2, 3]];
                     }
                 }
                 """,
@@ -2550,17 +2550,6 @@ public class UseCollectionExpressionForArrayTests
                 """,
             FixedCode = """
                 using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r = [new[] { 1 }, new int[] { 2 }];
-                    }
-                }
-                """,
-            BatchFixedCode = """
-                using System;
                 
                 class C
                 {
@@ -2595,22 +2584,6 @@ public class UseCollectionExpressionForArrayTests
                 }
                 """,
             FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            // Leading
-                            new[] { 1 }, // Trailing
-                            new int[] { 2 },
-                        ];
-                    }
-                }
-                """,
-            BatchFixedCode = """
                 using System;
                 
                 class C
@@ -2654,25 +2627,6 @@ public class UseCollectionExpressionForArrayTests
                 }
                 """,
             FixedCode = """
-                using System;
-
-                class C
-                {
-                    void M(int i, int j)
-                    {
-                        int[][] r =
-                        [
-                            new[]
-                            {
-                                // Leading
-                                1 // Trailing
-                            },
-                            new int[] { 2 },
-                        ];
-                    }
-                }
-                """,
-            BatchFixedCode = """
                 using System;
                 
                 class C

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -234,11 +234,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (source.Kind == BoundKind.UnconvertedCollectionExpression)
                 {
                     Debug.Assert(conversion.IsCollectionExpression || !conversion.Exists);
-                    source = ConvertCollectionExpression(
+
+                    var collectionExpression = ConvertCollectionExpression(
                         (BoundUnconvertedCollectionExpression)source,
                         destination,
-                        wasCompilerGenerated,
+                        conversion,
                         diagnostics);
+                    return new BoundConversion(
+                        syntax,
+                        collectionExpression,
+                        conversion,
+                        @checked: CheckOverflowAtRuntime,
+                        explicitCastInCode: isCast && !wasCompilerGenerated,
+                        conversionGroupOpt,
+                        constantValueOpt: null,
+                        type: destination);
                 }
 
                 if (source.Kind == BoundKind.UnconvertedConditionalOperator)
@@ -335,7 +345,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else if (source.Type?.IsNullableType() == true)
                     {
-
                         _ = CreateConversion(
                                 syntax,
                                 new BoundValuePlaceholder(source.Syntax, source.Type.GetNullableUnderlyingType()),
@@ -529,28 +538,164 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression ConvertCollectionExpression(
             BoundUnconvertedCollectionExpression node,
             TypeSymbol targetType,
-            bool wasCompilerGenerated,
+            Conversion conversion,
             BindingDiagnosticBag diagnostics)
         {
-            TypeSymbol? elementType;
-            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(Compilation, targetType, out elementType);
+            var collectionTypeKind = conversion.GetCollectionExpressionTypeKind(out var elementType);
+
+            if (collectionTypeKind == CollectionExpressionTypeKind.None)
+            {
+                return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+            }
+
+            var syntax = (ExpressionSyntax)node.Syntax;
+            MethodSymbol? collectionBuilderMethod = null;
+
             switch (collectionTypeKind)
             {
-                case CollectionExpressionTypeKind.CollectionInitializer:
-                    return BindCollectionInitializerCollectionExpression(node, collectionTypeKind, targetType, wasCompilerGenerated: wasCompilerGenerated, diagnostics);
-                case CollectionExpressionTypeKind.Array:
                 case CollectionExpressionTypeKind.Span:
+                    _ = GetWellKnownTypeMember(WellKnownMember.System_Span_T__ctor_Array, diagnostics, syntax: syntax);
+                    break;
+
                 case CollectionExpressionTypeKind.ReadOnlySpan:
-                    return BindArrayOrSpanCollectionExpression(node, targetType, wasCompilerGenerated: wasCompilerGenerated, collectionTypeKind, elementType!, diagnostics);
+                    _ = GetWellKnownTypeMember(WellKnownMember.System_ReadOnlySpan_T__ctor_Array, diagnostics, syntax: syntax);
+                    break;
+
                 case CollectionExpressionTypeKind.CollectionBuilder:
-                    return BindCollectionBuilderCollectionExpression(node, (NamedTypeSymbol)targetType, wasCompilerGenerated: wasCompilerGenerated, diagnostics);
-                case CollectionExpressionTypeKind.ListInterface:
-                    return BindListInterfaceCollectionExpression(node, targetType, wasCompilerGenerated: wasCompilerGenerated, elementType!, diagnostics);
-                case CollectionExpressionTypeKind.None:
-                    return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(collectionTypeKind);
+                    {
+                        Debug.Assert(elementType is { });
+
+                        var namedType = (NamedTypeSymbol)targetType;
+                        bool result = namedType.HasCollectionBuilderAttribute(out TypeSymbol? builderType, out string? methodName);
+                        Debug.Assert(result);
+
+                        var targetTypeOriginalDefinition = targetType.OriginalDefinition;
+                        result = TryGetCollectionIterationType(syntax, targetTypeOriginalDefinition, out TypeWithAnnotations elementTypeOriginalDefinition);
+                        Debug.Assert(result);
+
+                        var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+                        collectionBuilderMethod = GetCollectionBuilderMethod(namedType, elementTypeOriginalDefinition.Type, builderType, methodName, ref useSiteInfo);
+                        diagnostics.Add(syntax, useSiteInfo);
+                        if (collectionBuilderMethod is null)
+                        {
+                            diagnostics.Add(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, syntax, methodName ?? "", elementTypeOriginalDefinition, targetTypeOriginalDefinition);
+                            return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                        }
+
+                        ReportUseSite(collectionBuilderMethod, diagnostics, syntax.Location);
+
+                        var parameterType = (NamedTypeSymbol)collectionBuilderMethod.Parameters[0].Type;
+                        Debug.Assert(parameterType.OriginalDefinition.Equals(Compilation.GetWellKnownType(WellKnownType.System_ReadOnlySpan_T), TypeCompareKind.AllIgnoreOptions));
+
+                        elementType = parameterType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].Type;
+
+                        collectionBuilderMethod.CheckConstraints(
+                            new ConstraintsHelper.CheckConstraintsArgs(Compilation, Conversions, syntax.Location, diagnostics));
+
+                        ReportDiagnosticsIfObsolete(diagnostics, collectionBuilderMethod.ContainingType, syntax, hasBaseReceiver: false);
+                        ReportDiagnosticsIfObsolete(diagnostics, collectionBuilderMethod, syntax, hasBaseReceiver: false);
+                        ReportDiagnosticsIfUnmanagedCallersOnly(diagnostics, collectionBuilderMethod, syntax, isDelegateConversion: false);
+                    }
+                    break;
             }
+
+            var elements = node.Elements;
+            BoundExpression? collectionCreation = null;
+            BoundObjectOrCollectionValuePlaceholder? implicitReceiver = null;
+
+            if (collectionTypeKind == CollectionExpressionTypeKind.CollectionInitializer)
+            {
+                implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, targetType) { WasCompilerGenerated = true };
+                if (targetType is NamedTypeSymbol namedType)
+                {
+                    var analyzedArguments = AnalyzedArguments.GetInstance();
+                    // https://github.com/dotnet/roslyn/issues/68785: Use ctor with `int capacity` when the size is known.
+                    collectionCreation = BindClassCreationExpression(syntax, namedType.Name, syntax, namedType, analyzedArguments, diagnostics);
+                    collectionCreation.WasCompilerGenerated = true;
+                    analyzedArguments.Free();
+                }
+                else if (targetType is TypeParameterSymbol typeParameter)
+                {
+                    var arguments = AnalyzedArguments.GetInstance();
+                    collectionCreation = BindTypeParameterCreationExpression(syntax, typeParameter, arguments, initializerOpt: null, typeSyntax: syntax, wasTargetTyped: true, diagnostics);
+                    arguments.Free();
+                }
+                else
+                {
+                    collectionCreation = new BoundBadExpression(syntax, LookupResultKind.NotCreatable, ImmutableArray<Symbol?>.Empty, ImmutableArray<BoundExpression>.Empty, targetType);
+                }
+            }
+            else if (collectionTypeKind == CollectionExpressionTypeKind.ListInterface ||
+                elements.Any(e => e is BoundCollectionExpressionSpreadElement)) // https://github.com/dotnet/roslyn/issues/68785: Avoid intermediate List<T> if all spread elements have Length property.
+            {
+                Debug.Assert(elementType is { });
+
+                var implicitReceiverType = GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, node.Syntax).Construct(elementType);
+                implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, implicitReceiverType) { WasCompilerGenerated = true };
+
+                var analyzedArguments = AnalyzedArguments.GetInstance();
+                // https://github.com/dotnet/roslyn/issues/68785: Use well-known List<T> constructor directly
+                // rather than lookup, and use the constructor with `int capacity` when the size is known.
+                collectionCreation = BindClassCreationExpression(syntax, implicitReceiver!.Type.Name, syntax, implicitReceiverType, analyzedArguments, diagnostics);
+                collectionCreation.WasCompilerGenerated = true;
+                analyzedArguments.Free();
+
+                if (collectionTypeKind != CollectionExpressionTypeKind.ListInterface)
+                {
+                    _ = GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ToArray, diagnostics, syntax: syntax);
+                }
+            }
+
+            var builder = ArrayBuilder<BoundExpression>.GetInstance(elements.Length);
+
+            if (implicitReceiver is { })
+            {
+                var collectionInitializerAddMethodBinder = this.WithAdditionalFlags(BinderFlags.CollectionInitializerAddMethod);
+                foreach (var element in elements)
+                {
+                    BoundExpression convertedElement = BindCollectionExpressionElementAddMethod(
+                        element,
+                        collectionInitializerAddMethodBinder,
+                        implicitReceiver,
+                        diagnostics,
+                        out _);
+                    builder.Add(convertedElement);
+                }
+            }
+            else
+            {
+                var elementConversions = conversion.UnderlyingConversions;
+
+                Debug.Assert(elementType is { });
+                Debug.Assert(elements.Length == elementConversions.Length);
+                Debug.Assert(elementConversions.All(c => c.Exists));
+
+                for (int i = 0; i < elements.Length; i++)
+                {
+                    var element = elements[i];
+                    var elementConversion = elementConversions[i];
+                    var convertedElement = CreateConversion(
+                        element.Syntax,
+                        element,
+                        elementConversion,
+                        isCast: false,
+                        conversionGroupOpt: null,
+                        wasCompilerGenerated: true,
+                        destination: elementType,
+                        diagnostics);
+                    convertedElement.WasCompilerGenerated = true;
+                    builder.Add(convertedElement!);
+                }
+            }
+
+            return new BoundCollectionExpression(
+                syntax,
+                collectionTypeKind,
+                implicitReceiver,
+                collectionCreation,
+                collectionBuilderMethod,
+                builder.ToImmutableAndFree(),
+                targetType);
         }
 
         internal bool TryGetCollectionIterationType(ExpressionSyntax syntax, TypeSymbol collectionType, out TypeWithAnnotations iterationType)
@@ -564,170 +709,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindingDiagnosticBag.Discarded,
                 out iterationType,
                 builder: out _);
-        }
-
-        private BoundCollectionExpression BindArrayOrSpanCollectionExpression(
-            BoundUnconvertedCollectionExpression node,
-            TypeSymbol targetType,
-            bool wasCompilerGenerated,
-            CollectionExpressionTypeKind collectionTypeKind,
-            TypeSymbol elementType,
-            BindingDiagnosticBag diagnostics)
-        {
-            var syntax = node.Syntax;
-
-            switch (collectionTypeKind)
-            {
-                case CollectionExpressionTypeKind.Span:
-                    _ = GetWellKnownTypeMember(WellKnownMember.System_Span_T__ctor_Array, diagnostics, syntax: syntax);
-                    break;
-                case CollectionExpressionTypeKind.ReadOnlySpan:
-                    _ = GetWellKnownTypeMember(WellKnownMember.System_ReadOnlySpan_T__ctor_Array, diagnostics, syntax: syntax);
-                    break;
-            }
-
-            var elements = node.Elements;
-            if (elements.Any(e => e is BoundCollectionExpressionSpreadElement))
-            {
-                // The array initializer includes at least one spread element, so we'll create an intermediate List<T> instance.
-                // https://github.com/dotnet/roslyn/issues/68785: Avoid intermediate List<T> if all spread elements have Length property.
-                _ = GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ToArray, diagnostics, syntax: syntax);
-                var result = BindCollectionInitializerCollectionExpression(
-                    node,
-                    collectionTypeKind,
-                    GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, syntax).Construct(elementType),
-                    wasCompilerGenerated: wasCompilerGenerated,
-                    diagnostics);
-                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, targetType);
-            }
-
-            var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, targetType) { WasCompilerGenerated = true };
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(elements.Length);
-            foreach (var element in elements)
-            {
-                builder.Add(ConvertCollectionExpressionArrayElement(element, elementType, diagnostics));
-            }
-            return new BoundCollectionExpression(
-                syntax,
-                collectionTypeKind,
-                implicitReceiver,
-                collectionCreation: null,
-                collectionBuilderMethod: null,
-                builder.ToImmutableAndFree(),
-                targetType)
-            { WasCompilerGenerated = wasCompilerGenerated };
-        }
-
-        private BoundExpression ConvertCollectionExpressionArrayElement(BoundExpression element, TypeSymbol elementType, BindingDiagnosticBag diagnostics)
-        {
-            var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            var conversion = Conversions.ClassifyImplicitConversionFromExpression(element, elementType, ref useSiteInfo);
-            diagnostics.Add(element.Syntax, useSiteInfo);
-            bool hasErrors = !conversion.IsValid;
-            if (hasErrors)
-            {
-                GenerateImplicitConversionError(diagnostics, element.Syntax, conversion, element, elementType);
-                // Suppress any additional diagnostics
-                diagnostics = BindingDiagnosticBag.Discarded;
-            }
-            var result = CreateConversion(
-                element.Syntax,
-                element,
-                conversion,
-                isCast: false,
-                conversionGroupOpt: null,
-                wasCompilerGenerated: true,
-                destination: elementType,
-                diagnostics,
-                hasErrors: hasErrors);
-            result.WasCompilerGenerated = true;
-            return result;
-        }
-
-        private BoundCollectionExpression BindCollectionInitializerCollectionExpression(
-            BoundUnconvertedCollectionExpression node,
-            CollectionExpressionTypeKind collectionTypeKind,
-            TypeSymbol targetType,
-            bool wasCompilerGenerated,
-            BindingDiagnosticBag diagnostics,
-            bool hasErrors = false)
-        {
-            var syntax = node.Syntax;
-
-            BoundExpression collectionCreation;
-            if (targetType is NamedTypeSymbol namedType)
-            {
-                var analyzedArguments = AnalyzedArguments.GetInstance();
-                // https://github.com/dotnet/roslyn/issues/68785: Use ctor with `int capacity` when the size is known.
-                collectionCreation = BindClassCreationExpression(syntax, namedType.Name, syntax, namedType, analyzedArguments, diagnostics);
-                collectionCreation.WasCompilerGenerated = true;
-                analyzedArguments.Free();
-            }
-            else if (targetType is TypeParameterSymbol typeParameter)
-            {
-                var arguments = AnalyzedArguments.GetInstance();
-                collectionCreation = BindTypeParameterCreationExpression(syntax, typeParameter, arguments, initializerOpt: null, typeSyntax: syntax, wasTargetTyped: true, diagnostics);
-                arguments.Free();
-            }
-            else
-            {
-                collectionCreation = new BoundBadExpression(syntax, LookupResultKind.NotCreatable, ImmutableArray<Symbol?>.Empty, ImmutableArray<BoundExpression>.Empty, targetType);
-            }
-
-            var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, targetType) { WasCompilerGenerated = true };
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(node.Elements.Length);
-            if (node.Elements.Length > 0)
-            {
-                var collectionInitializerAddMethodBinder = this.WithAdditionalFlags(BinderFlags.CollectionInitializerAddMethod);
-                foreach (var element in node.Elements)
-                {
-                    var result = element switch
-                    {
-                        BoundBadExpression => element,
-                        BoundCollectionExpressionSpreadElement spreadElement => BindCollectionInitializerSpreadElementAddMethod(
-                                (SpreadElementSyntax)spreadElement.Syntax,
-                                spreadElement,
-                                collectionInitializerAddMethodBinder,
-                                implicitReceiver,
-                                diagnostics),
-                        _ => BindCollectionInitializerElementAddMethod(
-                            (ExpressionSyntax)element.Syntax,
-                            ImmutableArray.Create(element),
-                            hasEnumerableInitializerType: true,
-                            collectionInitializerAddMethodBinder,
-                            diagnostics,
-                            implicitReceiver),
-                    };
-                    result.WasCompilerGenerated = true;
-                    builder.Add(result);
-                }
-            }
-            return new BoundCollectionExpression(
-                syntax,
-                collectionTypeKind,
-                implicitReceiver,
-                collectionCreation,
-                collectionBuilderMethod: null,
-                builder.ToImmutableAndFree(),
-                targetType,
-                hasErrors)
-            { WasCompilerGenerated = wasCompilerGenerated };
-        }
-
-        private BoundCollectionExpression BindListInterfaceCollectionExpression(
-            BoundUnconvertedCollectionExpression node,
-            TypeSymbol targetType,
-            bool wasCompilerGenerated,
-            TypeSymbol elementType,
-            BindingDiagnosticBag diagnostics)
-        {
-            var result = BindCollectionInitializerCollectionExpression(
-                node,
-                CollectionExpressionTypeKind.ListInterface,
-                GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, node.Syntax).Construct(elementType),
-                wasCompilerGenerated: wasCompilerGenerated,
-                diagnostics);
-            return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, result.CollectionBuilderMethod, result.Elements, targetType);
         }
 
         private BoundCollectionExpression BindCollectionExpressionForErrorRecovery(
@@ -752,85 +733,87 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors: true);
         }
 
-        private BoundCollectionExpression BindCollectionBuilderCollectionExpression(
+        private void GenerateImplicitConversionErrorForCollectionExpression(
             BoundUnconvertedCollectionExpression node,
-            NamedTypeSymbol targetType,
-            bool wasCompilerGenerated,
+            TypeSymbol targetType,
             BindingDiagnosticBag diagnostics)
         {
-            var syntax = (ExpressionSyntax)node.Syntax;
-
-            bool hasAttribute = targetType.HasCollectionBuilderAttribute(out TypeSymbol? builderType, out string? methodName);
-            Debug.Assert(hasAttribute);
-
-            var targetTypeOriginalDefinition = targetType.OriginalDefinition;
-            TryGetCollectionIterationType(syntax, targetTypeOriginalDefinition, out TypeWithAnnotations elementTypeOriginalDefinition);
-            if (!elementTypeOriginalDefinition.HasType)
+            var collectionTypeKind = ConversionsBase.GetCollectionExpressionTypeKind(Compilation, targetType, out var elementType);
+            if (collectionTypeKind == CollectionExpressionTypeKind.CollectionBuilder &&
+                elementType is null)
             {
-                diagnostics.Add(ErrorCode.ERR_CollectionBuilderNoElementType, syntax, targetType);
-                return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                Error(diagnostics, ErrorCode.ERR_CollectionBuilderNoElementType, node.Syntax, targetType);
+                return;
             }
 
-            var constructMethod = GetCollectionBuilderMethod(syntax, targetType, elementTypeOriginalDefinition.Type, builderType, methodName, diagnostics);
-            if (constructMethod is null)
+            bool reportedErrors = false;
+
+            if (collectionTypeKind == CollectionExpressionTypeKind.CollectionInitializer)
             {
-                diagnostics.Add(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, syntax, methodName ?? "", elementTypeOriginalDefinition, targetTypeOriginalDefinition);
-                return BindCollectionExpressionForErrorRecovery(node, targetType, diagnostics);
+                BoundObjectOrCollectionValuePlaceholder? implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(node.Syntax, isNewInstance: true, targetType) { WasCompilerGenerated = true };
+                var collectionInitializerAddMethodBinder = this.WithAdditionalFlags(BinderFlags.CollectionInitializerAddMethod);
+                foreach (var element in node.Elements)
+                {
+                    _ = BindCollectionExpressionElementAddMethod(
+                        element,
+                        collectionInitializerAddMethodBinder,
+                        implicitReceiver,
+                        diagnostics,
+                        out bool hasErrors);
+                    reportedErrors = reportedErrors || hasErrors;
+                }
+                Debug.Assert(reportedErrors);
+            }
+            else if (collectionTypeKind != CollectionExpressionTypeKind.None &&
+                elementType is { })
+            {
+                var elements = node.Elements;
+                var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+                foreach (var element in elements)
+                {
+                    if (element is BoundCollectionExpressionSpreadElement spreadElement)
+                    {
+                        var enumeratorInfo = spreadElement.EnumeratorInfoOpt;
+                        if (enumeratorInfo is null)
+                        {
+                            Error(diagnostics, ErrorCode.ERR_NoImplicitConv, spreadElement.Expression.Syntax, spreadElement.Expression.Display, elementType);
+                            reportedErrors = true;
+                        }
+                        else
+                        {
+                            Conversion elementConversion = Conversions.GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo);
+                            if (!elementConversion.Exists)
+                            {
+                                GenerateImplicitConversionError(diagnostics, this.Compilation, spreadElement.Expression.Syntax, elementConversion, enumeratorInfo.ElementType, elementType);
+                                reportedErrors = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Conversion elementConversion = Conversions.ClassifyImplicitConversionFromExpression(element, elementType, ref useSiteInfo);
+                        if (!elementConversion.Exists)
+                        {
+                            GenerateImplicitConversionError(diagnostics, element.Syntax, elementConversion, element, elementType);
+                            reportedErrors = true;
+                        }
+                    }
+                }
+                Debug.Assert(reportedErrors);
             }
 
-            constructMethod.CheckConstraints(
-                new ConstraintsHelper.CheckConstraintsArgs(Compilation, Conversions, syntax.Location, diagnostics));
-
-            ReportDiagnosticsIfObsolete(diagnostics, constructMethod.ContainingType, syntax, hasBaseReceiver: false);
-            ReportDiagnosticsIfObsolete(diagnostics, constructMethod, syntax, hasBaseReceiver: false);
-            ReportDiagnosticsIfUnmanagedCallersOnly(diagnostics, constructMethod, syntax, isDelegateConversion: false);
-
-            var readOnlySpanType = (NamedTypeSymbol)constructMethod.Parameters[0].Type;
-            Debug.Assert(readOnlySpanType.OriginalDefinition.Equals(Compilation.GetWellKnownType(WellKnownType.System_ReadOnlySpan_T), TypeCompareKind.AllIgnoreOptions));
-
-            var elementType = readOnlySpanType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].Type;
-
-            var elements = node.Elements;
-            if (elements.Any(e => e is BoundCollectionExpressionSpreadElement))
+            if (!reportedErrors)
             {
-                // The array initializer includes at least one spread element, so we'll create an intermediate List<T> instance.
-                // https://github.com/dotnet/roslyn/issues/68785: Avoid intermediate List<T> if all spread elements have Length property.
-                // https://github.com/dotnet/roslyn/issues/68785: Use CollectionsMarshal.AsSpan<T>(List<T>) to create a span
-                // from the list, to avoid creating an additional intermediate array.
-                _ = GetWellKnownTypeMember(WellKnownMember.System_Collections_Generic_List_T__ToArray, diagnostics, syntax: syntax);
-                var result = BindCollectionInitializerCollectionExpression(
-                    node,
-                    CollectionExpressionTypeKind.CollectionBuilder,
-                    GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, diagnostics, syntax).Construct(elementType),
-                    wasCompilerGenerated: wasCompilerGenerated,
-                    diagnostics);
-                return result.Update(result.CollectionTypeKind, result.Placeholder, result.CollectionCreation, constructMethod, result.Elements, targetType);
+                Error(diagnostics, ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, node.Syntax, targetType);
             }
-
-            var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(syntax, isNewInstance: true, readOnlySpanType) { WasCompilerGenerated = true };
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(elements.Length);
-            foreach (var element in elements)
-            {
-                builder.Add(ConvertCollectionExpressionArrayElement(element, elementType, diagnostics));
-            }
-            return new BoundCollectionExpression(
-                syntax,
-                CollectionExpressionTypeKind.CollectionBuilder,
-                implicitReceiver,
-                collectionCreation: null,
-                collectionBuilderMethod: constructMethod,
-                builder.ToImmutableAndFree(),
-                targetType)
-            { WasCompilerGenerated = wasCompilerGenerated };
         }
 
         private MethodSymbol? GetCollectionBuilderMethod(
-            ExpressionSyntax syntax,
             NamedTypeSymbol targetType,
             TypeSymbol elementTypeOriginalDefinition,
             TypeSymbol? builderType,
             string? methodName,
-            BindingDiagnosticBag diagnostics)
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (!SourceNamedTypeSymbol.IsValidCollectionBuilderType(builderType))
             {
@@ -851,8 +834,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                var useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                if (!IsAccessible(method, ref useSiteInfo))
+                var accessibilityInfo = new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo);
+                if (!IsAccessible(method, ref accessibilityInfo))
                 {
                     continue;
                 }
@@ -887,13 +870,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     method = method.Construct(allTypeArguments);
                 }
+                else
+                {
+                    var spanElementType = ((NamedTypeSymbol)parameterType).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].Type;
+                    if (!elementTypeOriginalDefinition.Equals(spanElementType, TypeCompareKind.AllIgnoreOptions))
+                    {
+                        continue;
+                    }
+                }
 
                 if (!targetType.Equals(method.ReturnType, TypeCompareKind.AllIgnoreOptions))
                 {
                     continue;
                 }
 
-                diagnostics.Add(syntax, useSiteInfo);
+                useSiteInfo.AddDiagnostics(accessibilityInfo.Diagnostics);
                 return method;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5901,7 +5901,32 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        private BoundCollectionExpressionSpreadElement BindCollectionInitializerSpreadElementAddMethod(
+        internal BoundExpression BindCollectionExpressionElementAddMethod(
+            BoundExpression element,
+            Binder collectionInitializerAddMethodBinder,
+            BoundObjectOrCollectionValuePlaceholder implicitReceiver,
+            BindingDiagnosticBag diagnostics,
+            out bool hasErrors)
+        {
+            var result = element is BoundCollectionExpressionSpreadElement spreadElement ?
+                BindCollectionExpressionSpreadElementAddMethod(
+                    (SpreadElementSyntax)spreadElement.Syntax,
+                    spreadElement,
+                    collectionInitializerAddMethodBinder,
+                    implicitReceiver,
+                    diagnostics) :
+                BindCollectionInitializerElementAddMethod(
+                    (ExpressionSyntax)element.Syntax,
+                    ImmutableArray.Create(element),
+                    hasEnumerableInitializerType: true,
+                    collectionInitializerAddMethodBinder,
+                    diagnostics,
+                    implicitReceiver);
+            hasErrors = result.HasErrors;
+            return result;
+        }
+
+        private BoundCollectionExpressionSpreadElement BindCollectionExpressionSpreadElementAddMethod(
             SpreadElementSyntax syntax,
             BoundCollectionExpressionSpreadElement element,
             Binder collectionInitializerAddMethodBinder,
@@ -5913,7 +5938,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return element.Update(
                     BindToNaturalType(element.Expression, BindingDiagnosticBag.Discarded, reportNoTargetType: false),
-                    element.EnumeratorInfoOpt,
+                    enumeratorInfo,
                     element.ElementPlaceholder,
                     element.AddElementPlaceholder,
                     element.AddMethodInvocation,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2375,8 +2375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.UnconvertedCollectionExpression:
                     {
-                        Debug.Assert(operand.Type is null);
-                        Error(diagnostics, ErrorCode.ERR_CollectionExpressionTargetTypeNotConstructible, syntax, targetType);
+                        GenerateImplicitConversionErrorForCollectionExpression((BoundUnconvertedCollectionExpression)operand, targetType, diagnostics);
                         return;
                     }
                 case BoundKind.AddressOfOperator when targetType.IsFunctionPointer():

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -23,25 +23,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // most conversions are trivial and do not require additional data besides Kind
         // in uncommon cases an instance of this class is attached to the conversion.
-        private class UncommonData
+        private abstract class UncommonData
         {
-            public static readonly UncommonData NoApplicableOperators = new UncommonData(
+        }
+
+        private sealed class MethodUncommonData : UncommonData
+        {
+            public static readonly MethodUncommonData NoApplicableOperators = new MethodUncommonData(
                 isExtensionMethod: false,
                 isArrayIndex: false,
                 conversionResult: UserDefinedConversionResult.NoApplicableOperators(ImmutableArray<UserDefinedConversionAnalysis>.Empty),
-                conversionMethod: null,
-                nestedConversions: default);
+                conversionMethod: null);
 
-            public UncommonData(
+            public MethodUncommonData(
                 bool isExtensionMethod,
                 bool isArrayIndex,
                 UserDefinedConversionResult conversionResult,
-                MethodSymbol? conversionMethod,
-                ImmutableArray<Conversion> nestedConversions)
+                MethodSymbol? conversionMethod)
             {
                 _conversionMethod = conversionMethod;
                 _conversionResult = conversionResult;
-                _nestedConversionsOpt = nestedConversions;
 
                 _flags = isExtensionMethod ? IsExtensionMethodMask : (byte)0;
                 if (isArrayIndex)
@@ -51,10 +52,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             internal readonly MethodSymbol? _conversionMethod;
-            internal readonly ImmutableArray<Conversion> _nestedConversionsOpt;
-#if DEBUG
-            internal bool _nestedConversionsChecked;
-#endif
 
             //no effect on Equals/GetHashCode
             internal readonly UserDefinedConversionResult _conversionResult;
@@ -81,10 +78,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private class DeconstructionUncommonData : UncommonData
+        private class NestedUncommonData : UncommonData
+        {
+            public NestedUncommonData(ImmutableArray<Conversion> nestedConversions)
+            {
+                _nestedConversionsOpt = nestedConversions;
+            }
+
+            internal readonly ImmutableArray<Conversion> _nestedConversionsOpt;
+#if DEBUG
+            internal bool _nestedConversionsChecked;
+#endif
+        }
+
+        private sealed class DeconstructionUncommonData : UncommonData
         {
             internal DeconstructionUncommonData(DeconstructMethodInfo deconstructMethodInfoOpt, ImmutableArray<(BoundValuePlaceholder? placeholder, BoundExpression? conversion)> deconstructConversionInfo)
-                : base(isExtensionMethod: false, isArrayIndex: false, conversionResult: default, conversionMethod: null, nestedConversions: default)
             {
                 Debug.Assert(!deconstructConversionInfo.IsDefaultOrEmpty);
                 DeconstructMethodInfo = deconstructMethodInfoOpt;
@@ -95,17 +104,32 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal readonly ImmutableArray<(BoundValuePlaceholder? placeholder, BoundExpression? conversion)> DeconstructConversionInfo;
         }
 
+        private sealed class CollectionExpressionUncommonData : NestedUncommonData
+        {
+            internal CollectionExpressionUncommonData(CollectionExpressionTypeKind collectionExpressionTypeKind, TypeSymbol? elementType, ImmutableArray<Conversion> elementConversions) :
+                base(elementConversions)
+            {
+                CollectionExpressionTypeKind = collectionExpressionTypeKind;
+                ElementType = elementType;
+            }
+
+            internal readonly CollectionExpressionTypeKind CollectionExpressionTypeKind;
+            internal readonly TypeSymbol? ElementType;
+        }
+
+        internal static Conversion CreateCollectionExpressionConversion(CollectionExpressionTypeKind collectionExpressionTypeKind, TypeSymbol? elementType, ImmutableArray<Conversion> elementConversions)
+        {
+            return new Conversion(
+                ConversionKind.CollectionExpression,
+                new CollectionExpressionUncommonData(collectionExpressionTypeKind, elementType, elementConversions));
+        }
+
         private Conversion(
             ConversionKind kind,
-            UncommonData? uncommonData)
+            UncommonData? uncommonData = null)
         {
             _kind = kind;
             _uncommonData = uncommonData;
-        }
-
-        private Conversion(ConversionKind kind)
-            : this(kind, null)
-        {
         }
 
         internal Conversion(UserDefinedConversionResult conversionResult, bool isImplicit)
@@ -115,35 +139,29 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : isImplicit ? ConversionKind.ImplicitUserDefined : ConversionKind.ExplicitUserDefined;
 
             _uncommonData = conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators && conversionResult.Results.IsEmpty
-                ? UncommonData.NoApplicableOperators
-                : new UncommonData(
+                ? MethodUncommonData.NoApplicableOperators
+                : new MethodUncommonData(
                     isExtensionMethod: false,
                     isArrayIndex: false,
                     conversionResult: conversionResult,
-                    conversionMethod: null,
-                    nestedConversions: default);
+                    conversionMethod: null);
         }
 
         // For the method group, lambda and anonymous method conversions
         internal Conversion(ConversionKind kind, MethodSymbol conversionMethod, bool isExtensionMethod)
         {
             this._kind = kind;
-            _uncommonData = new UncommonData(
+            _uncommonData = new MethodUncommonData(
                 isExtensionMethod: isExtensionMethod,
                 isArrayIndex: false,
                 conversionResult: default,
-                conversionMethod: conversionMethod,
-                nestedConversions: default);
+                conversionMethod: conversionMethod);
         }
 
         internal Conversion(ConversionKind kind, ImmutableArray<Conversion> nestedConversions)
         {
             this._kind = kind;
-            _uncommonData = new UncommonData(
-                isExtensionMethod: false,
-                isArrayIndex: false,
-                conversionResult: default,
-                conversionMethod: null,
+            _uncommonData = new NestedUncommonData(
                 nestedConversions: nestedConversions);
         }
 
@@ -174,12 +192,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return new Conversion(
                 _kind,
-                new UncommonData(
+                new MethodUncommonData(
                     isExtensionMethod: false,
                     isArrayIndex: true,
                     conversionResult: default,
-                    conversionMethod: null,
-                    nestedConversions: default));
+                    conversionMethod: null));
         }
 
         [Conditional("DEBUG")]
@@ -350,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _uncommonData?.IsExtensionMethod == true;
+                return _uncommonData is MethodUncommonData { IsExtensionMethod: true };
             }
         }
 
@@ -358,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _uncommonData?.IsArrayIndex == true;
+                return _uncommonData is MethodUncommonData { IsArrayIndex: true };
             }
         }
 
@@ -366,7 +383,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _uncommonData?._nestedConversionsOpt ?? default(ImmutableArray<Conversion>);
+                return _uncommonData is NestedUncommonData { _nestedConversionsOpt: var conversions } ?
+                    conversions :
+                    default(ImmutableArray<Conversion>);
             }
         }
 
@@ -374,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal void AssertUnderlyingConversionsChecked()
         {
 #if DEBUG
-            Debug.Assert(_uncommonData?._nestedConversionsChecked ?? true);
+            Debug.Assert((_uncommonData as NestedUncommonData)?._nestedConversionsChecked ?? true);
 #endif
         }
 
@@ -404,9 +423,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal void MarkUnderlyingConversionsChecked()
         {
 #if DEBUG
-            if (_uncommonData is not null)
+            if (_uncommonData is NestedUncommonData nestedUncommonData)
             {
-                _uncommonData._nestedConversionsChecked = true;
+                nestedUncommonData._nestedConversionsChecked = true;
             }
 #endif
         }
@@ -417,7 +436,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             if (_uncommonData is not null)
             {
-                _uncommonData._nestedConversionsChecked = true;
+                if (_uncommonData is NestedUncommonData nestedUncommonData)
+                {
+                    nestedUncommonData._nestedConversionsChecked = true;
+                }
 
                 var underlyingConversions = UnderlyingConversions;
 
@@ -442,26 +464,28 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var uncommonData = _uncommonData;
-                if (uncommonData != null)
+                switch (_uncommonData)
                 {
-                    if (uncommonData._conversionMethod is object)
-                    {
-                        return uncommonData._conversionMethod;
-                    }
+                    case MethodUncommonData methodUncommonData:
+                        if (methodUncommonData._conversionMethod is { })
+                        {
+                            return methodUncommonData._conversionMethod;
+                        }
 
-                    var conversionResult = uncommonData._conversionResult;
-                    if (conversionResult.Kind == UserDefinedConversionResultKind.Valid)
-                    {
-                        UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
-                        return analysis.Operator;
-                    }
+                        var conversionResult = methodUncommonData._conversionResult;
+                        if (conversionResult.Kind == UserDefinedConversionResultKind.Valid)
+                        {
+                            UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
+                            return analysis.Operator;
+                        }
+                        break;
 
-                    if (uncommonData is DeconstructionUncommonData deconstruction
-                        && deconstruction.DeconstructMethodInfo.Invocation is BoundCall call)
-                    {
-                        return call.Method;
-                    }
+                    case DeconstructionUncommonData deconstructionUncommonData:
+                        if (deconstructionUncommonData.DeconstructMethodInfo.Invocation is BoundCall call)
+                        {
+                            return call.Method;
+                        }
+                        break;
                 }
 
                 return null;
@@ -472,10 +496,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var uncommonData = _uncommonData;
-                if (uncommonData != null && uncommonData._conversionMethod is null)
+                if (_uncommonData is MethodUncommonData { _conversionMethod: null } methodUncommonData)
                 {
-                    var conversionResult = uncommonData._conversionResult;
+                    var conversionResult = methodUncommonData._conversionResult;
                     if (conversionResult.Kind == UserDefinedConversionResultKind.Valid)
                     {
                         UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
@@ -505,6 +528,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal CollectionExpressionTypeKind GetCollectionExpressionTypeKind(out TypeSymbol? elementType)
+        {
+            if (_uncommonData is CollectionExpressionUncommonData collectionExpressionData)
+            {
+                elementType = collectionExpressionData.ElementType;
+                return collectionExpressionData.CollectionExpressionTypeKind;
+            }
+            elementType = null;
+            return CollectionExpressionTypeKind.None;
+        }
+
         // CONSIDER: public?
         internal bool IsValid
         {
@@ -515,10 +549,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                var nestedConversionsOpt = _uncommonData?._nestedConversionsOpt;
-                if (nestedConversionsOpt != null)
+                if (_uncommonData is NestedUncommonData { _nestedConversionsOpt: { IsDefault: false } nestedConversions })
                 {
-                    foreach (var conv in nestedConversionsOpt)
+                    foreach (var conv in nestedConversions)
                     {
                         if (!conv.IsValid)
                         {
@@ -532,7 +565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return !this.IsUserDefined ||
                     this.Method is object ||
-                    _uncommonData?._conversionResult.Kind == UserDefinedConversionResultKind.Valid;
+                    (_uncommonData as MethodUncommonData)?._conversionResult.Kind == UserDefinedConversionResultKind.Valid;
             }
         }
 
@@ -977,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var conversionResult = _uncommonData?._conversionResult ?? default(UserDefinedConversionResult);
+                var conversionResult = (_uncommonData as MethodUncommonData)?._conversionResult ?? default(UserDefinedConversionResult);
 
                 switch (conversionResult.Kind)
                 {
@@ -1043,23 +1076,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // the IDE wants information about the *inferred* method, not the original unconstructed
                 // generic method.
 
-                if (_uncommonData == null)
+                if (_uncommonData is MethodUncommonData { _conversionResult: { Kind: not UserDefinedConversionResultKind.NoApplicableOperators } conversionResult })
                 {
-                    return ImmutableArray<MethodSymbol>.Empty;
+                    var builder = ArrayBuilder<MethodSymbol>.GetInstance();
+                    foreach (var analysis in conversionResult.Results)
+                    {
+                        builder.Add(analysis.Operator);
+                    }
+                    return builder.ToImmutableAndFree();
                 }
 
-                var conversionResult = _uncommonData._conversionResult;
-                if (conversionResult.Kind == UserDefinedConversionResultKind.NoApplicableOperators)
-                {
-                    return ImmutableArray<MethodSymbol>.Empty;
-                }
-
-                var builder = ArrayBuilder<MethodSymbol>.GetInstance();
-                foreach (var analysis in conversionResult.Results)
-                {
-                    builder.Add(analysis.Operator);
-                }
-                return builder.ToImmutableAndFree();
+                return ImmutableArray<MethodSymbol>.Empty;
             }
         }
 
@@ -1067,14 +1094,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                if (_uncommonData == null)
-                {
-                    return null;
-                }
-
-                var conversionResult = _uncommonData._conversionResult;
-
-                if (conversionResult.Kind == UserDefinedConversionResultKind.Valid)
+                if (_uncommonData is MethodUncommonData { _conversionResult: { Kind: UserDefinedConversionResultKind.Valid } conversionResult })
                 {
                     UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
                     return analysis;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -74,6 +74,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected abstract Conversion GetInterpolatedStringConversion(BoundExpression source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo);
 
+#nullable enable
+        protected abstract Conversion GetCollectionExpressionConversion(BoundUnconvertedCollectionExpression source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo);
+#nullable disable
+
         protected abstract bool IsAttributeArgumentBinding { get; }
 
         protected abstract bool IsParameterDefaultValueBinding { get; }
@@ -1103,9 +1107,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return Conversion.ObjectCreation;
 
                 case BoundKind.UnconvertedCollectionExpression:
-                    if (GetCollectionExpressionTypeKind(Compilation, destination, out _) != CollectionExpressionTypeKind.None)
+                    var collectionExpressionConversion = GetCollectionExpressionConversion((BoundUnconvertedCollectionExpression)sourceExpression, destination, ref useSiteInfo);
+                    if (collectionExpressionConversion.Exists)
                     {
-                        return Conversion.CollectionExpression;
+                        return collectionExpressionConversion;
                     }
                     break;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
@@ -6,9 +6,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,6 +54,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override Conversion GetInterpolatedStringConversion(BoundExpression source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             // Conversions involving interpolated strings require a Binder.
+            throw ExceptionUtilities.Unreachable();
+        }
+
+        protected override Conversion GetCollectionExpressionConversion(BoundUnconvertedCollectionExpression source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            // Conversions involving collection expressions require a Binder.
             throw ExceptionUtilities.Unreachable();
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -59,9 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return objectCreation;
 
                 case ConversionKind.CollectionExpression:
-                    // Skip through target-typed collection expressions
-                    Debug.Assert(node.Type.Equals(node.Operand.Type, TypeCompareKind.AllIgnoreOptions));
-                    return VisitExpression(node.Operand)!;
+                    return RewriteCollectionExpressionConversion(node.Conversion, (BoundCollectionExpression)node.Operand);
             }
 
             var rewrittenType = VisitType(node.Type);

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/CollectionExpressionTests.cs
@@ -951,6 +951,223 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void OverloadResolution_ElementConversions_01()
+        {
+            string source = """
+                class Program
+                {
+                    static string[] F(string[] arg) => arg;
+                    static int?[] F(int?[] arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([null, 2, 3]);
+                        x.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(System.Nullable<System.Int32>[]) [null, 2, 3], ");
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_02()
+        {
+            string source = """
+                class Program
+                {
+                    static string[] F(string[] arg) => arg;
+                    static int?[] F(int?[] arg) => arg;
+                    static void Main()
+                    {
+                        int?[] x = [null, 2, 3];
+                        var y = F([..x]);
+                        y.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(System.Nullable<System.Int32>[]) [null, 2, 3], ");
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_03()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    private List<int> _items = new();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                    public void Add(int i) { _items.Add(i); }
+                }
+                class Program
+                {
+                    static MyCollection F(MyCollection arg) => arg;
+                    static int?[] F(int?[] arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([1, null]);
+                        x.Report(includeType: true);
+                        int?[] y = [null, 2];
+                        var z = F([..y]);
+                        z.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(System.Nullable<System.Int32>[]) [1, null], (System.Nullable<System.Int32>[]) [null, 2], ");
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_04()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection : IEnumerable
+                {
+                    private List<int?> _items = new();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                    public void Add(int? i) { _items.Add(i); }
+                }
+                class Program
+                {
+                    static MyCollection F(MyCollection arg) => arg;
+                    static int[] F(int[] arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([1, null]);
+                        x.Report(includeType: true);
+                        int?[] y = [null, 2];
+                        var z = F([..y]);
+                        z.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(MyCollection) [1, null], (MyCollection) [null, 2], ");
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_05()
+        {
+            string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+                class MyCollection1 : IEnumerable
+                {
+                    private List<int?> _items = new();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                    public void Add(int? i) { _items.Add(i); }
+                }
+                class MyCollection2 : IEnumerable
+                {
+                    private List<object> _items = new();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                    public void Add(int i) { _items.Add(i); }
+                    public void Add(string s) { _items.Add(s); }
+                }
+                class Program
+                {
+                    static MyCollection1 F(MyCollection1 arg) => arg;
+                    static MyCollection2 F(MyCollection2 arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([1, (string)null]);
+                        x.Report(includeType: true);
+                        int?[] y = [null, 2];
+                        var z = F([..y]);
+                        z.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(MyCollection2) [1, null], (MyCollection1) [null, 2], ");
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_06()
+        {
+            string sourceA = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create1))]
+                class MyCollection1 : IEnumerable<int?>
+                {
+                    private List<int?> _list;
+                    public MyCollection1(List<int?> list) { _list = list; }
+                    IEnumerator<int?> IEnumerable<int?>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create2))]
+                class MyCollection2 : IEnumerable<string>
+                {
+                    private List<string> _list;
+                    public MyCollection2(List<string> list) { _list = list; }
+                    IEnumerator<string> IEnumerable<string>.GetEnumerator() => _list.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+                }
+                class MyCollectionBuilder
+                {
+                    public static MyCollection1 Create1(ReadOnlySpan<int?> items) => new MyCollection1(new(items.ToArray()));
+                    public static MyCollection2 Create2(ReadOnlySpan<string> items) => new MyCollection2(new(items.ToArray()));
+                }
+                """;
+            string sourceB = """
+                class Program
+                {
+                    static MyCollection1 F(MyCollection1 arg) => arg;
+                    static MyCollection2 F(MyCollection2 arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([null, 2, 3]);
+                        x.Report(includeType: true);
+                        string[] y = [null];
+                        var z = F([..y]);
+                        z.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { sourceA, sourceB, s_collectionExtensions, CollectionBuilderAttributeDefinition },
+                targetFramework: TargetFramework.Net80,
+                verify: Verification.Fails,
+                expectedOutput: IncludeExpectedOutput("(MyCollection1) [null, 2, 3], (MyCollection2) [null], "));
+        }
+
+        [Fact]
+        public void OverloadResolution_ElementConversions_07()
+        {
+            string source = """
+                using System.Collections.Generic;
+                class Program
+                {
+                    static ICollection<string> F(ICollection<string> arg) => arg;
+                    static ICollection<int?> F(ICollection<int?> arg) => arg;
+                    static void Main()
+                    {
+                        var x = F([null, 2, 3]);
+                        x.Report(includeType: true);
+                        string[] y = [null];
+                        var z = F([..y]);
+                        z.Report(includeType: true);
+                    }
+                }
+                """;
+            CompileAndVerify(
+                new[] { source, s_collectionExtensions },
+                expectedOutput: "(System.Collections.Generic.List<System.Nullable<System.Int32>>) [null, 2, 3], (System.Collections.Generic.List<System.String>) [null], ");
+        }
+
+        [Fact]
         public void OverloadResolution_ArgumentErrors()
         {
             string source = """
@@ -1040,13 +1257,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("System.ReadOnlySpan<long>", "T[]", null)] // cannot convert long to int
         [InlineData("System.ReadOnlySpan<object>", "long[]", null)] // cannot convert object to long
         [InlineData("System.ReadOnlySpan<long>", "object[]", "System.ReadOnlySpan<System.Int64>")]
-        [InlineData("System.ReadOnlySpan<long>", "string[]", null)] // https://github.com/dotnet/roslyn/issues/69634: should use System.ReadOnlySpan<System.Int64>
+        [InlineData("System.ReadOnlySpan<long>", "string[]", "System.ReadOnlySpan<System.Int64>")]
         [InlineData("System.ReadOnlySpan<T>", "System.Span<T>", "System.Span<System.Int32>")] // implicit conversion from Span<T> to ReadOnlySpan<T>
         [InlineData("System.ReadOnlySpan<T>", "System.Span<int>", "System.Span<System.Int32>")]
         [InlineData("System.ReadOnlySpan<T>", "System.ReadOnlySpan<object>", null)] // cannot convert between ReadOnlySpan<int> and ReadOnlySpan<object>
         [InlineData("System.ReadOnlySpan<T>", "System.ReadOnlySpan<long>", null)] // cannot convert between ReadOnlySpan<int> and ReadOnlySpan<long>
         [InlineData("System.ReadOnlySpan<object>", "System.ReadOnlySpan<long>", null)] // cannot convert between ReadOnlySpan<object> and ReadOnlySpan<long>
-        [InlineData("System.ReadOnlySpan<int>", "System.ReadOnlySpan<string>", null)] // https://github.com/dotnet/roslyn/issues/69634: should use System.ReadOnlySpan<System.Int32>
+        [InlineData("System.ReadOnlySpan<int>", "System.ReadOnlySpan<string>", "System.ReadOnlySpan<System.Int32>")]
         [InlineData("System.Span<int>", "int?[]", "System.Span<System.Int32>")]
         [InlineData("System.Span<int?>", "int[]", null)] // cannot convert int? to int
         [InlineData("System.Collections.Generic.List<int>", "System.Collections.Generic.IEnumerable<int>", "System.Collections.Generic.List<System.Int32>")]
@@ -1185,6 +1402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_AmbigCall, "ArrayDerived").WithArguments("Program.ArrayDerived(System.Span<object>)", "Program.ArrayDerived(string[])").WithLocation(6, 9));
         }
 
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69634")]
         [Fact]
         public void BetterConversionFromExpression_03()
         {
@@ -1207,7 +1425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         Unrelated(new[] { 1 }); // Span<int>
                         Unrelated(new[] { string.Empty }); // string[]
 
-                        Unrelated([2]); // Span<string>
+                        Unrelated([2]); // Span<int>
                         Unrelated([string.Empty]); // string[]
                     }
                 }
@@ -1216,14 +1434,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 new[] { sourceA, sourceB1 },
                 targetFramework: TargetFramework.Net80,
                 options: TestOptions.ReleaseExe);
-            // https://github.com/dotnet/roslyn/issues/69634: Should use Span<int>, string[], Span<int>, string[]
-            comp.VerifyEmitDiagnostics(
-                // 1.cs(8,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Unrelated(Span<int>)' and 'Program.Unrelated(string[])'
-                //         Unrelated([2]); // Span<string>
-                Diagnostic(ErrorCode.ERR_AmbigCall, "Unrelated").WithArguments("Program.Unrelated(System.Span<int>)", "Program.Unrelated(string[])").WithLocation(8, 9),
-                // 1.cs(9,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Unrelated(Span<int>)' and 'Program.Unrelated(string[])'
-                //         Unrelated([string.Empty]); // string[]
-                Diagnostic(ErrorCode.ERR_AmbigCall, "Unrelated").WithArguments("Program.Unrelated(System.Span<int>)", "Program.Unrelated(string[])").WithLocation(9, 9));
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("""
+                Span<int>
+                string[]
+                Span<int>
+                string[]
+                """));
 
             string sourceB2 = """
                 partial class Program
@@ -1258,9 +1474,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 class Program
                 {
                     static void F1(int[] x, int[] y) { throw null; }
-                    static void F1(Span<object> x, ReadOnlySpan<int> y) { }
+                    static void F1(Span<object> x, ReadOnlySpan<int> y) { x.Report(); y.Report(); }
                     static void F2(object x, string[] y) { throw null; }
-                    static void F2(string x, Span<object> y) { }
+                    static void F2(string x, Span<object> y) { y.Report(); }
                     static void Main()
                     {
                         F1([1], [2]);
@@ -1269,10 +1485,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 """;
             CompileAndVerify(
-                source,
+                new[] { source, s_collectionExtensionsWithSpan },
                 targetFramework: TargetFramework.Net80,
                 verify: Verification.Skipped,
-                expectedOutput: IncludeExpectedOutput(""));
+                expectedOutput: IncludeExpectedOutput("[1], [2], [4], "));
         }
 
         [Fact]
@@ -1552,9 +1768,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (9,9): error CS0411: The type arguments for method 'Program.AsArray<T>(T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         AsArray([]);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "AsArray").WithArguments("Program.AsArray<T>(T[])").WithLocation(9, 9),
-                // (10,21): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
+                // (10,17): error CS1503: Argument 1: cannot convert from 'collection expressions' to 'int[]'
                 //         AsArray([1, null]);
-                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(10, 21));
+                Diagnostic(ErrorCode.ERR_BadArgType, "[1, null]").WithArguments("1", "collection expressions", "int[]").WithLocation(10, 17));
         }
 
         [Fact]
@@ -2122,18 +2338,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (6,11): error CS1729: 'string' does not contain a constructor that takes 0 arguments
                 //         F([], ['B']);
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[]").WithArguments("string", "0").WithLocation(6, 11),
-                // (7,11): error CS1729: 'string' does not contain a constructor that takes 0 arguments
+                // (7,11): error CS1503: Argument 1: cannot convert from 'collection expressions' to 'string'
                 //         F([default], ['B']);
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[default]").WithArguments("string", "0").WithLocation(7, 11),
-                // (7,12): error CS1061: 'string' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         F([default], ['B']);
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "default").WithArguments("string", "Add").WithLocation(7, 12),
-                // (8,11): error CS1729: 'string' does not contain a constructor that takes 0 arguments
+                Diagnostic(ErrorCode.ERR_BadArgType, "[default]").WithArguments("1", "collection expressions", "string").WithLocation(7, 11),
+                // (8,11): error CS1503: Argument 1: cannot convert from 'collection expressions' to 'string'
                 //         F(['A'], ['B']);
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "['A']").WithArguments("string", "0").WithLocation(8, 11),
-                // (8,12): error CS1061: 'string' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
-                //         F(['A'], ['B']);
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "'A'").WithArguments("string", "Add").WithLocation(8, 12));
+                Diagnostic(ErrorCode.ERR_BadArgType, "['A']").WithArguments("1", "collection expressions", "string").WithLocation(8, 11));
         }
 
         [Fact]
@@ -4394,9 +4604,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (6,13): error CS1729: 'string' does not contain a constructor that takes 0 arguments
                 //         s = [];
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "[]").WithArguments("string", "0").WithLocation(6, 13),
-                // (7,13): error CS1729: 'string' does not contain a constructor that takes 0 arguments
-                //         s = ['a'];
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "['a']").WithArguments("string", "0").WithLocation(7, 13),
                 // (7,14): error CS1061: 'string' does not contain a definition for 'Add' and no accessible extension method 'Add' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         s = ['a'];
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "'a'").WithArguments("string", "Add").WithLocation(7, 14));
@@ -4634,16 +4841,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             comp = CreateCompilation(new[] { sourceC, s_collectionExtensions }, references: new[] { refB });
             comp.VerifyEmitDiagnostics(
-                // (6,13): error CS0012: The type 'A1' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // 0.cs(6,13): error CS0012: The type 'A1' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         x = [];
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "[]").WithArguments("A1", $"{assemblyA}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(6, 13),
-                // (8,13): error CS0012: The type 'A1' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // 0.cs(8,13): error CS0012: The type 'A1' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         x = [1, 2];
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "[1, 2]").WithArguments("A1", $"{assemblyA}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(8, 13),
-                // (13,14): error CS0012: The type 'A2' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // 0.cs(13,14): error CS0012: The type 'A2' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         y = [3, 4];
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "3").WithArguments("A2", $"{assemblyA}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(13, 14),
-                // (13,17): error CS0012: The type 'A2' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // 0.cs(13,17): error CS0012: The type 'A2' is defined in an assembly that is not referenced. You must add a reference to assembly 'a897d975-a839-4fff-828b-deccf9495adc, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         y = [3, 4];
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "4").WithArguments("A2", $"{assemblyA}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(13, 17));
         }
@@ -5471,12 +5678,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (6,11): error CS1503: Argument 1: cannot convert from 'collection expressions' to 'System.Collections.IEnumerable'
                 //         F([1, 2, 3]);
                 Diagnostic(ErrorCode.ERR_BadArgType, "[1, 2, 3]").WithArguments("1", "collection expressions", "System.Collections.IEnumerable").WithLocation(6, 11),
-                // (8,39): error CS1950: The best overloaded Add method 'List<int>.Add(int)' for the collection initializer has some invalid arguments
+                // (8,41): error CS0029: Cannot implicitly convert type 'object' to 'int'
                 //     static int[] F(IEnumerable s) => [..s];
-                Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "..s").WithArguments("System.Collections.Generic.List<int>.Add(int)").WithLocation(8, 39),
-                // (8,39): error CS1503: Argument 1: cannot convert from 'object' to 'int'
-                //     static int[] F(IEnumerable s) => [..s];
-                Diagnostic(ErrorCode.ERR_BadArgType, "..s").WithArguments("1", "object", "int").WithLocation(8, 39));
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "s").WithArguments("object", "int").WithLocation(8, 41));
         }
 
         [Theory]
@@ -5570,6 +5774,66 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     }
                     """);
             }
+        }
+
+        [Fact]
+        public void SpreadElement_12()
+        {
+            string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        object x = new[] { 2, 3 };
+                        int[] y = [1, ..x];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,25): error CS1579: foreach statement cannot operate on variables of type 'object' because 'object' does not contain a public instance or extension definition for 'GetEnumerator'
+                //         int[] y = [1, ..x];
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "x").WithArguments("object", "GetEnumerator").WithLocation(6, 25));
+        }
+
+        [Fact]
+        public void SpreadElement_Dynamic_02()
+        {
+            string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        dynamic x = new[] { 2, 3 };
+                        object[] y = [1, ..x];
+                        y.Report();
+                    }
+                }
+                """;
+            CompileAndVerify(new[] { source, s_collectionExtensions }, references: new[] { CSharpRef }, expectedOutput: "[1, 2, 3], ");
+        }
+
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69704")]
+        [Fact]
+        public void SpreadElement_Dynamic_03()
+        {
+            string source = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        dynamic x = new[] { 2, 3 };
+                        int[] y = [1, ..x];
+                        y.Report();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(new[] { source, s_collectionExtensions }, references: new[] { CSharpRef });
+            // https://github.com/dotnet/roslyn/issues/69704: Should compile and run with expectedOutput: "[1, 2, 3], "
+            comp.VerifyEmitDiagnostics(
+                // 0.cs(6,25): error CS0029: Cannot implicitly convert type 'object' to 'int'
+                //         int[] y = [1, ..x];
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "x").WithArguments("object", "int").WithLocation(6, 25));
         }
 
         [Fact]
@@ -7431,6 +7695,75 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 targetFramework: TargetFramework.Net80,
                 verify: Verification.Fails,
                 expectedOutput: IncludeExpectedOutput("(C<System.String>) [null], (C<System.Int32>) [E(1), null], "));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ElementTypeMismatch_01()
+        {
+            string source = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                class MyCollection : IEnumerable
+                {
+                    private List<string> _items;
+                    public MyCollection(List<string> items) { _items = items; }
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+                class MyCollectionBuilder
+                {
+                    public static MyCollection Create(ReadOnlySpan<string> items) => new MyCollection(new(items.ToArray()));
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c = [null];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (20,26): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<object>' and return type 'MyCollection'.
+                //         MyCollection c = [null];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[null]").WithArguments("Create", "object", "MyCollection").WithLocation(20, 26));
+        }
+
+        [Fact]
+        public void CollectionBuilder_ElementTypeMismatch_02()
+        {
+            string source = """
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using System.Runtime.CompilerServices;
+                [CollectionBuilder(typeof(MyCollectionBuilder), nameof(MyCollectionBuilder.Create))]
+                class MyCollection : IEnumerable<object>
+                {
+                    private List<string> _items;
+                    public MyCollection(List<string> items) { _items = items; }
+                    IEnumerator<object> IEnumerable<object>.GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+                class MyCollectionBuilder
+                {
+                    public static MyCollection Create(ReadOnlySpan<string> items) => new MyCollection(new(items.ToArray()));
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection c = [null];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (21,26): error CS9187: Could not find an accessible 'Create' method with the expected signature: a static method with a single parameter of type 'ReadOnlySpan<object>' and return type 'MyCollection'.
+                //         MyCollection c = [null];
+                Diagnostic(ErrorCode.ERR_CollectionBuilderAttributeMethodNotFound, "[null]").WithArguments("Create", "object", "MyCollection").WithLocation(21, 26));
         }
 
         [CombinatorialData]
@@ -9822,7 +10155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // 0.cs(24,31): error CS9188: 'MyCollection<int>' has a CollectionBuilderAttribute but no element type.
+                // (24,31): error CS9188: 'MyCollection<int>' has a CollectionBuilderAttribute but no element type.
                 //         MyCollection<int> c = [];
                 Diagnostic(ErrorCode.ERR_CollectionBuilderNoElementType, "[]").WithArguments("MyCollection<int>").WithLocation(24, 31));
         }
@@ -9896,10 +10229,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """;
             var comp = CreateCompilation(source, targetFramework: TargetFramework.Net80);
             comp.VerifyEmitDiagnostics(
-                // 0.cs(8,42): error CS9188: 'MyCollection<T>' has a CollectionBuilderAttribute but no element type.
+                // (8,42): error CS9188: 'MyCollection<T>' has a CollectionBuilderAttribute but no element type.
                 //     public static MyCollection<T> F() => [];
                 Diagnostic(ErrorCode.ERR_CollectionBuilderNoElementType, "[]").WithArguments("MyCollection<T>").WithLocation(8, 42),
-                // 0.cs(18,31): error CS9188: 'MyCollection<int>' has a CollectionBuilderAttribute but no element type.
+                // (18,31): error CS9188: 'MyCollection<int>' has a CollectionBuilderAttribute but no element type.
                 //         MyCollection<int> c = [];
                 Diagnostic(ErrorCode.ERR_CollectionBuilderNoElementType, "[]").WithArguments("MyCollection<int>").WithLocation(18, 31));
         }
@@ -10052,6 +10385,123 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // (7,34): error CS0518: Predefined type 'System.Int32' is not defined or imported
                 //         MyCollection<string> y = ["2"];
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"[""2""]").WithArguments("System.Int32").WithLocation(7, 34));
+        }
+
+        [Fact]
+        public void CollectionBuilder_UseSiteError_Method()
+        {
+            // [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+            // public sealed class MyCollection<T>
+            // {
+            //     public IEnumerator<T> GetEnumerator() { }
+            // }
+            // public static class MyCollectionBuilder
+            // {
+            //     [CompilerFeatureRequired("MyFeature")]
+            //     public static MyCollection<T> MyCollectionBuilder.Create<T>(ReadOnlySpan<T>) { }
+            // }
+            string sourceA = """
+                .assembly extern System.Runtime { .ver 8:0:0:0 .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A) }
+                .class public sealed MyCollection`1<T>
+                {
+                  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CollectionBuilderAttribute::.ctor(class [System.Runtime]System.Type, string) = { type(MyCollectionBuilder) string('Create') }
+                  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+                  .method public instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!T> GetEnumerator() { ldnull ret }
+                }
+                .class public abstract sealed MyCollectionBuilder
+                {
+                  .method public static class MyCollection`1<!!T> Create<T>(valuetype [System.Runtime]System.ReadOnlySpan`1<!!T> items)
+                  {
+                    .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = { string('MyFeature') }
+                    ldnull ret
+                  }
+                }
+                """;
+            var refA = CompileIL(sourceA);
+
+            string sourceB = """
+                #pragma warning disable 219
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> x = [];
+                        MyCollection<string> y = [null];
+                        MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,31): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<int> x = [];
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "[]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(6, 31),
+                // (7,34): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<string> y = [null];
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "[null]").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(7, 34),
+                // (8,54): error CS9041: 'MyCollectionBuilder.Create<T>(ReadOnlySpan<T>)' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder.Create<T>(System.ReadOnlySpan<T>)", "MyFeature").WithLocation(8, 54));
+        }
+
+        [Fact]
+        public void CollectionBuilder_UseSiteError_ContainingType()
+        {
+            // [CollectionBuilder(typeof(MyCollectionBuilder), "Create")]
+            // public sealed class MyCollection<T>
+            // {
+            //     public IEnumerator<T> GetEnumerator() { }
+            // }
+            // [CompilerFeatureRequired("MyFeature")]
+            // public static class MyCollectionBuilder
+            // {
+            //     public static MyCollection<T> MyCollectionBuilder.Create<T>(ReadOnlySpan<T>) { }
+            // }
+            string sourceA = """
+                .assembly extern System.Runtime { .ver 8:0:0:0 .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A) }
+                .class public sealed MyCollection`1<T>
+                {
+                  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CollectionBuilderAttribute::.ctor(class [System.Runtime]System.Type, string) = { type(MyCollectionBuilder) string('Create') }
+                  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+                  .method public instance class [System.Runtime]System.Collections.Generic.IEnumerator`1<!T> GetEnumerator() { ldnull ret }
+                }
+                .class public abstract sealed MyCollectionBuilder
+                {
+                  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute::.ctor(string) = { string('MyFeature') }
+                  .method public static class MyCollection`1<!!T> Create<T>(valuetype [System.Runtime]System.ReadOnlySpan`1<!!T> items)
+                  {
+                    ldnull ret
+                  }
+                }
+                """;
+            var refA = CompileIL(sourceA);
+
+            string sourceB = """
+                #pragma warning disable 219
+                class Program
+                {
+                    static void Main()
+                    {
+                        MyCollection<int> x = [];
+                        MyCollection<string> y = [null];
+                        MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                    }
+                }
+                """;
+            var comp = CreateCompilation(sourceB, references: new[] { refA }, targetFramework: TargetFramework.Net80);
+            comp.VerifyEmitDiagnostics(
+                // (6,31): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<int> x = [];
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "[]").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(6, 31),
+                // (7,34): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<string> y = [null];
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "[null]").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(7, 34),
+                // (8,34): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "MyCollectionBuilder").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(8, 34),
+                // (8,54): error CS9041: 'MyCollectionBuilder' requires compiler feature 'MyFeature', which is not supported by this version of the C# compiler.
+                //         MyCollection<object> z = MyCollectionBuilder.Create<object>(default);
+                Diagnostic(ErrorCode.ERR_UnsupportedCompilerFeature, "Create<object>").WithArguments("MyCollectionBuilder", "MyFeature").WithLocation(8, 54));
         }
 
         [Fact]
@@ -10562,7 +11012,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         => new MyCollection<T>(new List<T>(items.ToArray()));
                 }
                 """;
-            var comp = CreateCompilation(new[] { sourceA, CollectionBuilderAttributeDefinition }, targetFramework: targetFramework);
+            var comp = CreateCompilation(
+                targetFramework == TargetFramework.Net80 ? new[] { sourceA } : new[] { sourceA, CollectionBuilderAttributeDefinition },
+                targetFramework: targetFramework);
             comp.VerifyEmitDiagnostics();
             var refA = comp.EmitToImageReference();
 
@@ -13405,7 +13857,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         => new MyCollection<T>(new List<T>(items.ToArray()));
                 }
                 """;
-            var comp = CreateCompilation(new[] { sourceA, CollectionBuilderAttributeDefinition }, targetFramework: targetFramework);
+            var comp = CreateCompilation(
+                targetFramework == TargetFramework.Net80 ? new[] { sourceA } : new[] { sourceA, CollectionBuilderAttributeDefinition },
+                targetFramework: targetFramework);
             comp.VerifyEmitDiagnostics();
             var refA = comp.EmitToImageReference();
 


### PR DESCRIPTION
Check that the collection expression elements are implicitly convertible to the iteration type of the target type (see [conversions](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#conversions)).

Previously, the *collection expression conversion* calculation only considered whether the target type was a valid collection type. That meant overloads could be considered applicable, even though binding might fail for some of those overloads.

This change adds a `CollectionExpressionUncommonData` type that holds the element type and implicit element conversions for a *collection expression conversion*.

Fixes https://github.com/dotnet/roslyn/issues/69634