### PR TITLE
Lower the priority of 'Convert number' and have nested options when there is a long list.

### DIFF
--- a/src/Features/CSharp/Portable/ConvertNumericLiteral/CSharpConvertNumericLiteralCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertNumericLiteral/CSharpConvertNumericLiteralCodeRefactoringProvider.cs
@@ -2,25 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ConvertNumericLiteral;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Microsoft.CodeAnalysis.CSharp.ConvertNumericLiteral
-{
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertNumericLiteral), Shared]
-    internal sealed class CSharpConvertNumericLiteralCodeRefactoringProvider : AbstractConvertNumericLiteralCodeRefactoringProvider<LiteralExpressionSyntax>
-    {
-        [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public CSharpConvertNumericLiteralCodeRefactoringProvider()
-        {
-        }
+namespace Microsoft.CodeAnalysis.CSharp.ConvertNumericLiteral;
 
-        protected override (string hexPrefix, string binaryPrefix) GetNumericLiteralPrefixes() => (hexPrefix: "0x", binaryPrefix: "0b");
-    }
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertNumericLiteral), Shared]
+[method: ImportingConstructor]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+internal sealed class CSharpConvertNumericLiteralCodeRefactoringProvider()
+    : AbstractConvertNumericLiteralCodeRefactoringProvider<LiteralExpressionSyntax>(hexPrefix: "0x", binaryPrefix: "0b")
+{
 }

--- a/src/Features/CSharpTest/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
+++ b/src/Features/CSharpTest/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ConvertNumericLiteral;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
@@ -12,143 +12,145 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertNumericLiteral
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertNumericLiteral;
+
+[Trait(Traits.Feature, Traits.Features.CodeActionsConvertNumericLiteral)]
+public sealed class ConvertNumericLiteralTests : AbstractCSharpCodeActionTest
 {
-    [Trait(Traits.Feature, Traits.Features.CodeActionsConvertNumericLiteral)]
-    public class ConvertNumericLiteralTests : AbstractCSharpCodeActionTest
+    protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+        => new CSharpConvertNumericLiteralCodeRefactoringProvider();
+
+    protected override ImmutableArray<CodeAction> MassageActions(ImmutableArray<CodeAction> actions)
+        => FlattenActions(actions);
+
+    private enum Refactoring { ChangeBase1, ChangeBase2, AddOrRemoveDigitSeparators }
+
+    private async Task TestMissingOneAsync(string initial)
+        => await TestMissingInRegularAndScriptAsync(CreateTreeText("[||]" + initial));
+
+    private async Task TestFixOneAsync(string initial, string expected, Refactoring refactoring)
+        => await TestInRegularAndScript1Async(CreateTreeText("[||]" + initial), CreateTreeText(expected), (int)refactoring);
+
+    private static string CreateTreeText(string initial)
+        => @"class X { void F() { var x = " + initial + @"; } }";
+
+    [Fact]
+    public async Task TestRemoveDigitSeparators()
+        => await TestFixOneAsync("0b1_0_01UL", "0b1001UL", Refactoring.AddOrRemoveDigitSeparators);
+
+    [Fact]
+    public async Task TestConvertToBinary()
+        => await TestFixOneAsync("5", "0b101", Refactoring.ChangeBase1);
+
+    [Fact]
+    public async Task TestConvertToDecimal()
+        => await TestFixOneAsync("0b101", "5", Refactoring.ChangeBase1);
+
+    [Fact]
+    public async Task TestConvertToHex()
+        => await TestFixOneAsync("10", "0xA", Refactoring.ChangeBase2);
+
+    [Fact]
+    public async Task TestSeparateThousands()
+        => await TestFixOneAsync("100000000", "100_000_000", Refactoring.AddOrRemoveDigitSeparators);
+
+    [Fact]
+    public async Task TestSeparateWords()
+        => await TestFixOneAsync("0x1111abcd1111", "0x1111_abcd_1111", Refactoring.AddOrRemoveDigitSeparators);
+
+    [Fact]
+    public async Task TestSeparateNibbles()
+        => await TestFixOneAsync("0b10101010", "0b1010_1010", Refactoring.AddOrRemoveDigitSeparators);
+
+    [Fact]
+    public async Task TestMissingOnFloatingPoint()
+        => await TestMissingOneAsync("1.1");
+
+    [Fact]
+    public async Task TestMissingOnScientificNotation()
+        => await TestMissingOneAsync("1e5");
+
+    [Fact]
+    public async Task TestConvertToDecimal_02()
+        => await TestFixOneAsync("0x1e5", "485", Refactoring.ChangeBase1);
+
+    [Fact]
+    public async Task TestTypeCharacter()
+        => await TestFixOneAsync("0x1e5UL", "0b111100101UL", Refactoring.ChangeBase2);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19225")]
+    public async Task TestPreserveWhitespaces()
     {
-        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
-            => new CSharpConvertNumericLiteralCodeRefactoringProvider();
-
-        private enum Refactoring { ChangeBase1, ChangeBase2, AddOrRemoveDigitSeparators }
-
-        private async Task TestMissingOneAsync(string initial)
-            => await TestMissingInRegularAndScriptAsync(CreateTreeText("[||]" + initial));
-
-        private async Task TestFixOneAsync(string initial, string expected, Refactoring refactoring)
-            => await TestInRegularAndScript1Async(CreateTreeText("[||]" + initial), CreateTreeText(expected), (int)refactoring);
-
-        private static string CreateTreeText(string initial)
-            => @"class X { void F() { var x = " + initial + @"; } }";
-
-        [Fact]
-        public async Task TestRemoveDigitSeparators()
-            => await TestFixOneAsync("0b1_0_01UL", "0b1001UL", Refactoring.AddOrRemoveDigitSeparators);
-
-        [Fact]
-        public async Task TestConvertToBinary()
-            => await TestFixOneAsync("5", "0b101", Refactoring.ChangeBase1);
-
-        [Fact]
-        public async Task TestConvertToDecimal()
-            => await TestFixOneAsync("0b101", "5", Refactoring.ChangeBase1);
-
-        [Fact]
-        public async Task TestConvertToHex()
-            => await TestFixOneAsync("10", "0xA", Refactoring.ChangeBase2);
-
-        [Fact]
-        public async Task TestSeparateThousands()
-            => await TestFixOneAsync("100000000", "100_000_000", Refactoring.AddOrRemoveDigitSeparators);
-
-        [Fact]
-        public async Task TestSeparateWords()
-            => await TestFixOneAsync("0x1111abcd1111", "0x1111_abcd_1111", Refactoring.AddOrRemoveDigitSeparators);
-
-        [Fact]
-        public async Task TestSeparateNibbles()
-            => await TestFixOneAsync("0b10101010", "0b1010_1010", Refactoring.AddOrRemoveDigitSeparators);
-
-        [Fact]
-        public async Task TestMissingOnFloatingPoint()
-            => await TestMissingOneAsync("1.1");
-
-        [Fact]
-        public async Task TestMissingOnScientificNotation()
-            => await TestMissingOneAsync("1e5");
-
-        [Fact]
-        public async Task TestConvertToDecimal_02()
-            => await TestFixOneAsync("0x1e5", "485", Refactoring.ChangeBase1);
-
-        [Fact]
-        public async Task TestTypeCharacter()
-            => await TestFixOneAsync("0x1e5UL", "0b111100101UL", Refactoring.ChangeBase2);
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19225")]
-        public async Task TestPreserveWhitespaces()
-        {
-            await TestInRegularAndScriptAsync(
-                """
-                class Program
+        await TestInRegularAndScriptAsync(
+            """
+            class Program
+            {
+                void M()
                 {
-                    void M()
-                    {
-                        var numbers = new int[] {
-                            [||]0x1, 0x2
-                        };
-                    }
+                    var numbers = new int[] {
+                        [||]0x1, 0x2
+                    };
                 }
-                """,
-                """
-                class Program
+            }
+            """,
+            """
+            class Program
+            {
+                void M()
                 {
-                    void M()
-                    {
-                        var numbers = new int[] {
-                            0b1, 0x2
-                        };
-                    }
+                    var numbers = new int[] {
+                        0b1, 0x2
+                    };
                 }
-                """, index: (int)Refactoring.ChangeBase2);
-        }
+            }
+            """, index: (int)Refactoring.ChangeBase2);
+    }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19369")]
-        public async Task TestCaretPositionAtTheEnd()
-        {
-            await TestInRegularAndScriptAsync(
-                """
-                class C
-                {
-                    int a = 42[||];
-                }
-                """,
-                """
-                class C
-                {
-                    int a = 0b101010;
-                }
-                """, index: (int)Refactoring.ChangeBase1);
-        }
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/19369")]
+    public async Task TestCaretPositionAtTheEnd()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                int a = 42[||];
+            }
+            """,
+            """
+            class C
+            {
+                int a = 0b101010;
+            }
+            """, index: (int)Refactoring.ChangeBase1);
+    }
 
-        [Fact]
-        public async Task TestSelectionMatchesToken()
-        {
-            await TestInRegularAndScriptAsync(
-                """
-                class C
-                {
-                    int a = [|42|];
-                }
-                """,
-                """
-                class C
-                {
-                    int a = 0b101010;
-                }
-                """, index: (int)Refactoring.ChangeBase1);
-        }
+    [Fact]
+    public async Task TestSelectionMatchesToken()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                int a = [|42|];
+            }
+            """,
+            """
+            class C
+            {
+                int a = 0b101010;
+            }
+            """, index: (int)Refactoring.ChangeBase1);
+    }
 
