### PR TITLE
Update "Current Document" background analysis semantics and fix Full Solution analysis with project config changes

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -668,7 +668,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.ActiveFile:
+                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
                 case BackgroundAnalysisScope.OpenFiles:
                     workspace.OpenAdditionalDocument(firstAdditionalDocument.Id);
                     await incrementalAnalyzer.AnalyzeNonSourceDocumentAsync(firstAdditionalDocument, InvocationReasons.SyntaxChanged, CancellationToken.None);
@@ -686,7 +686,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
 
             var expectedCount = (analysisScope, testMultiple) switch
             {
-                (BackgroundAnalysisScope.ActiveFile or BackgroundAnalysisScope.None, _) => 0,
+                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.None, _) => 0,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
                 (BackgroundAnalysisScope.OpenFiles, true) => 2,
                 (BackgroundAnalysisScope.FullSolution, true) => 4,
@@ -704,7 +704,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
                         d => d.Id == analyzer.Descriptor.Id && d.DataLocation.UnmappedFileSpan.Path == additionalDoc.FilePath);
 
                     var text = await additionalDoc.GetTextAsync();
-                    if (analysisScope is BackgroundAnalysisScope.ActiveFile or BackgroundAnalysisScope.None)
+                    if (analysisScope is BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.None)
                     {
                         Assert.Empty(applicableDiagnostics);
                     }
@@ -779,7 +779,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.ActiveFile:
+                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
                     workspace.OpenDocument(document.Id);
                     var documentTrackingService = (TestDocumentTrackingService)workspace.Services.GetService<IDocumentTrackingService>();
                     documentTrackingService.SetActiveDocument(document.Id);
@@ -910,7 +910,7 @@ class A
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.ActiveFile:
+                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
                     if (isSourceGenerated)
                         workspace.OpenSourceGeneratedDocument(document.Id);
                     else

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -688,7 +688,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
             {
                 (BackgroundAnalysisScope.None, _) => 0,
                 (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
-                (BackgroundAnalysisScope.OpenFiles, true) => 2,
+                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles, true) => 2,
                 (BackgroundAnalysisScope.FullSolution, true) => 4,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
@@ -704,11 +704,11 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
                         d => d.Id == analyzer.Descriptor.Id && d.DataLocation.UnmappedFileSpan.Path == additionalDoc.FilePath);
 
                     var text = await additionalDoc.GetTextAsync();
-                    if (analysisScope is BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.None)
+                    if (analysisScope is BackgroundAnalysisScope.None)
                     {
                         Assert.Empty(applicableDiagnostics);
                     }
