### PR TITLE
Upgrade MSBuildLocator to 1.6.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>7.2.1.6856</ICSharpCodeDecompilerVersion>
     <InputSimulatorPlusVersion>1.0.7</InputSimulatorPlusVersion>
-    <MicrosoftBuildLocatorVersion>1.5.5</MicrosoftBuildLocatorVersion>
+    <MicrosoftBuildLocatorVersion>1.6.1</MicrosoftBuildLocatorVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <!--
       SourceBuild will requires that all dependencies also be source buildable. We are referencing a


### PR DESCRIPTION
This version should better discover MSBuild on some Mac machines that have .NET installed by Homebrew.

Fixes https://github.com/dotnet/vscode-csharp/issues/6063
Fixes https://github.com/dotnet/vscode-csharp/issues/6253
Fixes https://github.com/dotnet/vscode-csharp/issues/6122
Fixes https://github.com/dotnet/vscode-csharp/issues/6198