### PR TITLE
Fix the ArgumentOutOfRangeException in inline rename

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 if (value != _session.ReplacementText)
                 {
-                    _session.ApplyReplacementText(value, propagateEditImmediately: true);
+                    _session.ApplyReplacementText(value, propagateEditImmediately: true, updateSelection: false);
                     NotifyPropertyChanged(nameof(IdentifierText));
                 }
             }

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -262,8 +262,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 // in tests `ActiveTextview` could be null so don't depend on it
                 return ActiveTextView == null ||
-                    _referenceSpanToLinkedRenameSpanMap.Keys
-                    .Select(s => s.ToSpan())
+                    _referenceSpanToLinkedRenameSpanMap.Values
+                    .Select(renameTrackingSpan => renameTrackingSpan.TrackingSpan.GetSpan(_subjectBuffer.CurrentSnapshot))
                     .All(s =>
                         s.End <= _subjectBuffer.CurrentSnapshot.Length && // span is valid for the snapshot
                         ActiveTextView.GetSpanInView(_subjectBuffer.CurrentSnapshot.GetSpan(s)).Count != 0); // spans were successfully projected

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -254,9 +254,31 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
+            /// <summary>
+            /// This is a work around for a bug in Razor where the projection spans can get out-of-sync with the
+            /// identifiers.  When that bug is fixed this helper can be deleted.
+            /// </summary>
+            private bool AreAllReferenceSpansMappable()
+            {
+                // in tests `ActiveTextview` could be null so don't depend on it
+                return ActiveTextView == null ||
+                    _referenceSpanToLinkedRenameSpanMap.Keys
+                    .Select(s => s.ToSpan())
+                    .All(s =>
+                        s.End <= _subjectBuffer.CurrentSnapshot.Length && // span is valid for the snapshot
+                        ActiveTextView.GetSpanInView(_subjectBuffer.CurrentSnapshot.GetSpan(s)).Count != 0); // spans were successfully projected
+            }
+
             internal void ApplyReplacementText(bool updateSelection = true)
             {
                 _session._threadingContext.ThrowIfNotOnUIThread();
+
+                if (!AreAllReferenceSpansMappable())
+                {
+                    // don't dynamically update the reference spans for documents with unmappable projections
+                    return;
+                }
+
                 _session.UndoManager.ApplyCurrentState(
                     _subjectBuffer,
                     s_propagateSpansEditTag,
@@ -294,6 +316,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             internal void ApplyConflictResolutionEdits(IInlineRenameReplacementInfo conflictResolution, LinkedFileMergeSessionResult mergeResult, IEnumerable<Document> documents, CancellationToken cancellationToken)
             {
                 _session._threadingContext.ThrowIfNotOnUIThread();
+
+                if (!AreAllReferenceSpansMappable())
+                {
+                    // don't dynamically update the reference spans for documents with unmappable projections
+                    return;
+                }
+
                 using (new SelectionTracking(this))
                 {
                     // 1. Undo any previous edits and update the buffer to resulting document after conflict resolution

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// <summary>
         /// Updates the replacement text for the rename session and propagates it to all live buffers.
         /// </summary>
-        internal void ApplyReplacementText(string replacementText, bool propagateEditImmediately, bool updateSelection = false)
+        internal void ApplyReplacementText(string replacementText, bool propagateEditImmediately, bool updateSelection = true)
         {
             _threadingContext.ThrowIfNotOnUIThread();
             VerifyNotDismissed();

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// <summary>
         /// Updates the replacement text for the rename session and propagates it to all live buffers.
         /// </summary>
-        internal void ApplyReplacementText(string replacementText, bool propagateEditImmediately)
+        internal void ApplyReplacementText(string replacementText, bool propagateEditImmediately, bool updateSelection = false)
         {
             _threadingContext.ThrowIfNotOnUIThread();
             VerifyNotDismissed();
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 {
                     foreach (var openBuffer in _openTextBuffers.Values)
                     {
-                        openBuffer.ApplyReplacementText();
+                        openBuffer.ApplyReplacementText(updateSelection);
                     }
                 }
 


### PR DESCRIPTION
Fix two places that might cause ArgumentOutOfRange exception in inline rename during my testing.
