### PR TITLE
Avoid static overhead for switch-over-string optimization

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1758,6 +1758,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     && arrayBuilder.Count < ArrayBuilder<T>.PooledArrayLengthLimitExclusive
                     && arrayBuilder.Capacity > arrayBuilder.Count * 2)
                 {
+                    // An ArrayBuilder<T> meeting these conditions will satisfy the following:
+                    //
+                    // 1. The current backing array is too large to be returned to the pool (i.e. it will be GC whenever
+                    //    no longer used).
+                    // 2. The resized backing array from trimming is small enough to be returned to the pool (i.e. it
+                    //    will not be wasted after this builder is freed).
+                    // 3. At least half of the storage of the current builder is unused.
+                    //
                     // If we can save half the space without wasting an array that would fit in the pool, go ahead and
                     // do so by trimming the array builder.
                     arrayBuilder.Capacity = arrayBuilder.Count;

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1754,6 +1754,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             public FrozenArrayBuilder(ArrayBuilder<T> arrayBuilder)
             {
                 Debug.Assert(arrayBuilder != null);
+                if (arrayBuilder.Capacity >= ArrayBuilder<T>.PooledArrayLengthLimitExclusive
+                    && arrayBuilder.Count < ArrayBuilder<T>.PooledArrayLengthLimitExclusive
+                    && arrayBuilder.Capacity > arrayBuilder.Count * 2)
+                {
+                    // If we can save half the space without wasting an array that would fit in the pool, go ahead and
+                    // do so by trimming the array builder.
+                    arrayBuilder.Capacity = arrayBuilder.Count;
+                }
+
                 _arrayBuilder = arrayBuilder;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1756,12 +1756,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(arrayBuilder != null);
                 if (arrayBuilder.Capacity >= ArrayBuilder<T>.PooledArrayLengthLimitExclusive
                     && arrayBuilder.Count < ArrayBuilder<T>.PooledArrayLengthLimitExclusive
-                    && arrayBuilder.Capacity > arrayBuilder.Count * 2)
+                    && arrayBuilder.Capacity >= arrayBuilder.Count * 2)
                 {
                     // An ArrayBuilder<T> meeting these conditions will satisfy the following:
                     //
-                    // 1. The current backing array is too large to be returned to the pool (i.e. it will be GC whenever
-                    //    no longer used).
+                    // 1. The current backing array is too large to be returned to the pool (i.e. it will be garbage
+                    //    collected whenever no longer used).
                     // 2. The resized backing array from trimming is small enough to be returned to the pool (i.e. it
                     //    will not be wasted after this builder is freed).
                     // 3. At least half of the storage of the current builder is unused.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -3286,7 +3286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (sourceSig.CallingConvention == Cci.CallingConvention.Unmanaged &&
-                !sourceSig.GetCallingConventionModifiers().SetEquals(destinationSig.GetCallingConventionModifiers()))
+                !sourceSig.GetCallingConventionModifiers().SetEqualsWithoutIntermediateHashSet(destinationSig.GetCallingConventionModifiers()))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1801,7 +1801,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (sourceSignature.GetCallingConventionModifiers(), targetSignature.GetCallingConventionModifiers()) switch
             {
                 (null, null) => true,
-                ({ } sourceModifiers, { } targetModifiers) when sourceModifiers.SetEquals(targetModifiers) => true,
+                ({ } sourceModifiers, { } targetModifiers) when sourceModifiers.SetEqualsWithoutIntermediateHashSet(targetModifiers) => true,
                 _ => false
             };
         }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((compareKind & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0)
             {
                 if (CallingConvention.IsCallingConvention(CallingConvention.Unmanaged)
-                    && !GetCallingConventionModifiers().SetEquals(other.GetCallingConventionModifiers()))
+                    && !GetCallingConventionModifiers().SetEqualsWithoutIntermediateHashSet(other.GetCallingConventionModifiers()))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSet.cs
@@ -17,7 +17,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// relational operators for it; such a set can be formed only by including explicitly mentioned
         /// members (or the inverse, excluding them, by complementing the set).
         /// </summary>
-        private sealed class EnumeratedValueSet<T, TTC> : IValueSet<T> where TTC : struct, IEquatableValueTC<T> where T : notnull
+        private sealed class EnumeratedValueSet<T, TTC> : IValueSet<T>
+            where TTC : struct, IEquatableValueTC<T>
+            where T : notnull
         {
             /// <summary>
             /// In <see cref="_included"/>, then members are listed by inclusion.  Otherwise all members
@@ -150,8 +152,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             IValueSet IValueSet.Union(IValueSet other) => Union((IValueSet<T>)other);
 
-            public override bool Equals(object? obj) => obj is EnumeratedValueSet<T, TTC> other &&
-                this._included == other._included && this._membersIncludedOrExcluded.SetEquals(other._membersIncludedOrExcluded);
+            public override bool Equals(object? obj)
+            {
+                if (obj is not EnumeratedValueSet<T, TTC> other)
+                    return false;
+
+                return this._included == other._included
+                    && this._membersIncludedOrExcluded.SetEqualsWithoutIntermediateHashSet(other._membersIncludedOrExcluded);
+            }
 
             public override int GetHashCode() => Hash.Combine(this._included.GetHashCode(), this._membersIncludedOrExcluded.GetHashCode());
 

--- a/src/Compilers/Core/Portable/Collections/ImmutableHashSetExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableHashSetExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis;
+
+internal static class ImmutableHashSetExtensions
+{
+    /// <summary>
+    /// Performs a <see cref="ImmutableHashSet{T}.SetEquals"/> comparison without allocating an intermediate
+    /// <see cref="HashSet{T}"/>.
+    /// </summary>
+    /// <seealso href="https://github.com/dotnet/runtime/issues/90986"/>
+    public static bool SetEqualsWithoutIntermediateHashSet<T>(this ImmutableHashSet<T> set, ImmutableHashSet<T> other)
+    {
+        if (set is null)
+            throw new ArgumentNullException(nameof(set));
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
+        if (ReferenceEquals(set, other))
+            return true;
+
+        var otherSet = other.WithComparer(set.KeyComparer);
+        if (set.Count != otherSet.Count)
+            return false;
+
+        foreach (var item in other)
+        {
+            if (!set.Contains(item))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             return other != null &&
-                this.Suppressions.SetEquals(other.Suppressions);
+                this.Suppressions.SetEqualsWithoutIntermediateHashSet(other.Suppressions);
         }
 
         public override bool Equals(object? obj)

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.PooledObjects
     [DebuggerTypeProxy(typeof(ArrayBuilder<>.DebuggerProxy))]
     internal sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>
     {
+        /// <summary>
+        /// See <see cref="Free()"/> for an explanation of this constant value.
+        /// </summary>
+        public const int PooledArrayLengthLimitExclusive = 128;
+
         #region DebuggerProxy
 
         private sealed class DebuggerProxy
@@ -105,6 +110,19 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             set
             {
                 _builder.Count = value;
+            }
+        }
+
+        public int Capacity
+        {
+            get
+            {
+                return _builder.Capacity;
+            }
+
+            set
+            {
+                _builder.Capacity = value;
             }
         }
 
@@ -379,7 +397,7 @@ namespace Microsoft.CodeAnalysis.PooledObjects
                 // while the chance that we will need their size is diminishingly small.
                 // It makes sense to constrain the size to some "not too small" number. 
                 // Overall perf does not seem to be very sensitive to this number, so I picked 128 as a limit.
-                if (_builder.Capacity < 128)
+                if (_builder.Capacity < PooledArrayLengthLimitExclusive)
                 {
                     if (this.Count != 0)
                     {

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <IsShipping>false</IsShipping>
-    <LangVersion>9</LangVersion>
+    <LangVersion>11</LangVersion>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
   </PropertyGroup>
 

--- a/src/Tools/IdeCoreBenchmarks/SwitchStatementBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/SwitchStatementBenchmarks.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Test.Utilities;
+
+namespace IdeCoreBenchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, invocationCount: 1)]
+public class SwitchStatementBenchmarks
+{
+    [Params(100, 1000, 5000, 10000)]
+    public int SwitchCount
+    {
+        get;
+        set;
+    }
+
+    private static string CreateSourceFile(int switchCount)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(
+            """
+            class TestClass
+            {
+              int TestMethod(string arg)
+              {
+                switch (arg)
+                {
+            """);
+
+        for (var i = 0; i < switchCount; i++)
+        {
+            builder.AppendLine(
+                $"""
+                      case "Text{i}": return {i};
+                """);
+        }
+
+        builder.AppendLine(
+            """
+                  default: return 0;
+                }
+              }
+            }
+
+            """);
+
+        return builder.ToString();
+    }
+
+    [Benchmark]
+    public object BindFile()
+    {
+        var projectId = ProjectId.CreateNewId();
+        var documentId = DocumentId.CreateNewId(projectId);
+
+        using var workspace = new AdhocWorkspace();
+
+        var solution = workspace.CurrentSolution
+            .AddProject(projectId, "ProjectName", "AssemblyName", LanguageNames.CSharp)
+            .AddDocument(documentId, "DocumentName", CreateSourceFile(SwitchCount));
+
+        solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
+        solution = solution.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var project = solution.Projects.First();
+        var compilation = project.GetCompilationAsync().Result;
+        return compilation.EmitToStream();
+    }
+}


### PR DESCRIPTION
* Avoid retaining large, sparse arrays
* Avoid allocating intermediate hash sets (https://github.com/dotnet/runtime/issues/90986)

Fixes [AB#1874059](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1874059)

### Baseline

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.7.23376.3
  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT
  Job-SDXWZP : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT

InvocationCount=1  RunStrategy=Throughput  UnrollFactor=1
```

|   Method | SwitchCount |         Mean |      Error |     StdDev |        Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|--------- |------------ |-------------:|-----------:|-----------:|-------------:|-----------:|----------:|----------:|
| BindFile |         100 |     21.11 ms |   0.407 ms |   0.380 ms |            - |          - |         - |      3 MB |
| BindFile |        1000 |    472.88 ms |   9.296 ms |   9.130 ms |   21000.0000 |  8000.0000 | 1000.0000 |    125 MB |
| BindFile |        5000 | 10,243.52 ms |  52.573 ms |  49.177 ms |  292000.0000 | 45000.0000 | 4000.0000 |  2,746 MB |
| BindFile |       10000 | 45,215.70 ms | 583.825 ms | 546.110 ms | 1042000.0000 | 74000.0000 | 5000.0000 | 11,298 MB |

### Avoid retaining large arrays with few elements

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.7.23376.3
  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT
  Job-CLGAKY : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT

InvocationCount=1  RunStrategy=Throughput  UnrollFactor=1
```

|   Method | SwitchCount |         Mean |      Error |     StdDev |        Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|--------- |------------ |-------------:|-----------:|-----------:|-------------:|-----------:|----------:|----------:|
| BindFile |         100 |     21.07 ms |   0.416 ms |   0.541 ms |            - |          - |         - |      3 MB |
| BindFile |        1000 |    456.06 ms |   8.680 ms |   8.525 ms |   21000.0000 |  5000.0000 | 1000.0000 |    125 MB |
| BindFile |        5000 | 10,411.66 ms |  80.092 ms |  74.918 ms |  296000.0000 | 40000.0000 | 8000.0000 |  2,746 MB |
| BindFile |       10000 | 42,928.17 ms | 326.267 ms | 254.728 ms | 1046000.0000 | 72000.0000 | 9000.0000 | 11,298 MB |

### Avoid intermediate HashSet<T>

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.7.23376.3
  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT
  Job-ZMBVHX : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT

InvocationCount=1  RunStrategy=Throughput  UnrollFactor=1
```

|   Method | SwitchCount |         Mean |      Error |     StdDev |       Median |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|--------- |------------ |-------------:|-----------:|-----------:|-------------:|------------:|-----------:|----------:|----------:|
| BindFile |         100 |     20.68 ms |   0.413 ms |   0.843 ms |     20.30 ms |           - |          - |         - |      3 MB |
| BindFile |        1000 |    417.38 ms |   7.990 ms |  10.936 ms |    418.08 ms |  20000.0000 |  5000.0000 | 1000.0000 |    114 MB |
| BindFile |        5000 |  8,663.36 ms |  89.757 ms |  79.568 ms |  8,660.18 ms | 253000.0000 | 41000.0000 | 7000.0000 |  2,484 MB |
| BindFile |       10000 | 37,244.51 ms | 423.100 ms | 375.067 ms | 37,137.94 ms | 978000.0000 | 72000.0000 | 9000.0000 | 10,253 MB |
