### PR TITLE
Add granular opt-in property for interceptors

### DIFF
--- a/docs/features/interceptors.md
+++ b/docs/features/interceptors.md
@@ -193,9 +193,8 @@ Interceptors are treated like a post-compilation step in this design. Diagnostic
 
 To use interceptors, the user project must specify the property `<InterceptorsPreviewNamespaces>`. This is a list of namespaces which are allowed to contain interceptors.
 ```xml
-<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;System.Text.RegularExpressions.Generated</InterceptorsPreviewNamespaces>
+<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>
 ```
-Note that `RegularExpressions`` is only provided as an example here, and is not intended to imply that a interceptors-based regex generator is forthcoming in .NET 8.
 
 It's expected that each entry in the `InterceptorsPreviewNamespaces` list roughly corresponds to one source generator. Well-behaved components are expected to not insert interceptors into namespaces they do not own.
 

--- a/docs/features/interceptors.md
+++ b/docs/features/interceptors.md
@@ -191,7 +191,13 @@ Interceptors are treated like a post-compilation step in this design. Diagnostic
 
 ### User opt-in
 
-Interceptors will require a feature flag during the experimental phase. The flag can be enabled with `/features=InterceptorsPreview` on the command line or `<Features>InterceptorsPreview</Features>` in msbuild.
+To use interceptors, the user project must specify the property `<InterceptorsPreviewNamespaces>`. This is a list of namespaces which are allowed to contain interceptors.
+```xml
+<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;System.Text.RegularExpressions.Generated</InterceptorsPreviewNamespaces>
+```
+Note that `RegularExpressions`` is only provided as an example here, and is not intended to imply that a interceptors-based regex generator is forthcoming in .NET 8.
+
+It's expected that each entry in the `InterceptorsPreviewNamespaces` list roughly corresponds to one source generator. Well-behaved components are expected to not insert interceptors into namespaces they do not own.
 
 ### Implementation strategy
 

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -175,6 +175,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal ImmutableArray<ImmutableArray<string>> _interceptorsPreviewNamespaces;
+        internal ImmutableArray<ImmutableArray<string>> InterceptorsPreviewNamespaces
+        {
+            get
+            {
+                if (!_interceptorsPreviewNamespaces.IsDefault)
+                {
+                    return _interceptorsPreviewNamespaces;
+                }
+
+                // e.g. [["System", "Threading"], ["System", "Collections"]]
+                ImmutableArray<ImmutableArray<string>> previewNamespaces;
+                if (Features.TryGetValue("InterceptorsPreviewNamespaces", out var namespaces))
+                {
+                    previewNamespaces = namespaces
+                        .Split(';')
+                        .SelectAsArray(segment => segment.Split('.').ToImmutableArray());
+                }
+                else
+                {
+                    previewNamespaces = ImmutableArray<ImmutableArray<string>>.Empty;
+                }
+                ImmutableInterlocked.InterlockedInitialize(ref _interceptorsPreviewNamespaces, previewNamespaces);
+                return previewNamespaces;
+            }
+        }
+
         internal override void ValidateOptions(ArrayBuilder<Diagnostic> builder)
         {
             ValidateOptions(builder, MessageProvider.Instance);

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -257,6 +257,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            if (InterceptorsPreviewNamespaces != other.InterceptorsPreviewNamespaces)
+            {
+                return false;
+            }
+
             return this.SpecifiedLanguageVersion == other.SpecifiedLanguageVersion;
         }
 
@@ -264,7 +269,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return
                 Hash.Combine(base.GetHashCodeHelper(),
-                Hash.Combine((int)this.SpecifiedLanguageVersion, 0));
+                Hash.Combine(InterceptorsPreviewNamespaces.GetHashCode(),
+                Hash.Combine((int)this.SpecifiedLanguageVersion, 0)));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -257,11 +257,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (InterceptorsPreviewNamespaces != other.InterceptorsPreviewNamespaces)
-            {
-                return false;
-            }
-
             return this.SpecifiedLanguageVersion == other.SpecifiedLanguageVersion;
         }
 
@@ -269,8 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return
                 Hash.Combine(base.GetHashCodeHelper(),
-                Hash.Combine(InterceptorsPreviewNamespaces.GetHashCode(),
-                Hash.Combine((int)this.SpecifiedLanguageVersion, 0)));
+                Hash.Combine((int)this.SpecifiedLanguageVersion, 0));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static CSharpParseOptions Default { get; } = new CSharpParseOptions();
 
         private ImmutableDictionary<string, string> _features;
