### PR TITLE
Add ctor to Stack Trace Explorer

### DIFF
--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
@@ -34,6 +34,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
                     argumentList: EmptyParams)
                 );
 
+        [Fact]
+        public void TestStaticCtor()
+            => Verify(
+                @"at ConsoleApp4.MyClass..cctor()",
+                methodDeclaration: MethodDeclaration(
+                    QualifiedName(
+                        QualifiedName(
+                            Identifier("ConsoleApp4", leadingTrivia: AtTrivia),
+                            Identifier("MyClass")),
+                        StaticConstructor),
+                    argumentList: EmptyParams)
+                );
+
         [Theory]
         [InlineData("C", 1)]
         [InlineData("C", 100)]

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
@@ -21,6 +21,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
                     argumentList: EmptyParams)
                 );
 
+        [Fact]
+        public void TestCtor()
+            => Verify(
+                @"at ConsoleApp4.MyClass..ctor()",
+                methodDeclaration: MethodDeclaration(
+                    QualifiedName(
+                        QualifiedName(
+                            Identifier("ConsoleApp4", leadingTrivia: AtTrivia),
+                            Identifier("MyClass")),
+                        Constructor),
+                    argumentList: EmptyParams)
+                );
+
         [Theory]
         [InlineData("C", 1)]
         [InlineData("C", 100)]
@@ -423,6 +436,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
         [InlineData("M.N(\r\n)")]
         [InlineData("M.N(\r)")]
         [InlineData("M.N(\n)")]
+        [InlineData("at M..ctor.N()")] // Constructor on lhs of qualified name
         public void TestInvalidInputs(string input)
             => Verify(input, expectFailure: true);
 

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
@@ -46,10 +46,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
         public static readonly StackFrameToken ColonToken = CreateToken(StackFrameKind.ColonToken, ":");
         public static readonly StackFrameToken DollarToken = CreateToken(StackFrameKind.DollarToken, "$");
         public static readonly StackFrameToken PipeToken = CreateToken(StackFrameKind.PipeToken, "|");
+        public static readonly StackFrameToken ConstructorToken = CreateToken(StackFrameKind.ConstructorToken, ".ctor");
 
         public static readonly StackFrameTrivia AtTrivia = CreateTrivia(StackFrameKind.AtTrivia, "at ");
         public static readonly StackFrameTrivia LineTrivia = CreateTrivia(StackFrameKind.LineTrivia, "line ");
         public static readonly StackFrameTrivia InTrivia = CreateTrivia(StackFrameKind.InTrivia, " in ");
+
+        public static readonly StackFrameConstructorNode Constructor = new(ConstructorToken);
 
         public static readonly StackFrameParameterList EmptyParams = ParameterList(OpenParenToken, CloseParenToken);
 

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
@@ -47,12 +47,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
         public static readonly StackFrameToken DollarToken = CreateToken(StackFrameKind.DollarToken, "$");
         public static readonly StackFrameToken PipeToken = CreateToken(StackFrameKind.PipeToken, "|");
         public static readonly StackFrameToken ConstructorToken = CreateToken(StackFrameKind.ConstructorToken, ".ctor");
+        public static readonly StackFrameToken StaticConstructorToken = CreateToken(StackFrameKind.ConstructorToken, ".cctor");
 
         public static readonly StackFrameTrivia AtTrivia = CreateTrivia(StackFrameKind.AtTrivia, "at ");
         public static readonly StackFrameTrivia LineTrivia = CreateTrivia(StackFrameKind.LineTrivia, "line ");
         public static readonly StackFrameTrivia InTrivia = CreateTrivia(StackFrameKind.InTrivia, " in ");
 
         public static readonly StackFrameConstructorNode Constructor = new(ConstructorToken);
+        public static readonly StackFrameConstructorNode StaticConstructor = new(StaticConstructorToken);
 
         public static readonly StackFrameParameterList EmptyParams = ParameterList(OpenParenToken, CloseParenToken);
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/IStackFrameNodeVisitor.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/IStackFrameNodeVisitor.cs
@@ -19,5 +19,6 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         void Visit(StackFrameParameterDeclarationNode node);
         void Visit(StackFrameGeneratedMethodNameNode stackFrameGeneratedNameNode);
         void Visit(StackFrameLocalMethodNameNode stackFrameLocalMethodNameNode);
+        void Visit(StackFrameConstructorNode constructorNode);
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameKind.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameKind.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         ParameterList,
         ArrayExpression,
         FileInformation,
+        Constructor,
 
         // Tokens 
         EndOfFrame,
@@ -49,6 +50,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         PipeToken,
         GeneratedNameSeparatorToken, // {character}__{identifier}
         GeneratedNameSuffixToken, // {numeric}_{numeric}
