### PR TITLE
Work around restore issue

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -127,7 +127,7 @@
             We have to run restore first with the PublishReadyToRun flag set to true to ensure that the correct crossgen packages get restored.
             See https://github.com/dotnet/sdk/issues/20701
         -->
-        <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreWithR2R=true" />
+        <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreWithR2R=true;RestoreUseStaticGraphEvaluation=false" />
 
         <MSBuild Projects="@(ProjectToPublish)" Targets="Publish" BuildInParallel="true" />
 


### PR DESCRIPTION
Running `Build.cmd -pack -restore` on most machines is leading to the following error:

> \NuGet.RestoreEx.targets(19,5): error : The filename or extension is
too long

This seems to be caused by an excessively long command line being passed to a tool within the NuGetRestoreEx task. Temporarily working around this by disabling static graph on this restore operation.

https://github.com/NuGet/Home/issues/12843