### PR TITLE
Fix import completion in LSP workspace

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Completion.Providers.Snippets;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -211,6 +212,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // for the completion list itself.
                 if (roslynItem.Flags.IsCached())
                     roslynItem.Span = completionListSpan;
+
+                // Adding import is not allowed in debugger view
+                if (_textView is IDebuggerTextView)
+                    roslynItem = ImportCompletionItem.MarkItemToAlwaysFullyQualify(roslynItem);
 
                 change = completionService.GetChangeAsync(document, roslynItem, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
             }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -392,7 +392,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 options = options with
                 {
                     FilterOutOfScopeLocals = false,
-                    ShowXmlDocCommentCompletion = false
+                    ShowXmlDocCommentCompletion = false,
+                    // Adding import is not allowed in debugger view
+                    CanAddImportStatement = false,
                 };
             }
 

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -36,6 +36,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public bool UpdateImportCompletionCacheInBackground { get; init; } = false;
 
+        /// <summary>
+        /// Whether completion can add import statement as part of committed change.
+        /// For example, adding import is not allowed in debugger view.
+        /// </summary>
+        public bool CanAddImportStatement { get; init; } = true;
+
         public bool FilterOutOfScopeLocals { get; init; } = true;
         public bool ShowXmlDocCommentCompletion { get; init; } = true;
         public bool? ShowNewSnippetExperienceUserOption { get; init; } = null;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -20,8 +20,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     {
         protected abstract string GenericSuffix { get; }
 
+        // Don't provide unimported extension methods if adding import is not supported,
+        // since we are current incapable of making a change using its fully qualify form.
         protected override bool ShouldProvideCompletion(CompletionContext completionContext, SyntaxContext syntaxContext)
-            => syntaxContext.IsRightOfNameSeparator && IsAddingImportsSupported(completionContext.Document);
+            => syntaxContext.IsRightOfNameSeparator && IsAddingImportsSupported(completionContext.Document, completionContext.CompletionOptions);
 
         protected override void LogCommit()
             => CompletionProvidersLogger.LogCommitOfExtensionMethodImportCompletionItem();

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private const string MethodKey = nameof(MethodKey);
         private const string ReceiverKey = nameof(ReceiverKey);
         private const string OverloadCountKey = nameof(OverloadCountKey);
-        private const string AlwaysAddMissingImportKey = nameof(AlwaysAddMissingImportKey);
+        private const string AlwaysFullyQualifyKey = nameof(AlwaysFullyQualifyKey);
 
         public static CompletionItem Create(
             string name,
@@ -211,8 +211,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return (compilation.GetTypeByMetadataName(fullyQualifiedName), 0);
         }
 
-        public static CompletionItem MarkItemToAlwaysAddMissingImport(CompletionItem item) => item.WithProperties(item.Properties.Add(AlwaysAddMissingImportKey, AlwaysAddMissingImportKey));
+        public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item) => item.WithProperties(item.Properties.Add(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey));
 
