### PR TITLE
Bump NuGet version used by tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,7 +207,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.4.0-preview.1.54</NuGetCommonVersion>
+    <NuGetCommonVersion>6.4.2-rc.1</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>


### PR DESCRIPTION
The latest run indicated the version of NuGet being used by the tests is too low for the SDK it is running against. See https://dev.azure.com/dnceng-public/public/_build/results?buildId=381495&view=results (microsoft). Since 17.2 is pinned to a 7.0.1xx SDK, I pulled the current NuGet version used by that SDK branch. See https://github.com/dotnet/sdk/blob/f3ae0f15572bc5d0a0d8e8deda31ef043d9211a3/eng/Versions.props#L66C36-L66C46

```
  Failed Microsoft.CodeAnalysis.MSBuild.UnitTests.NetCoreTests.TestOpenProject_NetCoreApp [5 s]
  Error Message:
   System.Exception : Workspace failure Failure:Msbuild failed when processing the file 'T:\RoslynTests\4ba65cbd-e442-4551-bb39-ee81ef718f38\Project.csproj' with message: D:\a\_work\1\s\.dotnet\sdk\7.0.105\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets: (90, 5): The "ProcessFrameworkReferences" task failed unexpectedly.
System.IO.FileLoadException: Could not load file or assembly 'NuGet.Frameworks, Version=6.4.0.123, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. Could not find or load a specific file. (0x80131621)
File name: 'NuGet.Frameworks, Version=6.4.0.123, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
```