### PR TITLE
Update the severity combo boxes in EditorConfig UX to reflect the correct semantics

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditorConfigSettings/Updater/SettingsUpdaterTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             Assert.Equal(updatedEditorConfig, result?.ToString());
         }
 
-        private static async Task TestAsync(string initialEditorConfig, string updatedEditorConfig, params (AnalyzerSetting, DiagnosticSeverity)[] options)
+        private static async Task TestAsync(string initialEditorConfig, string updatedEditorConfig, params (AnalyzerSetting, ReportDiagnostic)[] options)
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();
             var analyzerConfigDocument = CreateAnalyzerConfigDocument(workspace, initialEditorConfig);
@@ -110,8 +110,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         internal async Task TestAddNewAnalyzerOptionOptionAsync(
             [CombinatorialValues(Language.CSharp, Language.VisualBasic, (Language.CSharp | Language.VisualBasic))]
             Language language,
-            [CombinatorialValues(DiagnosticSeverity.Warning, DiagnosticSeverity.Error, DiagnosticSeverity.Info, DiagnosticSeverity.Hidden)]
-            DiagnosticSeverity severity)
+            [CombinatorialValues(ReportDiagnostic.Warn, ReportDiagnostic.Error, ReportDiagnostic.Info, ReportDiagnostic.Hidden, ReportDiagnostic.Suppress)]
+            ReportDiagnostic severity)
         {
             var expectedHeader = "";
             if (language.HasFlag(Language.CSharp) && language.HasFlag(Language.VisualBasic))
@@ -331,7 +331,7 @@ csharp_new_line_before_else = true";
             var id = "Test001";
             var descriptor = new DiagnosticDescriptor(id: id, title: "", messageFormat: "", category: "Naming", defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: false);
             var analyzerSetting = new AnalyzerSetting(descriptor, ReportDiagnostic.Suppress, updater, Language.CSharp, new SettingLocation(EditorConfigSettings.LocationKind.VisualStudio, null));
-            analyzerSetting.ChangeSeverity(DiagnosticSeverity.Error);
+            analyzerSetting.ChangeSeverity(ReportDiagnostic.Error);
             var updates = await updater.GetChangedEditorConfigAsync(default);
             var update = Assert.Single(updates);
             Assert.Equal($"[*.cs]\r\ndotnet_diagnostic.{id}.severity = error", update.NewText);
@@ -354,7 +354,7 @@ csharp_new_line_before_else = true";
                 EditorconfigPath);
 
             var setting = CodeStyleSetting.Create(CSharpCodeStyleOptions.AllowBlankLineAfterColonInConstructorInitializer, "description", options, updater);
-            setting.ChangeSeverity(DiagnosticSeverity.Error);
+            setting.ChangeSeverity(ReportDiagnostic.Error);
             var updates = await updater.GetChangedEditorConfigAsync(default);
             var update = Assert.Single(updates);
             Assert.Equal("[*.cs]\r\ncsharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:error", update.NewText);

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/AnalyzerSetting.cs
@@ -24,19 +24,14 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
         {
             _descriptor = descriptor;
             _settingsUpdater = settingsUpdater;
-            DiagnosticSeverity severity = default;
             if (effectiveSeverity == ReportDiagnostic.Default)
             {
-                severity = descriptor.DefaultSeverity;
-            }
-            else if (effectiveSeverity.ToDiagnosticSeverity() is DiagnosticSeverity severity1)
-            {
-                severity = severity1;
+                effectiveSeverity = descriptor.DefaultSeverity.ToReportDiagnostic();
             }
 
             var enabled = effectiveSeverity != ReportDiagnostic.Suppress;
             IsEnabled = enabled;
-            Severity = severity;
+            Severity = effectiveSeverity;
             Language = language;
             IsNotConfigurable = descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.NotConfigurable);
             Location = location;
@@ -46,13 +41,13 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
         public string Title => _descriptor.Title.ToString(CultureInfo.CurrentUICulture);
         public string Description => _descriptor.Description.ToString(CultureInfo.CurrentUICulture);
         public string Category => _descriptor.Category;
-        public DiagnosticSeverity Severity { get; private set; }
+        public ReportDiagnostic Severity { get; private set; }
         public bool IsEnabled { get; private set; }
         public Language Language { get; }
         public bool IsNotConfigurable { get; set; }
         public SettingLocation Location { get; }
 
