### PR TITLE
Trim ToString calls when converting to interpolated strings when there are interpolated string handlers available.

### DIFF
--- a/src/Features/CSharp/Portable/ConvertToInterpolatedString/CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertToInterpolatedString/CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -9,21 +9,23 @@ using Microsoft.CodeAnalysis.ConvertToInterpolatedString;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 
-namespace Microsoft.CodeAnalysis.CSharp.ConvertToInterpolatedString
-{
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertConcatenationToInterpolatedString), Shared]
-    internal sealed class CSharpConvertConcatenationToInterpolatedStringRefactoringProvider :
-        AbstractConvertConcatenationToInterpolatedStringRefactoringProvider<ExpressionSyntax>
-    {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpConvertConcatenationToInterpolatedStringRefactoringProvider()
-        {
-        }
+namespace Microsoft.CodeAnalysis.CSharp.ConvertToInterpolatedString;
 
-        protected override string GetTextWithoutQuotes(string text, bool isVerbatim, bool isCharacterLiteral)
-            => isVerbatim
-                ? text.Substring("@'".Length, text.Length - "@''".Length)
-                : text.Substring("'".Length, text.Length - "''".Length);
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertConcatenationToInterpolatedString), Shared]
+internal sealed class CSharpConvertConcatenationToInterpolatedStringRefactoringProvider :
+    AbstractConvertConcatenationToInterpolatedStringRefactoringProvider<ExpressionSyntax>
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public CSharpConvertConcatenationToInterpolatedStringRefactoringProvider()
+    {
     }
+
+    protected override bool SupportsInterpolatedStringHandler(Compilation compilation)
+        => compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DefaultInterpolatedStringHandler") != null;
+
+    protected override string GetTextWithoutQuotes(string text, bool isVerbatim, bool isCharacterLiteral)
+        => isVerbatim
+            ? text.Substring("@'".Length, text.Length - "@''".Length)
+            : text.Substring("'".Length, text.Length - "''".Length);
 }

--- a/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -1196,33 +1196,33 @@ class C
     [InlineData("""
         "\t" [|+|] 1
         """,
-               """
-               $"\t{1}"
-               """)]
+        """
+        $"\t{1}"
+        """)]
     [InlineData("""
         "😀" [|+|] 1
         """,
-               """
-               $"😀{1}"
-               """)]
+        """
+        $"😀{1}"
+        """)]
     [InlineData("""
         "\u2764" [|+|] 1
         """,
-               """
-               $"\u2764{1}"
-               """)]
+        """
+        $"\u2764{1}"
+        """)]
     [InlineData("""
         "\"" [|+|] 1
         """,
-               """
-               $"\"{1}"
-               """)]
+        """
+        $"\"{1}"
+        """)]
     [InlineData("""
         "{}" [|+|] 1
         """,
-               """
-               $"{{}}{1}"
-               """)]
+        """
+        $"{{}}{1}"
+        """)]
     public async Task TestUnicodeAndEscapeHandling(string before, string after)
     {
         var initialMarkup = $@"
@@ -1246,27 +1246,27 @@ class C
     [InlineData("""
         "a" [|+|] (1 + 1)
         """,
-               """
-               $"a{1 + 1}"
-               """)]
+        """
+        $"a{1 + 1}"
+        """)]
     [InlineData("""
         "a" [||]+ (1 + 1) + "b" + (2 + 2)
         """,
-               """
-               $"a{1 + 1}b{2 + 2}"
-               """)]
+        """
+        $"a{1 + 1}b{2 + 2}"
+        """)]
     [InlineData("""
         "a" [|+|] (true ? "t" : "f")
         """,
-               """
-               $"a{(true ? "t" : "f")}"
-               """)]
+        """
+        $"a{(true ? "t" : "f")}"
+        """)]
     [InlineData("""
         "a" [|+|] $"{(1 + 1)}"
         """,
-               """
-               $"a{(1 + 1)}"
-               """)]
+        """
+        $"a{(1 + 1)}"
+        """)]
     public async Task TestRemovalOfSuperflousParenthesis(string before, string after)
     {
         var initialMarkup = $@"
@@ -1286,7 +1286,7 @@ class C
         await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
     public async Task TestToString1()
     {
         await new VerifyCS.Test
@@ -1318,7 +1318,7 @@ class C
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
     public async Task TestToString1_Net6()
     {
         await new VerifyCS.Test
@@ -1351,7 +1351,7 @@ class C
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
     public async Task TestToString2()
     {
         await new VerifyCS.Test
@@ -1368,19 +1368,16 @@ class C
             FixedCode = """
                 struct ValueTuple<T>
                 {
-                    public T Item1;
-                    public T Item2;
-                
                     public override string ToString()
                     {
-                        return $"({(1 + 1).ToString()}, {(1 + 1).ToString()})";
+                        return $"({(1 + 1).ToString()}, {(2 + 2).ToString()})";
                     }
                 }
                 """,
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69721")]
     public async Task TestToString2_Net6()
     {
         await new VerifyCS.Test
@@ -1397,9 +1394,6 @@ class C
             FixedCode = """
                 struct ValueTuple<T>
                 {
-                    public T Item1;
-                    public T Item2;
-                
                     public override string ToString()
                     {
                         return $"({1 + 1}, {2 + 2})";

--- a/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -1225,20 +1225,22 @@ class C
         """)]
     public async Task TestUnicodeAndEscapeHandling(string before, string after)
     {
-        var initialMarkup = $@"
-class C
-{{
-    void M() {{
-        _ = {before};
-    }}
-}}";
-        var expected = $@"
-class C
-{{
-    void M() {{
-        _ = {after};
-    }}
-}}";
+        var initialMarkup = $$"""
+            class C
+            {
+                void M() {
+                    _ = {{before}};
+                }
+            }
+            """;
+        var expected = $$"""
+            class C
+            {
+                void M() {
+                    _ = {{after}};
+                }
+            }
+            """;
         await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
     }
 
@@ -1269,20 +1271,22 @@ class C
         """)]
     public async Task TestRemovalOfSuperflousParenthesis(string before, string after)
     {
-        var initialMarkup = $@"
-class C
-{{
-    void M() {{
-        _ = {before};
-    }}
-}}";
-        var expected = $@"
-class C
-{{
-    void M() {{
-        _ = {after};
-    }}
-}}";
+        var initialMarkup = $$"""
+            class C
+            {
+                void M() {
+                    _ = {{before}};
+                }
+            }
+            """;
+        var expected = $$"""
+            class C
+            {
+                void M() {
+                    _ = {{after}};
+                }
+            }
+            """;
         await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
     }
 

--- a/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/Features/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -11,1082 +11,1287 @@ using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedString
-{
-    using VerifyCS = CSharpCodeRefactoringVerifier<CSharpConvertConcatenationToInterpolatedStringRefactoringProvider>;
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertToInterpolatedString;
 
-    [Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
-    public class ConvertConcatenationToInterpolatedStringTests
+using VerifyCS = CSharpCodeRefactoringVerifier<CSharpConvertConcatenationToInterpolatedStringRefactoringProvider>;
+
+[Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+public class ConvertConcatenationToInterpolatedStringTests
+{
+    [Fact]
+    public async Task TestMissingOnSimpleString()
     {
-        [Fact]
-        public async Task TestMissingOnSimpleString()
-        {
-            var code = @"
-public class C
-{
-    void M()
-    {
-        var v = [||]""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestMissingOnConcatenatedStrings1()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = [||]""string"" + ""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestMissingOnConcatenatedStrings2()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = ""string"" + [||]""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestMissingOnConcatenatedStrings3()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = ""string"" + '.' + [||]""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestWithStringOnLeft()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = [||]""string"" + 1;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestRightSideOfString()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = ""string""[||] + 1;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithStringOnRight()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{1}string"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithComplexExpressionOnLeft()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 + 2 + [||]""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{1 + 2}string"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithTrivia1()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"
-public class C
-{
-    void M()
-    {
-        var v =
-            // Leading trivia
-            1 + 2 + [||]""string"" /* trailing trivia */;
-    }
-}",
-@"
-public class C
-{
-    void M()
-    {
-        var v =
-            // Leading trivia
-            $""{1 + 2}string"" /* trailing trivia */;
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithComplexExpressions()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 + 2 + [||]""string"" + 3 + 4;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{1 + 2}string{3}{4}"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithEscapes1()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"
-public class C
-{
-    void M()
-    {
-        var v = ""\r"" + 2 + [||]""string"" + 3 + ""\n"";
-    }
-}",
-@"
-public class C
-{
-    void M()
-    {
-        var v = $""\r{2}string{3}\n"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithEscapes2()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"
-public class C
-{
-    void M()
-    {
-        var v = ""\\r"" + 2 + [||]""string"" + 3 + ""\\n"";
-    }
-}",
-@"
-public class C
-{
-    void M()
-    {
-        var v = $""\\r{2}string{3}\\n"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithVerbatimString1()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]@""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $@""{1}string"";
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestMissingWithMixedStringTypes1()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]@""string"" + 2 + ""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestMissingWithMixedStringTypes2()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = 1 + @""string"" + 2 + [||]""string"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestMissingWithMixedStringTypes3()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = 1 + @""string"" + 2 + [||]'\n';
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact]
-        public async Task TestWithOverloadedOperator()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class D
-{
-    public static bool operator +(D d, string s) => false;
-    public static bool operator +(string s, D d) => false;
-}
-
-public class C
-{
-    void M()
-    {
-        D d = null;
-        var v = 1 + [||]""string"" + d;
-    }
-}",
-@"public class D
-{
-    public static bool operator +(D d, string s) => false;
-    public static bool operator +(string s, D d) => false;
-}
-
-public class C
-{
-    void M()
-    {
-        D d = null;
-        var v = $""{1}string"" + d;
-    }
-}");
-        }
-
-        [Fact]
-        public async Task TestWithOverloadedOperator2()
-        {
-            var code = @"public class D
-{
-    public static int operator +(D d, string s) => 0;
-    public static int operator +(string s, D d) => 0;
-}
-
-public class C
-{
-    void M()
-    {
-        D d = null;
-        var v = d + [||]""string"" + 1;
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
-        public async Task TestWithMultipleStringConcatenations()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = ""A"" + 1 + [||]""B"" + ""C"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""A{1}BC"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
-        public async Task TestWithMultipleStringConcatenations2()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = ""A"" + [||]""B"" + ""C"" + 1;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""ABC{1}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
-        public async Task TestWithMultipleStringConcatenations3()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = ""A"" + 1 + [||]""B"" + ""C"" + 2 +""D""+ ""E""+ ""F"" + 3;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""A{1}BC{2}DEF{3}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
-        public async Task TestWithMultipleStringConcatenations4()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = ""A"" + 1 + [||]""B"" + @""C"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20943")]
-        public async Task TestMissingWithDynamic1()
-        {
-            var code = @"class C
-{
-    void M()
-    {
-        dynamic a = ""b"";
-        string c = [||]""d"" + a + ""e"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20943")]
-        public async Task TestMissingWithDynamic2()
-        {
-            var code = @"class C
-{
-    void M()
-    {
-        dynamic dynamic = null;
-        var x = dynamic.someVal + [||]"" $"";
-    }
-}";
-
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithStringLiteralWithBraces()
-        {
+        var code = """
+            public class C
             {
-                await VerifyCS.VerifyRefactoringAsync(
-    @"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]""{string}"";
-    }
-}",
-    @"public class C
-{
-    void M()
-    {
-        var v = $""{1}{{string}}"";
-    }
-}");
+                void M()
+                {
+                    var v = [||]"string";
+                }
             }
-        }
+            """;
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithStringLiteralWithBraces2()
-        {
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestMissingOnConcatenatedStrings1()
+    {
+        var code = """
+            public class C
             {
-                await VerifyCS.VerifyRefactoringAsync(
-    @"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]""{string}"" + ""{string}"";
-    }
-}",
-    @"public class C
-{
-    void M()
-    {
-        var v = $""{1}{{string}}{{string}}"";
-    }
-}");
+                void M()
+                {
+                    var v = [||]"string" + "string";
+                }
             }
