### PR TITLE
Fix issue where dedenting a namespace did not dedent raw string literals

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -16,385 +16,377 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
+namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
+
+internal static class ConvertNamespaceTransform
 {
-    internal static class ConvertNamespaceTransform
+    public static Task<Document> ConvertAsync(Document document, BaseNamespaceDeclarationSyntax baseNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
+        => baseNamespace switch
+        {
+            FileScopedNamespaceDeclarationSyntax fileScopedNamespace => ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, options, cancellationToken),
+            NamespaceDeclarationSyntax namespaceDeclaration => ConvertNamespaceDeclarationAsync(document, namespaceDeclaration, options, cancellationToken),
+            _ => throw ExceptionUtilities.UnexpectedValue(baseNamespace.Kind()),
+        };
+
+    /// <summary>
+    /// Asynchronous implementation for code fixes.
+    /// </summary>
+    public static async Task<Document> ConvertNamespaceDeclarationAsync(Document document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
     {
-        public static async Task<Document> ConvertAsync(Document document, BaseNamespaceDeclarationSyntax baseNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
+        var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        // Replace the block namespace with the file scoped namespace.
+        var annotation = new SyntaxAnnotation();
+        var (updatedRoot, _) = ReplaceWithFileScopedNamespace(parsedDocument, namespaceDeclaration, annotation);
+        var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+
+        // Determine how much indentation we had inside the original block namespace. We'll attempt to remove
+        // that much indentation from each applicable line after we conver the block namespace to a file scoped
+        // namespace.
+        var indentation = GetIndentation(parsedDocument, namespaceDeclaration, options, cancellationToken);
+        if (indentation == null)
+            return updatedDocument;
+
+        // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
+        var updatedParsedDocument = await ParsedDocument.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
+        var (dedentedText, _) = DedentNamespace(updatedParsedDocument, indentation, annotation, cancellationToken);
+        return document.WithText(dedentedText);
+    }
+
+    /// <summary>
+    /// Synchronous implementation for a command handler.
+    /// </summary>
+    public static (SourceText text, TextSpan semicolonSpan) ConvertNamespaceDeclaration(ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+    {
+        // Replace the block namespace with the file scoped namespace.
+        var annotation = new SyntaxAnnotation();
+        var (updatedRoot, semicolonSpan) = ReplaceWithFileScopedNamespace(document, namespaceDeclaration, annotation);
+        var updatedDocument = document.WithChangedRoot(updatedRoot, cancellationToken);
+
+        // Determine how much indentation we had inside the original block namespace. We'll attempt to remove
+        // that much indentation from each applicable line after we conver the block namespace to a file scoped
+        // namespace.
+
+        var indentation = GetIndentation(document, namespaceDeclaration, options, cancellationToken);
+        if (indentation == null)
+            return (updatedDocument.Text, semicolonSpan);
+
+        // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
+        return DedentNamespace(updatedDocument, indentation, annotation, cancellationToken);
+    }
+
+    private static (SyntaxNode root, TextSpan semicolonSpan) ReplaceWithFileScopedNamespace(
+        ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxAnnotation annotation)
+    {
+        var converted = ConvertNamespaceDeclaration(namespaceDeclaration);
+        var updatedRoot = document.Root.ReplaceNode(
+            namespaceDeclaration,
+            converted.WithAdditionalAnnotations(annotation));
+        var fileScopedNamespace = (FileScopedNamespaceDeclarationSyntax)updatedRoot.GetAnnotatedNodes(annotation).Single();
+        return (updatedRoot, fileScopedNamespace.SemicolonToken.Span);
+    }
+
+    private static string? GetIndentation(ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+    {
+        var openBraceLine = document.Text.Lines.GetLineFromPosition(namespaceDeclaration.OpenBraceToken.SpanStart).LineNumber;
+        var closeBraceLine = document.Text.Lines.GetLineFromPosition(namespaceDeclaration.CloseBraceToken.SpanStart).LineNumber;
+        if (openBraceLine == closeBraceLine)
+            return null;
+
+        // Auto-formatting options are not relevant since they only control behavior on typing.
+        var indentationOptions = new IndentationOptions(options);
+
+        var indentationService = document.LanguageServices.GetRequiredService<IIndentationService>();
+        var indentation = indentationService.GetIndentation(document, openBraceLine + 1, indentationOptions, cancellationToken);
+
+        return indentation.GetIndentationString(document.Text, options.UseTabs, options.TabSize);
+    }
+
+    private static (SourceText text, TextSpan semicolonSpan) DedentNamespace(
+        ParsedDocument document, string indentation, SyntaxAnnotation annotation, CancellationToken cancellationToken)
+    {
+        var syntaxTree = document.SyntaxTree;
+        var text = document.Text;
+        var root = document.Root;
+
+        var fileScopedNamespace = (FileScopedNamespaceDeclarationSyntax)root.GetAnnotatedNodes(annotation).Single();
+        var semicolonLine = text.Lines.GetLineFromPosition(fileScopedNamespace.SemicolonToken.SpanStart).LineNumber;
+
+        using var _ = ArrayBuilder<TextChange>.GetInstance(out var changes);
+        for (var line = semicolonLine + 1; line < text.Lines.Count; line++)
+            changes.AddIfNotNull(TryDedentLine(syntaxTree, text, indentation, text.Lines[line], cancellationToken));
+
+        var dedentedText = text.WithChanges(changes);
+        return (dedentedText, fileScopedNamespace.SemicolonToken.Span);
+    }
+
+    private static TextChange? TryDedentLine(
+        SyntaxTree tree, SourceText text, string indentation, TextLine textLine, CancellationToken cancellationToken)
+    {
+        // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
+        // touch what is inside there.  Note: this will not apply to raw-string literals, which can potentially be
+        // dedented safely depending on the position of their close terminator.
+        if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, out var stringLiteral, cancellationToken) &&
+            stringLiteral.Kind() is not SyntaxKind.MultiLineRawStringLiteralToken and not SyntaxKind.Utf8MultiLineRawStringLiteralToken)
         {
-            switch (baseNamespace)
+            return null;
+        }
+
+        // Determine the amount of indentation this text line starts with.
+        var commonIndentation = 0;
+        while (commonIndentation < indentation.Length && commonIndentation < textLine.Span.Length)
+        {
+            if (indentation[commonIndentation] != text[textLine.Start + commonIndentation])
+                break;
+
+            commonIndentation++;
+        }
+
+        return new TextChange(new TextSpan(textLine.Start, commonIndentation), newText: "");
+    }
+
+    private static SourceText IndentNamespace(
+        ParsedDocument document, string indentation, SyntaxAnnotation annotation, CancellationToken cancellationToken)
+    {
+        var syntaxTree = document.SyntaxTree;
+        var text = document.Text;
+        var root = document.Root;
+
+        var blockScopedNamespace = (NamespaceDeclarationSyntax)root.GetAnnotatedNodes(annotation).Single();
+        var openBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.OpenBraceToken.SpanStart).LineNumber;
+        var closeBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.CloseBraceToken.SpanStart).LineNumber;
+
+        using var _ = ArrayBuilder<TextChange>.GetInstance(Math.Max(0, closeBraceLine - openBraceLine - 1), out var changes);
+        for (var line = openBraceLine + 1; line < closeBraceLine; line++)
+            changes.AddIfNotNull(TryIndentLine(syntaxTree, root, indentation, text.Lines[line], cancellationToken));
+
+        var dedentedText = text.WithChanges(changes);
+        return dedentedText;
+    }
+
+    private static TextChange? TryIndentLine(
+        SyntaxTree tree, SyntaxNode root, string indentation, TextLine textLine, CancellationToken cancellationToken)
+    {
+        if (textLine.IsEmptyOrWhitespace())
+            return null;
+
+        // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
+        // touch what is inside there.  Note: this will not apply to raw-string literals, which can be indented
+        // safely.
+        if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, cancellationToken))
+            return null;
+
+        if (textLine.Text![textLine.Start] == '#')
+        {
+            var token = root.FindToken(textLine.Start, findInsideTrivia: true);
+            if (token.IsKind(SyntaxKind.HashToken) && token.Parent!.Kind() is not (SyntaxKind.RegionDirectiveTrivia or SyntaxKind.EndRegionDirectiveTrivia))
             {
-                case FileScopedNamespaceDeclarationSyntax fileScopedNamespace:
-                    return await ConvertFileScopedNamespaceAsync(document, fileScopedNamespace, options, cancellationToken).ConfigureAwait(false);
-
-                case NamespaceDeclarationSyntax namespaceDeclaration:
-                    return await ConvertNamespaceDeclarationAsync(document, namespaceDeclaration, options, cancellationToken).ConfigureAwait(false);
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(baseNamespace.Kind());
-            }
-        }
-
-        /// <summary>
-        /// Asynchrounous implementation for code fixes.
-        /// </summary>
-        public static async ValueTask<Document> ConvertNamespaceDeclarationAsync(Document document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        {
-            var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
-            // Replace the block namespace with the file scoped namespace.
-            var annotation = new SyntaxAnnotation();
-            var (updatedRoot, _) = ReplaceWithFileScopedNamespace(parsedDocument, namespaceDeclaration, annotation);
-            var updatedDocument = document.WithSyntaxRoot(updatedRoot);
-
-            // Determine how much indentation we had inside the original block namespace. We'll attempt to remove
-            // that much indentation from each applicable line after we conver the block namespace to a file scoped
-            // namespace.
-            var indentation = GetIndentation(parsedDocument, namespaceDeclaration, options, cancellationToken);
-            if (indentation == null)
-                return updatedDocument;
-
-            // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
-            var updatedParsedDocument = await ParsedDocument.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
-            var (dedentedText, _) = DedentNamespace(updatedParsedDocument, indentation, annotation, cancellationToken);
-            return document.WithText(dedentedText);
-        }
-
-        /// <summary>
-        /// Synchronous implementation for a command handler.
-        /// </summary>
-        public static (SourceText text, TextSpan semicolonSpan) ConvertNamespaceDeclaration(ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        {
-            // Replace the block namespace with the file scoped namespace.
-            var annotation = new SyntaxAnnotation();
-            var (updatedRoot, semicolonSpan) = ReplaceWithFileScopedNamespace(document, namespaceDeclaration, annotation);
-            var updatedDocument = document.WithChangedRoot(updatedRoot, cancellationToken);
-
-            // Determine how much indentation we had inside the original block namespace. We'll attempt to remove
-            // that much indentation from each applicable line after we conver the block namespace to a file scoped
-            // namespace.
-
-            var indentation = GetIndentation(document, namespaceDeclaration, options, cancellationToken);
-            if (indentation == null)
-                return (updatedDocument.Text, semicolonSpan);
-
-            // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
-            return DedentNamespace(updatedDocument, indentation, annotation, cancellationToken);
-        }
-
-        private static (SyntaxNode root, TextSpan semicolonSpan) ReplaceWithFileScopedNamespace(
-            ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxAnnotation annotation)
-        {
-            var converted = ConvertNamespaceDeclaration(namespaceDeclaration);
-            var updatedRoot = document.Root.ReplaceNode(
-                namespaceDeclaration,
-                converted.WithAdditionalAnnotations(annotation));
-            var fileScopedNamespace = (FileScopedNamespaceDeclarationSyntax)updatedRoot.GetAnnotatedNodes(annotation).Single();
-            return (updatedRoot, fileScopedNamespace.SemicolonToken.Span);
-        }
-
-        private static string? GetIndentation(ParsedDocument document, NamespaceDeclarationSyntax namespaceDeclaration, SyntaxFormattingOptions options, CancellationToken cancellationToken)
-        {
-            var openBraceLine = document.Text.Lines.GetLineFromPosition(namespaceDeclaration.OpenBraceToken.SpanStart).LineNumber;
-            var closeBraceLine = document.Text.Lines.GetLineFromPosition(namespaceDeclaration.CloseBraceToken.SpanStart).LineNumber;
-            if (openBraceLine == closeBraceLine)
+                // only #region and #endregion get indented
                 return null;
-
-            // Auto-formatting options are not relevant since they only control behavior on typing.
-            var indentationOptions = new IndentationOptions(options);
-
-            var indentationService = document.LanguageServices.GetRequiredService<IIndentationService>();
-            var indentation = indentationService.GetIndentation(document, openBraceLine + 1, indentationOptions, cancellationToken);
-
-            return indentation.GetIndentationString(document.Text, options.UseTabs, options.TabSize);
+            }
         }
 
-        private static (SourceText text, TextSpan semicolonSpan) DedentNamespace(
-            ParsedDocument document, string indentation, SyntaxAnnotation annotation, CancellationToken cancellationToken)
+        return new TextChange(new TextSpan(textLine.Start, 0), newText: indentation);
+    }
+
+    public static async Task<Document> ConvertFileScopedNamespaceAsync(
+        Document document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
+    {
+        var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        // Replace the block namespace with the file scoped namespace.
+        var annotation = new SyntaxAnnotation();
+        var updatedRoot = ReplaceWithBlockScopedNamespace(parsedDocument, fileScopedNamespace, options.NewLine, options.NewLines, annotation);
+        var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+
+        // Auto-formatting options are not relevant since they only control behavior on typing.
+        var indentation = FormattingExtensions.CreateIndentationString(options.IndentationSize, options.UseTabs, options.TabSize);
+        if (indentation == "")
+            return updatedDocument;
+
+        // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
+        var updatedParsedDocument = await ParsedDocument.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
+        var indentedText = IndentNamespace(updatedParsedDocument, indentation, annotation, cancellationToken);
+        return document.WithText(indentedText);
+    }
+
+    private static SyntaxNode ReplaceWithBlockScopedNamespace(
+        ParsedDocument document, FileScopedNamespaceDeclarationSyntax namespaceDeclaration, string lineEnding, NewLinePlacement newLinePlacement, SyntaxAnnotation annotation)
+    {
+        var converted = ConvertFileScopedNamespace(document, namespaceDeclaration, lineEnding, newLinePlacement);
+
+        // If the leading trivia of the token after the end of the file scoped namespace spans multiple lines, make
+        // sure all the lines preceding the line with the next token are placed inside the block body namespace.
+        var tokenAfterNamespace = namespaceDeclaration.GetLastToken(includeZeroWidth: true, includeSkipped: true).GetNextTokenOrEndOfFile(includeZeroWidth: true, includeSkipped: true);
+        var lineWithNextToken = document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart);
+        var (splitPosition, needsAdditionalLineEnding) = lineWithNextToken.GetFirstNonWhitespacePosition() < tokenAfterNamespace.SpanStart
+            ? (tokenAfterNamespace.SpanStart, true)
+            : (document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart).Start, false);
+        var triviaBeforeSplit = tokenAfterNamespace.LeadingTrivia.TakeWhile(trivia => trivia.SpanStart < splitPosition).ToArray();
+        var triviaAfterSplit = tokenAfterNamespace.LeadingTrivia.Skip(triviaBeforeSplit.Length).ToArray();
+
+        if (triviaBeforeSplit.Length > 0)
         {
-            var syntaxTree = document.SyntaxTree;
-            var text = document.Text;
-            var root = document.Root;
+            if (needsAdditionalLineEnding)
+                triviaBeforeSplit = triviaBeforeSplit.Append(SyntaxFactory.EndOfLine(lineEnding));
 
-            var fileScopedNamespace = (FileScopedNamespaceDeclarationSyntax)root.GetAnnotatedNodes(annotation).Single();
-            var semicolonLine = text.Lines.GetLineFromPosition(fileScopedNamespace.SemicolonToken.SpanStart).LineNumber;
-
-            using var _ = ArrayBuilder<TextChange>.GetInstance(out var changes);
-            for (var line = semicolonLine + 1; line < text.Lines.Count; line++)
-                changes.AddIfNotNull(TryDedentLine(syntaxTree, text, indentation, text.Lines[line], cancellationToken));
-
-            var dedentedText = text.WithChanges(changes);
-            return (dedentedText, fileScopedNamespace.SemicolonToken.Span);
+            converted = converted.WithCloseBraceToken(converted.CloseBraceToken.WithPrependedLeadingTrivia(triviaBeforeSplit));
         }
 
