### PR TITLE
Reduce overhead due to lsp semantic token refresh requests.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueue.cs
@@ -1,13 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -44,6 +47,7 @@ internal class SemanticTokensRefreshQueue :
 
     private readonly LspWorkspaceManager _lspWorkspaceManager;
     private readonly IClientLanguageServerManager _notificationManager;
+    private readonly ICapabilitiesProvider _capabilitiesProvider;
 
     private readonly IAsynchronousOperationListener _asyncListener;
     private readonly CancellationTokenSource _disposalTokenSource;
@@ -61,7 +65,8 @@ internal class SemanticTokensRefreshQueue :
         IAsynchronousOperationListenerProvider asynchronousOperationListenerProvider,
         LspWorkspaceRegistrationService lspWorkspaceRegistrationService,
         LspWorkspaceManager lspWorkspaceManager,
-        IClientLanguageServerManager notificationManager)
+        IClientLanguageServerManager notificationManager,
+        ICapabilitiesProvider capabilitiesProvider)
     {
         _asyncListener = asynchronousOperationListenerProvider.GetListener(FeatureAttribute.Classification);
 
@@ -70,11 +75,14 @@ internal class SemanticTokensRefreshQueue :
 
         _lspWorkspaceManager = lspWorkspaceManager;
         _notificationManager = notificationManager;
+        _capabilitiesProvider = capabilitiesProvider;
     }
 
     public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken _)
     {
-        if (_semanticTokenRefreshQueue is null && clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport is true)
+        if (_semanticTokenRefreshQueue is null
+            && clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport is true
+            && _capabilitiesProvider.GetCapabilities(clientCapabilities).SemanticTokensOptions is not null)
         {
             // Only send a refresh notification to the client every 2s (if needed) in order to avoid
             // sending too many notifications at once.  This ensures we batch up workspace notifications,
@@ -141,21 +149,52 @@ internal class SemanticTokensRefreshQueue :
 
     private void OnLspSolutionChanged(object? sender, WorkspaceChangeEventArgs e)
     {
-        if (e.DocumentId is not null && e.Kind is WorkspaceChangeKind.DocumentChanged)
-        {
-            var document = e.NewSolution.GetRequiredDocument(e.DocumentId);
-            var documentUri = document.GetURI();
+        Uri? documentUri = null;
 
+        if (e.DocumentId is not null)
+        {
             // We enqueue the URI since there's a chance the client is already tracking the
             // document, in which case we don't need to send a refresh notification.
             // We perform the actual check when processing the batch to ensure we have the
             // most up-to-date list of tracked documents.
-            EnqueueSemanticTokenRefreshNotification(documentUri);
+            if (e.Kind is WorkspaceChangeKind.DocumentChanged)
+            {
+                var document = e.NewSolution.GetRequiredDocument(e.DocumentId);
+                documentUri = document.GetURI();
+            }
+            else if (e.Kind is WorkspaceChangeKind.AdditionalDocumentChanged)
+            {
+                var document = e.NewSolution.GetRequiredAdditionalDocument(e.DocumentId);
+
+                // Changes to files with certain extensions (eg: razor) shouldn't trigger semantic a token refresh
+                if (DisallowsAdditionalDocumentChangedRefreshes(document.FilePath))
+                    return;
+            }
+            else if (e.Kind is WorkspaceChangeKind.DocumentReloaded)
+            {
+                var newDocument = e.NewSolution.GetRequiredDocument(e.DocumentId);
+                var oldDocument = e.OldSolution.GetDocument(e.DocumentId);
+
+                // If the document's attributes haven't changed, then use the document's URI for
+                //   the call to EnqueueSemanticTokenRefreshNotification which will enable the
+                //   tracking check before sending the WorkspaceSemanticTokensRefreshName message.
+                if (oldDocument?.State.Attributes is IChecksummedObject oldChecksumObject
+                    && newDocument.State.Attributes is IChecksummedObject newChecksumObject
+                    && oldChecksumObject.Checksum == newChecksumObject.Checksum)
+                {
+                    documentUri = newDocument.GetURI();
+                }
+            }
         }
-        else
-        {
-            EnqueueSemanticTokenRefreshNotification(documentUri: null);
-        }
+
+        EnqueueSemanticTokenRefreshNotification(documentUri);
+    }
+
+    // Duplicated from Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.LoadedProject.TreatAsIsDynamicFile
+    private static bool DisallowsAdditionalDocumentChangedRefreshes(string? filePath)
+    {
+        var extension = Path.GetExtension(filePath);
+        return extension is ".cshtml" or ".razor";
     }
 
     private void EnqueueSemanticTokenRefreshNotification(Uri? documentUri)

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueueFactory.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRefreshQueueFactory.cs
@@ -29,8 +29,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
         {
             var notificationManager = lspServices.GetRequiredService<IClientLanguageServerManager>();
             var lspWorkspaceManager = lspServices.GetRequiredService<LspWorkspaceManager>();
+            var capabilitiesProvider = lspServices.GetRequiredService<ICapabilitiesProvider>();
 
-            return new SemanticTokensRefreshQueue(_asyncListenerProvider, _lspWorkspaceRegistrationService, lspWorkspaceManager, notificationManager);
+            return new SemanticTokensRefreshQueue(_asyncListenerProvider, _lspWorkspaceRegistrationService, lspWorkspaceManager, notificationManager, capabilitiesProvider);
         }
     }
 }


### PR DESCRIPTION
Previously, typing a single character in a razor markup segment would cause 5 semantic token refresh requests, and consequently 12 semantic token range requests for the simple razor page I was testing. This PR reduces that count to 1 semantic token refresh request and 6 semantic token range requests for the same edit. It does this by:

1) Not listening to workspace events if the language server doesn't support semantic tokens. 
2) Changing DocumentReloaded handling to detect whether something other than the text has changed on the file, and if not, prevents a refresh message if the file is being tracked. 
3) Changing AdditionalDocumentChanged to special case razor files and not send refresh notifications due to their modification.