-        }
+            """;
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithStringLiteralWithDoubleBraces()
-        {
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestMissingOnConcatenatedStrings2()
+    {
+        var code = """
+            public class C
             {
-                await VerifyCS.VerifyRefactoringAsync(
-    @"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]""{{string}}"";
-    }
-}",
-    @"public class C
-{
-    void M()
-    {
-        var v = $""{1}{{{{string}}}}"";
-    }
-}");
+                void M()
+                {
+                    var v = "string" + [||]"string";
+                }
             }
-        }
+            """;
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithMultipleStringLiteralsWithBraces()
-        {
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestMissingOnConcatenatedStrings3()
+    {
+        var code = """
+            public class C
             {
-                await VerifyCS.VerifyRefactoringAsync(
-    @"public class C
-{
-    void M()
-    {
-        var v = ""{"" + 1 + [||]""}"";
-    }
-}",
-    @"public class C
-{
-    void M()
-    {
-        var v = $""{{{1}}}"";
-    }
-}");
+                void M()
+                {
+                    var v = "string" + '.' + [||]"string";
+                }
             }
-        }
+            """;
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithVerbatimStringWithBraces()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 + [||]@""{string}"";
+        await VerifyCS.VerifyRefactoringAsync(code, code);
     }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $@""{1}{{string}}"";
-    }
-}");
-        }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
-        public async Task TestWithMultipleVerbatimStringsWithBraces()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
+    [Fact]
+    public async Task TestWithStringOnLeft()
     {
-        var v = @""{"" + 1 + [||]@""}"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $@""{{{1}}}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithSelectionOnEntireToBeInterpolatedString()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = [|""string"" + 1|];
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestMissingWithSelectionOnPartOfToBeInterpolatedStringPrefix()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = [|""string"" + 1|] + ""string"";
-    }
-}";
-
-            // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestMissingWithSelectionOnPartOfToBeInterpolatedStringSuffix()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = ""string"" + [|1 + ""string""|];
-    }
-}";
-
-            // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
-        [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestMissingWithSelectionOnMiddlePartOfToBeInterpolatedString()
-        {
-            var code = @"public class C
-{
-    void M()
-    {
-        var v = ""a"" + [|1 + ""string""|] + ""b"";
-    }
-}";
-
-            // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
-            await VerifyCS.VerifyRefactoringAsync(code, code);
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithSelectionExceedingToBeInterpolatedString()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        [|var v = ""string"" + 1|];
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretBeforeNonStringToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = [||]3 + ""string"" + 1 + ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretAfterNonStringToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 3[||] + ""string"" + 1 + ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretBeforePlusToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 3 [||]+ ""string"" + 1 + ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretAfterPlusToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 3 +[||] ""string"" + 1 + ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretBeforeLastPlusToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 3 + ""string"" + 1 [||]+ ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
-        public async Task TestWithCaretAfterLastPlusToken()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 3 + ""string"" + 1 +[||] ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{3}string{1}string"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32864")]
-        public async Task TestConcatenationWithNoStringLiterals()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var v = 1 [||]+ (""string"");
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""{1}{""string""}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
-        public async Task TestConcatenationWithChar()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var hello = ""hello"";
-        var world = ""world"";
-        var str = hello [||]+ ' ' + world;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var hello = ""hello"";
-        var world = ""world"";
-        var str = $""{hello} {world}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
-        public async Task TestConcatenationWithCharAfterStringLiteral()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var world = ""world"";
-        var str = ""hello"" [||]+ ' ' + world;
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var world = ""world"";
-        var str = $""hello {world}"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
-        public async Task TestConcatenationWithCharBeforeStringLiteral()
-        {
-            await VerifyCS.VerifyRefactoringAsync(
-@"public class C
-{
-    void M()
-    {
-        var hello = ""hello"";
-        var str = hello [||]+ ' ' + ""world"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var hello = ""hello"";
-        var str = $""{hello} world"";
-    }
-}");
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
-        public async Task TestConcatenationWithConstMember()
-        {
-            var code = @"
-class C
-{
-    const string Hello = ""Hello"";
-    const string World = ""World"";
-    const string Message = Hello + "" "" + [||]World;
-}";
-            var fixedCode = @"
-class C
-{
-    const string Hello = ""Hello"";
-    const string World = ""World"";
-    const string Message = $""{Hello} {World}"";
-}";
-
-            await new VerifyCS.Test
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
             {
-                LanguageVersion = LanguageVersion.CSharp9,
-                TestCode = code,
-                FixedCode = code,
-            }.RunAsync();
-
-            await new VerifyCS.Test
+                void M()
+                {
+                    var v = [||]"string" + 1;
+                }
+            }
+            """,
+            """
+            public class C
             {
-                LanguageVersion = LanguageVersion.Preview,
-                TestCode = code,
-                FixedCode = fixedCode,
-            }.RunAsync();
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
-        public async Task TestConcatenationWithConstDeclaration()
-        {
-            var code = @"
-class C
-{
-    void M() {
-        const string Hello = ""Hello"";
-        const string World = ""World"";
-        const string Message = Hello + "" "" + [||]World;
+                void M()
+                {
+                    var v = $"string{1}";
+                }
+            }
+            """);
     }