-        private static TextChange? TryDedentLine(
-            SyntaxTree tree, SourceText text, string indentation, TextLine textLine, CancellationToken cancellationToken)
+        // If the block namespace starts with a blank line, remove one blank line as an adjustment relative to the
+        // file scoped namespace. This check is performed here to account for cases where the token after the
+        // opening brace is the closing brace token, and the leading newline for the closing brace token was
+        // introduced by the trivia relocation above.
+        var firstBodyToken = converted.OpenBraceToken.GetNextToken(includeZeroWidth: true, includeSkipped: true);
+        if (firstBodyToken.Kind() != SyntaxKind.EndOfFileToken
+            && HasLeadingBlankLine(firstBodyToken, out var firstBodyTokenWithoutBlankLine))
         {
-            // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
-            // touch what is inside there.  Note: this will not apply to raw-string literals, which can potentially be
-            // dedented safely depending on the position of their close terminator.
-            if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, out var stringLiteral, cancellationToken) &&
-                stringLiteral.Kind() is not SyntaxKind.MultiLineRawStringLiteralToken and not SyntaxKind.Utf8MultiLineRawStringLiteralToken)
-            {
-                return null;
-            }
-
-            // Determine the amount of indentation this text line starts with.
-            var commonIndentation = 0;
-            while (commonIndentation < indentation.Length && commonIndentation < textLine.Span.Length)
-            {
-                if (indentation[commonIndentation] != text[textLine.Start + commonIndentation])
-                    break;
-
-                commonIndentation++;
-            }
-
-            return new TextChange(new TextSpan(textLine.Start, commonIndentation), newText: "");
+            converted = converted.ReplaceToken(firstBodyToken, firstBodyTokenWithoutBlankLine);
         }
 