-        [Fact]
-        public async Task TestSelectionDoesntMatchToken()
-        {
-            await TestMissingInRegularAndScriptAsync(
-                """
-                class C
-                {
-                    int a = [|42 * 2|];
-                }
-                """);
-        }
+    [Fact]
+    public async Task TestSelectionDoesntMatchToken()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            class C
+            {
+                int a = [|42 * 2|];
+            }
+            """);
     }
 }

--- a/src/Features/CSharpTest/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
+++ b/src/Features/CSharpTest/ConvertNumericLiteral/ConvertNumericLiteralTests.cs
@@ -143,7 +143,7 @@ public sealed class ConvertNumericLiteralTests : AbstractCSharpCodeActionTest
     }
 
     [Fact]
-    public async Task TestSelectionDoesntMatchToken()
+    public async Task TestSelectionDoesNotMatchToken()
     {
         await TestMissingInRegularAndScriptAsync(
             """

--- a/src/Features/Core/Portable/ConvertNumericLiteral/AbstractConvertNumericLiteralCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertNumericLiteral/AbstractConvertNumericLiteralCodeRefactoringProvider.cs
@@ -4,169 +4,164 @@
 
 using System;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
-namespace Microsoft.CodeAnalysis.ConvertNumericLiteral
+namespace Microsoft.CodeAnalysis.ConvertNumericLiteral;
+
+internal abstract class AbstractConvertNumericLiteralCodeRefactoringProvider<TNumericLiteralExpression>
+    : CodeRefactoringProvider
+    where TNumericLiteralExpression : SyntaxNode
 {
-    internal abstract class AbstractConvertNumericLiteralCodeRefactoringProvider<TNumericLiteralExpression> : CodeRefactoringProvider where TNumericLiteralExpression : SyntaxNode
+    protected abstract (string hexPrefix, string binaryPrefix) GetNumericLiteralPrefixes();
+
+    /// <summary>
+    /// Converting numbers is a fairly uncommon task.  Put these at the end of the list after more relevant
+    /// refactorings.
+    /// </summary>
+    protected override CodeActionRequestPriority ComputeRequestPriority()
+        => CodeActionRequestPriority.Low;
+
+    public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
-        protected abstract (string hexPrefix, string binaryPrefix) GetNumericLiteralPrefixes();
+        var (document, _, cancellationToken) = context;
+        var numericToken = await GetNumericTokenAsync(context).ConfigureAwait(false);
 
-        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        if (numericToken == default || numericToken.ContainsDiagnostics)
+            return;
+
+        var syntaxNode = numericToken.GetRequiredParent();
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var symbol = semanticModel.GetTypeInfo(syntaxNode, cancellationToken).Type;
+        if (symbol == null)
+            return;
+
+        if (!IsIntegral(symbol.SpecialType))
+            return;
+
+        var valueOpt = semanticModel.GetConstantValue(syntaxNode);
+        if (!valueOpt.HasValue)
+            return;
+
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var value = IntegerUtilities.ToInt64(valueOpt.Value);
+        var numericText = numericToken.ToString();
+        var (hexPrefix, binaryPrefix) = GetNumericLiteralPrefixes();
+        var (prefix, number, suffix) = GetNumericLiteralParts(numericText, hexPrefix, binaryPrefix);
+        var kind = string.IsNullOrEmpty(prefix) ? NumericKind.Decimal
+            : prefix.Equals(hexPrefix, StringComparison.OrdinalIgnoreCase) ? NumericKind.Hexadecimal
+            : prefix.Equals(binaryPrefix, StringComparison.OrdinalIgnoreCase) ? NumericKind.Binary
+            : NumericKind.Unknown;
+
+        if (kind == NumericKind.Unknown)
+            return;
+
+        using var result = TemporaryArray<CodeAction>.Empty;
+
+        if (kind != NumericKind.Decimal)
+            result.Add(CreateCodeAction(value.ToString(), FeaturesResources.Convert_to_decimal));
+
+        if (kind != NumericKind.Binary)
+            result.Add(CreateCodeAction(binaryPrefix + Convert.ToString(value, toBase: 2), FeaturesResources.Convert_to_binary));
+
+        if (kind != NumericKind.Hexadecimal)
+            result.Add(CreateCodeAction(hexPrefix + value.ToString("X"), FeaturesResources.Convert_to_hex));
+
+        const string DigitSeparator = "_";
+        if (numericText.Contains(DigitSeparator))
         {
-            var (document, _, cancellationToken) = context;
-            var numericToken = await GetNumericTokenAsync(context).ConfigureAwait(false);
-
-            if (numericToken == default || numericToken.ContainsDiagnostics)
+            result.Add(CreateCodeAction(prefix + number.Replace(DigitSeparator, string.Empty), FeaturesResources.Remove_separators));
+        }
+        else
+        {
+            result.AsRef().AddIfNotNull(kind switch
             {
-                return;
-            }
-
-            var syntaxNode = numericToken.GetRequiredParent();
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var symbol = semanticModel.GetTypeInfo(syntaxNode, cancellationToken).Type;
-            if (symbol == null)
-            {
-                return;
-            }
-
-            if (!IsIntegral(symbol.SpecialType))
-            {
-                return;
-            }
-
-            var valueOpt = semanticModel.GetConstantValue(syntaxNode);
-            if (!valueOpt.HasValue)
-            {
-                return;
-            }
-
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var value = IntegerUtilities.ToInt64(valueOpt.Value);
-            var numericText = numericToken.ToString();
-            var (hexPrefix, binaryPrefix) = GetNumericLiteralPrefixes();
-            var (prefix, number, suffix) = GetNumericLiteralParts(numericText, hexPrefix, binaryPrefix);
-            var kind = string.IsNullOrEmpty(prefix) ? NumericKind.Decimal
-                : prefix.Equals(hexPrefix, StringComparison.OrdinalIgnoreCase) ? NumericKind.Hexadecimal
-                : prefix.Equals(binaryPrefix, StringComparison.OrdinalIgnoreCase) ? NumericKind.Binary
-                : NumericKind.Unknown;
-
-            if (kind == NumericKind.Unknown)
-            {
-                return;
-            }
-
-            if (kind != NumericKind.Decimal)
-            {
-                RegisterRefactoringWithResult(value.ToString(), FeaturesResources.Convert_to_decimal);
-            }
-
-            if (kind != NumericKind.Binary)
-            {
-                RegisterRefactoringWithResult(binaryPrefix + Convert.ToString(value, toBase: 2), FeaturesResources.Convert_to_binary);
-            }
-
-            if (kind != NumericKind.Hexadecimal)
-            {
-                RegisterRefactoringWithResult(hexPrefix + value.ToString("X"), FeaturesResources.Convert_to_hex);
-            }
-
-            const string DigitSeparator = "_";
-            if (numericText.Contains(DigitSeparator))
-            {
-                RegisterRefactoringWithResult(prefix + number.Replace(DigitSeparator, string.Empty), FeaturesResources.Remove_separators);
-            }
-            else
-            {
-                switch (kind)
-                {
-                    case NumericKind.Decimal when number.Length > 3:
-                        RegisterRefactoringWithResult(AddSeparators(number, interval: 3), FeaturesResources.Separate_thousands);
-                        break;
-
-                    case NumericKind.Hexadecimal when number.Length > 4:
-                        RegisterRefactoringWithResult(hexPrefix + AddSeparators(number, interval: 4), FeaturesResources.Separate_words);
-                        break;
-
-                    case NumericKind.Binary when number.Length > 4:
-                        RegisterRefactoringWithResult(binaryPrefix + AddSeparators(number, interval: 4), FeaturesResources.Separate_nibbles);
-                        break;
-                }
-            }
-
-            void RegisterRefactoringWithResult(string text, string title)
-            {
-                context.RegisterRefactoring(
-                    CodeAction.Create(title, c => ReplaceTokenAsync(document, root, numericToken, value, text, suffix), title),
-                    numericToken.Span);
-            }
+                NumericKind.Decimal when number.Length > 3 => CreateCodeAction(AddSeparators(number, interval: 3), FeaturesResources.Separate_thousands),
+                NumericKind.Hexadecimal when number.Length > 4 => CreateCodeAction(hexPrefix + AddSeparators(number, interval: 4), FeaturesResources.Separate_words),
+                NumericKind.Binary when number.Length > 4 => CreateCodeAction(binaryPrefix + AddSeparators(number, interval: 4), FeaturesResources.Separate_nibbles),
+                _ => null,
+            });
         }
 