-}";
-            var fixedCode = @"
-class C
-{
-    void M() {
-        const string Hello = ""Hello"";
-        const string World = ""World"";
-        const string Message = $""{Hello} {World}"";
-    }
-}";
 
-            await new VerifyCS.Test
+    [Fact]
+    public async Task TestRightSideOfString()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
             {
-                LanguageVersion = LanguageVersion.CSharp9,
-                TestCode = code,
-                FixedCode = code,
-            }.RunAsync();
-
-            await new VerifyCS.Test
+                void M()
+                {
+                    var v = "string"[||] + 1;
+                }
+            }
+            """,
+            """
+            public class C
             {
-                LanguageVersion = LanguageVersion.Preview,
-                TestCode = code,
-                FixedCode = fixedCode,
-            }.RunAsync();
-        }
-
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
-        public async Task TestConcatenationWithInlineString()
-        {
-            await VerifyCS.VerifyRefactoringAsync(@"
-using System;
-class C
-{
-    void M() {
-        const string Hello = ""Hello"";
-        const string World = ""World"";
-        Console.WriteLine(Hello + "" "" + [||]World);
+                void M()
+                {
+                    var v = $"string{1}";
+                }
+            }
+            """);
     }
-}",
-@"
-using System;
-class C
-{
-    void M() {
-        const string Hello = ""Hello"";
-        const string World = ""World"";
-        Console.WriteLine($""{Hello} {World}"");
-    }
-}");
-        }
 
-        [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
-        [InlineData(@"[|""a"" + $""{1:000}""|]",
-                     @"$""a{1:000}""")]
-        [InlineData(@"[|""a"" + $""b{1:000}""|]",
-                     @"$""ab{1:000}""")]
-        [InlineData(@"[|$""a{1:000}"" + ""b""|]",
-                     @"$""a{1:000}b""")]
-        [InlineData(@"[|""a"" + $""b{1:000}c"" + ""d""|]",
-                     @"$""ab{1:000}cd""")]
-        [InlineData(@"[|""a"" + $""{1:000}b"" + ""c""|]",
-                     @"$""a{1:000}bc""")]
-        [InlineData(@"[|""a"" + $""{1:000}"" + $""{2:000}"" + ""b""|]",
-                     @"$""a{1:000}{2:000}b""")]
-        [InlineData(@"[|@""a"" + @$""{1:000}""|]",
-                     @"$@""a{1:000}""")]
-        [InlineData(@"[|@""a"" + $""{1:000}""|]",
-                     @"$@""a{$""{1:000}""}""")]
-        [InlineData(@"[|""a"" + @$""{1:000}""|]",
-                     @"$""a{@$""{1:000}""}""")]
-        public async Task TestInliningOfInterpolatedString(string before, string after)
+    [Fact]
+    public async Task TestWithStringOnRight()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + [||]"string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithComplexExpressionOnLeft()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + 2 + [||]"string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{1 + 2}string";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithTrivia1()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v =
+                        // Leading trivia
+                        1 + 2 + [||]"string" /* trailing trivia */;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v =
+                        // Leading trivia
+                        $"{1 + 2}string" /* trailing trivia */;
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithComplexExpressions()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + 2 + [||]"string" + 3 + 4;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{1 + 2}string{3}{4}";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithEscapes1()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = "\r" + 2 + [||]"string" + 3 + "\n";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"\r{2}string{3}\n";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithEscapes2()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = "\\r" + 2 + [||]"string" + 3 + "\\n";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"\\r{2}string{3}\\n";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithVerbatimString1()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + [||]@"string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $@"{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestMissingWithMixedStringTypes1()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + [||]@"string" + 2 + "string";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestMissingWithMixedStringTypes2()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + @"string" + 2 + [||]"string";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestMissingWithMixedStringTypes3()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + @"string" + 2 + [||]'\n';
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact]
+    public async Task TestWithOverloadedOperator()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class D
+            {
+                public static bool operator +(D d, string s) => false;
+                public static bool operator +(string s, D d) => false;
+            }
+
+            public class C
+            {
+                void M()
+                {
+                    D d = null;
+                    var v = 1 + [||]"string" + d;
+                }
+            }
+            """,
+            """
+            public class D
+            {
+                public static bool operator +(D d, string s) => false;
+                public static bool operator +(string s, D d) => false;
+            }
+
+            public class C
+            {
+                void M()
+                {
+                    D d = null;
+                    var v = $"{1}string" + d;
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestWithOverloadedOperator2()
+    {
+        var code = """
+            public class D
+            {
+                public static int operator +(D d, string s) => 0;
+                public static int operator +(string s, D d) => 0;
+            }
+
+            public class C
+            {
+                void M()
+                {
+                    D d = null;
+                    var v = d + [||]"string" + 1;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
+    public async Task TestWithMultipleStringConcatenations()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = "A" + 1 + [||]"B" + "C";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"A{1}BC";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
+    public async Task TestWithMultipleStringConcatenations2()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = "A" + [||]"B" + "C" + 1;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"ABC{1}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
+    public async Task TestWithMultipleStringConcatenations3()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = "A" + 1 + [||]"B" + "C" + 2 +"D"+ "E"+ "F" + 3;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"A{1}BC{2}DEF{3}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16820")]
+    public async Task TestWithMultipleStringConcatenations4()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = "A" + 1 + [||]"B" + @"C";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20943")]
+    public async Task TestMissingWithDynamic1()
+    {
+        var code = """
+            class C
+            {
+                void M()
+                {
+                    dynamic a = "b";
+                    string c = [||]"d" + a + "e";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20943")]
+    public async Task TestMissingWithDynamic2()
+    {
+        var code = """
+            class C
+            {
+                void M()
+                {
+                    dynamic dynamic = null;
+                    var x = dynamic.someVal + [||]" $";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithStringLiteralWithBraces()
+    {
         {
-            var initialMarkup = $@"
+            await VerifyCS.VerifyRefactoringAsync(
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = 1 + [||]"{string}";
+                    }
+                }
+                """,
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = $"{1}{{string}}";
+                    }
+                }
+                """);
+        }
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithStringLiteralWithBraces2()
+    {
+        {
+            await VerifyCS.VerifyRefactoringAsync(
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = 1 + [||]"{string}" + "{string}";
+                    }
+                }
+                """,
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = $"{1}{{string}}{{string}}";
+                    }
+                }
+                """);
+        }
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithStringLiteralWithDoubleBraces()
+    {
+        {
+            await VerifyCS.VerifyRefactoringAsync(
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = 1 + [||]"{{string}}";
+                    }
+                }
+                """,
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = $"{1}{{{{string}}}}";
+                    }
+                }
+                """);
+        }
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithMultipleStringLiteralsWithBraces()
+    {
+        {
+            await VerifyCS.VerifyRefactoringAsync(
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = "{" + 1 + [||]"}";
+                    }
+                }
+                """,
+                """
+                public class C
+                {
+                    void M()
+                    {
+                        var v = $"{{{1}}}";
+                    }
+                }
+                """);
+        }
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithVerbatimStringWithBraces()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 + [||]@"{string}";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $@"{1}{{string}}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/23536")]
+    public async Task TestWithMultipleVerbatimStringsWithBraces()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = @"{" + 1 + [||]@"}";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $@"{{{1}}}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithSelectionOnEntireToBeInterpolatedString()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = [|"string" + 1|];
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"string{1}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestMissingWithSelectionOnPartOfToBeInterpolatedStringPrefix()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = [|"string" + 1|] + "string";
+                }
+            }
+            """;
+
+        // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestMissingWithSelectionOnPartOfToBeInterpolatedStringSuffix()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = "string" + [|1 + "string"|];
+                }
+            }
+            """;
+
+        // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35525")]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestMissingWithSelectionOnMiddlePartOfToBeInterpolatedString()
+    {
+        var code = """
+            public class C
+            {
+                void M()
+                {
+                    var v = "a" + [|1 + "string"|] + "b";
+                }
+            }
+            """;
+
+        // see comment in AbstractConvertConcatenationToInterpolatedStringRefactoringProvider:ComputeRefactoringsAsync
+        await VerifyCS.VerifyRefactoringAsync(code, code);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithSelectionExceedingToBeInterpolatedString()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    [|var v = "string" + 1|];
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"string{1}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretBeforeNonStringToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = [||]3 + "string" + 1 + "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretAfterNonStringToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 3[||] + "string" + 1 + "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretBeforePlusToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 3 [||]+ "string" + 1 + "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretAfterPlusToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 3 +[||] "string" + 1 + "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretBeforeLastPlusToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 3 + "string" + 1 [||]+ "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16981")]
+    public async Task TestWithCaretAfterLastPlusToken()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 3 + "string" + 1 +[||] "string";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{3}string{1}string";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32864")]
+    public async Task TestConcatenationWithNoStringLiterals()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = 1 [||]+ ("string");
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var v = $"{1}{"string"}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
+    public async Task TestConcatenationWithChar()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var hello = "hello";
+                    var world = "world";
+                    var str = hello [||]+ ' ' + world;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var hello = "hello";
+                    var world = "world";
+                    var str = $"{hello} {world}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
+    public async Task TestConcatenationWithCharAfterStringLiteral()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var world = "world";
+                    var str = "hello" [||]+ ' ' + world;
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var world = "world";
+                    var str = $"hello {world}";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/37324")]
+    public async Task TestConcatenationWithCharBeforeStringLiteral()
+    {
+        await VerifyCS.VerifyRefactoringAsync(
+            """
+            public class C
+            {
+                void M()
+                {
+                    var hello = "hello";
+                    var str = hello [||]+ ' ' + "world";
+                }
+            }
+            """,
+            """
+            public class C
+            {
+                void M()
+                {
+                    var hello = "hello";
+                    var str = $"{hello} world";
+                }
+            }
+            """);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
+    public async Task TestConcatenationWithConstMember()
+    {
+        var code = """
+            class C
+            {
+                const string Hello = "Hello";
+                const string World = "World";
+                const string Message = Hello + " " + [||]World;
+            }
+            """;
+        var fixedCode = """
+            class C
+            {
+                const string Hello = "Hello";
+                const string World = "World";
+                const string Message = $"{Hello} {World}";
+            }
+            """;
+
+        await new VerifyCS.Test
+        {
+            LanguageVersion = LanguageVersion.CSharp9,
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync();
+
+        await new VerifyCS.Test
+        {
+            LanguageVersion = LanguageVersion.Preview,
+            TestCode = code,
+            FixedCode = fixedCode,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
+    public async Task TestConcatenationWithConstDeclaration()
+    {
+        var code = """
+            class C
+            {
+                void M() {
+                    const string Hello = "Hello";
+                    const string World = "World";
+                    const string Message = Hello + " " + [||]World;
+                }
+            }
+            """;
+        var fixedCode = """
+            class C
+            {
+                void M() {
+                    const string Hello = "Hello";
+                    const string World = "World";
+                    const string Message = $"{Hello} {World}";
+                }
+            }
+            """;
+
+        await new VerifyCS.Test
+        {
+            LanguageVersion = LanguageVersion.CSharp9,
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync();
+
+        await new VerifyCS.Test
+        {
+            LanguageVersion = LanguageVersion.Preview,
+            TestCode = code,
+            FixedCode = fixedCode,
+        }.RunAsync();
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40413")]
+    public async Task TestConcatenationWithInlineString()
+    {
+        await VerifyCS.VerifyRefactoringAsync("""
+            using System;
+            class C
+            {
+                void M() {
+                    const string Hello = "Hello";
+                    const string World = "World";
+                    Console.WriteLine(Hello + " " + [||]World);
+                }
+            }
+            """,
+            """
+            using System;
+            class C
+            {
+                void M() {
+                    const string Hello = "Hello";
+                    const string World = "World";
+                    Console.WriteLine($"{Hello} {World}");
+                }
+            }
+            """);
+    }
+
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
+    [InlineData(@"[|""a"" + $""{1:000}""|]",
+                 """
+                 $"a{1:000}"
+                 """)]
+    [InlineData(@"[|""a"" + $""b{1:000}""|]",
+                 """
+                 $"ab{1:000}"
+                 """)]
+    [InlineData(@"[|$""a{1:000}"" + ""b""|]",
+                 """
+                 $"a{1:000}b"
+                 """)]
+    [InlineData(@"[|""a"" + $""b{1:000}c"" + ""d""|]",
+                 """
+                 $"ab{1:000}cd"
+                 """)]
+    [InlineData(@"[|""a"" + $""{1:000}b"" + ""c""|]",
+                 """
+                 $"a{1:000}bc"
+                 """)]
+    [InlineData(@"[|""a"" + $""{1:000}"" + $""{2:000}"" + ""b""|]",
+                 """
+                 $"a{1:000}{2:000}b"
+                 """)]
+    [InlineData(@"[|@""a"" + @$""{1:000}""|]",
+                 """
+                 $@"a{1:000}"
+                 """)]
+    [InlineData(@"[|@""a"" + $""{1:000}""|]",
+                 """
+                 $@"a{$"{1:000}"}"
+                 """)]
+    [InlineData(@"[|""a"" + @$""{1:000}""|]",
+                 """
+                 $"a{@$"{1:000}"}"
+                 """)]
+    public async Task TestInliningOfInterpolatedString(string before, string after)
+    {
+        var initialMarkup = $@"
 class C
 {{
     void M() {{
         _ = {before};
     }}
 }}";
-            var expected = $@"
+        var expected = $@"
 class C
 {{
     void M() {{
         _ = {after};
     }}
 }}";
-            await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
-        }
+        await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
+    }
 
-        [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
-        [InlineData(@"""\t"" [|+|] 1",
-                   @"$""\t{1}""")]
-        [InlineData(@"""😀"" [|+|] 1",
-                   @"$""😀{1}""")]
-        [InlineData(@"""\u2764"" [|+|] 1",
-                   @"$""\u2764{1}""")]
-        [InlineData(@"""\"""" [|+|] 1",
-                   @"$""\""{1}""")]
-        [InlineData(@"""{}"" [|+|] 1",
-                   @"$""{{}}{1}""")]
-        public async Task TestUnicodeAndEscapeHandling(string before, string after)
-        {
-            var initialMarkup = $@"
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
+    [InlineData("""
+        "\t" [|+|] 1
+        """,
+               """
+               $"\t{1}"
+               """)]
+    [InlineData("""
+        "😀" [|+|] 1
+        """,
+               """
+               $"😀{1}"
+               """)]
+    [InlineData("""
+        "\u2764" [|+|] 1
+        """,
+               """
+               $"\u2764{1}"
+               """)]
+    [InlineData("""
+        "\"" [|+|] 1
+        """,
+               """
+               $"\"{1}"
+               """)]
+    [InlineData("""
+        "{}" [|+|] 1
+        """,
+               """
+               $"{{}}{1}"
+               """)]
+    public async Task TestUnicodeAndEscapeHandling(string before, string after)
+    {
+        var initialMarkup = $@"
 class C
 {{
     void M() {{
         _ = {before};
     }}
 }}";
-            var expected = $@"
+        var expected = $@"
 class C
 {{
     void M() {{
         _ = {after};
     }}
 }}";
-            await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
-        }
+        await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
+    }
 
-        [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
-        [InlineData(@"""a"" [|+|] (1 + 1)",
-                   @"$""a{1 + 1}""")]
-        [InlineData(@"""a"" [||]+ (1 + 1) + ""b"" + (2 + 2)",
-                   @"$""a{1 + 1}b{2 + 2}""")]
-        [InlineData(@"""a"" [|+|] (true ? ""t"" : ""f"")",
-                   @"$""a{(true ? ""t"" : ""f"")}""")]
-        [InlineData(@"""a"" [|+|] $""{(1 + 1)}""",
-                   @"$""a{(1 + 1)}""")]
-        public async Task TestRemovalOfSuperflousParenthesis(string before, string after)
-        {
-            var initialMarkup = $@"
+    [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/49229")]
+    [InlineData("""
+        "a" [|+|] (1 + 1)
+        """,
+               """
+               $"a{1 + 1}"
+               """)]
+    [InlineData("""
+        "a" [||]+ (1 + 1) + "b" + (2 + 2)
+        """,
+               """
+               $"a{1 + 1}b{2 + 2}"
+               """)]
+    [InlineData("""
+        "a" [|+|] (true ? "t" : "f")
+        """,
+               """
+               $"a{(true ? "t" : "f")}"
+               """)]
+    [InlineData("""
+        "a" [|+|] $"{(1 + 1)}"
+        """,
+               """
+               $"a{(1 + 1)}"
+               """)]
+    public async Task TestRemovalOfSuperflousParenthesis(string before, string after)
+    {
+        var initialMarkup = $@"
 class C
 {{
     void M() {{
         _ = {before};
     }}
 }}";
-            var expected = $@"
+        var expected = $@"
 class C
 {{
     void M() {{
         _ = {after};
     }}
 }}";
-            await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
-        }
+        await VerifyCS.VerifyRefactoringAsync(initialMarkup, expected);
+    }
 
-        [Fact]
-        public async Task TestToString1()
+    [Fact]
+    public async Task TestToString1()
+    {
+        await new VerifyCS.Test
         {
-            await new VerifyCS.Test
-            {
-                TestCode = """
+            TestCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1098,7 +1303,7 @@ class C
                     }
                 }
                 """,
-                FixedCode = """
+            FixedCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1110,15 +1315,15 @@ class C
                     }
                 }
                 """,
-            }.RunAsync();
-        }
+        }.RunAsync();
+    }
 
-        [Fact]
-        public async Task TestToString1_Net6()
+    [Fact]
+    public async Task TestToString1_Net6()
+    {
+        await new VerifyCS.Test
         {
-            await new VerifyCS.Test
-            {
-                TestCode = """
+            TestCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1130,7 +1335,7 @@ class C
                     }
                 }
                 """,
-                FixedCode = """
+            FixedCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1142,16 +1347,16 @@ class C
                     }
                 }
                 """,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-            }.RunAsync();
-        }
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+        }.RunAsync();
+    }
 
-        [Fact]
-        public async Task TestToString2()
+    [Fact]
+    public async Task TestToString2()
+    {
+        await new VerifyCS.Test
         {
-            await new VerifyCS.Test
-            {
-                TestCode = """
+            TestCode = """
                 struct ValueTuple<T>
                 {
                     public override string ToString()
@@ -1160,7 +1365,7 @@ class C
                     }
                 }
                 """,
-                FixedCode = """
+            FixedCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1172,15 +1377,15 @@ class C
                     }
                 }
                 """,
-            }.RunAsync();
-        }
+        }.RunAsync();
+    }
 
-        [Fact]
-        public async Task TestToString2_Net6()
+    [Fact]
+    public async Task TestToString2_Net6()
+    {
+        await new VerifyCS.Test
         {
-            await new VerifyCS.Test
-            {
-                TestCode = """
+            TestCode = """
                 struct ValueTuple<T>
                 {
                     public override string ToString()
@@ -1189,7 +1394,7 @@ class C
                     }
                 }
                 """,
-                FixedCode = """
+            FixedCode = """
                 struct ValueTuple<T>
                 {
                     public T Item1;
@@ -1201,8 +1406,7 @@ class C
                     }
                 }
                 """,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-            }.RunAsync();
-        }
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+        }.RunAsync();
     }
 }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -90,9 +90,9 @@ internal abstract class AbstractConvertConcatenationToInterpolatedStringRefactor
             // tokens if they're all the same type.
             var firstStringToken = stringLiterals[0].GetFirstToken();
             isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
-            foreach (var literal in stringLiterals)
+            for (int i = 1, n = stringLiterals.Length; i < n; i++)
             {
-                if (isVerbatimStringLiteral != syntaxFacts.IsVerbatimIdentifier(literal.GetFirstToken()))
+                if (isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(stringLiterals[i].GetFirstToken()))
                     return;
             }
         }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -15,242 +14,273 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 
-namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
+namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString;
+
+/// <summary>
+/// Code refactoring that converts expressions of the form:  a + b + " str " + d + e
+/// into:
+///     $"{a + b} str {d}{e}".
+/// </summary>
+internal abstract class AbstractConvertConcatenationToInterpolatedStringRefactoringProvider<TExpressionSyntax> : CodeRefactoringProvider
+    where TExpressionSyntax : SyntaxNode
 {
-    /// <summary>
-    /// Code refactoring that converts expressions of the form:  a + b + " str " + d + e
-    /// into:
-    ///     $"{a + b} str {d}{e}".
-    /// </summary>
-    internal abstract class AbstractConvertConcatenationToInterpolatedStringRefactoringProvider<TExpressionSyntax> : CodeRefactoringProvider
-        where TExpressionSyntax : SyntaxNode
+    protected abstract bool SupportsInterpolatedStringHandler(Compilation compilation);
+
+    protected abstract string GetTextWithoutQuotes(string text, bool isVerbatimStringLiteral, bool isCharacterLiteral);
+
+    public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
     {
-        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        var (document, textSpan, cancellationToken) = context;
+        var possibleExpressions = await context.GetRelevantNodesAsync<TExpressionSyntax>().ConfigureAwait(false);
+
+        var generator = SyntaxGenerator.GetGenerator(document);
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        // let's take the largest (last) StringConcat we can given current textSpan
+        var top = possibleExpressions
+            .Where(expr => IsStringConcat(syntaxFacts, expr, semanticModel, cancellationToken))
+            .LastOrDefault();
+
+        if (top == null)
+            return;
+
+        if (!syntaxFacts.SupportsConstantInterpolatedStrings(document.Project.ParseOptions!))
         {
-            var (document, textSpan, cancellationToken) = context;
-            var possibleExpressions = await context.GetRelevantNodesAsync<TExpressionSyntax>().ConfigureAwait(false);
-
-            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            // let's take the largest (last) StringConcat we can given current textSpan
-            var top = possibleExpressions
-                .Where(expr => IsStringConcat(syntaxFacts, expr, semanticModel, cancellationToken))
-                .LastOrDefault();
-
-            if (top == null)
-            {
+            // if there is a const keyword, the refactoring shouldn't show because interpolated string is not const string
+            var declarator = top.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsVariableDeclarator);
+            if (declarator != null && generator.GetModifiers(declarator).IsConst)
                 return;
-            }
+        }
 
-            if (!syntaxFacts.SupportsConstantInterpolatedStrings(document.Project.ParseOptions!))
+        // Currently we can concatenate only full subtrees. Therefore we can't support arbitrary selection. We could
+        // theoretically support selecting the selections that correspond to full sub-trees (e.g. prefixes of 
+        // correct length but from UX point of view that it would feel arbitrary). 
+        // Thus, we only support selection that takes the whole topmost expression. It breaks some leniency around under-selection
+        // but it's the best solution so far.
+        if (CodeRefactoringHelpers.IsNodeUnderselected(top, textSpan) ||
+            IsStringConcat(syntaxFacts, top.Parent, semanticModel, cancellationToken))
+        {
+            return;
+        }
+
+        // Now walk down the concatenation collecting all the pieces that we are
+        // concatenating.
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var pieces);
+        CollectPiecesDown(syntaxFacts, pieces, top, semanticModel, cancellationToken);
+
+        var stringLiterals = pieces
+            .Where(x => syntaxFacts.IsStringLiteralExpression(x) || syntaxFacts.IsCharacterLiteralExpression(x))
+            .ToImmutableArray();
+
+        // If the entire expression is just concatenated strings, then don't offer to
+        // make an interpolated string.  The user likely manually split this for
+        // readability.
+        if (stringLiterals.Length == pieces.Count)
+            return;
+
+        var isVerbatimStringLiteral = false;
+        if (stringLiterals.Length > 0)
+        {
+
+            // Make sure that all the string tokens we're concatenating are the same type
+            // of string literal.  i.e. if we have an expression like: @" "" " + " \r\n "
+            // then we don't merge this.  We don't want to be munging different types of
+            // escape sequences in these strings, so we only support combining the string
+            // tokens if they're all the same type.
+            var firstStringToken = stringLiterals[0].GetFirstToken();
+            isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
+            foreach (var literal in stringLiterals)
             {
-                // if there is a const keyword, the refactoring shouldn't show because interpolated string is not const string
-                var declarator = top.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsVariableDeclarator);
-                if (declarator != null)
-                {
-                    var generator = SyntaxGenerator.GetGenerator(document);
-                    if (generator.GetModifiers(declarator).IsConst)
-                    {
-                        return;
-                    }
-                }
-            }
-
-            // Currently we can concatenate only full subtrees. Therefore we can't support arbitrary selection. We could
-            // theoretically support selecting the selections that correspond to full sub-trees (e.g. prefixes of 
-            // correct length but from UX point of view that it would feel arbitrary). 
-            // Thus, we only support selection that takes the whole topmost expression. It breaks some leniency around under-selection
-            // but it's the best solution so far.
-            if (CodeRefactoringHelpers.IsNodeUnderselected(top, textSpan) ||
-                IsStringConcat(syntaxFacts, top.Parent, semanticModel, cancellationToken))
-            {
-                return;
-            }
-
-            // Now walk down the concatenation collecting all the pieces that we are
-            // concatenating.
-            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var pieces);
-            CollectPiecesDown(syntaxFacts, pieces, top, semanticModel, cancellationToken);
-
-            var stringLiterals = pieces
-                .Where(x => syntaxFacts.IsStringLiteralExpression(x) || syntaxFacts.IsCharacterLiteralExpression(x))
-                .ToImmutableArray();
-
-            // If the entire expression is just concatenated strings, then don't offer to
-            // make an interpolated string.  The user likely manually split this for
-            // readability.
-            if (stringLiterals.Length == pieces.Count)
-            {
-                return;
-            }
-
-            var isVerbatimStringLiteral = false;
-            if (stringLiterals.Length > 0)
-            {
-
-                // Make sure that all the string tokens we're concatenating are the same type
-                // of string literal.  i.e. if we have an expression like: @" "" " + " \r\n "
-                // then we don't merge this.  We don't want to be munging different types of
-                // escape sequences in these strings, so we only support combining the string
-                // tokens if they're all the same type.
-                var firstStringToken = stringLiterals[0].GetFirstToken();
-                isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
-                if (stringLiterals.Any(
-                        static (lit, arg) => arg.isVerbatimStringLiteral != arg.syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken()), (syntaxFacts, isVerbatimStringLiteral)))
-                {
+                if (isVerbatimStringLiteral != syntaxFacts.IsVerbatimIdentifier(literal.GetFirstToken()))
                     return;
+            }
+        }
+
+        var piecesArray = pieces.ToImmutable();
+        context.RegisterRefactoring(
+            CodeAction.Create(
+                FeaturesResources.Convert_to_interpolated_string,
+                cancellationToken => UpdateStringAsync(document, top, isVerbatimStringLiteral, piecesArray, cancellationToken),
+                nameof(FeaturesResources.Convert_to_interpolated_string)),
+            top.Span);
+    }
+
+    private async Task<Document> UpdateStringAsync(
+        Document document, SyntaxNode top, bool isVerbatimStringLiteral, ImmutableArray<SyntaxNode> pieces, CancellationToken cancellationToken)
+    {
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var interpolatedString = await CreateInterpolatedStringAsync(
+            document, isVerbatimStringLiteral, pieces, cancellationToken).ConfigureAwait(false);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(top, interpolatedString));
+    }
+
+    protected async Task<SyntaxNode> CreateInterpolatedStringAsync(
+        Document document, bool isVerbatimStringLiteral, ImmutableArray<SyntaxNode> pieces, CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var supportsInterpolatedStringHandler = this.SupportsInterpolatedStringHandler(semanticModel.Compilation);
+
+        var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+        var generator = SyntaxGenerator.GetGenerator(document);
+        var startToken = generator
+            .CreateInterpolatedStringStartToken(isVerbatimStringLiteral)
+            .WithLeadingTrivia(pieces.First().GetLeadingTrivia());
+        var endToken = generator
+            .CreateInterpolatedStringEndToken()
+            .WithTrailingTrivia(pieces.Last().GetTrailingTrivia());
+
+        using var _ = ArrayBuilder<SyntaxNode>.GetInstance(pieces.Length, out var content);
+        var previousContentWasStringLiteralExpression = false;
+        foreach (var piece in pieces)
+        {
+            var isCharacterLiteral = syntaxFacts.IsCharacterLiteralExpression(piece);
+            var currentContentIsStringOrCharacterLiteral = syntaxFacts.IsStringLiteralExpression(piece) || isCharacterLiteral;
+            if (currentContentIsStringOrCharacterLiteral)
+            {
+                var text = piece.GetFirstToken().Text;
+                var value = piece.GetFirstToken().Value?.ToString() ?? piece.GetFirstToken().ValueText;
+                var textWithEscapedBraces = text.Replace("{", "{{").Replace("}", "}}");
+                var valueTextWithEscapedBraces = value.Replace("{", "{{").Replace("}", "}}");
+                var textWithoutQuotes = GetTextWithoutQuotes(textWithEscapedBraces, isVerbatimStringLiteral, isCharacterLiteral);
+                if (previousContentWasStringLiteralExpression)
+                {
+                    // Last part we added to the content list was also an interpolated-string-text-node.
+                    // We need to combine these as the API for creating an interpolated strings
+                    // does not expect to be given a list containing non-contiguous string nodes.
+                    // Essentially if we combine '"A" + 1 + "B" + "C"' into '$"A{1}BC"' it must be:
+                    //      {InterpolatedStringText}{Interpolation}{InterpolatedStringText}
+                    // not:
+                    //      {InterpolatedStringText}{Interpolation}{InterpolatedStringText}{InterpolatedStringText}
+                    var existingInterpolatedStringTextNode = content.Last();
+                    var newText = ConcatenateTextToTextNode(generator, existingInterpolatedStringTextNode, textWithoutQuotes, valueTextWithEscapedBraces);
+                    content[^1] = newText;
+                }
+                else
+                {
+                    // This is either the first string literal we have encountered or it is the most recent one we've seen
+                    // after adding an interpolation.  Add a new interpolated-string-text-node to the list.
+                    content.Add(generator.InterpolatedStringText(generator.InterpolatedStringTextToken(textWithoutQuotes, valueTextWithEscapedBraces)));
                 }
             }
-
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var interpolatedString = CreateInterpolatedString(document, isVerbatimStringLiteral, pieces);
-            context.RegisterRefactoring(
-                CodeAction.Create(
-                    FeaturesResources.Convert_to_interpolated_string,
-                    _ => UpdateDocumentAsync(document, root, top, interpolatedString),
-                    nameof(FeaturesResources.Convert_to_interpolated_string)),
-                top.Span);
-        }
-
-        private static Task<Document> UpdateDocumentAsync(Document document, SyntaxNode root, SyntaxNode top, SyntaxNode interpolatedString)
-        {
-            var newRoot = root.ReplaceNode(top, interpolatedString);
-            return Task.FromResult(document.WithSyntaxRoot(newRoot));
-        }
-
-        protected SyntaxNode CreateInterpolatedString(
-            Document document, bool isVerbatimStringLiteral, ArrayBuilder<SyntaxNode> pieces)
-        {
-            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-            var generator = SyntaxGenerator.GetGenerator(document);
-            var startToken = generator.CreateInterpolatedStringStartToken(isVerbatimStringLiteral)
-                                .WithLeadingTrivia(pieces.First().GetLeadingTrivia());
-            var endToken = generator.CreateInterpolatedStringEndToken()
-                                .WithTrailingTrivia(pieces.Last().GetTrailingTrivia());
-
-            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(pieces.Count, out var content);
-            var previousContentWasStringLiteralExpression = false;
-            foreach (var piece in pieces)
+            else if (syntaxFacts.IsInterpolatedStringExpression(piece) &&
+                syntaxFacts.IsVerbatimInterpolatedStringExpression(piece) == isVerbatimStringLiteral)
             {
-                var isCharacterLiteral = syntaxFacts.IsCharacterLiteralExpression(piece);
-                var currentContentIsStringOrCharacterLiteral = syntaxFacts.IsStringLiteralExpression(piece) || isCharacterLiteral;
-                if (currentContentIsStringOrCharacterLiteral)
+                // "piece" is itself an interpolated string (of the same "verbatimity" as the new interpolated string)
+                // "a" + $"{1+ 1}" -> instead of $"a{$"{1 + 1}"}" inline the interpolated part: $"a{1 + 1}"
+                syntaxFacts.GetPartsOfInterpolationExpression(piece, out var _, out var contentParts, out var _);
+                foreach (var contentPart in contentParts)
                 {
-                    var text = piece.GetFirstToken().Text;
-                    var value = piece.GetFirstToken().Value?.ToString() ?? piece.GetFirstToken().ValueText;
-                    var textWithEscapedBraces = text.Replace("{", "{{").Replace("}", "}}");
-                    var valueTextWithEscapedBraces = value.Replace("{", "{{").Replace("}", "}}");
-                    var textWithoutQuotes = GetTextWithoutQuotes(textWithEscapedBraces, isVerbatimStringLiteral, isCharacterLiteral);
-                    if (previousContentWasStringLiteralExpression)
+                    // Track the state of currentContentIsStringOrCharacterLiteral for the inlined parts
+                    // so any text at the end of piece can be merge with the next string literal:
+                    // $"{1 + 1}a" + "b" -> "a" and "b" get merged in the next "pieces" loop
+                    currentContentIsStringOrCharacterLiteral = syntaxFacts.IsInterpolatedStringText(contentPart);
+                    if (currentContentIsStringOrCharacterLiteral && previousContentWasStringLiteralExpression)
                     {
-                        // Last part we added to the content list was also an interpolated-string-text-node.
-                        // We need to combine these as the API for creating an interpolated strings
-                        // does not expect to be given a list containing non-contiguous string nodes.
-                        // Essentially if we combine '"A" + 1 + "B" + "C"' into '$"A{1}BC"' it must be:
-                        //      {InterpolatedStringText}{Interpolation}{InterpolatedStringText}
-                        // not:
-                        //      {InterpolatedStringText}{Interpolation}{InterpolatedStringText}{InterpolatedStringText}
-                        var existingInterpolatedStringTextNode = content.Last();
-                        var newText = ConcatenateTextToTextNode(generator, existingInterpolatedStringTextNode, textWithoutQuotes, valueTextWithEscapedBraces);
+                        // if piece starts with a text and the previous part was a string, merge the two parts (see also above)
+                        // "a" + $"b{1 + 1}" -> "a" and "b" get merged
+                        var newText = ConcatenateTextToTextNode(generator, content.Last(), contentPart.GetFirstToken().Text, contentPart.GetFirstToken().ValueText);
                         content[^1] = newText;
                     }
                     else
                     {
-                        // This is either the first string literal we have encountered or it is the most recent one we've seen
-                        // after adding an interpolation.  Add a new interpolated-string-text-node to the list.
-                        content.Add(generator.InterpolatedStringText(generator.InterpolatedStringTextToken(textWithoutQuotes, valueTextWithEscapedBraces)));
+                        content.Add(contentPart);
                     }
+
+                    // Only the first contentPart can be merged, therefore we set previousContentWasStringLiteralExpression to false
+                    previousContentWasStringLiteralExpression = false;
                 }
-                else if (syntaxFacts.IsInterpolatedStringExpression(piece) &&
-                    syntaxFacts.IsVerbatimInterpolatedStringExpression(piece) == isVerbatimStringLiteral)
+            }
+            else
+            {
+                // Remove `.ToString()` from expression is safe and efficient to do so.
+                var converted = TryRemoveToString(piece);
+
+                // Add Simplifier annotation to remove superfluous parenthesis after transformation:
+                // (1 + 1) + "a" -> $"{1 + 1}a"
+                converted = syntaxFacts.IsParenthesizedExpression(converted)
+                    ? converted.WithAdditionalAnnotations(Simplifier.Annotation)
+                    : converted;
+                content.Add(generator.Interpolation(converted.WithoutTrivia()));
+            }
+            // Update this variable to be true every time we encounter a new string literal expression
+            // so we know to concatenate future string literals together if we encounter them.
+            previousContentWasStringLiteralExpression = currentContentIsStringOrCharacterLiteral;
+        }
+
+        return generator.InterpolatedStringExpression(startToken, content, endToken);
+
+        SyntaxNode TryRemoveToString(SyntaxNode piece)
+        {
+            if (supportsInterpolatedStringHandler)
+            {
+                // if it's a call to object's .ToString (or any override), then we can remove this if the runtime
+                // supports interpolated string handlers. This gies the most flexibility to the handler to decide what
+                // it wants to do.
+                if (syntaxFacts.IsInvocationExpression(piece))
                 {
-                    // "piece" is itself an interpolated string (of the same "verbatimity" as the new interpolated string)
-                    // "a" + $"{1+ 1}" -> instead of $"a{$"{1 + 1}"}" inline the interpolated part: $"a{1 + 1}"
-                    syntaxFacts.GetPartsOfInterpolationExpression(piece, out var _, out var contentParts, out var _);
-                    foreach (var contentPart in contentParts)
+                    syntaxFacts.GetPartsOfInvocationExpression(piece, out var memberAccess, out var argumentList);
+                    if (syntaxFacts.IsMemberAccessExpression(memberAccess))
                     {
-                        // Track the state of currentContentIsStringOrCharacterLiteral for the inlined parts
-                        // so any text at the end of piece can be merge with the next string literal:
-                        // $"{1 + 1}a" + "b" -> "a" and "b" get merged in the next "pieces" loop
-                        currentContentIsStringOrCharacterLiteral = syntaxFacts.IsInterpolatedStringText(contentPart);
-                        if (currentContentIsStringOrCharacterLiteral && previousContentWasStringLiteralExpression)
+                        syntaxFacts.GetPartsOfMemberAccessExpression(memberAccess, out var expression, out var name);
+                        if (syntaxFacts.GetIdentifierOfSimpleName(name).ValueText == nameof(ToString))
                         {
-                            // if piece starts with a text and the previous part was a string, merge the two parts (see also above)
-                            // "a" + $"b{1 + 1}" -> "a" and "b" get merged
-                            var newText = ConcatenateTextToTextNode(generator, content.Last(), contentPart.GetFirstToken().Text, contentPart.GetFirstToken().ValueText);
-                            content[^1] = newText;
-                        }
-                        else
-                        {
-                            content.Add(contentPart);
-                        }
+                            var symbol = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol as IMethodSymbol;
+                            while (symbol?.OverriddenMethod != null)
+                                symbol = symbol.OverriddenMethod;
 
-                        // Only the first contentPart can be merged, therefore we set previousContentWasStringLiteralExpression to false
-                        previousContentWasStringLiteralExpression = false;
+                            if (symbol?.ContainingType.SpecialType == SpecialType.System_Object)
+                                return expression;
+                        }
                     }
                 }
-                else
-                {
-                    // Add Simplifier annotation to remove superfluous parenthesis after transformation:
-                    // (1 + 1) + "a" -> $"{1 + 1}a"
-                    var otherExpression = syntaxFacts.IsParenthesizedExpression(piece)
-                        ? piece.WithAdditionalAnnotations(Simplifier.Annotation)
-                        : piece;
-                    content.Add(generator.Interpolation(otherExpression.WithoutTrivia()));
-                }
-                // Update this variable to be true every time we encounter a new string literal expression
-                // so we know to concatenate future string literals together if we encounter them.
-                previousContentWasStringLiteralExpression = currentContentIsStringOrCharacterLiteral;
             }
 
-            return generator.InterpolatedStringExpression(startToken, content, endToken);
+            return piece;
         }
+    }
 
-        private static SyntaxNode ConcatenateTextToTextNode(SyntaxGenerator generator, SyntaxNode interpolatedStringTextNode, string textWithoutQuotes, string value)
+    private static SyntaxNode ConcatenateTextToTextNode(SyntaxGenerator generator, SyntaxNode interpolatedStringTextNode, string textWithoutQuotes, string value)
+    {
+        var existingText = interpolatedStringTextNode.GetFirstToken().Text;
+        var existingValue = interpolatedStringTextNode.GetFirstToken().ValueText;
+        var newText = existingText + textWithoutQuotes;
+        var newValue = existingValue + value;
+        return generator.InterpolatedStringText(generator.InterpolatedStringTextToken(newText, newValue));
+    }
+
+    private static void CollectPiecesDown(
+        ISyntaxFactsService syntaxFacts,
+        ArrayBuilder<SyntaxNode> pieces,
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (!IsStringConcat(syntaxFacts, node, semanticModel, cancellationToken))
         {
-            var existingText = interpolatedStringTextNode.GetFirstToken().Text;
-            var existingValue = interpolatedStringTextNode.GetFirstToken().ValueText;
-            var newText = existingText + textWithoutQuotes;
-            var newValue = existingValue + value;
-            return generator.InterpolatedStringText(generator.InterpolatedStringTextToken(newText, newValue));
+            pieces.Add(node);
+            return;
         }
 
-        protected abstract string GetTextWithoutQuotes(string text, bool isVerbatimStringLiteral, bool isCharacterLiteral);
+        syntaxFacts.GetPartsOfBinaryExpression(node, out var left, out var right);
 
-        private static void CollectPiecesDown(
-            ISyntaxFactsService syntaxFacts,
-            ArrayBuilder<SyntaxNode> pieces,
-            SyntaxNode node,
-            SemanticModel semanticModel,
-            CancellationToken cancellationToken)
+        CollectPiecesDown(syntaxFacts, pieces, left, semanticModel, cancellationToken);
+        pieces.Add(right);
+    }
+
+    private static bool IsStringConcat(
+        ISyntaxFactsService syntaxFacts, SyntaxNode? expression,
+        SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        if (!syntaxFacts.IsBinaryExpression(expression))
+            return false;
+
+        return semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol is IMethodSymbol
         {
-            if (!IsStringConcat(syntaxFacts, node, semanticModel, cancellationToken))
-            {
-                pieces.Add(node);
-                return;
-            }
-
-            syntaxFacts.GetPartsOfBinaryExpression(node, out var left, out var right);
-
-            CollectPiecesDown(syntaxFacts, pieces, left, semanticModel, cancellationToken);
-            pieces.Add(right);
-        }
-
-        private static bool IsStringConcat(
-            ISyntaxFactsService syntaxFacts, SyntaxNode? expression,
-            SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            if (!syntaxFacts.IsBinaryExpression(expression))
-            {
-                return false;
-            }
-
-            return semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol is IMethodSymbol method &&
-                   method.MethodKind == MethodKind.BuiltinOperator &&
-                   method.ContainingType?.SpecialType == SpecialType.System_String &&
-                   (method.MetadataName == WellKnownMemberNames.AdditionOperatorName ||
-                    method.MetadataName == WellKnownMemberNames.ConcatenateOperatorName);
-        }
+            MethodKind: MethodKind.BuiltinOperator,
+            ContainingType.SpecialType: SpecialType.System_String,
+            MetadataName: WellKnownMemberNames.AdditionOperatorName or WellKnownMemberNames.ConcatenateOperatorName,
+        };
     }
 }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -101,12 +101,12 @@ internal abstract class AbstractConvertConcatenationToInterpolatedStringRefactor
         context.RegisterRefactoring(
             CodeAction.Create(
                 FeaturesResources.Convert_to_interpolated_string,
-                cancellationToken => UpdateStringAsync(document, top, isVerbatimStringLiteral, piecesArray, cancellationToken),
+                cancellationToken => UpdateDocumentAsync(document, top, isVerbatimStringLiteral, piecesArray, cancellationToken),
                 nameof(FeaturesResources.Convert_to_interpolated_string)),
             top.Span);
     }
 
-    private async Task<Document> UpdateStringAsync(
+    private async Task<Document> UpdateDocumentAsync(
         Document document, SyntaxNode top, bool isVerbatimStringLiteral, ImmutableArray<SyntaxNode> pieces, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/VisualBasic/Portable/ConvertToInterpolatedString/VisualBasicConvertConcatenationToInterpolatedStringRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertToInterpolatedString/VisualBasicConvertConcatenationToInterpolatedStringRefactoringProvider.vb
@@ -19,6 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertToInterpolatedString
         End Sub
 
         Protected Overrides Function SupportsInterpolatedStringHandler(compilation As Compilation) As Boolean
+            ' VB does not support interpolated string handlers at all.
             Return False
         End Function
 

--- a/src/Features/VisualBasic/Portable/ConvertToInterpolatedString/VisualBasicConvertConcatenationToInterpolatedStringRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertToInterpolatedString/VisualBasicConvertConcatenationToInterpolatedStringRefactoringProvider.vb
@@ -18,6 +18,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertToInterpolatedString
         Public Sub New()
         End Sub
 
+        Protected Overrides Function SupportsInterpolatedStringHandler(compilation As Compilation) As Boolean
+            Return False
+        End Function
+
         Protected Overrides Function GetTextWithoutQuotes(text As String, isVerbatim As Boolean, isCharacterLiteral As Boolean) As String
             If isCharacterLiteral Then
                 Return text.Substring("'".Length, text.Length - "''C".Length)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69721