-        private static SourceText IndentNamespace(
-            ParsedDocument document, string indentation, SyntaxAnnotation annotation, CancellationToken cancellationToken)
+        return document.Root.ReplaceSyntax(
+            new SyntaxNode[] { namespaceDeclaration },
+            (_, _) => converted.WithAdditionalAnnotations(annotation),
+            new SyntaxToken[] { tokenAfterNamespace },
+            (_, _) => tokenAfterNamespace.WithLeadingTrivia(triviaAfterSplit),
+            Array.Empty<SyntaxTrivia>(),
+            (_, _) => throw ExceptionUtilities.Unreachable());
+    }
+
+    private static bool HasLeadingBlankLine(
+        SyntaxToken token, out SyntaxToken withoutBlankLine)
+    {
+        var leadingTrivia = token.LeadingTrivia;
+
+        if (leadingTrivia is [(kind: SyntaxKind.EndOfLineTrivia), ..])
         {
-            var syntaxTree = document.SyntaxTree;
-            var text = document.Text;
-            var root = document.Root;
-
-            var blockScopedNamespace = (NamespaceDeclarationSyntax)root.GetAnnotatedNodes(annotation).Single();
-            var openBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.OpenBraceToken.SpanStart).LineNumber;
-            var closeBraceLine = text.Lines.GetLineFromPosition(blockScopedNamespace.CloseBraceToken.SpanStart).LineNumber;
-
-            using var _ = ArrayBuilder<TextChange>.GetInstance(Math.Max(0, closeBraceLine - openBraceLine - 1), out var changes);
-            for (var line = openBraceLine + 1; line < closeBraceLine; line++)
-                changes.AddIfNotNull(TryIndentLine(syntaxTree, root, indentation, text.Lines[line], cancellationToken));
-
-            var dedentedText = text.WithChanges(changes);
-            return dedentedText;
+            withoutBlankLine = token.WithLeadingTrivia(leadingTrivia.RemoveAt(0));
+            return true;
         }
 
