### PR TITLE
Add to assembly crossgen to avoid JIT increase

### DIFF
--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -54,6 +54,9 @@
       <_R2RAssemblies Include="SQLitePCLRaw.batteries_v2.dll" />
       <_R2RAssemblies Include="StreamJsonRpc.dll" />
       <_R2RAssemblies Include="System.IO.Pipelines.dll" />
+      <_R2RAssemblies Include="System.Text.Json.dll" />
+      <_R2RAssemblies Include="System.Text.Encodings.Web.dll" />
+      <_R2RAssemblies Include="Microsoft.NET.StringTools.dll" />
 
       <!-- Find all assemblies (including Roslyn and all dependencies) from the actual published location -->
       <_AllPublishedAssemblyPaths Include="$(PublishDir)**\*.dll" Exclude="$(PublishDir)**\*.resources.dll" />


### PR DESCRIPTION
Fixes regression found in [internal builds](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=34023.218.dn-bot.230824.032638.493511&targetBranch=main&targetPerfBuildId=8300456&runGroup=PerfDDRITs64&since=2023-08-24&baselineBuild=34023.218&baselineBranch=main)