-        internal void ChangeSeverity(DiagnosticSeverity severity)
+        internal void ChangeSeverity(ReportDiagnostic severity)
         {
             if (severity == Severity)
                 return;

--- a/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyleSetting.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Data/CodeStyleSetting.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater;
 using Microsoft.CodeAnalysis.Options;
 
@@ -16,8 +15,13 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
 
         public abstract ICodeStyleOption GetCodeStyle();
 
-        public DiagnosticSeverity GetSeverity()
-            => GetCodeStyle().Notification.Severity.ToDiagnosticSeverity() ?? DiagnosticSeverity.Hidden;
+        public ReportDiagnostic GetSeverity()
+        {
+            var severity = GetCodeStyle().Notification.Severity;
+            if (severity is ReportDiagnostic.Default or ReportDiagnostic.Suppress)
+                severity = ReportDiagnostic.Hidden;
+            return severity;
+        }
 
         public sealed override object? GetValue()
             => GetCodeStyle();
@@ -27,14 +31,14 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Data
 
         protected abstract object GetPossibleValue(int valueIndex);
 
-        public void ChangeSeverity(DiagnosticSeverity severity)
+        public void ChangeSeverity(ReportDiagnostic severity)
         {
             var notification = severity switch
             {
-                DiagnosticSeverity.Hidden => NotificationOption2.Silent,
-                DiagnosticSeverity.Info => NotificationOption2.Suggestion,
-                DiagnosticSeverity.Warning => NotificationOption2.Warning,
-                DiagnosticSeverity.Error => NotificationOption2.Error,
+                ReportDiagnostic.Hidden => NotificationOption2.Silent,
+                ReportDiagnostic.Info => NotificationOption2.Suggestion,
+                ReportDiagnostic.Warn => NotificationOption2.Warning,
+                ReportDiagnostic.Error => NotificationOption2.Error,
                 _ => NotificationOption2.None,
             };
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/DataProvider/Analyzer/AnalyzerSettingsProvider.cs
@@ -16,7 +16,7 @@ using RoslynEnumerableExtensions = Microsoft.CodeAnalysis.Editor.EditorConfigSet
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.Analyzer
 {
-    internal sealed class AnalyzerSettingsProvider : SettingsProviderBase<AnalyzerSetting, AnalyzerSettingsUpdater, AnalyzerSetting, DiagnosticSeverity>
+    internal sealed class AnalyzerSettingsProvider : SettingsProviderBase<AnalyzerSetting, AnalyzerSettingsUpdater, AnalyzerSetting, ReportDiagnostic>
     {
         private readonly IDiagnosticAnalyzerService _analyzerService;
 

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/AnalyzerSettingsUpdater.cs
@@ -10,10 +10,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
 {
-    internal class AnalyzerSettingsUpdater(Workspace workspace, string editorconfigPath) : SettingsUpdaterBase<AnalyzerSetting, DiagnosticSeverity>(workspace, editorconfigPath)
+    internal class AnalyzerSettingsUpdater(Workspace workspace, string editorconfigPath) : SettingsUpdaterBase<AnalyzerSetting, ReportDiagnostic>(workspace, editorconfigPath)
     {
         protected override SourceText? GetNewText(SourceText sourceText,
-                                                  IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate,
+                                                  IReadOnlyList<(AnalyzerSetting option, ReportDiagnostic value)> settingsToUpdate,
                                                   CancellationToken token)
             => SettingsUpdateHelper.TryUpdateAnalyzerConfigDocument(sourceText, EditorconfigPath, settingsToUpdate);
     }

--- a/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
+++ b/src/EditorFeatures/Core/EditorConfigSettings/Updater/SettingsUpdateHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
 
         public static SourceText? TryUpdateAnalyzerConfigDocument(SourceText originalText,
                                                                   string filePath,
-                                                                  IReadOnlyList<(AnalyzerSetting option, DiagnosticSeverity value)> settingsToUpdate)
+                                                                  IReadOnlyList<(AnalyzerSetting option, ReportDiagnostic value)> settingsToUpdate)
         {
             if (originalText is null)
                 return null;
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.Updater
 
             return TryUpdateAnalyzerConfigDocument(originalText, filePath, settingsToUpdate.Select(x => GetOptionValueAndLanguage(x.option, x.value)));
 
-            static (string option, string value, Language language) GetOptionValueAndLanguage(AnalyzerSetting diagnostic, DiagnosticSeverity severity)
+            static (string option, string value, Language language) GetOptionValueAndLanguage(AnalyzerSetting diagnostic, ReportDiagnostic severity)
             {
                 var optionName = $"{DiagnosticOptionPrefix}{diagnostic.Id}{SeveritySuffix}";
                 var optionValue = severity.ToEditorConfigString();

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/View/ColumnDefinitions/AnalyzerSeverityColumnDefinition.cs
@@ -41,10 +41,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
 
             content = setting.Severity switch
             {
-                CodeAnalysis.DiagnosticSeverity.Hidden => ServicesVSResources.Disabled,
-                CodeAnalysis.DiagnosticSeverity.Info => ServicesVSResources.Suggestion,
-                CodeAnalysis.DiagnosticSeverity.Warning => ServicesVSResources.Warning,
-                CodeAnalysis.DiagnosticSeverity.Error => ServicesVSResources.Error,
+                CodeAnalysis.ReportDiagnostic.Suppress => ServicesVSResources.Disabled,
+                CodeAnalysis.ReportDiagnostic.Hidden => ServicesVSResources.Refactoring_Only,
+                CodeAnalysis.ReportDiagnostic.Info => ServicesVSResources.Suggestion,
+                CodeAnalysis.ReportDiagnostic.Warn => ServicesVSResources.Warning,
+                CodeAnalysis.ReportDiagnostic.Error => ServicesVSResources.Error,
                 _ => string.Empty,
             };
             return true;

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/SeverityViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Analyzers/ViewModel/SeverityViewModel.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         private static readonly string[] s_severities = new[]
         {
             ServicesVSResources.Disabled,
+            ServicesVSResources.Refactoring_Only,
             ServicesVSResources.Suggestion,
             ServicesVSResources.Warning,
             ServicesVSResources.Error
@@ -47,10 +48,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         {
             _selectedSeverityIndex = setting.Severity switch
             {
-                DiagnosticSeverity.Hidden => 0,
-                DiagnosticSeverity.Info => 1,
-                DiagnosticSeverity.Warning => 2,
-                DiagnosticSeverity.Error => 3,
+                ReportDiagnostic.Suppress => 0,
+                ReportDiagnostic.Hidden => 1,
+                ReportDiagnostic.Info => 2,
+                ReportDiagnostic.Warn => 3,
+                ReportDiagnostic.Error => 4,
                 _ => throw new InvalidOperationException(),
             };
 
@@ -67,10 +69,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Analyzers
         {
             var severity = selectedIndex switch
             {
-                0 => DiagnosticSeverity.Hidden,
-                1 => DiagnosticSeverity.Info,
-                2 => DiagnosticSeverity.Warning,
-                3 => DiagnosticSeverity.Error,
+                0 => ReportDiagnostic.Suppress,
+                1 => ReportDiagnostic.Hidden,
+                2 => ReportDiagnostic.Info,
+                3 => ReportDiagnostic.Warn,
+                4 => ReportDiagnostic.Error,
                 _ => throw new InvalidOperationException(),
             };
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSeverityViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/CodeStyle/ViewModel/CodeStyleSeverityViewModel.cs
@@ -10,9 +10,14 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
 {
     internal class CodeStyleSeverityViewModel
     {
+        // NOTE: 'ServicesVSResources.Disabled' severity is not supported for code style settings.
+        //       Code styles can instead be disabled by setting the option value that turns off the style.
+        //       Theoretically, we can support the 'Disabled' severity, which translates to 'none' value in
+        //       editorconfig. However, adding this support would require us to update all our IDE code style
+        //       analyzers to turn themselves off when 'option.Notification.Severity is ReportDiagnostic.Suppress'
         private static readonly string[] s_severities = new[]
         {
-            ServicesVSResources.Disabled,
+            ServicesVSResources.Refactoring_Only,
             ServicesVSResources.Suggestion,
             ServicesVSResources.Warning,
             ServicesVSResources.Error
@@ -45,10 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         {
             _selectedSeverityIndex = setting.GetSeverity() switch
             {
-                DiagnosticSeverity.Hidden => 0,
-                DiagnosticSeverity.Info => 1,
-                DiagnosticSeverity.Warning => 2,
-                DiagnosticSeverity.Error => 3,
+                ReportDiagnostic.Hidden => 0,
+                ReportDiagnostic.Info => 1,
+                ReportDiagnostic.Warn => 2,
+                ReportDiagnostic.Error => 3,
                 _ => throw new InvalidOperationException(),
             };
 
@@ -59,10 +64,10 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.CodeStyle
         {
             var severity = selectedIndex switch
             {
-                0 => DiagnosticSeverity.Hidden,
-                1 => DiagnosticSeverity.Info,
-                2 => DiagnosticSeverity.Warning,
-                3 => DiagnosticSeverity.Error,
+                0 => ReportDiagnostic.Hidden,
+                1 => ReportDiagnostic.Info,
+                2 => ReportDiagnostic.Warn,
+                3 => ReportDiagnostic.Error,
                 _ => throw new InvalidOperationException(),
             };
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/NamingStyle/View/ColumnDefinitions/NamingStylesSeverityColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/NamingStyle/View/ColumnDefinitions/NamingStylesSeverityColumnDefinition.cs
@@ -47,7 +47,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.NamingSty
             static string GetSeverityString(ReportDiagnostic severity)
                 => severity switch
                 {
-                    ReportDiagnostic.Hidden => ServicesVSResources.Disabled,
+                    ReportDiagnostic.Suppress => ServicesVSResources.Disabled,
+                    ReportDiagnostic.Hidden => ServicesVSResources.Refactoring_Only,
                     ReportDiagnostic.Info => ServicesVSResources.Suggestion,
                     ReportDiagnostic.Warn => ServicesVSResources.Warning,
                     ReportDiagnostic.Error => ServicesVSResources.Error,

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/NamingStyle/ViewModel/ColumnViewModels/NamingStylesSeverityViewModel.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/NamingStyle/ViewModel/ColumnViewModels/NamingStylesSeverityViewModel.cs
@@ -18,10 +18,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.NamingSty
             _setting = setting;
             var selectedSeverityIndex = _setting.Severity switch
             {
-                ReportDiagnostic.Hidden => 0,
-                ReportDiagnostic.Info => 1,
-                ReportDiagnostic.Warn => 2,
-                ReportDiagnostic.Error => 3,
+                ReportDiagnostic.Suppress => 0,
+                ReportDiagnostic.Hidden => 1,
+                ReportDiagnostic.Info => 2,
+                ReportDiagnostic.Warn => 3,
+                ReportDiagnostic.Error => 4,
                 _ => throw new InvalidOperationException(),
             };
 
@@ -32,10 +33,11 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.NamingSty
         {
             var severity = selectedIndex switch
             {
-                0 => ReportDiagnostic.Hidden,
-                1 => ReportDiagnostic.Info,
-                2 => ReportDiagnostic.Warn,
-                3 => ReportDiagnostic.Error,
+                0 => ReportDiagnostic.Suppress,
+                1 => ReportDiagnostic.Hidden,
+                2 => ReportDiagnostic.Info,
+                3 => ReportDiagnostic.Warn,
+                4 => ReportDiagnostic.Error,
                 _ => throw new InvalidOperationException(),
             };
             _setting.ChangeSeverity(severity);
@@ -50,6 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.NamingSty
         public static ImmutableArray<string> Severities { get; } =
             ImmutableArray.Create(
                 ServicesVSResources.Disabled,
+                ServicesVSResources.Refactoring_Only,
                 ServicesVSResources.Suggestion,
                 ServicesVSResources.Warning,
                 ServicesVSResources.Error


### PR DESCRIPTION
Fixes #69176

Current UX and semantics for severity combo boxes in each of the tabs in the EditorConfig UX, i.e. Analyzers, Naming Styles and Code Styles tabs, have Severity combo boxes with following strings: `Disabled`, `Suggestion`, `Warning` and `Error`. `Disabled` setting currently maps to "silent" severity value in editorconfig, which doesn't disable the analyzer, but converts it into a hidden analyzer for which code fixes are still offered, i.e. it is essentially a refactoring. This is indeed confusing for the users as the wordings don't match the actual semantics.

With this PR, we make the following changes:
- Analyzers and Naming Styles tab now have following values for Severity combo box: `Disabled`, `Refactoring Only`, `Suggestion`, `Warning` and `Error`. `Disabled` now correctly maps to "none" in editorconfig, which disables the rule. `Refactoring Only` maps to "silent".
- Code Styles tab has the following values for Severity combo box: `Refactoring Only`, `Suggestion`, `Warning` and `Error`. `Disabled` severity is not supported for code style settings. Code styles can instead be disabled by setting the option `Value` that turns off the style, such as "Yes/No", "Always/Never", etc. Theoretically, we can support the `Disabled` severity, which translates to 'none' value in editorconfig. However, adding this support would require us to update all our IDE code style analyzers to turn themselves off when 'option.Notification.Severity is ReportDiagnostic.Suppress', which is doable, but seems a bit of an overkill. We can wait for more feedback to see if this work is required.