-        private static TextChange? TryIndentLine(
-            SyntaxTree tree, SyntaxNode root, string indentation, TextLine textLine, CancellationToken cancellationToken)
+        if (leadingTrivia is [(kind: SyntaxKind.WhitespaceTrivia), (kind: SyntaxKind.EndOfLineTrivia), ..])
         {
-            if (textLine.IsEmptyOrWhitespace())
-                return null;
-
-            // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
-            // touch what is inside there.  Note: this will not apply to raw-string literals, which can be indented
-            // safely.
-            if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, cancellationToken))
-                return null;
-
-            if (textLine.Text![textLine.Start] == '#')
-            {
-                var token = root.FindToken(textLine.Start, findInsideTrivia: true);
-                if (token.IsKind(SyntaxKind.HashToken) && token.Parent!.Kind() is not (SyntaxKind.RegionDirectiveTrivia or SyntaxKind.EndRegionDirectiveTrivia))
-                {
-                    // only #region and #endregion get indented
-                    return null;
-                }
-            }
-
-            return new TextChange(new TextSpan(textLine.Start, 0), newText: indentation);
+            withoutBlankLine = token.WithLeadingTrivia(leadingTrivia.Skip(2));
+            return true;
         }
 
-        public static async Task<Document> ConvertFileScopedNamespaceAsync(
-            Document document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, CSharpSyntaxFormattingOptions options, CancellationToken cancellationToken)
+        withoutBlankLine = default;
+        return false;
+    }
+
+    private static FileScopedNamespaceDeclarationSyntax ConvertNamespaceDeclaration(NamespaceDeclarationSyntax namespaceDeclaration)
+    {
+        // If the open-brace token has any special trivia, then move them to after the semicolon.
+        var semiColon = SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+            .WithoutTrivia()
+            .WithTrailingTrivia(namespaceDeclaration.Name.GetTrailingTrivia())
+            .WithAppendedTrailingTrivia(namespaceDeclaration.OpenBraceToken.LeadingTrivia);
+
+        if (!namespaceDeclaration.OpenBraceToken.TrailingTrivia.All(static t => t.IsWhitespace()))
+            semiColon = semiColon.WithAppendedTrailingTrivia(namespaceDeclaration.OpenBraceToken.TrailingTrivia);
+
+        // Move trivia after the original name token to now be after the new semicolon token.
+        var fileScopedNamespace = SyntaxFactory.FileScopedNamespaceDeclaration(
+            namespaceDeclaration.AttributeLists,
+            namespaceDeclaration.Modifiers,
+            namespaceDeclaration.NamespaceKeyword,
+            namespaceDeclaration.Name.WithoutTrailingTrivia(),
+            semiColon,
+            namespaceDeclaration.Externs,
+            namespaceDeclaration.Usings,
+            namespaceDeclaration.Members);
+
+        // Copy trivia from the close brace to the end of the file scoped namespace (which means after all of the members)
+        fileScopedNamespace = fileScopedNamespace
+            .WithAppendedTrailingTrivia(namespaceDeclaration.CloseBraceToken.LeadingTrivia)
+            .WithAppendedTrailingTrivia(namespaceDeclaration.CloseBraceToken.TrailingTrivia);
+
+        var originalHadTrailingNewLine = namespaceDeclaration.GetTrailingTrivia() is [.., (kind: SyntaxKind.EndOfLineTrivia)];
+
+        // now, intelligently trim excess newlines to try to match what the original namespace looked like.
+        while (fileScopedNamespace.HasTrailingTrivia)
         {
-            var parsedDocument = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var trailingTrivia = fileScopedNamespace.GetTrailingTrivia();
 
-            // Replace the block namespace with the file scoped namespace.
-            var annotation = new SyntaxAnnotation();
-            var updatedRoot = ReplaceWithBlockScopedNamespace(parsedDocument, fileScopedNamespace, options.NewLine, options.NewLines, annotation);
-            var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+            // if the new namespace doesn't end with a newline, nothing for us to do.
+            if (trailingTrivia is not [.., (kind: SyntaxKind.EndOfLineTrivia)])
+                break;
 
-            // Auto-formatting options are not relevant since they only control behavior on typing.
-            var indentation = FormattingExtensions.CreateIndentationString(options.IndentationSize, options.UseTabs, options.TabSize);
-            if (indentation == "")
-                return updatedDocument;
+            // if the original had a newline, then we only want to trim the newlines as long as there is still one
+            // left at the end.
 
-            // Now, find the file scoped namespace in the updated doc and go and dedent every line if applicable.
-            var updatedParsedDocument = await ParsedDocument.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
-            var indentedText = IndentNamespace(updatedParsedDocument, indentation, annotation, cancellationToken);
-            return document.WithText(indentedText);
+            if (originalHadTrailingNewLine && trailingTrivia is not
+                [
+                    ..,
+                    (kind: SyntaxKind.EndOfLineTrivia or SyntaxKind.EndIfDirectiveTrivia or SyntaxKind.EndRegionDirectiveTrivia),
+                    (kind: SyntaxKind.EndOfLineTrivia)
+                ])
+            {
+                break;
+            }
+
+            // New namespace has excess newlines, remove the last one and try again.
+            fileScopedNamespace = fileScopedNamespace.WithTrailingTrivia(
+                trailingTrivia.Take(trailingTrivia.Count - 1));
         }
 
-        private static SyntaxNode ReplaceWithBlockScopedNamespace(
-            ParsedDocument document, FileScopedNamespaceDeclarationSyntax namespaceDeclaration, string lineEnding, NewLinePlacement newLinePlacement, SyntaxAnnotation annotation)
+        return fileScopedNamespace;
+    }
+
+    private static NamespaceDeclarationSyntax ConvertFileScopedNamespace(ParsedDocument document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, string lineEnding, NewLinePlacement newLinePlacement)
+    {
+        var nameSyntax = fileScopedNamespace.Name.WithAppendedTrailingTrivia(fileScopedNamespace.SemicolonToken.LeadingTrivia)
+            .WithAppendedTrailingTrivia(newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes) ? SyntaxFactory.EndOfLine(lineEnding) : SyntaxFactory.Space);
+        var openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
+
+        if (openBraceToken.TrailingTrivia is not [.., SyntaxTrivia(SyntaxKind.EndOfLineTrivia)])
         {
-            var converted = ConvertFileScopedNamespace(document, namespaceDeclaration, lineEnding, newLinePlacement);
-
-            // If the leading trivia of the token after the end of the file scoped namespace spans multiple lines, make
-            // sure all the lines preceding the line with the next token are placed inside the block body namespace.
-            var tokenAfterNamespace = namespaceDeclaration.GetLastToken(includeZeroWidth: true, includeSkipped: true).GetNextTokenOrEndOfFile(includeZeroWidth: true, includeSkipped: true);
-            var lineWithNextToken = document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart);
-            var (splitPosition, needsAdditionalLineEnding) = lineWithNextToken.GetFirstNonWhitespacePosition() < tokenAfterNamespace.SpanStart
-                ? (tokenAfterNamespace.SpanStart, true)
-                : (document.Text.Lines.GetLineFromPosition(tokenAfterNamespace.SpanStart).Start, false);
-            var triviaBeforeSplit = tokenAfterNamespace.LeadingTrivia.TakeWhile(trivia => trivia.SpanStart < splitPosition).ToArray();
-            var triviaAfterSplit = tokenAfterNamespace.LeadingTrivia.Skip(triviaBeforeSplit.Length).ToArray();
-
-            if (triviaBeforeSplit.Length > 0)
-            {
-                if (needsAdditionalLineEnding)
-                    triviaBeforeSplit = triviaBeforeSplit.Append(SyntaxFactory.EndOfLine(lineEnding));
-
-                converted = converted.WithCloseBraceToken(converted.CloseBraceToken.WithPrependedLeadingTrivia(triviaBeforeSplit));
-            }
-
-            // If the block namespace starts with a blank line, remove one blank line as an adjustment relative to the
-            // file scoped namespace. This check is performed here to account for cases where the token after the
-            // opening brace is the closing brace token, and the leading newline for the closing brace token was
-            // introduced by the trivia relocation above.
-            var firstBodyToken = converted.OpenBraceToken.GetNextToken(includeZeroWidth: true, includeSkipped: true);
-            if (firstBodyToken.Kind() != SyntaxKind.EndOfFileToken
-                && HasLeadingBlankLine(firstBodyToken, out var firstBodyTokenWithoutBlankLine))
-            {
-                converted = converted.ReplaceToken(firstBodyToken, firstBodyTokenWithoutBlankLine);
-            }
-
-            return document.Root.ReplaceSyntax(
-                new SyntaxNode[] { namespaceDeclaration },
-                (_, _) => converted.WithAdditionalAnnotations(annotation),
-                new SyntaxToken[] { tokenAfterNamespace },
-                (_, _) => tokenAfterNamespace.WithLeadingTrivia(triviaAfterSplit),
-                Array.Empty<SyntaxTrivia>(),
-                (_, _) => throw ExceptionUtilities.Unreachable());
+            openBraceToken = openBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
         }
 
