### PR TITLE
Pass project file name when building before running tests

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -118,9 +118,12 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
         var workingDirectory = Path.GetDirectoryName(document.Project.FilePath);
         Contract.ThrowIfNull(workingDirectory, $"Unable to get working directory for project {document.Project.Name}");
 
+        var projectFileName = Path.GetFileName(document.Project.FilePath);
+        Contract.ThrowIfNull(projectFileName, $"Unable to get project file name for project {document.Project.Name}");
+
         // TODO - we likely need to pass the no-restore flag once we have automatic restore enabled.
         // https://github.com/dotnet/vscode-csharp/issues/5725
-        var arguments = "build";
+        var arguments = $"build {projectFileName}";
         using var process = dotnetCliHelper.Run(arguments, workingDirectory, shouldLocalizeOutput: true);
 
         process.OutputDataReceived += (sender, args) => ReportProgress(progress, args.Data);


### PR DESCRIPTION
When multiple .sln or .csproj files are present in the same folder as the test project being built, dotnet errors asking for a specific file to build. Since we have the document which contains the tests, we can pass along the documents project when building.

```
MSBuild version 17.8.0-preview-23367-03+0ff2a83e9 for .NET

MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.

Error: Failed to run build, see test output for details
```