-        public static bool ShouldAlwaysAddMissingImport(CompletionItem item) => item.Properties.ContainsKey(AlwaysAddMissingImportKey);
+        public static bool ShouldAlwaysFullyQualify(CompletionItem item) => item.Properties.ContainsKey(AlwaysFullyQualifyKey);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
@@ -395,7 +395,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             CancellationToken cancellationToken)
         {
             Debug.Assert(selectedItem.Flags.IsExpanded());
-            selectedItem = ImportCompletionItem.MarkItemToAlwaysAddMissingImport(selectedItem);
             var completionChange = await completionService.GetChangeAsync(document, selectedItem, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -149,7 +149,7 @@ class A
         Assert.Equal(CompletionItemKind.Class, resolvedItem.Kind);
 
         TextEdit expectedAdditionalEdit = isInUsingStatement
-            ? new() { NewText = "System.Threading.Tasks.Task", Range = new() { Start = new(1, 20), End = new(1, 24) } }
+            ? new() { NewText = "System.Threading.Tasks.Task", Range = new() { Start = new(0, 20), End = new(0, 24) } }
             : new() { NewText = "using System.Threading.Tasks;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
 
         AssertJsonEquals(new[] { expectedAdditionalEdit }, resolvedItem.AdditionalTextEdits);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -95,10 +95,12 @@ public class A
     }
 
     [Theory, CombinatorialData]
-    public async Task TestImportCompletion(bool mutatingLspWorkspace)
+    [WorkItem("https://github.com/dotnet/roslyn/issues/68791")]
+    public async Task TestImportCompletionForType(bool mutatingLspWorkspace, bool isInUsingStatement)
     {
-        var markup =
-@"
+        var markup = isInUsingStatement
+            ? @"global using static Task{|caret:|}"
+            : @"
 class A
 {
     void M()
@@ -146,7 +148,10 @@ class A
         Assert.Equal("~Task  System.Threading.Tasks", resolvedItem.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem.Kind);
 
-        var expectedAdditionalEdit = new TextEdit() { NewText = "using System.Threading.Tasks;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
+        TextEdit expectedAdditionalEdit = isInUsingStatement
+            ? new() { NewText = "System.Threading.Tasks.Task", Range = new() { Start = new(1, 20), End = new(1, 24) } }
+            : new() { NewText = "using System.Threading.Tasks;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
+
         AssertJsonEquals(new[] { expectedAdditionalEdit }, resolvedItem.AdditionalTextEdits);
 
         Assert.Null(resolvedItem.LabelDetails.Detail);
@@ -160,6 +165,88 @@ class A
         {
             Kind = LSP.MarkupKind.PlainText,
             Value = "(awaitable) class System.Threading.Tasks.Task"
+        };
+        AssertJsonEquals(resolvedItem.Documentation, expectedDocumentation);
+    }
+
+    [Theory, CombinatorialData]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/69576")]
+    public async Task TestImportCompletionForExtensionMethod(bool mutatingLspWorkspace)
+    {
+        var markup =
+@"
+namespace NS2
+{
+    public static class ExtensionClass
+    {
+        public static bool ExtensionMethod(this object o) => true;
+    }
+}
+
+namespace NS1
+{
+    class Program
+    {
+        void M(object o)
+        {
+            o.{|caret:|}
+        }
+    }
+}";
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, DefaultClientCapabilities);
+        var completionParams = CreateCompletionParams(
+            testLspServer.GetLocations("caret").Single(),
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+            triggerCharacter: "\0",
+            triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+        // Make sure the import completion option is on.
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, true);
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation, true);
+
+        var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+
+        var completionResult = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None).ConfigureAwait(false);
+        Assert.NotNull(completionResult.ItemDefaults.EditRange);
+        Assert.NotNull(completionResult.ItemDefaults.Data);
+        Assert.NotNull(completionResult.ItemDefaults.CommitCharacters);
+
+        var actualItem = completionResult.Items.First(i => i.Label == "ExtensionMethod");
+        Assert.Equal("NS2", actualItem.LabelDetails.Description);
+        Assert.Equal("~ExtensionMethod NS2", actualItem.SortText);
+        Assert.Equal(CompletionItemKind.Method, actualItem.Kind);
+        Assert.Null(actualItem.LabelDetails.Detail);
+        Assert.Null(actualItem.FilterText);
+        Assert.Null(actualItem.TextEdit);
+        Assert.Null(actualItem.TextEditText);
+        Assert.Null(actualItem.AdditionalTextEdits);
+        Assert.Null(actualItem.Command);
+        Assert.Null(actualItem.CommitCharacters);
+        Assert.Null(actualItem.Data);
+        Assert.Null(actualItem.Detail);
+        Assert.Null(actualItem.Documentation);
+
+        actualItem.Data = completionResult.ItemDefaults.Data;
+
+        var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, actualItem, CancellationToken.None).ConfigureAwait(false);
+        Assert.Equal("NS2", resolvedItem.LabelDetails.Description);
+        Assert.Equal("~ExtensionMethod NS2", resolvedItem.SortText);
+        Assert.Equal(CompletionItemKind.Method, resolvedItem.Kind);
+
+        var expectedAdditionalEdit = new TextEdit() { NewText = "using NS2;\r\n\r\n", Range = new() { Start = new(1, 0), End = new(1, 0) } };
+        AssertJsonEquals(new[] { expectedAdditionalEdit }, resolvedItem.AdditionalTextEdits);
+
+        Assert.Null(resolvedItem.LabelDetails.Detail);
+        Assert.Null(resolvedItem.FilterText);
+        Assert.Null(resolvedItem.TextEdit);
+        Assert.Null(resolvedItem.TextEditText);
+        Assert.Null(resolvedItem.Command);
+        Assert.Null(resolvedItem.Detail);
+
+        var expectedDocumentation = new MarkupContent()
+        {
+            Kind = LSP.MarkupKind.PlainText,
+            Value = "(extension) bool object.ExtensionMethod()"
         };
         AssertJsonEquals(resolvedItem.Documentation, expectedDocumentation);
     }


### PR DESCRIPTION
1. Provide unimported extension methods
2. Fully qualify unimported type in using statement

Fix #68791 and #69576