-        private static bool HasLeadingBlankLine(
-            SyntaxToken token, out SyntaxToken withoutBlankLine)
+        FileScopedNamespaceDeclarationSyntax adjustedFileScopedNamespace;
+        var closeBraceToken = SyntaxFactory.Token(SyntaxKind.CloseBraceToken).WithoutLeadingTrivia().WithoutTrailingTrivia();
+
+        // Normally the block scoped namespace will have a newline after the closing brace. The only exception to
+        // this occurs when there are no tokens after the closing brace and the document with a file scoped
+        // namespace did not end in a trailing newline. For this case, we want the converted block scope namespace
+        // to also terminate without a final newline.
+        if (!fileScopedNamespace.GetLastToken().GetNextTokenOrEndOfFile().IsKind(SyntaxKind.EndOfFileToken)
+            || document.Text.Lines.GetLinePosition(document.Text.Length).Character == 0)
         {
-            var leadingTrivia = token.LeadingTrivia;
-
-            if (leadingTrivia is [(kind: SyntaxKind.EndOfLineTrivia), ..])
-            {
-                withoutBlankLine = token.WithLeadingTrivia(leadingTrivia.RemoveAt(0));
-                return true;
-            }
-
-            if (leadingTrivia is [(kind: SyntaxKind.WhitespaceTrivia), (kind: SyntaxKind.EndOfLineTrivia), ..])
-            {
-                withoutBlankLine = token.WithLeadingTrivia(leadingTrivia.Skip(2));
-                return true;
-            }
-
-            withoutBlankLine = default;
-            return false;
+            closeBraceToken = closeBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
+            adjustedFileScopedNamespace = fileScopedNamespace;
         }