+        private ImmutableArray<ImmutableArray<string>> _interceptorsPreviewNamespaces;
 
         /// <summary>
         /// Gets the effective language version, which the compiler uses to select the
@@ -175,7 +176,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal ImmutableArray<ImmutableArray<string>> _interceptorsPreviewNamespaces;
         internal ImmutableArray<ImmutableArray<string>> InterceptorsPreviewNamespaces
         {
             get

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7593,7 +7593,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>A switch expression arm does not begin with a 'case' keyword.</value>
   </data>
   <data name="ERR_InterceptorsFeatureNotEnabled" xml:space="preserve">
-    <value>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</value>
+    <value>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</value>
   </data>
   <data name="ERR_InterceptorContainingTypeCannotBeGeneric" xml:space="preserve">
     <value>Method '{0}' cannot be used as an interceptor because its containing type has type parameters.</value>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -267,7 +267,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            features.Add(value);
+                            // When a features value like "InterceptorsPreviewNamespaces=NS1;NS2" is provided,
+                            // the build system will quote it so that splitting doesn't occur in the wrong layer.
+                            // We need to unquote here so that subsequent layers can properly identify the feature name and value.
+                            features.Add(value.Unquote());
                         }
                         continue;
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">Experimentální funkce interceptors není povolená. Do projektu přidejte &lt;Features&gt;InterceptorsPreview&lt;/Features&gt;.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">Das experimentelle Feature "Interceptors" ist nicht aktiviert. Fügen Sie Ihrem Projekt "&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;" hinzu.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">La característica experimental "interceptores" no está habilitada. Agregue "&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;" al proyecto.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">La fonctionnalité expérimentale "intercepteurs" n'est pas activée. Ajoutez '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' à votre projet.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">La funzionalità sperimentale 'intercettori' non è abilitata. Aggiungere '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' al progetto.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">試験的な機能である 'interceptors' が有効になっていません。'&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' をプロジェクトに追加します。</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">'인터셉터' 실험 기능이 활성화되지 않았습니다. 프로젝트에 '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;'를 추가합니다.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">Funkcja eksperymentalna „interceptor” nie jest włączona. Dodaj element „&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;” do projektu.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">O recurso experimental 'interceptors' não está habilitado. Adicione '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' ao seu projeto.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">Экспериментальная функция «перехватчики» не включена. Добавьте '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' в свой проект.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">'Engelleyiciler' deneysel özelliği etkin değil. Projenize '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' ekleyin.</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">未启用“侦听器”实验性功能。向项目添加“&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;”。</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1048,8 +1048,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorsFeatureNotEnabled">
-        <source>The 'interceptors' experimental feature is not enabled. Add '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' to your project.</source>
-        <target state="translated">未啟用 'interceptors' (攔截) 實驗功能。將 '&lt;Features&gt;InterceptorsPreview&lt;/Features&gt;' 新增至您的專案。</target>
+        <source>The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</source>
+        <target state="new">The 'interceptors' experimental feature is not enabled. Add '{0}' to your project.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfaceImplementedByUnmanagedCallersOnlyMethod">

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -40,7 +40,6 @@ using Basic.Reference.Assemblies;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
 using static Roslyn.Test.Utilities.SharedResourceHelpers;
 using static Roslyn.Test.Utilities.TestMetadata;
-using System.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12156,66 +12156,6 @@ public class TestAnalyzer : DiagnosticAnalyzer
             Assert.Equal(new[] { "NS3", "NS4" }, previewNamespaces[1]);
         }
 
