### PR TITLE
Lazily build a case-insensitive comparison for performance

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -3662,13 +3662,10 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var (key, indexPair) in _lazyForwardedTypesToAssemblyIndexMap)
                 {
-                    if (!caseInsensitiveMap.ContainsKey(key))
-                    {
-                        caseInsensitiveMap.Add(key, indexPair);
-                    }
+                    _ = caseInsensitiveMap.TryAdd(key, indexPair);
                 }
 
-                RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap, caseInsensitiveMap.ToImmutable());
+                _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap = caseInsensitiveMap.ToImmutable();
             }
         }
 
@@ -3754,11 +3751,11 @@ namespace Microsoft.CodeAnalysis
 
                 if (typesToAssemblyIndexMap == null)
                 {
-                    RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyForwardedTypesToAssemblyIndexMap, ImmutableSegmentedDictionary<string, (int FirstIndex, int SecondIndex)>.Empty);
+                    _lazyForwardedTypesToAssemblyIndexMap = ImmutableSegmentedDictionary<string, (int FirstIndex, int SecondIndex)>.Empty;
                 }
                 else
                 {
-                    RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyForwardedTypesToAssemblyIndexMap, typesToAssemblyIndexMap.ToImmutable());
+                    _lazyForwardedTypesToAssemblyIndexMap = typesToAssemblyIndexMap.ToImmutable();
                 }
             }
         }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -46,6 +46,9 @@ namespace Microsoft.CodeAnalysis
 
         private ImmutableArray<AssemblyIdentity> _lazyAssemblyReferences;
 
+        private static readonly Dictionary<string, (int, int)> s_sharedEmptyForwardedTypes = new Dictionary<string, (int, int)>();
+        private static readonly Dictionary<string, OneOrMany<(int, int)>> s_sharedEmptyCaseInsensitiveForwardedTypes = new Dictionary<string, OneOrMany<(int, int)>>();
+
         /// <summary>
         /// This is a tuple for optimization purposes. In valid cases, we need to store
         /// only one assembly index per type. However, if we found more than one, we
@@ -3647,6 +3650,12 @@ namespace Microsoft.CodeAnalysis
                     return;
                 }
 
+                if (_lazyForwardedTypesToAssemblyIndexMap.Count == 0)
+                {
+                    _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap = s_sharedEmptyCaseInsensitiveForwardedTypes;
+                    return;
+                }
+
                 var caseInsensitiveMap = new Dictionary<string, OneOrMany<(int FirstIndex, int SecondIndex)>>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var (key, indexPair) in _lazyForwardedTypesToAssemblyIndexMap)
@@ -3744,7 +3753,14 @@ namespace Microsoft.CodeAnalysis
                 catch (BadImageFormatException)
                 { }
 
-                _lazyForwardedTypesToAssemblyIndexMap = typesToAssemblyIndexMap;
+                if (typesToAssemblyIndexMap.Count == 0)
+                {
+                    _lazyForwardedTypesToAssemblyIndexMap = s_sharedEmptyForwardedTypes;
+                }
+                else
+                {
+                    _lazyForwardedTypesToAssemblyIndexMap = typesToAssemblyIndexMap;
+                }
             }
         }
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -3662,10 +3662,13 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var (key, indexPair) in _lazyForwardedTypesToAssemblyIndexMap)
                 {
-                    _ = caseInsensitiveMap.TryAdd(key, indexPair);
+                    if (!caseInsensitiveMap.ContainsKey(key))
+                    {
+                        caseInsensitiveMap.Add(key, indexPair);
+                    }
                 }
 
-                _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap = caseInsensitiveMap.ToImmutable();
+                RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap, caseInsensitiveMap.ToImmutable());
             }
         }
 
@@ -3751,11 +3754,11 @@ namespace Microsoft.CodeAnalysis
 
                 if (typesToAssemblyIndexMap == null)
                 {
-                    _lazyForwardedTypesToAssemblyIndexMap = ImmutableSegmentedDictionary<string, (int FirstIndex, int SecondIndex)>.Empty;
+                    RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyForwardedTypesToAssemblyIndexMap, ImmutableSegmentedDictionary<string, (int FirstIndex, int SecondIndex)>.Empty);
                 }
                 else
                 {
-                    _lazyForwardedTypesToAssemblyIndexMap = typesToAssemblyIndexMap.ToImmutable();
+                    RoslynImmutableInterlocked.InterlockedInitialize(ref _lazyForwardedTypesToAssemblyIndexMap, typesToAssemblyIndexMap.ToImmutable());
                 }
             }
         }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -46,8 +46,7 @@ namespace Microsoft.CodeAnalysis
 
         private ImmutableArray<AssemblyIdentity> _lazyAssemblyReferences;
 