-
-        private static FileScopedNamespaceDeclarationSyntax ConvertNamespaceDeclaration(NamespaceDeclarationSyntax namespaceDeclaration)
+        else
         {
-            // If the open-brace token has any special trivia, then move them to after the semicolon.
-            var semiColon = SyntaxFactory.Token(SyntaxKind.SemicolonToken)
-                .WithoutTrivia()
-                .WithTrailingTrivia(namespaceDeclaration.Name.GetTrailingTrivia())
-                .WithAppendedTrailingTrivia(namespaceDeclaration.OpenBraceToken.LeadingTrivia);
-
-            if (!namespaceDeclaration.OpenBraceToken.TrailingTrivia.All(static t => t.IsWhitespace()))
-                semiColon = semiColon.WithAppendedTrailingTrivia(namespaceDeclaration.OpenBraceToken.TrailingTrivia);
-
-            // Move trivia after the original name token to now be after the new semicolon token.
-            var fileScopedNamespace = SyntaxFactory.FileScopedNamespaceDeclaration(
-                namespaceDeclaration.AttributeLists,
-                namespaceDeclaration.Modifiers,
-                namespaceDeclaration.NamespaceKeyword,
-                namespaceDeclaration.Name.WithoutTrailingTrivia(),
-                semiColon,
-                namespaceDeclaration.Externs,
-                namespaceDeclaration.Usings,
-                namespaceDeclaration.Members);
-
-            // Copy trivia from the close brace to the end of the file scoped namespace (which means after all of the members)
-            fileScopedNamespace = fileScopedNamespace
-                .WithAppendedTrailingTrivia(namespaceDeclaration.CloseBraceToken.LeadingTrivia)
-                .WithAppendedTrailingTrivia(namespaceDeclaration.CloseBraceToken.TrailingTrivia);
-
-            var originalHadTrailingNewLine = namespaceDeclaration.GetTrailingTrivia() is [.., (kind: SyntaxKind.EndOfLineTrivia)];
-
-            // now, intelligently trim excess newlines to try to match what the original namespace looked like.
-            while (fileScopedNamespace.HasTrailingTrivia)
-            {
-                var trailingTrivia = fileScopedNamespace.GetTrailingTrivia();
-
-                // if the new namespace doesn't end with a newline, nothing for us to do.
-                if (trailingTrivia is not [.., (kind: SyntaxKind.EndOfLineTrivia)])
-                    break;
-
-                // if the original had a newline, then we only want to trim the newlines as long as there is still one
-                // left at the end.
-
-                if (originalHadTrailingNewLine && trailingTrivia is not
-                    [
-                        ..,
-                        (kind: SyntaxKind.EndOfLineTrivia or SyntaxKind.EndIfDirectiveTrivia or SyntaxKind.EndRegionDirectiveTrivia),
-                        (kind: SyntaxKind.EndOfLineTrivia)
-                    ])
-                {
-                    break;
-                }
-
-                // New namespace has excess newlines, remove the last one and try again.
-                fileScopedNamespace = fileScopedNamespace.WithTrailingTrivia(
-                    trailingTrivia.Take(trailingTrivia.Count - 1));
-            }
-
-            return fileScopedNamespace;
+            // Make sure the body of the file scoped namespace ends with a trailing new line (so the closing brace
+            // of the converted block-body namespace appears on its own line), but don't add a new line after the
+            // closing brace.
+            adjustedFileScopedNamespace = fileScopedNamespace.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
         }
 
