### PR TITLE
Find symbols defined in a source-generated compilation in the originating compilation

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
@@ -66,6 +66,8 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
             if (service == null && asyncService == null)
                 return false;
 
+            Contract.ThrowIfNull(document);
+
             // In Live Share, typescript exports a gotodefinition service that returns no results and prevents the LSP
             // client from handling the request.  So prevent the local service from handling goto def commands in the
             // remote workspace. This can be removed once typescript implements LSP support for goto def.
@@ -77,8 +79,6 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
             var currentSnapshot = subjectBuffer.CurrentSnapshot;
             if (currentSnapshot.Length == 0)
                 return false;
-
-            Contract.ThrowIfNull(document);
 
             // If there's a selection, use the starting point of the selection as the invocation point. Otherwise, just
             // pick wherever the caret is exactly at.

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.PropertySymbols.vb
@@ -1087,6 +1087,147 @@ namespace ConsoleApplication22
         End Function
 
         <WpfTheory, CombinatorialData>
+        Public Async Function TestCSharp_PropertyDefinedInSourceGeneratedDocument1(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+namespace ConsoleApplication22
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </Document>
+        <DocumentFromSourceGenerator>
+
+using System;
+namespace ConsoleApplication22
+{
+    class C
+    {
+        static public int {|Definition:G$$oo|}
+        {
+            get
+            {
+                return 1;
+            }
+        } 
+    }
+}
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestCSharp_PropertyDefinedInSourceGeneratedDocument2(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+namespace ConsoleApplication22
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </Document>
+        <DocumentFromSourceGenerator>
+
+using System;
+namespace ConsoleApplication22
+{
+    class C
+    {
+        static public int {|Definition:G$$oo|}
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        void M()
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestCSharp_PropertyDefinedInSourceGeneratedDocument3(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+namespace ConsoleApplication22
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </Document>
+        <DocumentFromSourceGenerator>
+
+using System;
+namespace ConsoleApplication22
+{
+    class C
+    {
+        static public int {|Definition:G$$oo|}
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        void M()
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </DocumentFromSourceGenerator>
+        <DocumentFromSourceGenerator>
+
+using System;
+namespace ConsoleApplication22
+{
+    class D
+    {
+        void M()
+        {
+            int temp = C.[|Goo|];
+        }
+    }
+}
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
         Public Async Function TestCSharp_AbstractStaticPropertyInInterface(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>

--- a/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
+++ b/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
@@ -54,13 +54,13 @@ Friend Class GoToHelpers
                                 $"Expected: ({expected}) but got: ({actual})")
                 Next
 
-                Dim actualDefintionsWithoutSpans = context.GetDefinitions() _
-                    .Where(Function(d) d.SourceSpans.IsDefaultOrEmpty) _
-                    .Select(Function(di)
-                                Return String.Format("{0}:{1}",
-                                                     String.Join("", di.OriginationParts.Select(Function(t) t.Text)),
-                                                     String.Join("", di.NameDisplayParts.Select(Function(t) t.Text)))
-                            End Function).ToList()
+                Dim actualDefintionsWithoutSpans = context.GetDefinitions().
+                    Where(Function(d) d.SourceSpans.IsDefaultOrEmpty).
+                    Select(Function(di)
+                               Return String.Format("{0}:{1}",
+                                                    String.Join("", di.OriginationParts.Select(Function(t) t.Text)),
+                                                    String.Join("", di.NameDisplayParts.Select(Function(t) t.Text)))
+                           End Function).ToList()
 
                 actualDefintionsWithoutSpans.Sort()
 

--- a/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
+++ b/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
@@ -2,12 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.FindUsages
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.FindUsages
 Imports Microsoft.CodeAnalysis.Remote.Testing
 
 Friend Class GoToHelpers
@@ -23,7 +22,7 @@ Friend Class GoToHelpers
             Dim position = documentWithCursor.CursorPosition.Value
 
             Dim solution = workspace.CurrentSolution
-            Dim document = solution.GetDocument(documentWithCursor.Id)
+            Dim document = Await solution.GetRequiredDocumentAsync(documentWithCursor.Id, includeSourceGenerated:=True)
 
             Dim context = New SimpleFindUsagesContext(workspace.GlobalOptions)
             Await testingMethod(document, position, context)

--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -500,7 +500,7 @@ class D : C
 
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/43093")>
-        Public Async Function TestMultiTargetting1(host As TestHost) As Task
+        Public Async Function TestMultiTargeting1(host As TestHost) As Task
             Dim workspace =
 <Workspace>
     <Project Name="BaseProjectCore" Language="C#" CommonReferencesNetCoreApp="true">
@@ -532,7 +532,7 @@ public class [|Impl|] : IInterface
 
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/46818")>
-        Public Async Function TestCrossTargetting1(host As TestHost) As Task
+        Public Async Function TestCrossTargeting1(host As TestHost) As Task
             Dim workspace =
 <Workspace>
     <Project Name="BaseProjectCore" Language="C#" CommonReferencesNetCoreApp="true">
@@ -541,7 +541,7 @@ public class [|Impl|] : IInterface
 using System;
 using System.Threading.Tasks;
 
-namespace MultiTargettingCore
+namespace MultiTargetingCore
 {
     public class Class1
     {
@@ -579,7 +579,7 @@ public class StringCreator : IStringCreator
 
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/46818")>
-        Public Async Function TestCrossTargetting2(host As TestHost) As Task
+        Public Async Function TestCrossTargeting2(host As TestHost) As Task
             Dim workspace =
 <Workspace>
     <Project Name="BaseProjectCore" Language="C#" CommonReferencesNetCoreApp="true">
@@ -588,7 +588,7 @@ public class StringCreator : IStringCreator
 using System;
 using System.Threading.Tasks;
 
-namespace MultiTargettingCore
+namespace MultiTargetingCore
 {
     public class Class1
     {
@@ -626,7 +626,7 @@ public class StringCreator : IStringCreator
 
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/46818")>
-        Public Async Function TestCrossTargetting3(host As TestHost) As Task
+        Public Async Function TestCrossTargeting3(host As TestHost) As Task
             Dim workspace =
 <Workspace>
     <Project Name="BaseProjectCore" Language="C#" CommonReferencesNetCoreApp="true">
@@ -635,7 +635,7 @@ public class StringCreator : IStringCreator
 using System;
 using System.Threading.Tasks;
 
-namespace MultiTargettingCore
+namespace MultiTargetingCore
 {
     public class Class1
     {
@@ -727,6 +727,58 @@ interface I&lt;T&gt; { static abstract T operator $$>>>(T x, int y); }
         <Document>
 class C : I&lt;C&gt; { static C I&lt;C&gt;.operator [|>>>|](C x, int y) { return x; } }
 interface I&lt;T&gt; { static abstract T operator $$>>>(T x, int y); }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function TestInSourceGeneratedDocument1(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <DocumentFromSourceGenerator>
+interface I { void $$M(); }
+class C : I { public abstract void M() { } }
+class D : C { public override void [|M|]() { } }}
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function TestInSourceGeneratedDocument2(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <DocumentFromSourceGenerator>
+interface I { void $$M(); }
+class C : I { public abstract void M() { } }
+        </DocumentFromSourceGenerator>
+        <DocumentFromSourceGenerator>
+class D : C { public override void [|M|]() { } }}
+        </DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace, host)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function TestInSourceGeneratedDocument3(host As TestHost) As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <DocumentFromSourceGenerator>
+interface I { void $$M(); }
+class C : I { public abstract void M() { } }
+        </DocumentFromSourceGenerator>
+        <Document>
+class D : C { public override void [|M|]() { } }}
         </Document>
     </Project>
 </Workspace>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -421,7 +421,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             else
             {
                 // For a source project, find the project that that type was defined in.
-                var sourceProject = solution.GetOriginatingProject(type.ContainingAssembly);
+                var sourceProject =
+                    solution.GetProject(type.ContainingAssembly, cancellationToken) ??
+                    solution.GetOriginatingProject(type.ContainingAssembly);
                 if (sourceProject == null)
                     return SpecializedCollections.EmptySet<ProjectId>();
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Storage;
 using Roslyn.Utilities;
 
@@ -52,12 +52,22 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var namedTypes = new MultiDictionary<string, (DocumentId, DeclaredSymbolInfo)>(
                     project.Services.GetRequiredService<ISyntaxFactsService>().StringComparer);
 
+                var regularDocumentStates = project.State.DocumentStates;
+                var sourceGeneratorDocumentStates = await project.Solution.State.GetSourceGeneratedDocumentStatesAsync(project.State, cancellationToken).ConfigureAwait(false);
+
+                var regularDocumentStatesEnumerable = regularDocumentStates.States.Select(kvp => (kvp.Key, kvp.Value));
+                var sourceGeneratedDocumentStatesEnumerable = sourceGeneratorDocumentStates.States.Select(kvp => (kvp.Key, (DocumentState)kvp.Value));
+
+                var allStates = regularDocumentStatesEnumerable.Concat(sourceGeneratedDocumentStatesEnumerable);
+
+                var solutionKey = SolutionKey.ToSolutionKey(project.Solution);
+
                 // Avoid realizing actual Document instances here.  We don't need them, and it can allocate a lot of
                 // memory as we do background indexing.
-                foreach (var (documentId, document) in project.State.DocumentStates.States)
+                foreach (var (documentId, document) in allStates)
                 {
                     var syntaxTreeIndex = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(
-                        SolutionKey.ToSolutionKey(project.Solution), project.State, document, cancellationToken).ConfigureAwait(false);
+                        solutionKey, project.State, document, cancellationToken).ConfigureAwait(false);
                     foreach (var info in syntaxTreeIndex.DeclaredSymbolInfos)
                     {
                         switch (info.Kind)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder_ProjectIndex.cs
@@ -52,15 +52,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var namedTypes = new MultiDictionary<string, (DocumentId, DeclaredSymbolInfo)>(
                     project.Services.GetRequiredService<ISyntaxFactsService>().StringComparer);
 
+                var solutionKey = SolutionKey.ToSolutionKey(project.Solution);
+
                 var regularDocumentStates = project.State.DocumentStates;
                 var sourceGeneratorDocumentStates = await project.Solution.State.GetSourceGeneratedDocumentStatesAsync(project.State, cancellationToken).ConfigureAwait(false);
 
-                var regularDocumentStatesEnumerable = regularDocumentStates.States.Select(kvp => (kvp.Key, kvp.Value));
-                var sourceGeneratedDocumentStatesEnumerable = sourceGeneratorDocumentStates.States.Select(kvp => (kvp.Key, (DocumentState)kvp.Value));
-
-                var allStates = regularDocumentStatesEnumerable.Concat(sourceGeneratedDocumentStatesEnumerable);
-
-                var solutionKey = SolutionKey.ToSolutionKey(project.Solution);
+                var allStates =
+                    regularDocumentStates.States.Select(kvp => (kvp.Key, kvp.Value)).Concat(
+                    sourceGeneratorDocumentStates.States.Select(kvp => (kvp.Key, (DocumentState)kvp.Value)));
 
                 // Avoid realizing actual Document instances here.  We don't need them, and it can allocate a lot of
                 // memory as we do background indexing.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/69270
Fixes: https://github.com/dotnet/roslyn/issues/66008