### PR TITLE
Add extra validation for Compilations having the expected trees

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -16,7 +16,8 @@ internal static class WorkspaceConfigurationOptionsStorage
             EnableOpeningSourceGeneratedFiles: globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspace) ??
                                                globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
             DisableSharedSyntaxTrees: globalOptions.GetOption(DisableSharedSyntaxTrees),
-            DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText));
+            DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText),
+            ValidateCompilationTrackerStates: globalOptions.GetOption(ValidateCompilationTrackerStates));
 
     public static readonly Option2<StorageDatabase> Database = new(
         "dotnet_storage_database", WorkspaceConfigurationOptions.Default.CacheStorage, serializer: EditorConfigValueSerializer.CreateSerializerForEnum<StorageDatabase>());
@@ -29,6 +30,9 @@ internal static class WorkspaceConfigurationOptionsStorage
 
     public static readonly Option2<bool> DisableRecoverableText = new(
         "dotnet_disable_recoverable_text", WorkspaceConfigurationOptions.Default.DisableRecoverableText);
+
+    public static readonly Option2<bool> ValidateCompilationTrackerStates = new Option2<bool>(
+        "dotnet_validate_compilation_tracker_states", WorkspaceConfigurationOptions.Default.ValidateCompilationTrackerStates);
 
     /// <summary>
     /// This option allows the user to enable this. We are putting this behind a feature flag for now since we could have extensions

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -433,6 +433,7 @@ internal abstract class VisualStudioOptionStorage
         {"visual_studio_workspace_partial_load_mode", new FeatureFlagStorage(@"Roslyn.PartialLoadMode")},
         {"dotnet_disable_shared_syntax_trees", new FeatureFlagStorage(@"Roslyn.DisableSharedSyntaxTrees")},
         {"dotnet_disable_recoverable_text", new FeatureFlagStorage(@"Roslyn.DisableRecoverableText")},
+        {"dotnet_validate_compilation_tracker_states", new FeatureFlagStorage(@"Roslyn.ValidateCompilationTrackerStates")},
         {"dotnet_enable_diagnostics_in_source_generated_files", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableDiagnosticsInSourceGeneratedFilesExperiment")},
         {"dotnet_enable_diagnostics_in_source_generated_files_feature_flag", new FeatureFlagStorage(@"Roslyn.EnableDiagnosticsInSourceGeneratedFiles")},
         {"dotnet_enable_opening_source_generated_files_in_workspace", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableOpeningSourceGeneratedFilesInWorkspaceExperiment")},

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -41,7 +41,14 @@ namespace Microsoft.CodeAnalysis.Host
         [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
         [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
         [property: DataMember(Order = 2)] bool DisableSharedSyntaxTrees = false,
-        [property: DataMember(Order = 3)] bool DisableRecoverableText = false)
+        [property: DataMember(Order = 3)] bool DisableRecoverableText = false,
+        [property: DataMember(Order = 4)] bool ValidateCompilationTrackerStates =
+#if DEBUG // We will default this on in DEBUG builds
+            true
+#else
+            false
+#endif
+        )
     {
         public WorkspaceConfigurationOptions()
             : this(CacheStorage: StorageDatabase.SQLite)
@@ -52,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Host
 
         /// <summary>
         /// These values are such that the correctness of remote services is not affected if these options are changed from defaults
-        /// to non-defauls while the services have already been executing.
+        /// to non-defaults while the services have already been executing.
         /// </summary>
         public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
             CacheStorage: StorageDatabase.None,


### PR DESCRIPTION
We're still getting reports where we are finding compilations that don't match the trees we expect to be in them. Unfortunately those reports are happening well after the corrupted stated happened. This will add validation when we're still producing those bad states.

This is to help with the investigation for https://github.com/dotnet/roslyn/issues/67442, although I intend to leave the code in for other investigations down the road.