### PR TITLE
Bail out for primary constructor parameters in IDE0059 analyzer

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -9202,5 +9202,29 @@ class C
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
             }.RunAsync();
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69643")]
+        public async Task TestPrimaryConstructorParameterAssignment()
+        {
+            var source = """
+                class C(string str) {
+                	public void Reset() {
+                		str = string.Empty;
+                	}
+                }
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.UnusedValueAssignment, UnusedValuePreference.DiscardVariable },
+                },
+                LanguageVersion = LanguageVersion.CSharp12,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -255,7 +255,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             }
 
             public override void VisitParameterReference(IParameterReferenceOperation operation)
-                => OnReferenceFound(operation.Parameter, operation);
+            {
+                if (operation.Parameter.IsPrimaryConstructor(_cancellationToken))
+                {
+                    // Bail out for primary constructor parameters.
+                    return;
+                }
+
+                OnReferenceFound(operation.Parameter, operation);
+            }
 
             public override void VisitVariableDeclarator(IVariableDeclaratorOperation operation)
             {


### PR DESCRIPTION
Fixes #69643

We already did so for IDE0060 (unused parameters) in a prior PR. This adds a similar bailout check in the core dataflow analysis IOperation walker for IDE0059 (unused value assignment).

Verified that the added unit test fails with IDE0059 diagnostic prior to the product fix.