-        private static NamespaceDeclarationSyntax ConvertFileScopedNamespace(ParsedDocument document, FileScopedNamespaceDeclarationSyntax fileScopedNamespace, string lineEnding, NewLinePlacement newLinePlacement)
+        // If the file scoped namespace is indented, also indent the newly added braces to match
+        var outerIndentation = document.Text.GetLeadingWhitespaceOfLineAtPosition(fileScopedNamespace.SpanStart);
+        if (outerIndentation.Length > 0)
         {
-            var nameSyntax = fileScopedNamespace.Name.WithAppendedTrailingTrivia(fileScopedNamespace.SemicolonToken.LeadingTrivia)
-                .WithAppendedTrailingTrivia(newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes) ? SyntaxFactory.EndOfLine(lineEnding) : SyntaxFactory.Space);
-            var openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken).WithoutLeadingTrivia().WithTrailingTrivia(fileScopedNamespace.SemicolonToken.TrailingTrivia);
+            if (newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes))
+                openBraceToken = openBraceToken.WithLeadingTrivia(openBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
 
-            if (openBraceToken.TrailingTrivia is not [.., SyntaxTrivia(SyntaxKind.EndOfLineTrivia)])
-            {
-                openBraceToken = openBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
-            }
-
-            FileScopedNamespaceDeclarationSyntax adjustedFileScopedNamespace;
-            var closeBraceToken = SyntaxFactory.Token(SyntaxKind.CloseBraceToken).WithoutLeadingTrivia().WithoutTrailingTrivia();
-
-            // Normally the block scoped namespace will have a newline after the closing brace. The only exception to
-            // this occurs when there are no tokens after the closing brace and the document with a file scoped
-            // namespace did not end in a trailing newline. For this case, we want the converted block scope namespace
-            // to also terminate without a final newline.
-            if (!fileScopedNamespace.GetLastToken().GetNextTokenOrEndOfFile().IsKind(SyntaxKind.EndOfFileToken)
-                || document.Text.Lines.GetLinePosition(document.Text.Length).Character == 0)
-            {
-                closeBraceToken = closeBraceToken.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
-                adjustedFileScopedNamespace = fileScopedNamespace;
-            }
-            else
-            {
-                // Make sure the body of the file scoped namespace ends with a trailing new line (so the closing brace
-                // of the converted block-body namespace appears on its own line), but don't add a new line after the
-                // closing brace.
-                adjustedFileScopedNamespace = fileScopedNamespace.WithAppendedTrailingTrivia(SyntaxFactory.EndOfLine(lineEnding));
-            }
-
-            // If the file scoped namespace is indented, also indent the newly added braces to match
-            var outerIndentation = document.Text.GetLeadingWhitespaceOfLineAtPosition(fileScopedNamespace.SpanStart);
-            if (outerIndentation.Length > 0)
-            {
-                if (newLinePlacement.HasFlag(NewLinePlacement.BeforeOpenBraceInTypes))
-                    openBraceToken = openBraceToken.WithLeadingTrivia(openBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
-
-                closeBraceToken = closeBraceToken.WithLeadingTrivia(closeBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
-            }
-
-            var namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
-                adjustedFileScopedNamespace.AttributeLists,
-                adjustedFileScopedNamespace.Modifiers,
-                adjustedFileScopedNamespace.NamespaceKeyword,
-                nameSyntax,
-                openBraceToken,
-                adjustedFileScopedNamespace.Externs,
-                adjustedFileScopedNamespace.Usings,
-                adjustedFileScopedNamespace.Members,
-                closeBraceToken,
-                semicolonToken: default);
-
-            return namespaceDeclaration;
+            closeBraceToken = closeBraceToken.WithLeadingTrivia(closeBraceToken.LeadingTrivia.Add(SyntaxFactory.Whitespace(outerIndentation)));
         }
+
+        var namespaceDeclaration = SyntaxFactory.NamespaceDeclaration(
+            adjustedFileScopedNamespace.AttributeLists,
+            adjustedFileScopedNamespace.Modifiers,
+            adjustedFileScopedNamespace.NamespaceKeyword,
+            nameSyntax,
+            openBraceToken,
+            adjustedFileScopedNamespace.Externs,
+            adjustedFileScopedNamespace.Usings,
+            adjustedFileScopedNamespace.Members,
+            closeBraceToken,
+            semicolonToken: default);
+
+        return namespaceDeclaration;
     }
 }