-        private static Task<Document> ReplaceTokenAsync(Document document, SyntaxNode root, SyntaxToken numericToken, long value, string text, string suffix)
+        if (result.Count == 1)
         {
-            var generator = SyntaxGenerator.GetGenerator(document);
-            var updatedToken = generator.NumericLiteralToken(text + suffix, (ulong)value)
-                .WithTriviaFrom(numericToken);
-            var updatedRoot = root.ReplaceToken(numericToken, updatedToken);
-            return Task.FromResult(document.WithSyntaxRoot(updatedRoot));
+            context.RegisterRefactoring(result[0]);
+        }
+        else if (result.Count > 1)
+        {
+            context.RegisterRefactoring(CodeAction.Create(
+                FeaturesResources.Convert_number,
+                result.ToImmutableAndClear(),
+                isInlinable: true));
         }
 
-        internal virtual async Task<SyntaxToken> GetNumericTokenAsync(CodeRefactoringContext context)
-        {
-            var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
-
-            var literalNode = await context.TryGetRelevantNodeAsync<TNumericLiteralExpression>().ConfigureAwait(false);
-            var numericLiteralExpressionNode = syntaxFacts.IsNumericLiteralExpression(literalNode)
-                ? literalNode
-                : null;
-
-            return numericLiteralExpressionNode != null
-                ? numericLiteralExpressionNode.GetFirstToken()    // We know that TNumericLiteralExpression has always only one token: NumericLiteralToken
-                : default;
-        }
-
-        private static (string prefix, string number, string suffix) GetNumericLiteralParts(string numericText, string hexPrefix, string binaryPrefix)
-        {
-            // Match literal text and extract out base prefix, type suffix and the number itself.
-            var groups = Regex.Match(numericText, $"({hexPrefix}|{binaryPrefix})?([_0-9a-f]+)(.*)", RegexOptions.IgnoreCase).Groups;
-            return (prefix: groups[1].Value, number: groups[2].Value, suffix: groups[3].Value);
-        }
-
-        private static string AddSeparators(string numericText, int interval)
-        {
-            // Insert digit separators in the given interval.
-            var result = Regex.Replace(numericText, $"(.{{{interval}}})", "_$1", RegexOptions.RightToLeft);
-            // Fix for the case "0x_1111" that is not supported yet.
-            return result[0] == '_' ? result[1..] : result;
-        }
-
-        private static bool IsIntegral(SpecialType specialType)
-        {
-            switch (specialType)
-            {
-                case SpecialType.System_Byte:
-                case SpecialType.System_SByte:
-                case SpecialType.System_Int16:
-                case SpecialType.System_UInt16:
-                case SpecialType.System_Int32:
-                case SpecialType.System_UInt32:
-                case SpecialType.System_Int64:
-                case SpecialType.System_UInt64:
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        private enum NumericKind { Unknown, Decimal, Binary, Hexadecimal }
+        CodeAction CreateCodeAction(string text, string title)
+            => CodeAction.Create(title, c => ReplaceTokenAsync(document, root, numericToken, value, text, suffix), title);
     }
+
+    private static Task<Document> ReplaceTokenAsync(Document document, SyntaxNode root, SyntaxToken numericToken, long value, string text, string suffix)
+    {
+        var generator = SyntaxGenerator.GetGenerator(document);
+        var updatedToken = generator.NumericLiteralToken(text + suffix, (ulong)value)
+            .WithTriviaFrom(numericToken);
+        var updatedRoot = root.ReplaceToken(numericToken, updatedToken);
+        return Task.FromResult(document.WithSyntaxRoot(updatedRoot));
+    }
+
+    internal virtual async Task<SyntaxToken> GetNumericTokenAsync(CodeRefactoringContext context)
+    {
+        var syntaxFacts = context.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+        var literalNode = await context.TryGetRelevantNodeAsync<TNumericLiteralExpression>().ConfigureAwait(false);
+        var numericLiteralExpressionNode = syntaxFacts.IsNumericLiteralExpression(literalNode)
+            ? literalNode
+            : null;
+
+        return numericLiteralExpressionNode != null
+            ? numericLiteralExpressionNode.GetFirstToken()    // We know that TNumericLiteralExpression has always only one token: NumericLiteralToken
+            : default;
+    }
+
+    private static (string prefix, string number, string suffix) GetNumericLiteralParts(string numericText, string hexPrefix, string binaryPrefix)
+    {
+        // Match literal text and extract out base prefix, type suffix and the number itself.
+        var groups = Regex.Match(numericText, $"({hexPrefix}|{binaryPrefix})?([_0-9a-f]+)(.*)", RegexOptions.IgnoreCase).Groups;
+        return (prefix: groups[1].Value, number: groups[2].Value, suffix: groups[3].Value);
+    }
+
+    private static string AddSeparators(string numericText, int interval)
+    {
+        // Insert digit separators in the given interval.
+        var result = Regex.Replace(numericText, $"(.{{{interval}}})", "_$1", RegexOptions.RightToLeft);
+        // Fix for the case "0x_1111" that is not supported yet.
+        return result[0] == '_' ? result[1..] : result;
+    }
+
+    private static bool IsIntegral(SpecialType specialType)
+    {
+        switch (specialType)
+        {
+            case SpecialType.System_Byte:
+            case SpecialType.System_SByte:
+            case SpecialType.System_Int16:
+            case SpecialType.System_UInt16:
+            case SpecialType.System_Int32:
+            case SpecialType.System_UInt32:
+            case SpecialType.System_Int64:
+            case SpecialType.System_UInt64:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private enum NumericKind { Unknown, Decimal, Binary, Hexadecimal }
 }

--- a/src/Features/Core/Portable/ConvertNumericLiteral/AbstractConvertNumericLiteralCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertNumericLiteral/AbstractConvertNumericLiteralCodeRefactoringProvider.cs
@@ -110,29 +110,29 @@ internal abstract class AbstractConvertNumericLiteralCodeRefactoringProvider<TNu
 
         CodeAction CreateCodeAction(string text, string title)
             => CodeAction.Create(title, c => ReplaceTokenAsync(document, root, numericToken, value, text, suffix), title);
-    }
 
-    private static Task<Document> ReplaceTokenAsync(Document document, SyntaxNode root, SyntaxToken numericToken, long value, string text, string suffix)
-    {
-        var generator = SyntaxGenerator.GetGenerator(document);
-        var updatedToken = generator.NumericLiteralToken(text + suffix, (ulong)value)
-            .WithTriviaFrom(numericToken);
-        var updatedRoot = root.ReplaceToken(numericToken, updatedToken);
-        return Task.FromResult(document.WithSyntaxRoot(updatedRoot));
-    }
+        static string AddSeparators(string numericText, int interval)
+        {
+            // Insert digit separators in the given interval.
+            var result = Regex.Replace(numericText, $"(.{{{interval}}})", "_$1", RegexOptions.RightToLeft);
+            // Fix for the case "0x_1111" that is not supported yet.
+            return result[0] == '_' ? result[1..] : result;
+        }
 
-    private static (string prefix, string number, string suffix) GetNumericLiteralParts(string numericText, string hexPrefix, string binaryPrefix)
-    {
-        // Match literal text and extract out base prefix, type suffix and the number itself.
-        var groups = Regex.Match(numericText, $"({hexPrefix}|{binaryPrefix})?([_0-9a-f]+)(.*)", RegexOptions.IgnoreCase).Groups;
-        return (prefix: groups[1].Value, number: groups[2].Value, suffix: groups[3].Value);
-    }
+        static Task<Document> ReplaceTokenAsync(Document document, SyntaxNode root, SyntaxToken numericToken, long value, string text, string suffix)
+        {
+            var generator = SyntaxGenerator.GetGenerator(document);
+            var updatedToken = generator.NumericLiteralToken(text + suffix, (ulong)value)
+                .WithTriviaFrom(numericToken);
+            var updatedRoot = root.ReplaceToken(numericToken, updatedToken);
+            return Task.FromResult(document.WithSyntaxRoot(updatedRoot));
+        }
 
-    private static string AddSeparators(string numericText, int interval)
-    {
-        // Insert digit separators in the given interval.
-        var result = Regex.Replace(numericText, $"(.{{{interval}}})", "_$1", RegexOptions.RightToLeft);
-        // Fix for the case "0x_1111" that is not supported yet.
-        return result[0] == '_' ? result[1..] : result;
+        static (string prefix, string number, string suffix) GetNumericLiteralParts(string numericText, string hexPrefix, string binaryPrefix)
+        {
+            // Match literal text and extract out base prefix, type suffix and the number itself.
+            var groups = Regex.Match(numericText, $"({hexPrefix}|{binaryPrefix})?([_0-9a-f]+)(.*)", RegexOptions.IgnoreCase).Groups;
+            return (prefix: groups[1].Value, number: groups[2].Value, suffix: groups[3].Value);
+        }
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3234,4 +3234,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="_0_items_in_cache" xml:space="preserve">
     <value>'{0}' items in cache</value>
   </data>
+  <data name="Convert_number" xml:space="preserve">
+    <value>Convert number</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -545,6 +545,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Obsahující typ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Převést na LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -545,6 +545,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Enthaltender Typ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">In LINQ konvertieren</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -545,6 +545,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Tipo contenedor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Convertir a LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -545,6 +545,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Type conteneur</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Convertir en LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -545,6 +545,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Tipo contenitore</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Converti in LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -545,6 +545,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">含んでいる型</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ に変換</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -545,6 +545,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">포함하는 형식</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ로 변환</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -545,6 +545,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Zawierający typ</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Konwertuj na składnię LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -545,6 +545,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Contendo Tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Converter para LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -545,6 +545,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Содержащий тип</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">Преобразовать в LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -545,6 +545,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">Kapsayan Tür</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">LINQ to dönüştürme</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -545,6 +545,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">包含类型</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">转换为 LINQ</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -545,6 +545,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">包含的類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_number">
+        <source>Convert number</source>
+        <target state="new">Convert number</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_linq">
         <source>Convert to LINQ</source>
         <target state="translated">轉換至 LINQ</target>

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -42,7 +40,7 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         var expected = CreateCodeAction(
             title: CSharpAnalyzersResources.Use_implicit_type,
             kind: CodeActionKind.Refactor,
-            children: Array.Empty<LSP.VSInternalCodeAction>(),
+            children: Array.Empty<VSInternalCodeAction>(),
             data: CreateCodeActionResolveData(
                 CSharpAnalyzersResources.Use_implicit_type,
                 caretLocation,
@@ -77,7 +75,7 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         var expected = CreateCodeAction(
             title: string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
             kind: CodeActionKind.Refactor,
-            children: Array.Empty<LSP.VSInternalCodeAction>(),
+            children: Array.Empty<VSInternalCodeAction>(),
             data: CreateCodeActionResolveData(
                 FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
                 caretLocation),
@@ -91,7 +89,7 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         var topLevelAction = Assert.Single(results.Where(action => action.Title == FeaturesResources.Introduce_constant));
         var expectedChildActionTitle = FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1");
         var introduceConstant = topLevelAction.Children.FirstOrDefault(
-            r => ((JObject)r.Data).ToObject<CodeActionResolveData>().UniqueIdentifier == expectedChildActionTitle);
+            r => ((JObject)r.Data!).ToObject<CodeActionResolveData>()!.UniqueIdentifier == expectedChildActionTitle);
 
         AssertJsonEquals(expected, introduceConstant);
     }
@@ -112,11 +110,11 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
 
         var caret = testLspServer.GetLocations("caret").Single();
-        var codeActionParams = new LSP.CodeActionParams
+        var codeActionParams = new CodeActionParams
         {
             TextDocument = CreateTextDocumentIdentifier(caret.Uri),
             Range = caret.Range,
-            Context = new LSP.CodeActionContext
+            Context = new CodeActionContext
             {
                 Diagnostics = new[]
                 {
@@ -134,8 +132,8 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
 
         var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
         var addImport = results.FirstOrDefault(r => r.Title.Contains($"using System.Threading.Tasks"));
-        Assert.Equal(1, addImport.Diagnostics.Length);
-        Assert.Equal(AddImportDiagnosticIds.CS0103, addImport.Diagnostics.Single().Code.Value);
+        Assert.Equal(1, addImport.Diagnostics!.Length);
+        Assert.Equal(AddImportDiagnosticIds.CS0103, addImport.Diagnostics.Single().Code!.Value);
     }
 
     [WpfTheory, CombinatorialData]
@@ -153,11 +151,11 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
 
         var caret = testLspServer.GetLocations("caret").Single();
-        var codeActionParams = new LSP.CodeActionParams
+        var codeActionParams = new CodeActionParams
         {
             TextDocument = CreateTextDocumentIdentifier(caret.Uri),
             Range = caret.Range,
-            Context = new LSP.CodeActionContext
+            Context = new CodeActionContext
             {
                 Diagnostics = new[]
                 {
@@ -193,11 +191,11 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
 
         var caret = testLspServer.GetLocations("caret").Single();
-        var codeActionParams = new LSP.CodeActionParams
+        var codeActionParams = new CodeActionParams
         {
             TextDocument = CreateTextDocumentIdentifier(caret.Uri),
             Range = caret.Range,
-            Context = new LSP.CodeActionContext
+            Context = new CodeActionContext
             {
             }
         };
@@ -210,33 +208,33 @@ public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLang
         Assert.True(resultsTitles.Contains("Inline 'A()' -> Inline and keep 'A()'"));
     }
 
-    private static async Task<LSP.VSInternalCodeAction[]> RunGetCodeActionsAsync(
+    private static async Task<VSInternalCodeAction[]> RunGetCodeActionsAsync(
         TestLspServer testLspServer,
         CodeActionParams codeActionParams)
     {
-        var result = await testLspServer.ExecuteRequestAsync<LSP.CodeActionParams, LSP.CodeAction[]>(
+        var result = await testLspServer.ExecuteRequestAsync<CodeActionParams, CodeAction[]>(
             LSP.Methods.TextDocumentCodeActionName, codeActionParams, CancellationToken.None);
-        return result.Cast<LSP.VSInternalCodeAction>().ToArray();
+        return result.Cast<VSInternalCodeAction>().ToArray();
     }
 
-    internal static LSP.CodeActionParams CreateCodeActionParams(LSP.Location caret)
-        => new LSP.CodeActionParams
+    internal static CodeActionParams CreateCodeActionParams(LSP.Location caret)
+        => new CodeActionParams
         {
             TextDocument = CreateTextDocumentIdentifier(caret.Uri),
             Range = caret.Range,
-            Context = new LSP.CodeActionContext
+            Context = new CodeActionContext
             {
                 // TODO - Code actions should respect context.
             }
         };
 
-    internal static LSP.VSInternalCodeAction CreateCodeAction(
-        string title, LSP.CodeActionKind kind, LSP.VSInternalCodeAction[] children,
-        CodeActionResolveData data, LSP.Diagnostic[] diagnostics,
-        LSP.VSInternalPriorityLevel? priority, string groupName, LSP.Range applicableRange,
-        LSP.WorkspaceEdit edit = null, LSP.Command command = null)
+    internal static VSInternalCodeAction CreateCodeAction(
+        string title, CodeActionKind kind, VSInternalCodeAction[] children,
+        CodeActionResolveData data, LSP.Diagnostic[]? diagnostics,
+        VSInternalPriorityLevel? priority, string groupName, LSP.Range applicableRange,
+        WorkspaceEdit? edit = null, Command? command = null)
     {
-        var action = new LSP.VSInternalCodeAction
+        var action = new VSInternalCodeAction
         {
             Title = title,
             Kind = kind,

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -19,234 +19,237 @@ using Xunit;
 using Xunit.Abstractions;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions;
+
+public class CodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractLanguageServerProtocolTests(testOutputHelper)
 {
-    public class CodeActionsTests : AbstractLanguageServerProtocolTests
+    [WpfTheory, CombinatorialData]
+    public async Task TestCodeActionHandlerAsync(bool mutatingLspWorkspace)
     {
-        public CodeActionsTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
-        {
-        }
-
-        [WpfTheory, CombinatorialData]
-        public async Task TestCodeActionHandlerAsync(bool mutatingLspWorkspace)
-        {
-            var markup =
-@"class A
-{
-    void M()
-    {
-        {|caret:|}int i = 1;
-    }
-}";
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, initializationOptions: new InitializationOptions() { ClientCapabilities = new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true } });
-
-            var caretLocation = testLspServer.GetLocations("caret").Single();
-            var expected = CreateCodeAction(
-                title: CSharpAnalyzersResources.Use_implicit_type,
-                kind: CodeActionKind.Refactor,
-                children: Array.Empty<LSP.VSInternalCodeAction>(),
-                data: CreateCodeActionResolveData(
-                    CSharpAnalyzersResources.Use_implicit_type,
-                    caretLocation,
-                    customTags: new[] { PredefinedCodeRefactoringProviderNames.UseImplicitType }),
-                priority: VSInternalPriorityLevel.Low,
-                groupName: "Roslyn1",
-                applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 8 }, End = new Position { Line = 4, Character = 11 } },
-                diagnostics: null);
-
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
-            var useImplicitType = results.FirstOrDefault(r => r.Title == CSharpAnalyzersResources.Use_implicit_type);
-
-            AssertJsonEquals(expected, useImplicitType);
-        }
-
-        [WpfTheory, CombinatorialData]
-        public async Task TestCodeActionHandlerAsync_NestedAction(bool mutatingLspWorkspace)
-        {
-            var markup =
-@"class A
-{
-    void M()
-    {
-        int {|caret:|}i = 1;
-    }
-}";
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
-
-            var caretLocation = testLspServer.GetLocations("caret").Single();
-            var expected = CreateCodeAction(
-                title: string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
-                kind: CodeActionKind.Refactor,
-                children: Array.Empty<LSP.VSInternalCodeAction>(),
-                data: CreateCodeActionResolveData(
-                    FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
-                    caretLocation),
-                priority: VSInternalPriorityLevel.Normal,
-                groupName: "Roslyn3",
-                applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 12 }, End = new Position { Line = 4, Character = 12 } },
-                diagnostics: null);
-
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
-
-            var topLevelAction = Assert.Single(results.Where(action => action.Title == FeaturesResources.Introduce_constant));
-            var expectedChildActionTitle = FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1");
-            var introduceConstant = topLevelAction.Children.FirstOrDefault(
-                r => ((JObject)r.Data).ToObject<CodeActionResolveData>().UniqueIdentifier == expectedChildActionTitle);
-
-            AssertJsonEquals(expected, introduceConstant);
-        }
-
-        [WpfTheory, CombinatorialData]
-        public async Task TestCodeActionHasCorrectDiagnostics(bool mutatingLspWorkspace)
-        {
-            var markup =
-@"class A
-{
-    void M()
-    {
-        {|caret:|}Task.Delay(1);
-    }
-}";
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
-
-            var caret = testLspServer.GetLocations("caret").Single();
-            var codeActionParams = new LSP.CodeActionParams
+        var markup =
+            """
+            class A
             {
-                TextDocument = CreateTextDocumentIdentifier(caret.Uri),
-                Range = caret.Range,
-                Context = new LSP.CodeActionContext
+                void M()
                 {
-                    Diagnostics = new[]
+                    {|caret:|}int i = 1;
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, initializationOptions: new InitializationOptions() { ClientCapabilities = new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true } });
+
+        var caretLocation = testLspServer.GetLocations("caret").Single();
+        var expected = CreateCodeAction(
+            title: CSharpAnalyzersResources.Use_implicit_type,
+            kind: CodeActionKind.Refactor,
+            children: Array.Empty<LSP.VSInternalCodeAction>(),
+            data: CreateCodeActionResolveData(
+                CSharpAnalyzersResources.Use_implicit_type,
+                caretLocation,
+                customTags: new[] { PredefinedCodeRefactoringProviderNames.UseImplicitType }),
+            priority: VSInternalPriorityLevel.Low,
+            groupName: "Roslyn2",
+            applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 8 }, End = new Position { Line = 4, Character = 11 } },
+            diagnostics: null);
+
+        var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
+        var useImplicitType = results.FirstOrDefault(r => r.Title == CSharpAnalyzersResources.Use_implicit_type);
+
+        AssertJsonEquals(expected, useImplicitType);
+    }
+
+    [WpfTheory, CombinatorialData]
+    public async Task TestCodeActionHandlerAsync_NestedAction(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class A
+            {
+                void M()
+                {
+                    int {|caret:|}i = 1;
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+
+        var caretLocation = testLspServer.GetLocations("caret").Single();
+        var expected = CreateCodeAction(
+            title: string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
+            kind: CodeActionKind.Refactor,
+            children: Array.Empty<LSP.VSInternalCodeAction>(),
+            data: CreateCodeActionResolveData(
+                FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1"),
+                caretLocation),
+            priority: VSInternalPriorityLevel.Normal,
+            groupName: "Roslyn3",
+            applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 12 }, End = new Position { Line = 4, Character = 12 } },
+            diagnostics: null);
+
+        var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
+
+        var topLevelAction = Assert.Single(results.Where(action => action.Title == FeaturesResources.Introduce_constant));
+        var expectedChildActionTitle = FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1");
+        var introduceConstant = topLevelAction.Children.FirstOrDefault(
+            r => ((JObject)r.Data).ToObject<CodeActionResolveData>().UniqueIdentifier == expectedChildActionTitle);
+
+        AssertJsonEquals(expected, introduceConstant);
+    }
+
+    [WpfTheory, CombinatorialData]
+    public async Task TestCodeActionHasCorrectDiagnostics(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class A
+            {
+                void M()
+                {
+                    {|caret:|}Task.Delay(1);
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var caret = testLspServer.GetLocations("caret").Single();
+        var codeActionParams = new LSP.CodeActionParams
+        {
+            TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+            Range = caret.Range,
+            Context = new LSP.CodeActionContext
+            {
+                Diagnostics = new[]
+                {
+                    new LSP.Diagnostic
                     {
-                        new LSP.Diagnostic
-                        {
-                            Code = AddImportDiagnosticIds.CS0103
-                        },
-                        new LSP.Diagnostic
-                        {
-                            Code = "SomeCode"
-                        }
+                        Code = AddImportDiagnosticIds.CS0103
+                    },
+                    new LSP.Diagnostic
+                    {
+                        Code = "SomeCode"
                     }
                 }
-            };
+            }
+        };
 
-            var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
-            var addImport = results.FirstOrDefault(r => r.Title.Contains($"using System.Threading.Tasks"));
-            Assert.Equal(1, addImport.Diagnostics.Length);
-            Assert.Equal(AddImportDiagnosticIds.CS0103, addImport.Diagnostics.Single().Code.Value);
-        }
-
-        [WpfTheory, CombinatorialData]
-        public async Task TestNoSuppressionFixerInStandardLSP(bool mutatingLspWorkspace)
-        {
-            var markup = @"
-class ABC
-{
-    private static async void {|caret:XYZ|}()
-    {
+        var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
+        var addImport = results.FirstOrDefault(r => r.Title.Contains($"using System.Threading.Tasks"));
+        Assert.Equal(1, addImport.Diagnostics.Length);
+        Assert.Equal(AddImportDiagnosticIds.CS0103, addImport.Diagnostics.Single().Code.Value);
     }
-}";
 
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
-
-            var caret = testLspServer.GetLocations("caret").Single();
-            var codeActionParams = new LSP.CodeActionParams
+    [WpfTheory, CombinatorialData]
+    public async Task TestNoSuppressionFixerInStandardLSP(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class ABC
             {
-                TextDocument = CreateTextDocumentIdentifier(caret.Uri),
-                Range = caret.Range,
-                Context = new LSP.CodeActionContext
+                private static async void {|caret:XYZ|}()
                 {
-                    Diagnostics = new[]
+                }
+            }
+            """;
+
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var caret = testLspServer.GetLocations("caret").Single();
+        var codeActionParams = new LSP.CodeActionParams
+        {
+            TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+            Range = caret.Range,
+            Context = new LSP.CodeActionContext
+            {
+                Diagnostics = new[]
+                {
+                    new LSP.Diagnostic
                     {
-                        new LSP.Diagnostic
-                        {
-                            // async method lack of await.
-                            Code = "CS1998"
-                        }
+                        // async method lack of await.
+                        Code = "CS1998"
                     }
                 }
-            };
+            }
+        };
 
-            var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
-            Assert.Single(results);
-            Assert.Equal("Make method synchronous", results[0].Title);
-        }
-
-        [WpfTheory, CombinatorialData]
-        public async Task TestStandardLspNestedCodeAction(bool mutatingLspWorkspace)
-        {
-            var markup = @"
-class ABC
-{
-    private void XYZ()
-    {
-        var a = {|caret:A()|};
+        var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
+        Assert.Single(results);
+        Assert.Equal("Make method synchronous", results[0].Title);
     }
 
-    private int A() => 1;
-}";
-
-            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
-
-            var caret = testLspServer.GetLocations("caret").Single();
-            var codeActionParams = new LSP.CodeActionParams
+    [WpfTheory, CombinatorialData]
+    public async Task TestStandardLspNestedCodeAction(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class ABC
             {
-                TextDocument = CreateTextDocumentIdentifier(caret.Uri),
-                Range = caret.Range,
-                Context = new LSP.CodeActionContext
+                private void XYZ()
                 {
+                    var a = {|caret:A()|};
                 }
-            };
 
-            var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
-            var resultsTitles = results.Select(r => r.Title).ToArray();
-            // Inline method refactoring provide nested code actions.
-            // Make sure it is correctly displayed.
-            Assert.True(resultsTitles.Contains("Inline 'A()' -> Inline 'A()'"));
-            Assert.True(resultsTitles.Contains("Inline 'A()' -> Inline and keep 'A()'"));
-        }
+                private int A() => 1;
+            }
+            """;
 
-        private static async Task<LSP.VSInternalCodeAction[]> RunGetCodeActionsAsync(
-            TestLspServer testLspServer,
-            CodeActionParams codeActionParams)
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var caret = testLspServer.GetLocations("caret").Single();
+        var codeActionParams = new LSP.CodeActionParams
         {
-            var result = await testLspServer.ExecuteRequestAsync<LSP.CodeActionParams, LSP.CodeAction[]>(
-                LSP.Methods.TextDocumentCodeActionName, codeActionParams, CancellationToken.None);
-            return result.Cast<LSP.VSInternalCodeAction>().ToArray();
-        }
-
-        internal static LSP.CodeActionParams CreateCodeActionParams(LSP.Location caret)
-            => new LSP.CodeActionParams
+            TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+            Range = caret.Range,
+            Context = new LSP.CodeActionContext
             {
-                TextDocument = CreateTextDocumentIdentifier(caret.Uri),
-                Range = caret.Range,
-                Context = new LSP.CodeActionContext
-                {
-                    // TODO - Code actions should respect context.
-                }
-            };
+            }
+        };
 
-        internal static LSP.VSInternalCodeAction CreateCodeAction(
-            string title, LSP.CodeActionKind kind, LSP.VSInternalCodeAction[] children,
-            CodeActionResolveData data, LSP.Diagnostic[] diagnostics,
-            LSP.VSInternalPriorityLevel? priority, string groupName, LSP.Range applicableRange,
-            LSP.WorkspaceEdit edit = null, LSP.Command command = null)
+        var results = await RunGetCodeActionsAsync(testLspServer, codeActionParams);
+        var resultsTitles = results.Select(r => r.Title).ToArray();
+        // Inline method refactoring provide nested code actions.
+        // Make sure it is correctly displayed.
+        Assert.True(resultsTitles.Contains("Inline 'A()' -> Inline 'A()'"));
+        Assert.True(resultsTitles.Contains("Inline 'A()' -> Inline and keep 'A()'"));
+    }
+
+    private static async Task<LSP.VSInternalCodeAction[]> RunGetCodeActionsAsync(
+        TestLspServer testLspServer,
+        CodeActionParams codeActionParams)
+    {
+        var result = await testLspServer.ExecuteRequestAsync<LSP.CodeActionParams, LSP.CodeAction[]>(
+            LSP.Methods.TextDocumentCodeActionName, codeActionParams, CancellationToken.None);
+        return result.Cast<LSP.VSInternalCodeAction>().ToArray();
+    }
+
+    internal static LSP.CodeActionParams CreateCodeActionParams(LSP.Location caret)
+        => new LSP.CodeActionParams
         {
-            var action = new LSP.VSInternalCodeAction
+            TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+            Range = caret.Range,
+            Context = new LSP.CodeActionContext
             {
-                Title = title,
-                Kind = kind,
-                Children = children,
-                Data = JToken.FromObject(data),
-                Diagnostics = diagnostics,
-                Edit = edit,
-                Group = groupName,
-                Priority = priority,
-                ApplicableRange = applicableRange,
-                Command = command
-            };
+                // TODO - Code actions should respect context.
+            }
+        };
 
-            return action;
-        }
+    internal static LSP.VSInternalCodeAction CreateCodeAction(
+        string title, LSP.CodeActionKind kind, LSP.VSInternalCodeAction[] children,
+        CodeActionResolveData data, LSP.Diagnostic[] diagnostics,
+        LSP.VSInternalPriorityLevel? priority, string groupName, LSP.Range applicableRange,
+        LSP.WorkspaceEdit edit = null, LSP.Command command = null)
+    {
+        var action = new LSP.VSInternalCodeAction
+        {
+            Title = title,
+            Kind = kind,
+            Children = children,
+            Data = JToken.FromObject(data),
+            Diagnostics = diagnostics,
+            Edit = edit,
+            Group = groupName,
+            Priority = priority,
+            ApplicableRange = applicableRange,
+            Command = command
+        };
+
+        return action;
     }
 }

--- a/src/Features/VisualBasic/Portable/ConvertNumericLiteral/VisualBasicConvertNumericLiteralCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertNumericLiteral/VisualBasicConvertNumericLiteralCodeRefactoringProvider.vb
@@ -16,10 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertNumericLiteral
         <ImportingConstructor>
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New()
+            MyBase.New(hexPrefix:="&H", binaryPrefix:="&B")
         End Sub
-
-        Protected Overrides Function GetNumericLiteralPrefixes() As (hexPrefix As String, binaryPrefix As String)
-            Return (hexPrefix:="&H", binaryPrefix:="&B")
-        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasicTest/ConvertNumericLiteral/ConvertNumericLiteralTests.vb
+++ b/src/Features/VisualBasicTest/ConvertNumericLiteral/ConvertNumericLiteralTests.vb
@@ -2,6 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
 Imports Microsoft.CodeAnalysis.VisualBasic.ConvertNumericLiteral
@@ -13,6 +15,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.Conver
 
         Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
             Return New VisualBasicConvertNumericLiteralCodeRefactoringProvider()
+        End Function
+
+        Protected Overrides Function MassageActions(actions As ImmutableArray(Of CodeAction)) As ImmutableArray(Of CodeAction)
+            Return FlattenActions(actions)
         End Function
 
         Private Enum Refactoring


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69637

Looks like this now:

![image](https://github.com/dotnet/roslyn/assets/4564579/52bf832c-dbbf-4eec-9f39-f6ed1e6fa052)

First, the item is considered one of the lowest pri things to offer.  Second, we don't show all the items (and instead have a nested list) if tehre are already a bunch more refactorings already being shown.