### PR TITLE
Produce a warning for redundant patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
@@ -21,11 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var syntax = list.Syntax;
             var subpatterns = list.Subpatterns;
             var tests = ArrayBuilder<Tests>.GetInstance(4 + subpatterns.Length * 2);
-            output = input = MakeConvertToType(input, list.Syntax, list.NarrowedType, isExplicitTest: false, tests);
+            output = input = MakeConvertToType(input, list.Syntax, source: list, list.NarrowedType, isExplicitTest: false, tests);
 
             if (list.HasErrors)
             {
-                tests.Add(new Tests.One(new BoundDagTypeTest(list.Syntax, ErrorType(), input, hasErrors: true)));
+                MakeErrorTest(tests, list, input);
             }
             else if (list.HasSlice &&
                      subpatterns.Length == 1 &&
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 tests.Add(new Tests.One(lengthEvaluation));
                 var lengthTemp = new BoundDagTemp(syntax, _compilation.GetSpecialType(SpecialType.System_Int32), lengthEvaluation);
                 tests.Add(new Tests.One(list.HasSlice
-                    ? new BoundDagRelationalTest(syntax, BinaryOperatorKind.IntGreaterThanOrEqual, ConstantValue.Create(subpatterns.Length - 1), lengthTemp)
-                    : new BoundDagValueTest(syntax, ConstantValue.Create(subpatterns.Length), lengthTemp)));
+                    ? new BoundDagRelationalTest(syntax, BinaryOperatorKind.IntGreaterThanOrEqual, ConstantValue.Create(subpatterns.Length - 1), source: list, lengthTemp)
+                    : new BoundDagValueTest(syntax, ConstantValue.Create(subpatterns.Length), source: list, lengthTemp)));
 
                 int index = 0;
                 foreach (BoundPattern subpattern in subpatterns)

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -83,6 +83,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If no switch sections are subsumed, just return
             if (!switchSections.Any(static (s, reachableLabels) => s.SwitchLabels.Any(isSubsumed, reachableLabels), reachableLabels))
             {
+                var walker = new ReduntantPatternWalker(decisionDag, diagnostics);
+                foreach (BoundSwitchSection switchSection in switchSections)
+                {
+                    foreach (BoundSwitchLabel switchLabel in switchSection.SwitchLabels)
+                    {
+                        walker.VisitTopLevelPattern(switchLabel.Pattern);
+                    }
+                }
+
+                walker.Free();
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagTestOrEvaluation.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagTestOrEvaluation.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 #endif
-    partial class BoundDagTest
+    partial class BoundDagTestOrEvaluation
     {
-        public override bool Equals([NotNullWhen(true)] object? obj) => this.Equals(obj as BoundDagTest);
+        public override bool Equals([NotNullWhen(true)] object? obj) => this.Equals(obj as BoundDagTestOrEvaluation);
 
-        private bool Equals(BoundDagTest? other)
+        private bool Equals(BoundDagTestOrEvaluation? other)
         {
             if (other is null || this.Kind != other.Kind)
                 return false;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1536,9 +1536,13 @@
     <Field Name="Label" Type="LabelSymbol"/>
   </Node>
 
-  <AbstractNode Name="BoundDagTest" Base="BoundNode">
+  <AbstractNode Name="BoundDagTestOrEvaluation" Base="BoundNode">
     <!-- Input is the input to the decision point. -->
     <Field Name="Input" Type="BoundDagTemp"/>
+  </AbstractNode>
+  <AbstractNode Name="BoundDagTest" Base="BoundDagTestOrEvaluation">
+    <!-- Used to mark the source pattern as used. -->
+    <Field Name="Source" Type="BoundPattern?"/>
   </AbstractNode>
   <Node Name="BoundDagTemp" Base="BoundNode">
     <Field Name="Type" Type="TypeSymbol" Null="disallow"/>
@@ -1566,7 +1570,7 @@
     <Field Name="Value" Type="ConstantValue" Null="disallow"/>
   </Node>
   <!-- As a decision, an evaluation is considered to always succeed. -->
-  <AbstractNode Name="BoundDagEvaluation" Base="BoundDagTest">
+  <AbstractNode Name="BoundDagEvaluation" Base="BoundDagTestOrEvaluation">
   </AbstractNode>
   <Node Name="BoundDagDeconstructEvaluation" Base="BoundDagEvaluation">
     <Field Name="DeconstructMethod" Type="MethodSymbol" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7511,6 +7511,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_AddressOfInAsync_Title" xml:space="preserve">
     <value>The '&amp;' operator should not be used on parameters or local variables in async methods.</value>
   </data>
+  <data name="WRN_RedundantPattern" xml:space="preserve">
+    <value>The pattern is redundant.</value>
+  </data>
+  <data name="WRN_RedundantPattern_Title" xml:space="preserve">
+    <value>The pattern is redundant.</value>
+  </data>
   <data name="ERR_BadStaticAfterUnsafe" xml:space="preserve">
     <value>'static' modifier must precede 'unsafe' modifier.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2182,6 +2182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_StructLayoutCyclePrimaryConstructorParameter = 9121,
         ERR_UnexpectedParameterList = 9122,
         WRN_AddressOfInAsync = 9123,
+        WRN_RedundantPattern = 9124,
 
         ERR_BadRefInUsingAlias = 9130,
         ERR_BadUnsafeInUsingDirective = 9131,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -208,6 +208,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // docs/compilers/CSharp/Warnversion Warning Waves.md
             switch (code)
             {
+                case ErrorCode.WRN_RedundantPattern:
+                    //return 9;
                 case ErrorCode.WRN_AddressOfInAsync:
                     // Warning level 8 is exclusively for warnings introduced in the compiler
                     // shipped with dotnet 8 (C# 12) and that can be reported for pre-existing code.
@@ -2319,6 +2321,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_StructLayoutCyclePrimaryConstructorParameter:
                 case ErrorCode.ERR_UnexpectedParameterList:
                 case ErrorCode.WRN_AddressOfInAsync:
+                case ErrorCode.WRN_RedundantPattern:
                 case ErrorCode.ERR_BadRefInUsingAlias:
                 case ErrorCode.ERR_BadUnsafeInUsingDirective:
                 case ErrorCode.ERR_BadNullableReferenceTypeInUsingAlias:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -315,6 +315,7 @@
                 case ErrorCode.WRN_CapturedPrimaryConstructorParameterPassedToBase:
                 case ErrorCode.WRN_UnreadPrimaryConstructorParameter:
                 case ErrorCode.WRN_AddressOfInAsync:
+                case ErrorCode.WRN_RedundantPattern:
                 case ErrorCode.WRN_InterceptorSignatureMismatch:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnInterceptor:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnInterceptor:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -188,10 +188,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Translate the single test into _sideEffectBuilder and _conjunctBuilder.
             /// </summary>
-            private void LowerOneTest(BoundDagTest test, bool invert = false)
+            private void LowerOneTest(BoundDagTestOrEvaluation testOrEvaluation, bool invert = false)
             {
-                _factory.Syntax = test.Syntax;
-                switch (test)
+                _factory.Syntax = testOrEvaluation.Syntax;
+                switch (testOrEvaluation)
                 {
                     case BoundDagEvaluation eval:
                         {
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             _sideEffectBuilder.Add(sideEffect);
                             return;
                         }
-                    case var _:
+                    case BoundDagTest test:
                         {
                             var testExpression = LowerTest(test);
                             if (testExpression != null)
@@ -212,6 +212,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             return;
                         }
+                    default:
+                        throw ExceptionUtilities.Unreachable();
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Typy a aliasy by neměly mít název record</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Tento odkaz přiřadí {1} k {0}, ale {1} má užší řídicí obor než {0}.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Typen und Aliase dürfen nicht den Namen "record" aufweisen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Diese ref-Zuweisung weist "{1}" "{0}" zu, aber "{1}" weist einen kleineren Escapebereich auf als "{0}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Los tipos y los alias no deben denominarse "record".</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Esta referencia asigna "{1}" a "{0}", pero "{1}" tiene un ámbito de escape más limitado que "{0}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Les types et les alias ne doivent pas porter le nom 'record'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Effectue une attribution par référence de '{1}' vers '{0}', mais '{1}' a une portée de sortie plus limitée que '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Il nome di tipi e alias non deve essere 'record'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Questo riferimento assegna '{1}' a '{0}' ma '{1}' ha un ambito di escape più ristretto di '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">型およびエイリアスに 'record' という名前を指定することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">これは、'{1}' を '{0}' に ref 割り当てしますが、'{1}' には '{0}' より狭いエスケープ スコープがあります。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">형식 및 별칭의 이름은 'record'로 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">이 참조는 '{0}'에 '{1}'을(를) 할당하지만 '{1}'은(는) '{0}'보다 좁은 이스케이프 범위를 갖습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Typy i aliasy nie powinny mieć nazwy „record”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">To odwołanie przypisuje element „{1}” do elementu „{0}”, ale „{1}” ma węższy zakres ucieczki niż „{0}”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Os tipos e os aliases não devem ser nomeados como 'registro'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Essa referência atribui '{1}' a '{0}', mas '{1}' tem um escopo de escape mais estreito do que '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Типы и псевдонимы не могут иметь имя "record"</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Это присваивает по ссылке "{1}" "{0}", но "{1}" имеет более узкую область выхода, чем "{0}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">Türler ve diğer adlar 'record' olarak adlandırılmamalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">Bu başvuru, '{1}'i '{0}'ye atar, ancak '{1}', '{0}'ten daha dar bir kaçış kapsamına sahiptir.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">类型和别名不应命名为 "record"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">此 ref 将“{1}”分配给“{0}”，但“{1}”具有比“{0}”更窄的转义范围。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2527,6 +2527,16 @@
         <target state="translated">類型與別名不應命名為 'record'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_RedundantPattern">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_RedundantPattern_Title">
+        <source>The pattern is redundant.</source>
+        <target state="new">The pattern is redundant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_RefAssignNarrower">
         <source>This ref-assigns '{1}' to '{0}' but '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="translated">此參考指派 '{1}' 至 '{0}'，但 '{1}' 的逸出範圍比 '{0}' 還要窄。</target>

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -444,6 +444,7 @@ class X
                             Assert.Equal(7, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_AddressOfInAsync:
+                        case ErrorCode.WRN_RedundantPattern:
                             // These are the warnings introduced with the warning "wave" shipped with dotnet 8 and C# 12.
                             Assert.Equal(8, ErrorFacts.GetWarningLevel(errorCode));
                             break;


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/52674

Note that this won't warn on redundant subpatterns (excluding operands) unless the entire pattern can be removed, 
```cs
case (1, 2):
case (1, 3): // won't warn for `1`
```
That alone covers a lot of cases where a warning is not appropriate, however it falls short when it comes to an `or` operand that is only not emitted because it "completes" a switch. For instance:
```cs
_ = e switch
{
    [>= 0] => 1,
    [.., < 0] => 2,
    { Count: 0 or > 1 } => 3, // warns on '>1' but removing it will make this an incomplete match.
};
```
I don't think this should warn but it's not covered in this draft.