--- a/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -133,8 +133,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             // if this line is inside a string-literal or interpolated-text-content, then we definitely do not want to
             // touch what is inside there.  Note: this will not apply to raw-string literals, which can potentially be
             // dedented safely depending on the position of their close terminator.
-            if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, cancellationToken))
+            if (tree.IsEntirelyWithinStringLiteral(textLine.Span.Start, out var stringLiteral, cancellationToken) &&
+                stringLiteral.Kind() is not SyntaxKind.MultiLineRawStringLiteralToken and not SyntaxKind.Utf8MultiLineRawStringLiteralToken)
+            {
                 return null;
+            }
 
             // Determine the amount of indentation this text line starts with.
             var commonIndentation = 0;

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
@@ -679,7 +679,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
         }
 
         [Theory, InlineData(""), InlineData("u8")]
-        public async Task TestConvertToFileScopedWithMultiLineRawString(string suffix)
+        public async Task TestConvertToFileScopedWithMultiLineRawString1(string suffix)
         {
             await new VerifyCS.Test
             {
@@ -719,6 +719,56 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
                 }
                 """",
                 LanguageVersion = LanguageVersion.CSharp12,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Theory, InlineData(""), InlineData("u8")]
+        public async Task TestConvertToFileScopedWithMultiLineRawString2(string suffix)
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = $$""""
+                [|namespace N|]
+                {
+                    class C
+                    {
+                        void M()
+                        {
+                            System.Console.WriteLine("""
+                a
+                    b
+                        c
+                            d
+                                e
+                """{{suffix}});
+                        }
+                    }
+                }
+                """",
+                FixedCode = $$""""
+                namespace $$N;
+
+                class C
+                {
+                    void M()
+                    {
+                        System.Console.WriteLine("""
+                a
+                    b
+                        c
+                            d
+                                e
+                """{{suffix}});
+                    }
+                }
+                """",
+                LanguageVersion = LanguageVersion.CSharp12,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 Options =
                 {
                     { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }

--- a/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
@@ -678,12 +678,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
             }.RunAsync();
         }
 
-        [Fact]
-        public async Task TestConvertToFileScopedWithMultiLineRawString()
+        [Theory, InlineData(""), InlineData("u8")]
+        public async Task TestConvertToFileScopedWithMultiLineRawString(string suffix)
         {
             await new VerifyCS.Test
             {
-                TestCode = """"
+                TestCode = $$""""
                 [|namespace N|]
                 {
                     class C
@@ -696,12 +696,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
                             c
                                 d
                                     e
-                    """);
+                    """{{suffix}});
                         }
                     }
                 }
                 """",
-                FixedCode = """"
+                FixedCode = $$""""
                 namespace $$N;
 
                 class C
@@ -709,69 +709,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
                     void M()
                     {
                         System.Console.WriteLine("""
-                    a
-                        b
-                            c
-                                d
-                                    e
-                    """);
+                a
+                    b
+                        c
+                            d
+                                e
+                """{{suffix}});
                     }
                 }
                 """",
                 LanguageVersion = LanguageVersion.CSharp12,
-                Options =
-                {
-                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
-                }
-            }.RunAsync();
-        }
-
-        [Fact]
-        public async Task TestConvertToFileScopedWithUtf8MultiLineRawString()
-        {
-            await new VerifyCS.Test
-            {
-                TestCode = """"
-                [|namespace N|]
-                {
-                    class C
-                    {
-                        void M()
-                        {
-                            M2("""
-                    a
-                        b
-                            c
-                                d
-                                    e
-                    """u8);
-                        }
-
-                        void M2(System.ReadOnlySpan<byte> x) {}
-                    }
-                }
-                """",
-                FixedCode = """"
-                namespace $$N;
-
-                class C
-                {
-                    void M()
-                    {
-                        M2("""
-                    a
-                        b
-                            c
-                                d
-                                    e
-                    """u8);
-                    }
-
-                    void M2(System.ReadOnlySpan<byte> x) {}
-                }
-                """",
-                LanguageVersion = LanguageVersion.CSharp12,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 Options =
                 {
                     { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -412,18 +412,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 syntaxTree.IsEntirelyWithinCharLiteral(position, cancellationToken);
         }
 
+        public static bool IsEntirelyWithinStringLiteral(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+            => IsEntirelyWithinStringLiteral(syntaxTree, position, out _, cancellationToken);
+
         public static bool IsEntirelyWithinStringLiteral(
-            this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
+            this SyntaxTree syntaxTree, int position, out SyntaxToken stringLiteral, CancellationToken cancellationToken)
         {
             var token = syntaxTree.GetRoot(cancellationToken).FindToken(position, findInsideTrivia: true);
 
             // If we ask right at the end of the file, we'll get back nothing. We handle that case
             // specially for now, though SyntaxTree.FindToken should work at the end of a file.
             if (token.Kind() is SyntaxKind.EndOfDirectiveToken or SyntaxKind.EndOfFileToken)
-            {
                 token = token.GetPreviousToken(includeSkipped: true, includeDirectives: true);
-            }
 
+            stringLiteral = token;
             if (token.Kind() is
                     SyntaxKind.StringLiteralToken or
                     SyntaxKind.SingleLineRawStringLiteralToken or


### PR DESCRIPTION
Noticed this while dogfooding and converting existing test files over to file-scoped-namespaces.  