-        private static readonly Dictionary<string, (int, int)> s_sharedEmptyForwardedTypes = new Dictionary<string, (int, int)>();
-        private static readonly Dictionary<string, (int, int)> s_sharedEmptyCaseInsensitiveForwardedTypes = new Dictionary<string, (int, int)>();
+        private static readonly Dictionary<string, (int FirstIndex, int SecondIndex)> s_sharedEmptyForwardedTypes = new Dictionary<string, (int FirstIndex, int SecondIndex)>();
 
         /// <summary>
         /// This is a tuple for optimization purposes. In valid cases, we need to store
@@ -3623,6 +3622,9 @@ namespace Microsoft.CodeAnalysis
 
             if (ignoreCase)
             {
+                // We should only use this functionality when computing diagnostics, so we lazily construct
+                // a case-insensitive map when necessary. Note that we can't store the original map
+                // case-insensitively, since real metadata name lookup has to remain case sensitive.
                 ensureCaseInsensitiveDictionary();
 
                 if (_lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap.TryGetValue(fullName, out var value))
@@ -3652,7 +3654,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (_lazyForwardedTypesToAssemblyIndexMap.Count == 0)
                 {
-                    _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap = s_sharedEmptyCaseInsensitiveForwardedTypes;
+                    _lazyCaseInsensitiveForwardedTypesToAssemblyIndexMap = s_sharedEmptyForwardedTypes;
                     return;
                 }
 
@@ -3674,6 +3676,7 @@ namespace Microsoft.CodeAnalysis
         }
 
 #nullable enable
+        [MemberNotNull(nameof(_lazyForwardedTypesToAssemblyIndexMap))]
         private void EnsureForwardTypeToAssemblyMap()
         {
             if (_lazyForwardedTypesToAssemblyIndexMap == null)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
@@ -782,6 +782,83 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub LookupInvalidForwardedTypeIgnoringCase_Cycles()
+            Dim il1 = <![CDATA[
+.assembly extern pe2 { }
+.assembly pe1 { }
+
+.class extern forwarder UPPER
+{
+  .assembly extern pe2
+}
+
+.class extern forwarder lower.mIxEd
+{
+  .assembly extern pe2
+}
+]]>
+
+            Dim il2 = <![CDATA[
+.assembly extern pe1 { }
+.assembly pe2 { }
+
+.class extern forwarder UPPER
+{
+  .assembly extern pe1
+}
+
+.class extern forwarder lower.mIxEd
+{
+  .assembly extern pe1
+}
+]]>
+
+            Dim vb =
+<compilation name="TypeForwarders">
+    <file name="a.vb">
+Option Strict On
+
+Class Test 
+    Private F1 As upper
+    Private F2 As uPPeR
+    Private F3 As LOWER.mixed
+    Private F4 As lOwEr.MIXED
+End Class
+        </file>
+</compilation>
+
+            Dim ref1 = CompileIL(il1.Value, prependDefaultHeader:=False)
+            Dim ref2 = CompileIL(il2.Value, prependDefaultHeader:=False)
+
+            CreateCompilationWithMscorlib40AndReferences(vb, {ref1, ref2}).AssertTheseDiagnostics(<expected><![CDATA[
+BC31424: Type 'upper' in assembly 'TypeForwarders, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Either a reference to 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is missing from your project or the type 'upper' is missing from assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+    Private F1 As upper
+                  ~~~~~
+BC31425: 'upper' in assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to itself and so is an unsupported type.
+    Private F1 As upper
+                  ~~~~~
+BC31424: Type 'uPPeR' in assembly 'TypeForwarders, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Either a reference to 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is missing from your project or the type 'uPPeR' is missing from assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+    Private F2 As uPPeR
+                  ~~~~~
+BC31425: 'uPPeR' in assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to itself and so is an unsupported type.
+    Private F2 As uPPeR
+                  ~~~~~
+BC31424: Type 'LOWER.mixed' in assembly 'TypeForwarders, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Either a reference to 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is missing from your project or the type 'LOWER.mixed' is missing from assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+    Private F3 As LOWER.mixed
+                  ~~~~~~~~~~~
+BC31425: 'LOWER.mixed' in assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to itself and so is an unsupported type.
+    Private F3 As LOWER.mixed
+                  ~~~~~~~~~~~
+BC31424: Type 'lOwEr.MIXED' in assembly 'TypeForwarders, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Either a reference to 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is missing from your project or the type 'lOwEr.MIXED' is missing from assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+    Private F4 As lOwEr.MIXED
+                  ~~~~~~~~~~~
+BC31425: 'lOwEr.MIXED' in assembly 'pe2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' has been forwarded to itself and so is an unsupported type.
+    Private F4 As lOwEr.MIXED
+                  ~~~~~~~~~~~
+]]></expected>)
+        End Sub
+
+        <Fact>
         Public Sub NamespacesOnlyMentionedInForwarders()
             Dim il1 = <![CDATA[
 .assembly extern pe2 { }


### PR DESCRIPTION
This linear search was responsible for 5% of CPU time in a customer trace. This is one possible approach to reducing the time we spend doing the search, while keeping the standard case-sensitive comparison the same. This path should only be hit by error recovery in VB, so it shouldn't have an impact on C# or non-error scenarios.
