### PR TITLE
Bind fully-typed lambda only once for error recovery

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw ExceptionUtilities.Unreachable();
             }
 
-            protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, BindingDiagnosticBag diagnostics)
+            protected override BoundBlock BindLambdaBodyCore(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, BindingDiagnosticBag diagnostics)
             {
                 return _bodyFactory(lambdaSymbol, lambdaBodyBinder, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1781,6 +1781,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 unboundArgument.FunctionType is { } functionType &&
                                 functionType.GetInternalDelegateType() is { } delegateType)
                             {
+                                // Just assume we're not in an expression tree for the purposes of error recovery.
                                 _ = unboundArgument.Bind(delegateType, isExpressionTree: false);
                             }
                             else

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -516,7 +516,7 @@ $@"        if (F({i}))
         }
 
         [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/roslyn/issues/69093")]
-        public void NestedLambdas(bool localFunctions, bool concurrentBuild)
+        public void NestedLambdas(bool localFunctions)
         {
             const int overloads1Number = 20;
             const int overloads2Number = 10;
@@ -627,9 +627,12 @@ $@"        if (F({i}))
                 """;
             RunInThread(() =>
             {
-                var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithConcurrentBuild(concurrentBuild));
+                var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithConcurrentBuild(false));
+                var data = new LambdaBindingData();
+                comp.TestOnlyCompilationData = data;
                 comp.VerifyDiagnostics();
-            }, timeout: TimeSpan.FromSeconds(10));
+                Assert.Equal(localFunctions ? 20 : 220, data.LambdaBindingCount);
+            }, timeout: TimeSpan.FromSeconds(20));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69093 (as an alternative to https://github.com/dotnet/roslyn/pull/69505), although not exactly as suggested there - skipping lambda body binding in `HasAnonymousFunctionConversion` has no effect since the lambda is bound later for error recovery or in `CreateAnonymousFunctionConversion` anyway (and the result is cached) - see https://github.com/dotnet/roslyn/pull/69505#discussion_r1296868842. We could perhaps skip some unnecessary binding in `CreateAnonymousFunctionConversion`, but not sure if that could help since in my testing scenarios, the change in this PR already makes lambdas as fast as local functions.