+        ConstructorToken, // .ctor
 
         // Trivia
         WhitespaceTrivia,

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -91,6 +91,12 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
             var ch = CurrentChar;
             if (!UnicodeCharacterUtilities.IsIdentifierStartCharacter((char)ch.Value))
             {
+                var ctor = TryScanStringToken(".ctor", StackFrameKind.ConstructorToken);
+                if (ctor.HasValue)
+                {
+                    return ctor.Value;
+                }
+
                 // If we scan only trivia but don't get an identifier, we want to make sure
                 // to reset back to this original position to let the trivia be consumed
                 // in some other fashion if necessary 
@@ -454,6 +460,19 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
                 Position += valueToLookFor.Length;
 
                 return CreateTrivia(triviaKind, GetSubSequenceToCurrentPos(start));
+            }
+
+            return null;
+        }
+
+        private StackFrameToken? TryScanStringToken(string valueToLookFor, StackFrameKind tokenKind)
+        {
+            if (IsStringAtPosition(valueToLookFor))
+            {
+                var start = Position;
+                Position += valueToLookFor.Length;
+
+                return CreateToken(tokenKind, GetSubSequenceToCurrentPos(start));
             }
 
             return null;

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -500,13 +500,8 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         /// </summary>
         private StackFrameToken? TryScanConstructor()
         {
-            var ctor = TryScanStringToken(".ctor", StackFrameKind.ConstructorToken);
-            if (ctor.HasValue)
-            {
-                return ctor;
-            }
-
-            return TryScanStringToken(".cctor", StackFrameKind.ConstructorToken);
+            return TryScanStringToken(".ctor", StackFrameKind.ConstructorToken) ??
+                   TryScanStringToken(".cctor", StackFrameKind.ConstructorToken);
         }
 
         private static StackFrameKind GetKind(VirtualChar ch)

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
             var ch = CurrentChar;
             if (!UnicodeCharacterUtilities.IsIdentifierStartCharacter((char)ch.Value))
             {
-                var ctor = TryScanStringToken(".ctor", StackFrameKind.ConstructorToken);
+                var ctor = TryScanConstructor();
                 if (ctor.HasValue)
                 {
                     return ctor.Value;
@@ -493,6 +493,20 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
             }
 
             return CreateTrivia(StackFrameKind.WhitespaceTrivia, GetSubSequenceToCurrentPos(startPosition));
+        }
+
+        /// <summary>
+        /// Scans for .ctor or .cctor as a ConstructorToken
+        /// </summary>
+        private StackFrameToken? TryScanConstructor()
+        {
+            var ctor = TryScanStringToken(".ctor", StackFrameKind.ConstructorToken);
+            if (ctor.HasValue)
+            {
+                return ctor;
+            }
+
+            return TryScanStringToken(".cctor", StackFrameKind.ConstructorToken);
         }
 
         private static StackFrameKind GetKind(VirtualChar ch)

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameNodeDefinitions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
 
         protected StackFrameSimpleNameNode(StackFrameToken identifier, StackFrameKind kind) : base(kind)
         {
-            Debug.Assert(identifier.Kind == StackFrameKind.IdentifierToken);
+            Debug.Assert(identifier.Kind is StackFrameKind.IdentifierToken or StackFrameKind.ConstructorToken);
             Identifier = identifier;
         }
     }
@@ -105,6 +105,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         public StackFrameQualifiedNameNode(StackFrameNameNode left, StackFrameToken dotToken, StackFrameSimpleNameNode right) : base(StackFrameKind.MemberAccess)
         {
             Debug.Assert(dotToken.Kind == StackFrameKind.DotToken);
+            Debug.Assert(left.Kind is not StackFrameKind.Constructor);
 
             Left = left;
             DotToken = dotToken;
@@ -130,6 +131,21 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
     /// The simplest identifier node, which wraps a <see cref="StackFrameKind.IdentifierToken" />
     /// </summary>
     internal sealed class StackFrameIdentifierNameNode(StackFrameToken identifier) : StackFrameSimpleNameNode(identifier, StackFrameKind.TypeIdentifier)
+    {
+        internal override int ChildCount => 1;
+
+        public override void Accept(IStackFrameNodeVisitor visitor)
+            => visitor.Visit(this);
+
+        internal override StackFrameNodeOrToken ChildAt(int index)
+            => index switch
+            {
+                0 => Identifier,
+                _ => throw new InvalidOperationException()
+            };
+    }
+
+    internal sealed class StackFrameConstructorNode(StackFrameToken constructor) : StackFrameSimpleNameNode(constructor, StackFrameKind.Constructor)
     {
         internal override int ChildCount => 1;
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameParser.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameParser.cs
@@ -191,6 +191,13 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
                 return Result<StackFrameQualifiedNameNode>.Empty;
             }
 
+            if (lhs.Kind is StackFrameKind.Constructor ||
+                lhs is StackFrameQualifiedNameNode { Right.Kind: StackFrameKind.Constructor })
+            {
+                // Constructors cannot be the lhs of a qualified name
+                return Result<StackFrameQualifiedNameNode>.Abort;
+            }
+
             // Check if this is a generated identifier
             (var success, StackFrameSimpleNameNode? rhs) = TryScanGeneratedName();
             if (!success)
@@ -327,6 +334,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         {
             if (!_lexer.ScanCurrentCharAsTokenIfMatch(StackFrameKind.GraveAccentToken, out var graveAccentToken))
             {
+                if (identifierToken.Kind == StackFrameKind.ConstructorToken)
+                {
+                    return new(new StackFrameConstructorNode(identifierToken));
+                }
+
                 return new(new StackFrameIdentifierNameNode(identifierToken));
             }
 


### PR DESCRIPTION
This updates the lexer/parser to add a ctor specific node and token. Once this is done, symbol lookup worked correctly in testing a few cases.