-        [Fact]
-        public void FeaturesInterceptorsPreviewNamespaces_EndToEnd()
-        {
-            var tempDir = Temp.CreateDirectory();
-            var workingDir = Temp.CreateDirectory();
-            workingDir.CreateFile("a.cs").WriteAllText("""
-                using System;
-                using System.Runtime.CompilerServices;
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M1();
-                        C.M2();
-                    }
-                }
-
-                class C
-                {
-                    public static void M1() => throw null!;
-                    public static void M2() => throw null!;
-                }
-
-                namespace NS1.NS2
-                {
-                    class Interceptors
-                    {
-                        [InterceptsLocation("a.cs", 8, 11)]
-                        public static void M1() => Console.Write(1);
-                    }
-                }
-                
-                namespace NS0
-                {
-                    class Interceptors
-                    {
-                        [InterceptsLocation("a.cs", 9, 11)]
-                        public static void M2() => Console.Write(0);
-                    }
-                }
-
-                namespace System.Runtime.CompilerServices
-                {
-                    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-                    public sealed class InterceptsLocationAttribute : Attribute
-                    {
-                        public InterceptsLocationAttribute(string filePath, int line, int character)
-                        {
-                        }
-                    }
-                }
-                """);
-
-            var buildPaths = new BuildPaths(clientDir: "", workingDir: workingDir.Path, sdkDir: null, tempDir: tempDir.Path);
-            var csc = new MockCSharpCompiler(null, buildPaths, args: new[] { @"/features:InterceptorsPreviewNamespaces=NS1.NS2;NS3.NS4", "a.cs" });
-            var comp = (CSharpCompilation)csc.CreateCompilation(new StringWriter(), new TouchedFileLogger(), errorLogger: null);
-            comp.VerifyEmitDiagnostics();
-        }
-
         public class QuotedArgumentTests : CommandLineTestBase
         {
             private static readonly string s_rootPath = ExecutionConditionUtil.IsWindows

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -12156,6 +12156,25 @@ public class TestAnalyzer : DiagnosticAnalyzer
             Assert.Equal(new[] { "NS3", "NS4" }, previewNamespaces[1]);
         }
 
+        [Fact]
+        public void FeaturesInterceptorsPreviewNamespaces_Duplicate()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var workingDir = Temp.CreateDirectory();
+            workingDir.CreateFile("a.cs");
+
+            var buildPaths = new BuildPaths(clientDir: "", workingDir: workingDir.Path, sdkDir: null, tempDir: tempDir.Path);
+            var csc = new MockCSharpCompiler(null, buildPaths, args: new[] { @"/features:InterceptorsPreviewNamespaces=NS1.NS2", @"/features:InterceptorsPreviewNamespaces=NS3.NS4", "a.cs" });
+            var comp = (CSharpCompilation)csc.CreateCompilation(new StringWriter(), new TouchedFileLogger(), errorLogger: null);
+            var options = comp.SyntaxTrees[0].Options;
+            Assert.Equal(1, options.Features.Count);
+            Assert.Equal("NS3.NS4", options.Features["InterceptorsPreviewNamespaces"]);
+
+            var previewNamespaces = ((CSharpParseOptions)options).InterceptorsPreviewNamespaces;
+            Assert.Equal(1, previewNamespaces.Length);
+            Assert.Equal(new[] { "NS3", "NS4" }, previewNamespaces[0]);
+        }
+
         public class QuotedArgumentTests : CommandLineTestBase
         {
             private static readonly string s_rootPath = ExecutionConditionUtil.IsWindows

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -55,15 +55,15 @@ public class InterceptorsTests : CSharpTestBase
 
         var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource });
         comp.VerifyEmitDiagnostics(
-            // Program.cs(13,6): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>InterceptorsPreview</Features>' to your project.
+            // Program.cs(13,6): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>$(Features);InterceptorsPreview</Features>' to your project.
             //     [InterceptsLocation("Program.cs", 4, 3)]
-            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithLocation(13, 6));
+            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithArguments("<Features>$(Features);InterceptorsPreview</Features>").WithLocation(13, 6));
 
         comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreview-experimental"));
         comp.VerifyEmitDiagnostics(
-            // Program.cs(13,6): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>InterceptorsPreview</Features>' to your project.
+            // Program.cs(13,6): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>$(Features);InterceptorsPreview</Features>' to your project.
             //     [InterceptsLocation("Program.cs", 4, 3)]
-            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithLocation(13, 6));
+            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithArguments("<Features>$(Features);InterceptorsPreview</Features>").WithLocation(13, 6));
 
         var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors, expectedOutput: "1");
         verifier.VerifyDiagnostics();
@@ -102,9 +102,9 @@ public class InterceptorsTests : CSharpTestBase
 
         var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreviewNamespaces", "NS"));
         comp.VerifyEmitDiagnostics(
-            // Program.cs(17,6): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>InterceptorsPreview</Features>' to your project.
-            //     [InterceptsLocation("Program.cs", 5, 3)]
-            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 5, 3)").WithLocation(17, 6));
+            // Program.cs(15,10): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);NS1</InterceptorsPreviewNamespaces>' to your project.
+            //         [InterceptsLocation("Program.cs", 4, 3)]
+            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithArguments("<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);NS1</InterceptorsPreviewNamespaces>").WithLocation(15, 10));
 
         var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreviewNamespaces", "NS1"), expectedOutput: "1");
         verifier.VerifyDiagnostics();
