### PR TITLE
Add System.IO.Pipelines to Version.Details for source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,6 +11,11 @@
       <Sha>01850f2b7bff23e118d1faecb941d770c8e626f2</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.IO.Pipelines" Version="7.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23415.4">


### PR DESCRIPTION
This fixes an issue with System.IO.Pipelines, as described in https://github.com/dotnet/source-build/issues/3599, that is showing up as a reference assembly in the source-built SDK.

The reason a reference assembly exists in this case is because Roslyn has a reference to the 7.0.0 version of System.IO.Pipelines. When building with source-build, it loads that reference from [SBRP](https://github.com/dotnet/source-build-reference-packages) (which only contains reference assemblies) in order to fulfill compile time references. The problem is that the assembly is also getting included in the output. This should have been detected by poison leak detection [but that doesn't yet handle reference assemblies](https://github.com/dotnet/source-build/issues/2817).

It's not known whether the existence of this ref assembly causes a functional issue. But it is known that the source-built 7.0 SDK doesn't define this as a ref assembly but rather as an implementation assembly. So to maintain parity with 7.0 and avoid potential risk, it's best to ensure this is represented as an implementation assembly in the output.