-                    else if (analysisScope == BackgroundAnalysisScope.OpenFiles &&
+                    else if (analysisScope is BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles &&
                         firstAdditionalDocument != additionalDoc)
                     {
                         Assert.Empty(applicableDiagnostics);

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -686,8 +686,8 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
 
             var expectedCount = (analysisScope, testMultiple) switch
             {
-                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.None, _) => 0,
-                (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
+                (BackgroundAnalysisScope.None, _) => 0,
+                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
                 (BackgroundAnalysisScope.OpenFiles, true) => 2,
                 (BackgroundAnalysisScope.FullSolution, true) => 4,
                 _ => throw ExceptionUtilities.Unreachable(),

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -668,7 +668,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
+                case BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics:
                 case BackgroundAnalysisScope.OpenFiles:
                     workspace.OpenAdditionalDocument(firstAdditionalDocument.Id);
                     await incrementalAnalyzer.AnalyzeNonSourceDocumentAsync(firstAdditionalDocument, InvocationReasons.SyntaxChanged, CancellationToken.None);
@@ -686,7 +686,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
 
             var expectedCount = (analysisScope, testMultiple) switch
             {
-                (BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 0,
+                (BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, _) => 0,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
                 (BackgroundAnalysisScope.OpenFiles, true) => 2,
                 (BackgroundAnalysisScope.FullSolution, true) => 4,
@@ -704,7 +704,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
                         d => d.Id == analyzer.Descriptor.Id && d.DataLocation.UnmappedFileSpan.Path == additionalDoc.FilePath);
 
                     var text = await additionalDoc.GetTextAsync();
-                    if (analysisScope is BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)
+                    if (analysisScope is BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)
                     {
                         Assert.Empty(applicableDiagnostics);
                     }
@@ -779,7 +779,7 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
+                case BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics:
                     workspace.OpenDocument(document.Id);
                     var documentTrackingService = (TestDocumentTrackingService)workspace.Services.GetService<IDocumentTrackingService>();
                     documentTrackingService.SetActiveDocument(document.Id);
@@ -910,7 +910,7 @@ class A
             switch (analysisScope)
             {
                 case BackgroundAnalysisScope.None:
-                case BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics:
+                case BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics:
                     if (isSourceGenerated)
                         workspace.OpenSourceGeneratedDocument(document.Id);
                     else

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -686,9 +686,9 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
 
             var expectedCount = (analysisScope, testMultiple) switch
             {
-                (BackgroundAnalysisScope.None, _) => 0,
-                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
-                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles, true) => 2,
+                (BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 0,
+                (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution, false) => 1,
+                (BackgroundAnalysisScope.OpenFiles, true) => 2,
                 (BackgroundAnalysisScope.FullSolution, true) => 4,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
@@ -704,11 +704,11 @@ dotnet_diagnostic.{NamedTypeAnalyzer.DiagnosticId}.severity = warning
                         d => d.Id == analyzer.Descriptor.Id && d.DataLocation.UnmappedFileSpan.Path == additionalDoc.FilePath);
 
                     var text = await additionalDoc.GetTextAsync();
-                    if (analysisScope is BackgroundAnalysisScope.None)
+                    if (analysisScope is BackgroundAnalysisScope.None or BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)
                     {
                         Assert.Empty(applicableDiagnostics);
                     }
-                    else if (analysisScope is BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics or BackgroundAnalysisScope.OpenFiles &&
+                    else if (analysisScope == BackgroundAnalysisScope.OpenFiles &&
                         firstAdditionalDocument != additionalDoc)
                     {
                         Assert.Empty(applicableDiagnostics);

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/747226")]
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -271,8 +271,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -299,8 +299,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -327,8 +327,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -357,8 +357,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -385,8 +385,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -413,8 +413,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -441,8 +441,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             MakeFirstDocumentActive(workspace.CurrentSolution.Projects.First());
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.OpenFiles;
             var worker = await ExecuteOperationAsync(workspace, w => w.GlobalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             workspace.OnSolutionAdded(solutionInfo);
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.FullSolution;
             var worker = await ExecuteOperationAsync(workspace, w => w.GlobalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -549,8 +549,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -583,8 +583,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -613,8 +613,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -639,8 +639,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -685,8 +685,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -711,8 +711,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -754,8 +754,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -794,8 +794,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -849,8 +849,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -957,8 +957,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -980,14 +980,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
 
             var expectedSyntaxDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
-                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 1,
+                (BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, _) => 1,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
 
             var expectedDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
-                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 1,
+                (BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, _) => 1,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
@@ -1902,7 +1902,7 @@ class C
 
             public async Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
             {
-                if (_globalOptions.GetBackgroundAnalysisScope(document.Project.Language) != BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)
+                if (_globalOptions.GetBackgroundAnalysisScope(document.Project.Language) != BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)
                 {
                     return;
                 }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/747226")]
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -271,8 +271,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -299,8 +299,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -327,8 +327,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -357,8 +357,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -385,8 +385,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -413,8 +413,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -441,8 +441,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             MakeFirstDocumentActive(workspace.CurrentSolution.Projects.First());
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.ActiveFile, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.OpenFiles;
             var worker = await ExecuteOperationAsync(workspace, w => w.GlobalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             workspace.OnSolutionAdded(solutionInfo);
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.ActiveFile, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, workspace.GlobalOptions.GetBackgroundAnalysisScope(LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.FullSolution;
             var worker = await ExecuteOperationAsync(workspace, w => w.GlobalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.OpenFiles)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
@@ -549,8 +549,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -583,8 +583,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -613,8 +613,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -639,8 +639,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -685,8 +685,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -711,8 +711,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -754,8 +754,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
@@ -794,8 +794,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -849,8 +849,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -957,8 +957,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [InlineData(BackgroundAnalysisScope.None, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
-        [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, false)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, true)]
         [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
@@ -980,14 +980,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
 
             var expectedSyntaxDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
-                (BackgroundAnalysisScope.ActiveFile, _) => 1,
+                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 1,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
 
             var expectedDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
-                (BackgroundAnalysisScope.ActiveFile, _) => 1,
+                (BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, _) => 1,
                 (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable(),
             };
@@ -1902,7 +1902,7 @@ class C
 
             public async Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
             {
-                if (_globalOptions.GetBackgroundAnalysisScope(document.Project.Language) != BackgroundAnalysisScope.ActiveFile)
+                if (_globalOptions.GetBackgroundAnalysisScope(document.Project.Language) != BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)
                 {
                     return;
                 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         CompilerDiagnosticsScope.None => false,
 
                         // Compiler diagnostics are enabled for visible documents and open documents which had errors/warnings in prior snapshot.
-                        CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
+                        CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
 
                         // Compiler diagnostics are enabled for all open documents.
                         CompilerDiagnosticsScope.OpenFiles => isOpenDocument,
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         BackgroundAnalysisScope.None => false,
 
                         // Analyzers are enabled for visible documents and open documents which had errors/warnings in prior snapshot.
-                        BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
+                        BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
 
                         // Analyzers are enabled for all open documents.
                         BackgroundAnalysisScope.OpenFiles => isOpenDocument,
@@ -129,7 +129,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 bool isVisibleDocument,
                 bool isOpenDocument,
                 DocumentAnalysisData previousData)
-                => isVisibleDocument || (isOpenDocument && previousData.Items.Any(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning or DiagnosticSeverity.Info));
+            {
+                if (isVisibleDocument)
+                    return true;
+
+                return isOpenDocument
+                    && previousData.Items.Any(static d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning or DiagnosticSeverity.Info);
+            }
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 bool isVisibleDocument,
                 bool isOpenDocument,
                 DocumentAnalysisData previousData)
-                => isVisibleDocument || (isOpenDocument && !previousData.Items.Any(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning or DiagnosticSeverity.Info));
+                => isVisibleDocument || (isOpenDocument && previousData.Items.Any(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning or DiagnosticSeverity.Info));
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         CompilerDiagnosticsScope.None => false,
 
                         // Compiler diagnostics are enabled for visible documents and open documents which had errors/warnings in prior snapshot.
-                        CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => isVisibleDocument || (isOpenDocument && !previousData.Items.IsEmpty),
+                        CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
 
                         // Compiler diagnostics are enabled for all open documents.
                         CompilerDiagnosticsScope.OpenFiles => isOpenDocument,
@@ -111,8 +111,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         // Analyzers are disabled for all documents.
                         BackgroundAnalysisScope.None => false,
 
-                        // Analyzers are enabled for active document.
-                        BackgroundAnalysisScope.ActiveFile => isActiveDocument,
+                        // Analyzers are enabled for visible documents and open documents which had errors/warnings in prior snapshot.
+                        BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(isVisibleDocument, isOpenDocument, previousData),
 
                         // Analyzers are enabled for all open documents.
                         BackgroundAnalysisScope.OpenFiles => isOpenDocument,
@@ -124,6 +124,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     };
                 }
             }
+
+            static bool IsVisibleDocumentOrOpenDocumentWithPriorReportedVisibleDiagnostics(
+                bool isVisibleDocument,
+                bool isOpenDocument,
+                DocumentAnalysisData previousData)
+                => isVisibleDocument || (isOpenDocument && !previousData.Items.Any(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning or DiagnosticSeverity.Info));
         }
 
         /// <summary>

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -199,12 +200,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 RemoveInMemoryCache(_lastResult);
 
+                using var _ = PooledHashSet<DocumentId>.GetInstance(out var documentIdsToProcess);
+                documentIdsToProcess.AddRange(_lastResult.DocumentIdsOrEmpty);
+                documentIdsToProcess.AddRange(result.DocumentIdsOrEmpty);
+
                 // save last aggregated form of analysis result
                 _lastResult = result.ToAggregatedForm();
 
                 // serialization can't be canceled.
                 var serializerVersion = result.Version;
-                foreach (var documentId in result.DocumentIds)
+
+                foreach (var documentId in documentIdsToProcess)
                 {
                     var document = project.GetTextDocument(documentId);
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/SolutionCrawlerOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/SolutionCrawlerOptionsStorage.cs
@@ -78,7 +78,7 @@ internal static class SolutionCrawlerOptionsStorage
 
         return globalOptions.GetOption(SolutionBackgroundAnalysisScopeOption) switch
         {
-            BackgroundAnalysisScope.ActiveFile => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+            BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
             BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
             BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
             BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,

--- a/src/Features/LanguageServer/Protocol/Features/Options/SolutionCrawlerOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/SolutionCrawlerOptionsStorage.cs
@@ -73,12 +73,12 @@ internal static class SolutionCrawlerOptionsStorage
     {
         if (LowMemoryForcedMinimalBackgroundAnalysis)
         {
-            return CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics;
+            return CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics;
         }
 
         return globalOptions.GetOption(SolutionBackgroundAnalysisScopeOption) switch
         {
-            BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+            BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics,
             BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
             BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
             BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             compilerDiagnosticsScope ??= analyzerDiagnosticsScope switch
             {
                 BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,
-                BackgroundAnalysisScope.ActiveFile => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
                 BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
                 BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
                 _ => throw ExceptionUtilities.UnexpectedValue(analyzerDiagnosticsScope),

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             compilerDiagnosticsScope ??= analyzerDiagnosticsScope switch
             {
                 BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,
-                BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics,
                 BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
                 BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
                 _ => throw ExceptionUtilities.UnexpectedValue(analyzerDiagnosticsScope),

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => BackgroundAnalysisScope.None;
 
         public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Active_File_Tag
-            => BackgroundAnalysisScope.ActiveFile;
+            => BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics;
 
         public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Open_Files_Tag
             => BackgroundAnalysisScope.OpenFiles;

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => BackgroundAnalysisScope.None;
 
         public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Active_File_Tag
-            => BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics;
+            => BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics;
 
         public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Open_Files_Tag
             => BackgroundAnalysisScope.OpenFiles;
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             => CompilerDiagnosticsScope.None;
 
         public static CompilerDiagnosticsScope Option_Compiler_Diagnostics_Scope_Visible_Files_Tag
-            => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics;
+            => CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics;
 
         public static CompilerDiagnosticsScope Option_Compiler_Diagnostics_Scope_Open_Files_Tag
             => CompilerDiagnosticsScope.OpenFiles;

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, scope: null);
 
         private void OnSetAnalysisScopeCurrentDocumentStatus(object sender, EventArgs e)
-            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.ActiveFile);
+            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics);
 
         private void OnSetAnalysisScopeOpenDocumentsStatus(object sender, EventArgs e)
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.OpenFiles);
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             {
                 command.Text = GetBackgroundAnalysisScope(_workspace.CurrentSolution, _globalOptions) switch
                 {
-                    BackgroundAnalysisScope.ActiveFile => ServicesVSResources.Default_Current_Document,
+                    BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => ServicesVSResources.Default_Current_Document,
                     BackgroundAnalysisScope.OpenFiles => ServicesVSResources.Default_Open_Documents,
                     BackgroundAnalysisScope.FullSolution => ServicesVSResources.Default_Entire_Solution,
                     BackgroundAnalysisScope.None => ServicesVSResources.Default_None,
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScope(scope: null);
 
         private void OnSetAnalysisScopeCurrentDocument(object sender, EventArgs args)
-            => OnSetAnalysisScope(BackgroundAnalysisScope.ActiveFile);
+            => OnSetAnalysisScope(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics);
 
         private void OnSetAnalysisScopeOpenDocuments(object sender, EventArgs args)
             => OnSetAnalysisScope(BackgroundAnalysisScope.OpenFiles);

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, scope: null);
 
         private void OnSetAnalysisScopeCurrentDocumentStatus(object sender, EventArgs e)
-            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics);
+            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics);
 
         private void OnSetAnalysisScopeOpenDocumentsStatus(object sender, EventArgs e)
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.OpenFiles);
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             {
                 command.Text = GetBackgroundAnalysisScope(_workspace.CurrentSolution, _globalOptions) switch
                 {
-                    BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => ServicesVSResources.Default_Current_Document,
+                    BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => ServicesVSResources.Default_Current_Document,
                     BackgroundAnalysisScope.OpenFiles => ServicesVSResources.Default_Open_Documents,
                     BackgroundAnalysisScope.FullSolution => ServicesVSResources.Default_Entire_Solution,
                     BackgroundAnalysisScope.None => ServicesVSResources.Default_None,
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScope(scope: null);
 
         private void OnSetAnalysisScopeCurrentDocument(object sender, EventArgs args)
-            => OnSetAnalysisScope(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics);
+            => OnSetAnalysisScope(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics);
 
         private void OnSetAnalysisScopeOpenDocuments(object sender, EventArgs args)
             => OnSetAnalysisScope(BackgroundAnalysisScope.OpenFiles);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -918,7 +918,7 @@ dotnet_diagnostic.CS0168.severity = ", HangMitigatingCancellationToken);
         }
 
         [IdeTheory, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
-        [InlineData(BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics, CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics)]
+        [InlineData(BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics, CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics)]
         [InlineData(BackgroundAnalysisScope.FullSolution, CompilerDiagnosticsScope.FullSolution)]
         internal async Task ConfigureSeverityWithManualEditsToEditorconfig_CurrentDocumentScope(BackgroundAnalysisScope analyzerScope, CompilerDiagnosticsScope compilerScope)
         {

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -13,10 +13,13 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Extensibility.Testing;
+using Microsoft.VisualStudio.Shell.TableManager;
 using Roslyn.Test.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
 using Roslyn.VisualStudio.IntegrationTests.InProcess;
@@ -908,6 +911,129 @@ dotnet_diagnostic.CS0168.severity = ", HangMitigatingCancellationToken);
                 };
 
                 var actualContents = await testServices.ErrorList.GetErrorsAsync(cancellationToken);
+                AssertEx.EqualOrDiff(
+                    string.Join(Environment.NewLine, expectedContents),
+                    string.Join(Environment.NewLine, actualContents));
+            }
+        }
+
+        [IdeFact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+        public async Task ConfigureSeverityWithManualEditsToEditorconfig_CurrentDocumentScope()
+        {
+            var markup1 = @"
+class C
+{
+    public static void Main()
+    {
+        // CS0219: The variable 'x' is assigned but its value is never used
+        // IDE0059: Unnecessary assignment of a value to 'x'
+        int $$x = 0;
+    }
+}";
+
+            var markup2 = @"
+class C2
+{
+    public static void M()
+    {
+        // CS0219: The variable 'y' is assigned but its value is never used
+        // IDE0059: Unnecessary assignment of a value to 'y'
+        int $$y = 0;
+    }
+}";
+            await TestServices.Workspace.SetFullSolutionAnalysisAsync(
+                BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                HangMitigatingCancellationToken);
+
+            await SetUpEditorAsync(markup2, HangMitigatingCancellationToken);
+
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                new[]
+                {
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.ErrorSquiggles,
+                },
+                HangMitigatingCancellationToken);
+
+            await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "Class2.cs", open: true, cancellationToken: HangMitigatingCancellationToken);
+            await SetUpEditorAsync(markup1, HangMitigatingCancellationToken);
+
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                new[]
+                {
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.ErrorSquiggles,
+                },
+                HangMitigatingCancellationToken);
+
+            // Verify compiler and analyzer diagnostics in original code.
+            await VerifyDiagnosticsInErrorListAsync("warning", "info", TestServices, HangMitigatingCancellationToken);
+
+            // Add an .editorconfig file to the project to change severities to error.
+            await TestServices.SolutionExplorer.AddFileAsync(ProjectName, ".editorconfig", open: true, cancellationToken: HangMitigatingCancellationToken);
+            await TestServices.Editor.SetTextAsync(@"
+[*.cs]
+dotnet_diagnostic.CS0219.severity = error
+dotnet_diagnostic.IDE0059.severity = error", HangMitigatingCancellationToken);
+
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                new[]
+                {
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.ErrorSquiggles,
+                },
+                HangMitigatingCancellationToken);
+
+            // Verify compiler and analyzer diagnostics are now reported as errors.
+            await VerifyDiagnosticsInErrorListAsync("error", "error", TestServices, HangMitigatingCancellationToken);
+
+            // Edit editorconfig file to disable both compiler and analyzer diagnostics.
+            await TestServices.Editor.SetTextAsync(@"
+[*.cs]
+dotnet_diagnostic.CS0219.severity = none
+dotnet_diagnostic.IDE0059.severity = none", HangMitigatingCancellationToken);
+
+            await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
+                new[]
+                {
+                    FeatureAttribute.Workspace,
+                    FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.DiagnosticService,
+                    FeatureAttribute.ErrorSquiggles,
+                },
+                HangMitigatingCancellationToken);
+
+            // Verify compiler and analyzer diagnostics are now cleared.
+            await VerifyDiagnosticsInErrorListAsync("none", "none", TestServices, HangMitigatingCancellationToken);
+
+            static async Task VerifyDiagnosticsInErrorListAsync(string expectedCompilerDiagnosticSeverity, string expectedAnalyzerDiagnosticSeverity, TestServices testServices, CancellationToken cancellationToken)
+            {
+                await testServices.ErrorList.ShowErrorListAsync(cancellationToken);
+
+                using var _ = ArrayBuilder<string>.GetInstance(out var expectedContentsBuilder);
+
+                if (expectedCompilerDiagnosticSeverity != "none")
+                {
+                    expectedContentsBuilder.Add($"(Compiler) Class1.cs(8, 13): {expectedCompilerDiagnosticSeverity} CS0219: The variable 'y' is assigned but its value is never used");
+                    expectedContentsBuilder.Add($"(Compiler) Class2.cs(8, 13): {expectedCompilerDiagnosticSeverity} CS0219: The variable 'x' is assigned but its value is never used");
+                }
+
+                if (expectedAnalyzerDiagnosticSeverity != "none")
+                {
+                    expectedContentsBuilder.Add($"(Compiler) Class1.cs(8, 13): {expectedAnalyzerDiagnosticSeverity} IDE0059: Unnecessary assignment of a value to 'y'");
+                    expectedContentsBuilder.Add($"(Compiler) Class2.cs(8, 13): {expectedAnalyzerDiagnosticSeverity} IDE0059: Unnecessary assignment of a value to 'x'");
+                }
+
+                var expectedContents = expectedContentsBuilder.ToImmutable().Sort();
+                var actualContents = await testServices.ErrorList.GetErrorsAsync(ErrorSource.Other, Microsoft.VisualStudio.Shell.Interop.__VSERRORCATEGORY.EC_MESSAGE, cancellationToken);
+
                 AssertEx.EqualOrDiff(
                     string.Join(Environment.NewLine, expectedContents),
                     string.Join(Environment.NewLine, actualContents));

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
@@ -82,16 +82,21 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
                 new CodeStyleOption2<NamespaceDeclarationPreference>(value ? NamespaceDeclarationPreference.FileScoped : NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Suggestion));
         }
 
-        public async Task SetFullSolutionAnalysisAsync(bool value, CancellationToken cancellationToken)
+        public Task SetFullSolutionAnalysisAsync(bool value, CancellationToken cancellationToken)
+        {
+            var analyzerScope = value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default;
+            var compilerScope = value ? CompilerDiagnosticsScope.FullSolution : CompilerDiagnosticsScope.OpenFiles;
+            return SetFullSolutionAnalysisAsync(analyzerScope, compilerScope, cancellationToken);
+        }
+
+        public async Task SetFullSolutionAnalysisAsync(BackgroundAnalysisScope analyzerScope, CompilerDiagnosticsScope compilerScope, CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);
 
-            var scope = value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default;
-            globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, scope);
-            globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, scope);
+            globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp, analyzerScope);
+            globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, analyzerScope);
 
-            var compilerScope = value ? CompilerDiagnosticsScope.FullSolution : CompilerDiagnosticsScope.OpenFiles;
             globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.CompilerDiagnosticsScopeOption, LanguageNames.CSharp, compilerScope);
             globalOptions.SetGlobalOption(SolutionCrawlerOptionsStorage.CompilerDiagnosticsScopeOption, LanguageNames.VisualBasic, compilerScope);
         }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
@@ -86,10 +86,10 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
         {
             var analyzerScope = value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default;
             var compilerScope = value ? CompilerDiagnosticsScope.FullSolution : CompilerDiagnosticsScope.OpenFiles;
-            return SetFullSolutionAnalysisAsync(analyzerScope, compilerScope, cancellationToken);
+            return SetBackgroundAnalysisOptionsAsync(analyzerScope, compilerScope, cancellationToken);
         }
 
-        public async Task SetFullSolutionAnalysisAsync(BackgroundAnalysisScope analyzerScope, CompilerDiagnosticsScope compilerScope, CancellationToken cancellationToken)
+        public async Task SetBackgroundAnalysisOptionsAsync(BackgroundAnalysisScope analyzerScope, CompilerDiagnosticsScope compilerScope, CancellationToken cancellationToken)
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BackgroundAnalysisScope.None
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Active_File_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics
+            BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Open_Files_Tag As BackgroundAnalysisScope =
             BackgroundAnalysisScope.OpenFiles
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             CompilerDiagnosticsScope.None
 
         Public ReadOnly Property Option_Compiler_Diagnostics_Scope_Visible_Files_Tag As CompilerDiagnosticsScope =
-            CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics
+            CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics
 
         Public ReadOnly Property Option_Compiler_Diagnostics_Scope_Open_Files_Tag As CompilerDiagnosticsScope =
             CompilerDiagnosticsScope.OpenFiles

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BackgroundAnalysisScope.None
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Active_File_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.ActiveFile
+            BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Open_Files_Tag As BackgroundAnalysisScope =
             BackgroundAnalysisScope.OpenFiles

--- a/src/Workspaces/Core/Portable/Shared/Extensions/BackgroundAnalysisScopeExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/BackgroundAnalysisScopeExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => backgroundAnalysisScope switch
             {
                 BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,
-                BackgroundAnalysisScope.ActiveFile => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
                 BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
                 BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
                 _ => throw ExceptionUtilities.UnexpectedValue(backgroundAnalysisScope),

--- a/src/Workspaces/Core/Portable/Shared/Extensions/BackgroundAnalysisScopeExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/BackgroundAnalysisScopeExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => backgroundAnalysisScope switch
             {
                 BackgroundAnalysisScope.None => CompilerDiagnosticsScope.None,
-                BackgroundAnalysisScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+                BackgroundAnalysisScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics => CompilerDiagnosticsScope.VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics,
                 BackgroundAnalysisScope.OpenFiles => CompilerDiagnosticsScope.OpenFiles,
                 BackgroundAnalysisScope.FullSolution => CompilerDiagnosticsScope.FullSolution,
                 _ => throw ExceptionUtilities.UnexpectedValue(backgroundAnalysisScope),

--- a/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
@@ -12,8 +12,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// <summary>
         /// Analyzers are computed for visible documents
         /// and open documents which had errors/warnings in the prior solution snapshot.
+        /// We want to analyze such non-visible, open documents to ensure that these
+        /// prior reported errors/warnings get cleared out from the error list if they are
+        /// no longer valid in the latest solution snapshot, hence ensuring error list has
+        /// no stale entries.
         /// </summary>
-        VisibleFilesAndFilesWithPreviouslyReportedDiagnostics = 0,
+        VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics = 0,
 
         /// <summary>
         /// Analyzers are executed for all open documents.
@@ -31,6 +35,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         None = 3,
 
         Minimal = None,
-        Default = VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
+        Default = VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics,
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
@@ -10,9 +10,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         //       and that would break users who have saved a non-default scope for the option.
 
         /// <summary>
-        /// Analyzers are executed only for currently active document.
+        /// Analyzers are computed for visible documents
+        /// and open documents which had errors/warnings in the prior solution snapshot.
         /// </summary>
-        ActiveFile = 0,
+        VisibleFilesAndFilesWithPreviouslyReportedDiagnostics = 0,
 
         /// <summary>
         /// Analyzers are executed for all open documents.
@@ -30,6 +31,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         None = 3,
 
         Minimal = None,
-        Default = ActiveFile,
+        Default = VisibleFilesAndFilesWithPreviouslyReportedDiagnostics,
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/CompilerDiagnosticsScope.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/CompilerDiagnosticsScope.cs
@@ -17,8 +17,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// <summary>
         /// Compiler warnings and errors are computed for visible documents
         /// and open documents which had errors/warnings in the prior solution snapshot.
+        /// We want to analyze such non-visible, open documents to ensure that these
+        /// prior reported errors/warnings get cleared out from the error list if they are
+        /// no longer valid in the latest solution snapshot, hence ensuring error list has
+        /// no stale entries.
         /// </summary>
-        VisibleFilesAndFilesWithPreviouslyReportedDiagnostics = 1,
+        VisibleFilesAndOpenFilesWithPreviouslyReportedDiagnostics = 1,
 
         /// <summary>
         /// Compiler warnings and errors are computed for all open documents.


### PR DESCRIPTION
## Current Document scope change

Currently, setting the background analysis scope for analyzer diagnostics to `Current Document` only refreshes the diagnostics for the current document on all operations such as document edit, option changes, project configuration changes etc. This causes issues where any of these changes render these diagnostics as stale.
We already account for this behavior for compiler diagnostic background analysis scope by processing all visible documents AND open documents which had at least one non-hidden diagnostic reported in the prior document snapshot (i.e. has an entry in error list).
We now do the same for analyzer background analysis scope, and hence avoid analyzer stale diagnostics in non-active open documents with `Current Document` scope.

## FSA fix
Fixes #69763 with https://github.com/dotnet/roslyn/pull/69750/commits/23517e1c26c5df74ded2983fbcfc4e303ebb47c2 