@@ -139,9 +139,9 @@ public class InterceptorsTests : CSharpTestBase
 
         var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreviewNamespaces", "NS2"));
         comp.VerifyEmitDiagnostics(
-            // Program.cs(15,10): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<Features>InterceptorsPreview</Features>' to your project.
+            // Program.cs(15,10): error CS9137: The 'interceptors' experimental feature is not enabled. Add '<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);NS1.NS2</InterceptorsPreviewNamespaces>' to your project.
             //         [InterceptsLocation("Program.cs", 4, 3)]
-            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithLocation(15, 10));
+            Diagnostic(ErrorCode.ERR_InterceptorsFeatureNotEnabled, @"InterceptsLocation(""Program.cs"", 4, 3)").WithArguments("<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);NS1.NS2</InterceptorsPreviewNamespaces>").WithLocation(15, 10));
 
         var verifier = CompileAndVerify(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: TestOptions.Regular.WithFeature("InterceptorsPreviewNamespaces", "NS1"), expectedOutput: "1");
         verifier.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -148,8 +148,14 @@ public class InterceptorsTests : CSharpTestBase
         sadCase(" NS1");
         sadCase(";");
         sadCase("NS1 ;");
+        sadCase("NS1..NS2;");
+        sadCase("ns1");
+        sadCase("NS2.NS1");
+        sadCase("$NS1&");
 
         happyCase("NS1");
+        happyCase("NS1;");
+        happyCase(";NS1");
         happyCase("NS1.NS2");
         happyCase("NS2;NS1.NS2");
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CSharpParseOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CSharpParseOptionsTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
                 "Features",
                 "Language",
                 "LanguageVersion",
+                "InterceptorsPreviewNamespaces",
                 "PreprocessorSymbolNames",
                 "PreprocessorSymbols",
                 "SpecifiedLanguageVersion");

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -241,6 +241,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
 
             AddReferencesToCommandLine(commandLine, References);
+            AddInterceptorsPreviewNamespaces(commandLine, InterceptorsPreviewNamespaces);
 
             base.AddResponseFileCommands(commandLine);
 
@@ -278,6 +279,25 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         #endregion
 
         internal override RequestLanguage Language => RequestLanguage.CSharpCompile;
+
+        /// <param name="interceptorsNamespaces">
+        /// The value of the &lt;InterceptorsPreviewNamespaces&gt; property.
+        /// </param>
+        internal static void AddInterceptorsPreviewNamespaces(CommandLineBuilderExtension commandLine, string? interceptorsNamespaces)
+        {
+            if (string.IsNullOrEmpty(interceptorsNamespaces))
+            {
+                return;
+            }
+
+            commandLine.AppendSwitchIfNotNull("/features:", $"InterceptorsPreviewNamespaces={interceptorsNamespaces}");
+        }
+
+        public string? InterceptorsPreviewNamespaces
+        {
+            set { _store[nameof(InterceptorsPreviewNamespaces)] = value; }
+            get { return (string?)_store[nameof(InterceptorsPreviewNamespaces)]; }
+        }
 
         /// <summary>
         /// The C# compiler (starting with Whidbey) supports assembly aliasing for references.

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -108,6 +108,7 @@
          ErrorLog="$(ErrorLog)"
          ErrorReport="$(ErrorReport)"
          Features="$(Features)"
+         InterceptorsPreviewNamespaces="$(InterceptorsPreviewNamespaces)"
          FileAlignment="$(FileAlignment)"
          GeneratedFilesOutputPath="$(CompilerGeneratedFilesOutputPath)"
          GenerateFullPaths="$(GenerateFullPaths)"

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -214,6 +214,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void FeaturesInterceptorsPreview()
+        {
+            var csc = new Csc();
+            csc.InterceptorsPreviewNamespaces = "NS1.NS2;NS3.NS4";
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            AssertEx.Equal("""/features:"InterceptorsPreviewNamespaces=NS1.NS2;NS3.NS4" /out:test.exe test.cs""", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void FeaturesEmpty()
         {
             foreach (var cur in new[] { "", null })

--- a/src/Compilers/Core/RebuildTest/CSharpDeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/CSharpDeterministicKeyBuilderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
         public void VerifyUpToDate()
         {
             verifyCount<ParseOptions>(11);
-            verifyCount<CSharpParseOptions>(10);
+            verifyCount<CSharpParseOptions>(12);
             verifyCount<CompilationOptions>(63);
             verifyCount<CSharpCompilationOptions>(9);
 


### PR DESCRIPTION
The existing InterceptorsPreview feature flag will continue to work while we give folks time to onboard to this new scheme (detailed in the interceptors.md change).