### PR TITLE
Refactoring of synthesized types tracking across EnC generations

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -26,24 +26,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private readonly MatchSymbols _symbols;
 
         public CSharpSymbolMatcher(
-            IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
-            IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates,
-            IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames,
             SourceAssemblySymbol sourceAssembly,
             EmitContext sourceContext,
             SourceAssemblySymbol otherAssembly,
             EmitContext otherContext,
+            SynthesizedTypeMaps synthesizedTypes,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherSynthesizedMembers,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherDeletedMembers)
         {
             _defs = new MatchDefsToSource(sourceContext, otherContext);
-            _symbols = new MatchSymbols(anonymousTypeMap, anonymousDelegates, anonymousDelegatesWithIndexedNames, sourceAssembly, otherAssembly, otherSynthesizedMembers, otherDeletedMembers, new DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)));
+            _symbols = new MatchSymbols(sourceAssembly, otherAssembly, synthesizedTypes, otherSynthesizedMembers, otherDeletedMembers, new DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)));
         }
 
         public CSharpSymbolMatcher(
-            IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
-            IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates,
-            IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames,
+            SynthesizedTypeMaps synthesizedTypes,
             SourceAssemblySymbol sourceAssembly,
             EmitContext sourceContext,
             PEAssemblySymbol otherAssembly)
@@ -51,11 +47,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             _defs = new MatchDefsToMetadata(sourceContext, otherAssembly);
 
             _symbols = new MatchSymbols(
-                anonymousTypeMap,
-                anonymousDelegates,
-                anonymousDelegatesWithIndexedNames,
                 sourceAssembly,
                 otherAssembly,
+                synthesizedTypes,
                 otherSynthesizedMembers: null,
                 deepTranslator: null,
                 otherDeletedMembers: null);
@@ -281,9 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         private sealed class MatchSymbols : CSharpSymbolVisitor<Symbol?>
         {
-            private readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> _anonymousTypeMap;
-            private readonly IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> _anonymousDelegates;
-            private readonly IReadOnlyDictionary<string, AnonymousTypeValue> _anonymousDelegatesWithIndexedNames;
+            private readonly SynthesizedTypeMaps _synthesizedTypes;
             private readonly SourceAssemblySymbol _sourceAssembly;
 
             // metadata or source assembly:
@@ -309,18 +301,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             private readonly ConcurrentDictionary<ISymbolInternal, IReadOnlyDictionary<string, ImmutableArray<ISymbolInternal>>> _otherMembers = new(ReferenceEqualityComparer.Instance);
 
             public MatchSymbols(
-                IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
-                IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates,
-                IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames,
                 SourceAssemblySymbol sourceAssembly,
                 AssemblySymbol otherAssembly,
+                SynthesizedTypeMaps synthesizedTypes,
                 ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherSynthesizedMembers,
                 ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>? otherDeletedMembers,
                 DeepTranslator? deepTranslator)
             {
-                _anonymousTypeMap = anonymousTypeMap;
-                _anonymousDelegates = anonymousDelegates;
-                _anonymousDelegatesWithIndexedNames = anonymousDelegatesWithIndexedNames;
+                _synthesizedTypes = synthesizedTypes;
                 _sourceAssembly = sourceAssembly;
                 _otherAssembly = otherAssembly;
                 _otherSynthesizedMembers = otherSynthesizedMembers;
@@ -680,7 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 Debug.Assert((object)type.ContainingSymbol == (object)_sourceAssembly.GlobalNamespace);
 
-                return _anonymousTypeMap.TryGetValue(type.GetAnonymousTypeKey(), out otherType);
+                return _synthesizedTypes.AnonymousTypes.TryGetValue(type.GetAnonymousTypeKey(), out otherType);
             }
 
             internal bool TryFindAnonymousDelegate(AnonymousTypeManager.AnonymousDelegateTemplateSymbol delegateSymbol, out SynthesizedDelegateValue otherDelegateSymbol)
@@ -688,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 Debug.Assert((object)delegateSymbol.ContainingSymbol == (object)_sourceAssembly.GlobalNamespace);
 
                 var key = new SynthesizedDelegateKey(delegateSymbol.MetadataName);
-                return _anonymousDelegates.TryGetValue(key, out otherDelegateSymbol);
+                return _synthesizedTypes.AnonymousDelegates.TryGetValue(key, out otherDelegateSymbol);
             }
 
             internal bool TryFindAnonymousDelegateWithIndexedName(AnonymousTypeManager.AnonymousDelegateTemplateSymbol type, out AnonymousTypeValue otherType)
@@ -701,7 +689,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // expression may have been changed explicitly, or another lambda expression may have been inserted
                 // ahead of this one in source order. Therefore, we need to verify the signatures of the delegate types
                 // are equivalent - by comparing the Invoke() method signatures.
-                if (_anonymousDelegatesWithIndexedNames.TryGetValue(type.Name, out otherType) &&
+                if (_synthesizedTypes.AnonymousDelegatesWithIndexedNames.TryGetValue(type.Name, out otherType) &&
                     otherType.Type.GetInternalSymbol() is NamedTypeSymbol otherDelegateType &&
                     isCorrespondingAnonymousDelegate(type, otherDelegateType))
                 {

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -82,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 filterOpt: s => changes.RequiresCompilation(s.GetISymbol()),
                 cancellationToken: cancellationToken))
             {
-                if (!ContainsPreviousAnonymousDelegates(definitionMap, baseline.AnonymousDelegatesWithIndexedNames, moduleBeingBuilt.GetAnonymousDelegatesWithIndexedNames()))
+                if (!ContainsPreviousAnonymousDelegates(definitionMap, baseline.SynthesizedTypes.AnonymousDelegatesWithIndexedNames, compilation.AnonymousTypeManager.GetCreatedAnonymousDelegateTypesWithIndexedNames()))
                 {
                     diagnostics.Add(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged, Location.None);
                 }
@@ -120,32 +121,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         private static bool ContainsPreviousAnonymousDelegates(
             CSharpDefinitionMap definitionMap,
-            IReadOnlyDictionary<string, AnonymousTypeValue> previousDictionary,
-            IReadOnlyDictionary<string, AnonymousTypeValue> currentDictionary)
+            ImmutableDictionary<string, AnonymousTypeValue> previousDictionary,
+            IEnumerable<Cci.ITypeDefinition> currentTypes)
         {
             if (previousDictionary.Count == 0)
             {
                 return true;
             }
 
-            if (previousDictionary.Count > currentDictionary.Count)
+            var currentTypesByName = currentTypes.ToImmutableDictionary(getName);
+            if (previousDictionary.Count > currentTypesByName.Count)
             {
                 return false;
             }
 
-            Dictionary<string, Cci.ITypeDefinition> currentTypes = getTypes(currentDictionary).ToDictionary(t => getName(t));
-            IEnumerable<Cci.ITypeDefinition> previousTypes = getTypes(previousDictionary);
-            foreach (var previousType in previousTypes)
+            foreach (var previousType in previousDictionary)
             {
-                if (!currentTypes.TryGetValue(getName(previousType), out var currentType) ||
+                if (!currentTypesByName.TryGetValue(getName(previousType.Value.Type), out var currentType) ||
                     definitionMap.MapDefinition(currentType) is null)
                 {
                     return false;
                 }
             }
+
             return true;
 
-            static IEnumerable<Cci.ITypeDefinition> getTypes(IReadOnlyDictionary<string, AnonymousTypeValue> dictionary) => dictionary.Values.Select(v => v.Type);
             static string getName(Cci.ITypeDefinition type) => ((Cci.INamedEntity)type).Name!;
         }
 
@@ -175,25 +175,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             RoslynDebug.AssertNotNull(previousGeneration.PEModuleBuilder);
             RoslynDebug.AssertNotNull(moduleBeingBuilt.EncSymbolChanges);
 
+            var synthesizedTypes = moduleBeingBuilt.GetSynthesizedTypes();
             var currentSynthesizedMembers = moduleBeingBuilt.GetAllSynthesizedMembers();
             var currentDeletedMembers = moduleBeingBuilt.EncSymbolChanges.GetAllDeletedMembers();
 
             // Mapping from previous compilation to the current.
-            var anonymousTypeMap = moduleBeingBuilt.GetAnonymousTypeMap();
-            var anonymousDelegates = moduleBeingBuilt.GetAnonymousDelegates();
-            var anonymousDelegatesWithIndexedNames = moduleBeingBuilt.GetAnonymousDelegatesWithIndexedNames();
             var sourceAssembly = ((CSharpCompilation)previousGeneration.Compilation).SourceAssembly;
             var sourceContext = new EmitContext((PEModuleBuilder)previousGeneration.PEModuleBuilder, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
             var otherContext = new EmitContext(moduleBeingBuilt, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
 
             var matcher = new CSharpSymbolMatcher(
-                anonymousTypeMap,
-                anonymousDelegates,
-                anonymousDelegatesWithIndexedNames,
                 sourceAssembly,
                 sourceContext,
                 compilation.SourceAssembly,
                 otherContext,
+                synthesizedTypes,
                 currentSynthesizedMembers,
                 currentDeletedMembers);
 
@@ -204,13 +200,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             // TODO: can we reuse some data from the previous matcher?
             var matcherWithAllSynthesizedMembers = new CSharpSymbolMatcher(
-                anonymousTypeMap,
-                anonymousDelegates,
-                anonymousDelegatesWithIndexedNames,
                 sourceAssembly,
                 sourceContext,
                 compilation.SourceAssembly,
                 otherContext,
+                synthesizedTypes,
                 mappedSynthesizedMembers,
                 mappedDeletedMembers);
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         private static bool ContainsPreviousAnonymousDelegates(
             CSharpDefinitionMap definitionMap,
-            ImmutableDictionary<string, AnonymousTypeValue> previousDictionary,
+            ImmutableSegmentedDictionary<string, AnonymousTypeValue> previousDictionary,
             IEnumerable<Cci.ITypeDefinition> currentTypes)
         {
             if (previousDictionary.Count == 0)

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Emit
@@ -48,9 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var metadataAssembly = (PEAssemblySymbol)metadataDecoder.ModuleSymbol.ContainingAssembly;
 
             var matchToMetadata = new CSharpSymbolMatcher(
-                metadataSymbols.AnonymousTypes,
-                metadataSymbols.AnonymousDelegates,
-                metadataSymbols.AnonymousDelegatesWithIndexedNames,
+                metadataSymbols.SynthesizedTypes,
                 sourceAssembly,
                 context,
                 metadataAssembly);
@@ -65,13 +62,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 var previousContext = new EmitContext((PEModuleBuilder)previousGeneration.PEModuleBuilder, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
 
                 matchToPrevious = new CSharpSymbolMatcher(
-                    previousGeneration.AnonymousTypeMap,
-                    previousGeneration.AnonymousDelegates,
-                    previousGeneration.AnonymousDelegatesWithIndexedNames,
                     sourceAssembly: sourceAssembly,
                     sourceContext: context,
                     otherAssembly: previousAssembly,
                     otherContext: previousContext,
+                    previousGeneration.SynthesizedTypes,
                     otherSynthesizedMembers: previousGeneration.SynthesizedMembers,
                     otherDeletedMembers: previousGeneration.DeletedMembers);
             }
@@ -124,28 +119,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap;
             var metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All, out assemblyReferenceIdentityMap);
             var metadataDecoder = new MetadataDecoder(metadataAssembly.PrimaryModule);
-            GetAnonymousTypeMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder, out var metadataAnonymousTypes, out var metadataAnonymousDelegatesWithIndexedNames);
-            var metadataAnonymousDelegates = GetAnonymousDelegateMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder);
-            var metadataSymbols = new EmitBaseline.MetadataSymbols(metadataAnonymousTypes, metadataAnonymousDelegates, metadataAnonymousDelegatesWithIndexedNames, metadataDecoder, assemblyReferenceIdentityMap);
+
+            var synthesizedTypes = GetSynthesizedTypesFromMetadata(originalMetadata.MetadataReader, metadataDecoder);
+            var metadataSymbols = new EmitBaseline.MetadataSymbols(synthesizedTypes, metadataDecoder, assemblyReferenceIdentityMap);
 
             return InterlockedOperations.Initialize(ref initialBaseline.LazyMetadataSymbols, metadataSymbols);
         }
 
         // internal for testing
-        internal static void GetAnonymousTypeMapFromMetadata(
-            MetadataReader reader,
-            MetadataDecoder metadataDecoder,
-            out IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypes,
-            out IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames)
+        internal static SynthesizedTypeMaps GetSynthesizedTypesFromMetadata(MetadataReader reader, MetadataDecoder metadataDecoder)
         {
-            // In general, the anonymous type name is "<{module-id}>f__AnonymousType{index}#{submission-index}",
-            // but EnC is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index.
-            const string AnonymousTypeOrDelegateNamePrefix = "<>f__Anonymous";
-            const string AnonymousTypeNameWithoutModulePrefix = AnonymousTypeOrDelegateNamePrefix + "Type";
-            const string AnonymousDelegateNameWithoutModulePrefix = AnonymousTypeOrDelegateNamePrefix + "Delegate";
-
-            var types = new Dictionary<AnonymousTypeKey, AnonymousTypeValue>();
-            var delegates = new Dictionary<string, AnonymousTypeValue>();
+            var anonymousTypes = ImmutableDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
+            var anonymousDelegatesWithIndexedNames = ImmutableDictionary.CreateBuilder<string, AnonymousTypeValue>();
+            var anonymousDelegates = ImmutableDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
 
             foreach (var handle in reader.TypeDefinitions)
             {
@@ -155,17 +141,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     continue;
                 }
 
-                if (!reader.StringComparer.StartsWith(def.Name, AnonymousTypeOrDelegateNamePrefix))
+                if (reader.StringComparer.StartsWith(def.Name, GeneratedNames.ActionDelegateNamePrefix) ||
+                    reader.StringComparer.StartsWith(def.Name, GeneratedNames.FuncDelegateNamePrefix))
                 {
+                    // The name of a synthesized delegate neatly encodes everything we need to identify it, either
+                    // in the prefix (return void or not) or the name (ref kinds and arity) so we don't need anything
+                    // fancy for a key.
+                    var key = new SynthesizedDelegateKey(reader.GetString(def.Name));
+                    var type = (NamedTypeSymbol)metadataDecoder.GetTypeOfToken(handle);
+                    var value = new SynthesizedDelegateValue(type.GetCciAdapter());
+                    anonymousDelegates.Add(key, value);
                     continue;
                 }
 
-                var metadataName = reader.GetString(def.Name);
-                var name = MetadataHelpers.InferTypeArityAndUnmangleMetadataName(metadataName, out _);
-
-                if (name.StartsWith(AnonymousTypeNameWithoutModulePrefix, StringComparison.Ordinal))
+                // In general, the anonymous type name is "<{module-id}>f__AnonymousType{index}#{submission-index}",
+                // but EnC is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index.
+                if (reader.StringComparer.StartsWith(def.Name, GeneratedNames.AnonymousTypeNameWithoutModulePrefix))
                 {
-                    if (int.TryParse(name.Substring(AnonymousTypeNameWithoutModulePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out int index))
+                    var name = MetadataHelpers.InferTypeArityAndUnmangleMetadataName(reader.GetString(def.Name), out _);
+                    if (int.TryParse(name.Substring(GeneratedNames.AnonymousTypeNameWithoutModulePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out int index))
                     {
                         var builder = ArrayBuilder<AnonymousTypeKeyField>.GetInstance();
                         if (TryGetAnonymousTypeKey(reader, def, builder))
@@ -173,55 +167,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                             var type = (NamedTypeSymbol)metadataDecoder.GetTypeOfToken(handle);
                             var key = new AnonymousTypeKey(builder.ToImmutable());
                             var value = new AnonymousTypeValue(name, index, type.GetCciAdapter());
-                            types.Add(key, value);
+                            anonymousTypes.Add(key, value);
                         }
                         builder.Free();
                     }
+
+                    continue;
                 }
-                else if (name.StartsWith(AnonymousDelegateNameWithoutModulePrefix, StringComparison.Ordinal))
+
+                // In general, the anonymous type name is "<{module-id}>f__AnonymousDelegate{index}#{submission-index}",
+                // but EnC is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index.
+                if (reader.StringComparer.StartsWith(def.Name, GeneratedNames.AnonymousDelegateNameWithoutModulePrefix))
                 {
-                    if (int.TryParse(name.Substring(AnonymousDelegateNameWithoutModulePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out int index))
+                    var name = MetadataHelpers.InferTypeArityAndUnmangleMetadataName(reader.GetString(def.Name), out _);
+                    if (int.TryParse(name.Substring(GeneratedNames.AnonymousDelegateNameWithoutModulePrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out int index))
                     {
                         var type = (NamedTypeSymbol)metadataDecoder.GetTypeOfToken(handle);
                         var value = new AnonymousTypeValue(name, index, type.GetCciAdapter());
-                        delegates.Add(name, value);
+                        anonymousDelegatesWithIndexedNames.Add(name, value);
                     }
+
+                    continue;
                 }
             }
 
-            anonymousTypes = types;
-            anonymousDelegatesWithIndexedNames = delegates;
-        }
-
-        // internal for testing
-        internal static IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> GetAnonymousDelegateMapFromMetadata(MetadataReader reader, MetadataDecoder metadataDecoder)
-        {
-            var result = new Dictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>();
-            foreach (var handle in reader.TypeDefinitions)
-            {
-                var def = reader.GetTypeDefinition(handle);
-                if (!def.Namespace.IsNil)
-                {
-                    continue;
-                }
-
-                if (!reader.StringComparer.StartsWith(def.Name, GeneratedNames.ActionDelegateNamePrefix) &&
-                    !reader.StringComparer.StartsWith(def.Name, GeneratedNames.FuncDelegateNamePrefix))
-                {
-                    continue;
-                }
-
-                // The name of a synthesized delegate neatly encodes everything we need to identify it, either
-                // in the prefix (return void or not) or the name (ref kinds and arity) so we don't need anything
-                // fancy for a key.
-                var metadataName = reader.GetString(def.Name);
-                var key = new SynthesizedDelegateKey(metadataName);
-
-                var type = (NamedTypeSymbol)metadataDecoder.GetTypeOfToken(handle);
-                var value = new SynthesizedDelegateValue(type.GetCciAdapter());
-                result.Add(key, value);
-            }
-            return result;
+            return new SynthesizedTypeMaps(anonymousTypes.ToImmutable(), anonymousDelegates.ToImmutable(), anonymousDelegatesWithIndexedNames.ToImmutable());
         }
 
         private static bool TryGetAnonymousTypeKey(
@@ -247,28 +217,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get { return _previousDefinitions; }
         }
 
-        public IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> GetAnonymousTypeMap()
+        public SynthesizedTypeMaps GetSynthesizedTypes()
         {
-            var anonymousTypes = this.Compilation.AnonymousTypeManager.GetAnonymousTypeMap();
-            // Should contain all entries in previous generation.
-            Debug.Assert(_previousGeneration.AnonymousTypeMap.All(p => anonymousTypes.ContainsKey(p.Key)));
-            return anonymousTypes;
-        }
+            var result = new SynthesizedTypeMaps(
+                Compilation.AnonymousTypeManager.GetAnonymousTypeMap(),
+                Compilation.AnonymousTypeManager.GetAnonymousDelegates(),
+                Compilation.AnonymousTypeManager.GetAnonymousDelegatesWithIndexedNames());
 
-        public IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> GetAnonymousDelegates()
-        {
-            var anonymousDelegates = this.Compilation.AnonymousTypeManager.GetAnonymousDelegates();
             // Should contain all entries in previous generation.
-            Debug.Assert(_previousGeneration.AnonymousDelegates.All(p => anonymousDelegates.ContainsKey(p.Key)));
-            return anonymousDelegates;
-        }
+            Debug.Assert(_previousGeneration.SynthesizedTypes.IsSubsetOf(result));
 
-        public IReadOnlyDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
-        {
-            var anonymousDelegates = this.Compilation.AnonymousTypeManager.GetAnonymousDelegatesWithIndexedNames();
-            // Should contain all entries in previous generation.
-            Debug.Assert(_previousGeneration.AnonymousDelegatesWithIndexedNames.All(p => anonymousDelegates.ContainsKey(p.Key)));
-            return anonymousDelegates;
+            return result;
         }
 
         public override IEnumerable<Cci.INamespaceTypeDefinition> GetTopLevelTypeDefinitions(EmitContext context)
@@ -294,12 +253,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         internal override ImmutableArray<AnonymousTypeKey> GetPreviousAnonymousTypes()
         {
-            return ImmutableArray.CreateRange(_previousGeneration.AnonymousTypeMap.Keys);
+            return ImmutableArray.CreateRange(_previousGeneration.SynthesizedTypes.AnonymousTypes.Keys);
         }
 
         internal override ImmutableArray<SynthesizedDelegateKey> GetPreviousAnonymousDelegates()
         {
-            return ImmutableArray.CreateRange(_previousGeneration.AnonymousDelegates.Keys);
+            return ImmutableArray.CreateRange(_previousGeneration.SynthesizedTypes.AnonymousDelegates.Keys);
         }
 
         internal override int GetNextAnonymousTypeIndex()

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
@@ -129,9 +130,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         // internal for testing
         internal static SynthesizedTypeMaps GetSynthesizedTypesFromMetadata(MetadataReader reader, MetadataDecoder metadataDecoder)
         {
-            var anonymousTypes = ImmutableDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
-            var anonymousDelegatesWithIndexedNames = ImmutableDictionary.CreateBuilder<string, AnonymousTypeValue>();
-            var anonymousDelegates = ImmutableDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
+            var anonymousTypes = ImmutableSegmentedDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
+            var anonymousDelegatesWithIndexedNames = ImmutableSegmentedDictionary.CreateBuilder<string, AnonymousTypeValue>();
+            var anonymousDelegates = ImmutableSegmentedDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
 
             foreach (var handle in reader.TypeDefinitions)
             {
@@ -175,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     continue;
                 }
 
-                // In general, the anonymous type name is "<{module-id}>f__AnonymousDelegate{index}#{submission-index}",
+                // In general, the anonymous delegate name is "<{module-id}>f__AnonymousDelegate{index}#{submission-index}",
                 // but EnC is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index.
                 if (reader.StringComparer.StartsWith(def.Name, GeneratedNames.AnonymousDelegateNameWithoutModulePrefix))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -632,6 +632,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal IEnumerable<Cci.INamedTypeDefinition> GetCreatedAnonymousDelegateTypesWithIndexedNames()
+        {
+            var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
+            GetCreatedAnonymousDelegatesWithIndexedNames(templates);
+
+            foreach (var template in templates)
+            {
+                yield return template.GetCciAdapter();
+            }
+
+            templates.Free();
+        }
+
         /// <summary>
         /// The set of synthesized delegates created by
         /// this AnonymousTypeManager.
@@ -663,52 +676,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal IReadOnlyDictionary<CodeAnalysis.Emit.SynthesizedDelegateKey, CodeAnalysis.Emit.SynthesizedDelegateValue> GetAnonymousDelegates()
+        internal ImmutableDictionary<CodeAnalysis.Emit.SynthesizedDelegateKey, CodeAnalysis.Emit.SynthesizedDelegateValue> GetAnonymousDelegates()
         {
-            var result = new Dictionary<CodeAnalysis.Emit.SynthesizedDelegateKey, CodeAnalysis.Emit.SynthesizedDelegateValue>();
             var anonymousDelegates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegates(anonymousDelegates);
-            foreach (var delegateSymbol in anonymousDelegates)
-            {
-                var key = new CodeAnalysis.Emit.SynthesizedDelegateKey(delegateSymbol.MetadataName);
-                var value = new CodeAnalysis.Emit.SynthesizedDelegateValue(delegateSymbol.GetCciAdapter());
-                result.Add(key, value);
-            }
+
+            var result = anonymousDelegates.ToImmutableDictionary(
+                keySelector: delegateSymbol => new CodeAnalysis.Emit.SynthesizedDelegateKey(delegateSymbol.MetadataName),
+                elementSelector: delegateSymbol => new CodeAnalysis.Emit.SynthesizedDelegateValue(delegateSymbol.GetCciAdapter()));
+
             anonymousDelegates.Free();
             return result;
         }
 
-        internal IReadOnlyDictionary<Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue> GetAnonymousTypeMap()
+        internal ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> GetAnonymousTypeMap()
         {
-            var result = new Dictionary<Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue>();
-            var templates = ArrayBuilder<AnonymousTypeTemplateSymbol>.GetInstance();
             // Get anonymous types.
+            var templates = ArrayBuilder<AnonymousTypeTemplateSymbol>.GetInstance();
             GetCreatedAnonymousTypeTemplates(templates);
-            foreach (AnonymousTypeTemplateSymbol template in templates)
-            {
-                var nameAndIndex = template.NameAndIndex;
-                var key = template.GetAnonymousTypeKey();
-                var value = new Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(nameAndIndex.Name, nameAndIndex.Index, template.GetCciAdapter());
-                result.Add(key, value);
-            }
+
+            var result = templates.ToImmutableDictionary(
+                keySelector: template => template.GetAnonymousTypeKey(),
+                elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
+
             templates.Free();
             return result;
         }
 
-        internal IReadOnlyDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
+        internal ImmutableDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
         {
-            var result = new Dictionary<string, AnonymousTypeValue>();
-            var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             // Get anonymous delegates with indexed names (distinct from
             // anonymous delegates from GetAnonymousDelegates() above).
+            var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegatesWithIndexedNames(templates);
-            foreach (var template in templates)
-            {
-                var nameAndIndex = template.NameAndIndex;
-                var name = nameAndIndex.Name;
-                var value = new AnonymousTypeValue(name, nameAndIndex.Index, template.GetCciAdapter());
-                result.Add(name, value);
-            }
+            
+            var result = templates.ToImmutableDictionary(
+                keySelector: template => template.NameAndIndex.Name,
+                elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
+            
             templates.Free();
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -676,12 +677,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal ImmutableDictionary<CodeAnalysis.Emit.SynthesizedDelegateKey, CodeAnalysis.Emit.SynthesizedDelegateValue> GetAnonymousDelegates()
+        internal ImmutableSegmentedDictionary<CodeAnalysis.Emit.SynthesizedDelegateKey, CodeAnalysis.Emit.SynthesizedDelegateValue> GetAnonymousDelegates()
         {
             var anonymousDelegates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegates(anonymousDelegates);
 
-            var result = anonymousDelegates.ToImmutableDictionary(
+            var result = anonymousDelegates.ToImmutableSegmentedDictionary(
                 keySelector: delegateSymbol => new CodeAnalysis.Emit.SynthesizedDelegateKey(delegateSymbol.MetadataName),
                 elementSelector: delegateSymbol => new CodeAnalysis.Emit.SynthesizedDelegateValue(delegateSymbol.GetCciAdapter()));
 
@@ -689,13 +690,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> GetAnonymousTypeMap()
+        internal ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> GetAnonymousTypeMap()
         {
             // Get anonymous types.
             var templates = ArrayBuilder<AnonymousTypeTemplateSymbol>.GetInstance();
             GetCreatedAnonymousTypeTemplates(templates);
 
-            var result = templates.ToImmutableDictionary(
+            var result = templates.ToImmutableSegmentedDictionary(
                 keySelector: template => template.GetAnonymousTypeKey(),
                 elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
 
@@ -703,14 +704,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal ImmutableDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
+        internal ImmutableSegmentedDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
         {
             // Get anonymous delegates with indexed names (distinct from
             // anonymous delegates from GetAnonymousDelegates() above).
             var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegatesWithIndexedNames(templates);
             
-            var result = templates.ToImmutableDictionary(
+            var result = templates.ToImmutableSegmentedDictionary(
                 keySelector: template => template.NameAndIndex.Name,
                 elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
             

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -710,11 +710,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // anonymous delegates from GetAnonymousDelegates() above).
             var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegatesWithIndexedNames(templates);
-            
+
             var result = templates.ToImmutableSegmentedDictionary(
                 keySelector: template => template.NameAndIndex.Name,
                 elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
-            
+
             templates.Free();
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -361,6 +361,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return "<>p__" + StringExtensions.GetNumeral(uniqueId);
         }
 
+        internal const string AnonymousTypeNameWithoutModulePrefix = "<>f__AnonymousType";
+        internal const string AnonymousDelegateNameWithoutModulePrefix = "<>f__AnonymousDelegate";
         internal const string ActionDelegateNamePrefix = "<>A";
         internal const string FuncDelegateNamePrefix = "<>F";
         private const int DelegateNamePrefixLength = 3;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -31,6 +31,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             return (PEAssemblySymbol)CreateCompilation("", new[] { reference }).GetReferencedAssemblySymbol(reference);
         }
 
+        private static CSharpSymbolMatcher CreateMatcher(CSharpCompilation fromCompilation, CSharpCompilation toCompilation)
+            => new CSharpSymbolMatcher(
+                fromCompilation.SourceAssembly,
+                sourceContext: default,
+                toCompilation.SourceAssembly,
+                otherContext: default,
+                SynthesizedTypeMaps.Empty,
+                otherSynthesizedMembers: null,
+                otherDeletedMembers: null);
+
         [Fact]
         public void ConcurrentAccess()
         {
@@ -69,16 +79,7 @@ class B
 
             for (int i = 0; i < 10; i++)
             {
-                var matcher = new CSharpSymbolMatcher(
-                    null,
-                    null,
-                    null,
-                    compilation1.SourceAssembly,
-                    default,
-                    compilation0.SourceAssembly,
-                    default,
-                    null,
-                    null);
+                var matcher = CreateMatcher(compilation1, compilation0);
 
                 var tasks = new Task[10];
                 for (int j = 0; j < tasks.Length; j++)
@@ -129,16 +130,7 @@ class B
             var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members = compilation1.GetMember<NamedTypeSymbol>("A.B").GetMembers("M");
             Assert.Equal(2, members.Length);
             foreach (var member in members)
@@ -164,16 +156,7 @@ class C
             var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var member = compilation1.GetMember<MethodSymbol>("C.M");
             var other = matcher.MapDefinition(member.GetCciAdapter());
             Assert.NotNull(other);
@@ -201,16 +184,7 @@ class C
             Assert.Equal(1, ((PointerTypeSymbol)member1.Parameters[0].Type).PointedAtTypeWithAnnotations.CustomModifiers.Length);
             Assert.Equal(1, ((ArrayTypeSymbol)member1.ReturnType).ElementTypeWithAnnotations.CustomModifiers.Length);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var other = (MethodSymbol)matcher.MapDefinition(member1.GetCciAdapter()).GetInternalSymbol();
             Assert.NotNull(other);
@@ -247,16 +221,7 @@ abstract class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
             var g0 = compilation0.GetMember<MethodSymbol>("C.G");
@@ -338,16 +303,7 @@ public class C
             var compilation0 = CreateCompilation(source, new[] { lib0.ToMetadataReference() }, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source).WithReferences(MscorlibRef, lib1.ToMetadataReference());
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
             var f1 = compilation1.GetMember<MethodSymbol>("C.F");
@@ -381,16 +337,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var elementType = compilation1.GetMember<TypeSymbol>("C.D");
             var member = compilation1.CreateArrayTypeSymbol(elementType);
             var other = matcher.MapReference(member.GetCciAdapter());
@@ -421,16 +368,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var elementType = compilation1.GetMember<TypeSymbol>("C.D");
             var member = compilation1.CreateArrayTypeSymbol(elementType);
             var other = matcher.MapReference(member.GetCciAdapter());
@@ -462,16 +400,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var elementType = compilation1.GetMember<TypeSymbol>("C.D");
             var member = compilation1.CreatePointerTypeSymbol(elementType);
             var other = matcher.MapReference(member.GetCciAdapter());
@@ -506,16 +435,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var member = compilation1.GetMember<FieldSymbol>("C.y");
             var other = matcher.MapReference((Cci.ITypeReference)member.Type.GetCciAdapter());
             // For a newly added type, there is no match in the previous generation.
@@ -674,16 +594,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<FieldSymbol>("C.x");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -707,16 +618,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<FieldSymbol>("C.x");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -740,16 +642,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<MethodSymbol>("C.X");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -773,16 +666,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<MethodSymbol>("C.X");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -806,16 +690,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<PropertySymbol>("C.X");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -839,16 +714,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<PropertySymbol>("C.X");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -872,16 +738,7 @@ public struct Vector
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<FieldSymbol>("Vector.Coordinates");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -905,16 +762,7 @@ public struct Vector
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<FieldSymbol>("Vector.Coordinates");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -938,16 +786,7 @@ public class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<SourceNamedTypeSymbol>("C.F");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -971,16 +810,7 @@ public class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<SourceNamedTypeSymbol>("C.F");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1018,16 +848,7 @@ struct C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var s0 = compilation0.GetMember<MethodSymbol>("C.S");
             var t0 = compilation0.GetMember<MethodSymbol>("C.T");
@@ -1075,16 +896,7 @@ struct C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var s0 = compilation0.GetMember<PropertySymbol>("C.S");
             var t0 = compilation0.GetMember<PropertySymbol>("C.T");
@@ -1167,16 +979,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<MethodSymbol>("C.M");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1201,16 +1004,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<MethodSymbol>("C.M");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1235,16 +1029,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<MethodSymbol>("C.M");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1267,16 +1052,7 @@ class C
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<FieldSymbol>("C.S");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1381,16 +1157,7 @@ interface I
             var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var x0 = compilation0.GetMember<FieldSymbol>("I.X");
             var y0 = compilation0.GetMember<EventSymbol>("I.Y");
@@ -1439,16 +1206,7 @@ unsafe class C
             var compilation0 = CreateCompilation(source, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular9);
             var compilation1 = compilation0.WithSource(source);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             for (int i = 1; i <= 7; i++)
             {
@@ -1482,16 +1240,7 @@ unsafe class C
             var compilation0 = CreateCompilation(source1, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular9);
             var compilation1 = compilation0.WithSource(source2);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var f_1 = compilation1.GetMember<FieldSymbol>($"C.f1");
 
@@ -1542,16 +1291,7 @@ unsafe class C
                 var compilation0 = CreateCompilation(source1, options: TestOptions.UnsafeDebugDll, parseOptions: TestOptions.Regular9);
                 var compilation1 = compilation0.WithSource(source2);
 
-                var matcher = new CSharpSymbolMatcher(
-                    null,
-                    null,
-                    null,
-                    compilation1.SourceAssembly,
-                    default,
-                    compilation0.SourceAssembly,
-                    default,
-                    null,
-                    null);
+                var matcher = CreateMatcher(compilation1, compilation0);
 
                 var f_1 = compilation1.GetMember<FieldSymbol>($"C.f1");
 
@@ -1574,16 +1314,7 @@ public record R
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member = compilation1.GetMember<SourceOrdinaryMethodSymbol>("R.ToString");
             var other = matcher.MapDefinition(member.GetCciAdapter());
@@ -1605,16 +1336,7 @@ public record R
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member0 = compilation0.GetMember<SynthesizedRecordPrintMembers>("R.PrintMembers");
             var member1 = compilation1.GetMember<SourceOrdinaryMethodSymbol>("R.PrintMembers");
@@ -1637,16 +1359,7 @@ public record R
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member0 = compilation0.GetMember<SourceOrdinaryMethodSymbol>("R.PrintMembers");
             var member1 = compilation1.GetMember<SynthesizedRecordPrintMembers>("R.PrintMembers");
@@ -1667,16 +1380,7 @@ public record R(int X)
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var member0 = compilation0.GetMember<SynthesizedRecordPropertySymbol>("R.X");
             var member1 = compilation1.GetMember<SourcePropertySymbol>("R.X");
@@ -1702,16 +1406,7 @@ public record R
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
 
             var members = compilation1.GetMembers("R..ctor");
             // There are two, one is the copy constructor
@@ -2007,16 +1702,7 @@ class A
             var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members1 = compilation1.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             var members0 = compilation0.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             Assert.Equal(6, members1.Length);
@@ -2058,16 +1744,7 @@ class A
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members1 = compilation1.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             var members0 = compilation0.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             Assert.Equal(6, members1.Length);
@@ -2119,16 +1796,7 @@ class A
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members1 = compilation1.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             var members0 = compilation0.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             Assert.Equal(3, members1.Length);
@@ -2175,16 +1843,7 @@ class A
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members1 = compilation1.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             Assert.Equal(6, members1.Length);
 
@@ -2229,16 +1888,7 @@ class A
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                compilation0.SourceAssembly,
-                default,
-                null,
-                null);
+            var matcher = CreateMatcher(compilation1, compilation0);
             var members1 = compilation1.GetMember<NamedTypeSymbol>("A").GetMembers().OfType<MethodSymbol>().Where(m => m.MethodKind is (MethodKind.Conversion or MethodKind.UserDefinedOperator)).ToArray();
             Assert.Equal(6, members1.Length);
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -41,6 +41,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 otherSynthesizedMembers: null,
                 otherDeletedMembers: null);
 
+        private static CSharpSymbolMatcher CreateMatcher(CSharpCompilation fromCompilation, PEAssemblySymbol peAssemblySymbol)
+            => new CSharpSymbolMatcher(
+                SynthesizedTypeMaps.Empty,
+                fromCompilation.SourceAssembly,
+                sourceContext: default,
+                peAssemblySymbol);
+
         [Fact]
         public void ConcurrentAccess()
         {
@@ -265,13 +272,7 @@ abstract class C
 
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll).WithSource(source1);
 
-            var matcher = new CSharpSymbolMatcher(
-                null,
-                null,
-                null,
-                compilation1.SourceAssembly,
-                default,
-                peAssemblySymbol);
+            var matcher = CreateMatcher(compilation1, peAssemblySymbol);
 
             var f0 = peAssemblySymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember("F");
             var g0 = peAssemblySymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember("G");
@@ -477,7 +478,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out var anonymousTypeMap0, out _);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes;
             Assert.Equal("<>f__AnonymousType0", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("A", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal("<>f__AnonymousType1", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("B", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal(2, anonymousTypeMap0.Count);
@@ -500,7 +502,7 @@ class C
             Assert.Equal("x1", x1.Name);
             Assert.Equal("x2", x2.Name);
 
-            var matcher = new CSharpSymbolMatcher(anonymousTypeMap0, null, null, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
             var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
@@ -546,7 +548,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out var anonymousTypeMap0, out _);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes;
             Assert.Equal("<>f__AnonymousType0", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("A", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal("<>f__AnonymousType1", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("X", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal("<>f__AnonymousType2", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("Y", isKey: false, ignoreCase: false)))].Name);
@@ -569,7 +572,7 @@ class C
             var x1 = fields.Where(f => f.Name == "x1").Single();
             var x2 = fields.Where(f => f.Name == "x2").Single();
 
-            var matcher = new CSharpSymbolMatcher(anonymousTypeMap0, null, null, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedX1 = (Cci.IFieldDefinition)matcher.MapDefinition(x1);
             var mappedX2 = (Cci.IFieldDefinition)matcher.MapDefinition(x2);
@@ -952,7 +955,7 @@ class C : I<int, bool>
             Assert.Equal("anotherIndex", parameters[0].Name);
 
             var emitContext = new EmitContext(peAssemblyBuilder, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
-            var matcher = new CSharpSymbolMatcher(null, null, null, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(SynthesizedTypeMaps.Empty, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedProperty = (Cci.IPropertyDefinition)matcher.MapDefinition(property.GetCciAdapter());
 
@@ -1102,7 +1105,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out var anonymousTypeMap0, out _);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes;
             Assert.Equal("<>f__AnonymousType0", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("A", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal("<>f__AnonymousType1", anonymousTypeMap0[new AnonymousTypeKey(ImmutableArray.Create(new AnonymousTypeKeyField("B", isKey: false, ignoreCase: false)))].Name);
             Assert.Equal(2, anonymousTypeMap0.Count);
@@ -1124,7 +1128,7 @@ class C
             var y1 = fields.Where(f => f.Name == "y1").Single();
             var y2 = fields.Where(f => f.Name == "y2").Single();
 
-            var matcher = new CSharpSymbolMatcher(anonymousTypeMap0, null, null, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedY1 = (Cci.IFieldDefinition)matcher.MapDefinition(y1);
             var mappedY2 = (Cci.IFieldDefinition)matcher.MapDefinition(y2);
@@ -1454,10 +1458,11 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            var synthesizedDelegates0 = PEDeltaAssemblyBuilder.GetAnonymousDelegateMapFromMetadata(reader0, decoder0);
-            Assert.Contains(new SynthesizedDelegateKey("<>F{00000008}`3"), synthesizedDelegates0);
-            Assert.Contains(new SynthesizedDelegateKey("<>A{00000003}`2"), synthesizedDelegates0);
-            Assert.Contains(new SynthesizedDelegateKey("<>A{00000000,100000000}`33"), synthesizedDelegates0);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var synthesizedDelegates0 = synthesizedTypes0.AnonymousDelegates;
+            Assert.Contains(new SynthesizedDelegateKey("<>F{00000008}`3"), synthesizedDelegates0.Keys);
+            Assert.Contains(new SynthesizedDelegateKey("<>A{00000003}`2"), synthesizedDelegates0.Keys);
+            Assert.Contains(new SynthesizedDelegateKey("<>A{00000000,100000000}`33"), synthesizedDelegates0.Keys);
             Assert.Equal(3, synthesizedDelegates0.Count);
 
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll);
@@ -1480,7 +1485,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(null, synthesizedDelegates0, null, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedField1 = (Cci.IFieldDefinition)matcher.MapDefinition(field1);
             var mappedField2 = (Cci.IFieldDefinition)matcher.MapDefinition(field2);
@@ -1521,7 +1526,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out _, out var anonymousDelegates0);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
             Assert.Equal("<>f__AnonymousDelegate0", anonymousDelegates0["<>f__AnonymousDelegate0"].Name);
             Assert.Equal(1, anonymousDelegates0.Count);
 
@@ -1537,7 +1543,7 @@ class C
             var field0 = displayClass.GetFields(emitContext).Single(f => f.Name == "<>9__0_0");
             Assert.Equal("<>f__AnonymousDelegate0", field0.GetType(emitContext).ToString());
 
-            var matcher = new CSharpSymbolMatcher(null, null, anonymousDelegates0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
             var field1 = (Cci.IFieldDefinition)matcher.MapDefinition(field0);
             Assert.Equal("<>9__0_0", field1.Name);
         }
@@ -1580,7 +1586,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out _, out var anonymousDelegates0);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
             Assert.Equal(3, anonymousDelegates0.Count);
             Assert.Equal("<>f__AnonymousDelegate0<T1, T2, TResult>", anonymousDelegates0["<>f__AnonymousDelegate0"].Type.ToString());
             Assert.Equal("<>f__AnonymousDelegate1", anonymousDelegates0["<>f__AnonymousDelegate1"].Type.ToString());
@@ -1604,7 +1611,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(null, null, anonymousDelegates0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             Assert.Null(matcher.MapDefinition(field1));
             Assert.Null(matcher.MapDefinition(field2));
@@ -1647,7 +1654,8 @@ class C
             var reader0 = peModule0.Module.MetadataReader;
             var decoder0 = new MetadataDecoder(peModule0);
 
-            PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0, out _, out var anonymousDelegates0);
+            var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
+            var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
             Assert.Equal(3, anonymousDelegates0.Count);
             Assert.Equal("<>f__AnonymousDelegate0<T1, T2, TResult>", anonymousDelegates0["<>f__AnonymousDelegate0"].Type.ToString());
             Assert.Equal("<>f__AnonymousDelegate1", anonymousDelegates0["<>f__AnonymousDelegate1"].Type.ToString());
@@ -1671,7 +1679,7 @@ class C
             Assert.Equal("<>9__0_1", field2.Name);
             Assert.Equal("<>9__0_2", field3.Name);
 
-            var matcher = new CSharpSymbolMatcher(null, null, anonymousDelegates0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
+            var matcher = new CSharpSymbolMatcher(synthesizedTypes0, compilation1.SourceAssembly, emitContext, peAssemblySymbol0);
 
             var mappedField1 = (Cci.IFieldDefinition)matcher.MapDefinition(field1);
             var mappedField2 = (Cci.IFieldDefinition)matcher.MapDefinition(field2);

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedDictionaryTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedDictionaryTest.cs
@@ -300,6 +300,32 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.Contains(missingKey, exception.Message);
         }
 
+        [Fact]
+        public void Keys_All()
+        {
+            var map = ImmutableSegmentedDictionary.Create<string, string>()
+                .Add("a", "1")
+                .Add("b", "2");
+
+            Assert.False(map.Keys.All((key, arg) => key == arg, "a"));
+            Assert.True(map.Keys.All((key, arg) => key.Length == arg, 1));
+
+            Assert.True(ImmutableSegmentedDictionary<int, int>.Empty.Keys.All((_, _) => false, 0));
+        }
+
+        [Fact]
+        public void Values_All()
+        {
+            var map = ImmutableSegmentedDictionary.Create<string, string>()
+                .Add("a", "1")
+                .Add("b", "2");
+
+            Assert.False(map.Values.All((key, arg) => key == arg, "1"));
+            Assert.True(map.Values.All((key, arg) => key.Length == arg, 1));
+
+            Assert.True(ImmutableSegmentedDictionary<int, int>.Empty.Values.All((_, _) => false, 0));
+        }
+
         protected override IImmutableDictionary<TKey, TValue> Empty<TKey, TValue>()
         {
             return ImmutableSegmentedDictionaryTest.Empty<TKey, TValue>();

--- a/src/Compilers/Core/Portable/Emit/AnonymousTypeValue.cs
+++ b/src/Compilers/Core/Portable/Emit/AnonymousTypeValue.cs
@@ -2,28 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using Microsoft.Cci;
 using System.Diagnostics;
 
-namespace Microsoft.CodeAnalysis.Emit
+namespace Microsoft.CodeAnalysis.Emit;
+
+[DebuggerDisplay("{Name, nq}")]
+internal readonly struct AnonymousTypeValue(string name, int uniqueIndex, Cci.ITypeDefinition type)
 {
-    [DebuggerDisplay("{Name, nq}")]
-    internal readonly struct AnonymousTypeValue
-    {
-        public readonly string Name;
-        public readonly int UniqueIndex;
-        public readonly ITypeDefinition Type;
-
-        public AnonymousTypeValue(string name, int uniqueIndex, ITypeDefinition type)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(name));
-            Debug.Assert(uniqueIndex >= 0);
-
-            this.Name = name;
-            this.UniqueIndex = uniqueIndex;
-            this.Type = type;
-        }
-    }
+    public readonly string Name = name;
+    public readonly int UniqueIndex = uniqueIndex;
+    public readonly Cci.ITypeDefinition Type = type;
 }

--- a/src/Compilers/Core/Portable/Emit/AnonymousTypeValue.cs
+++ b/src/Compilers/Core/Portable/Emit/AnonymousTypeValue.cs
@@ -4,12 +4,23 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.CodeAnalysis.Emit;
-
-[DebuggerDisplay("{Name, nq}")]
-internal readonly struct AnonymousTypeValue(string name, int uniqueIndex, Cci.ITypeDefinition type)
+namespace Microsoft.CodeAnalysis.Emit
 {
-    public readonly string Name = name;
-    public readonly int UniqueIndex = uniqueIndex;
-    public readonly Cci.ITypeDefinition Type = type;
+    [DebuggerDisplay("{Name, nq}")]
+    internal readonly struct AnonymousTypeValue
+    {
+        public readonly string Name;
+        public readonly int UniqueIndex;
+        public readonly Cci.ITypeDefinition Type;
+
+        public AnonymousTypeValue(string name, int uniqueIndex, Cci.ITypeDefinition type)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(name));
+            Debug.Assert(uniqueIndex >= 0);
+
+            this.Name = name;
+            this.UniqueIndex = uniqueIndex;
+            this.Type = type;
+        }
+    }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -231,9 +231,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 userStringStreamLengthAdded: metadataSizes.GetAlignedHeapSize(HeapIndex.UserString) + _previousGeneration.UserStringStreamLengthAdded,
                 // Guid stream accumulates on the GUID heap unlike other heaps, so the previous generations are already included.
                 guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid],
-                anonymousTypeMap: ((IPEDeltaAssemblyBuilder)module).GetAnonymousTypeMap(),
-                anonymousDelegates: ((IPEDeltaAssemblyBuilder)module).GetAnonymousDelegates(),
-                anonymousDelegatesWithIndexedNames: ((IPEDeltaAssemblyBuilder)module).GetAnonymousDelegatesWithIndexedNames(),
+                synthesizedTypes: ((IPEDeltaAssemblyBuilder)module).GetSynthesizedTypes(),
                 synthesizedMembers: synthesizedMembers,
                 deletedMembers: deletedMembers,
                 addedOrChangedMethods: AddRange(_previousGeneration.AddedOrChangedMethods, addedOrChangedMethodsByIndex),

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Emit
             Debug.Assert(module != null);
             Debug.Assert(ordinal is 0 == (encId == default));
             Debug.Assert(ordinal is 0 == initialBaseline is null);
-            Debug.Assert(ordinal is 0 == synthesizedTypes.IsEmpty);
+            Debug.Assert(synthesizedTypes.IsEmpty || ordinal > 0);
             Debug.Assert(encId != module.GetModuleVersionId());
             Debug.Assert(debugInformationProvider != null);
             Debug.Assert(localSignatureProvider != null);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -62,52 +62,19 @@ namespace Microsoft.CodeAnalysis.Emit
     {
         private static readonly ImmutableArray<int> s_emptyTableSizes = ImmutableArray.Create(new int[MetadataTokens.TableCount]);
 
-        internal sealed class MetadataSymbols
+        internal sealed class MetadataSymbols(
+            SynthesizedTypeMaps synthesizedTypes,
+            object metadataDecoder,
+            ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap)
         {
-            /// <summary>
-            /// In C#, this is the set of anonymous types only; in VB, this is the set of anonymous types and delegates.
-            /// </summary>
-            public readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes;
-
-            /// <summary>
-            /// In C#, the set of anonymous delegates with name fully determined by signature;
-            /// in VB, this set is unused and empty.
-            /// </summary>
-            public readonly IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates;
-
-            /// <summary>
-            /// In C#, the set of anonymous delegates with name indexed by source order;
-            /// in VB, this set is unused and empty.
-            /// </summary>
-            public readonly IReadOnlyDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames;
+            public readonly SynthesizedTypeMaps SynthesizedTypes = synthesizedTypes;
+            public readonly object MetadataDecoder = metadataDecoder;
 
             /// <summary>
             /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
             /// Only includes identities that differ between these two.
             /// </summary>
-            public readonly ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> AssemblyReferenceIdentityMap;
-
-            public readonly object MetadataDecoder;
-
-            public MetadataSymbols(
-                IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypes,
-                IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates,
-                IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames,
-                object metadataDecoder,
-                ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> assemblyReferenceIdentityMap)
-            {
-                Debug.Assert(anonymousTypes != null);
-                Debug.Assert(anonymousDelegates != null);
-                Debug.Assert(anonymousDelegatesWithIndexedNames != null);
-                Debug.Assert(metadataDecoder != null);
-                Debug.Assert(assemblyReferenceIdentityMap != null);
-
-                this.AnonymousTypes = anonymousTypes;
-                this.AnonymousDelegates = anonymousDelegates;
-                this.AnonymousDelegatesWithIndexedNames = anonymousDelegatesWithIndexedNames;
-                this.MetadataDecoder = metadataDecoder;
-                this.AssemblyReferenceIdentityMap = assemblyReferenceIdentityMap;
-            }
+            public readonly ImmutableDictionary<AssemblyIdentity, AssemblyIdentity> AssemblyReferenceIdentityMap = assemblyReferenceIdentityMap;
         }
 
         /// <summary>
@@ -245,9 +212,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: 0,
                 userStringStreamLengthAdded: 0,
                 guidStreamLengthAdded: 0,
-                anonymousTypeMap: null, // Unset for initial metadata
-                anonymousDelegates: null, // Unset for initial metadata
-                anonymousDelegatesWithIndexedNames: null, // Unset for initial metadata
+                synthesizedTypes: SynthesizedTypeMaps.Empty,
                 synthesizedMembers: ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>.Empty,
                 deletedMembers: ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>>.Empty,
                 methodsAddedOrChanged: new Dictionary<int, AddedOrChangedMethodInfo>(),
@@ -335,9 +300,7 @@ namespace Microsoft.CodeAnalysis.Emit
         internal readonly IReadOnlyDictionary<int, int> TypeToEventMap;
         internal readonly IReadOnlyDictionary<int, int> TypeToPropertyMap;
         internal readonly IReadOnlyDictionary<MethodImplKey, int> MethodImpls;
-        private readonly IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue>? _anonymousTypeMap;
-        private readonly IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? _anonymousDelegates;
-        private readonly IReadOnlyDictionary<string, AnonymousTypeValue>? _anonymousDelegatesWithIndexedNames;
+        private readonly SynthesizedTypeMaps _synthesizedTypes;
         internal readonly ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> SynthesizedMembers;
         internal readonly ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> DeletedMembers;
 
@@ -366,9 +329,7 @@ namespace Microsoft.CodeAnalysis.Emit
             int stringStreamLengthAdded,
             int userStringStreamLengthAdded,
             int guidStreamLengthAdded,
-            IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue>? anonymousTypeMap,
-            IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? anonymousDelegates,
-            IReadOnlyDictionary<string, AnonymousTypeValue>? anonymousDelegatesWithIndexedNames,
+            SynthesizedTypeMaps synthesizedTypes,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> synthesizedMembers,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> deletedMembers,
             IReadOnlyDictionary<int, AddedOrChangedMethodInfo> methodsAddedOrChanged,
@@ -379,11 +340,9 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<MethodImplKey, int> methodImpls)
         {
             Debug.Assert(module != null);
-            Debug.Assert((ordinal == 0) == (encId == default));
-            Debug.Assert((ordinal == 0) == (initialBaseline == null));
-            Debug.Assert((ordinal == 0) == (anonymousTypeMap == null));
-            Debug.Assert((ordinal == 0) == (anonymousDelegates == null));
-            Debug.Assert((ordinal == 0) == (anonymousDelegatesWithIndexedNames == null));
+            Debug.Assert(ordinal is 0 == (encId == default));
+            Debug.Assert(ordinal is 0 == initialBaseline is null);
+            Debug.Assert(ordinal is 0 == synthesizedTypes.IsEmpty);
             Debug.Assert(encId != module.GetModuleVersionId());
             Debug.Assert(debugInformationProvider != null);
             Debug.Assert(localSignatureProvider != null);
@@ -435,9 +394,7 @@ namespace Microsoft.CodeAnalysis.Emit
             StringStreamLengthAdded = stringStreamLengthAdded;
             UserStringStreamLengthAdded = userStringStreamLengthAdded;
             GuidStreamLengthAdded = guidStreamLengthAdded;
-            _anonymousTypeMap = anonymousTypeMap;
-            _anonymousDelegates = anonymousDelegates;
-            _anonymousDelegatesWithIndexedNames = anonymousDelegatesWithIndexedNames;
+            _synthesizedTypes = synthesizedTypes;
             SynthesizedMembers = synthesizedMembers;
             DeletedMembers = deletedMembers;
             AddedOrChangedMethods = methodsAddedOrChanged;
@@ -471,23 +428,16 @@ namespace Microsoft.CodeAnalysis.Emit
             int stringStreamLengthAdded,
             int userStringStreamLengthAdded,
             int guidStreamLengthAdded,
-            IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
-            IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates,
-            IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegatesWithIndexedNames,
+            SynthesizedTypeMaps synthesizedTypes,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> synthesizedMembers,
             ImmutableDictionary<ISymbolInternal, ImmutableArray<ISymbolInternal>> deletedMembers,
             IReadOnlyDictionary<int, AddedOrChangedMethodInfo> addedOrChangedMethods,
             Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider,
             Func<MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider)
         {
-            Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap != null);
-            Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap.Count >= _anonymousTypeMap.Count);
-
-            Debug.Assert(_anonymousDelegates == null || anonymousDelegates != null);
-            Debug.Assert(_anonymousDelegates == null || anonymousDelegates.Count >= _anonymousDelegates.Count);
-
-            Debug.Assert(_anonymousDelegatesWithIndexedNames == null || anonymousDelegatesWithIndexedNames != null);
-            Debug.Assert(_anonymousDelegatesWithIndexedNames == null || anonymousDelegatesWithIndexedNames.Count >= _anonymousDelegatesWithIndexedNames.Count);
+            Debug.Assert(synthesizedTypes.AnonymousTypes.Count >= _synthesizedTypes.AnonymousTypes.Count);
+            Debug.Assert(synthesizedTypes.AnonymousDelegates.Count >= _synthesizedTypes.AnonymousDelegates.Count);
+            Debug.Assert(synthesizedTypes.AnonymousDelegatesWithIndexedNames.Count >= _synthesizedTypes.AnonymousDelegatesWithIndexedNames.Count);
 
             return new EmitBaseline(
                 InitialBaseline,
@@ -514,9 +464,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: stringStreamLengthAdded,
                 userStringStreamLengthAdded: userStringStreamLengthAdded,
                 guidStreamLengthAdded: guidStreamLengthAdded,
-                anonymousTypeMap: anonymousTypeMap,
-                anonymousDelegates: anonymousDelegates,
-                anonymousDelegatesWithIndexedNames: anonymousDelegatesWithIndexedNames,
+                synthesizedTypes: synthesizedTypes,
                 synthesizedMembers: synthesizedMembers,
                 deletedMembers: deletedMembers,
                 methodsAddedOrChanged: addedOrChangedMethods,
@@ -527,75 +475,34 @@ namespace Microsoft.CodeAnalysis.Emit
                 methodImpls: MethodImpls);
         }
 
-        internal IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypeMap
+        internal SynthesizedTypeMaps SynthesizedTypes
         {
             get
             {
                 if (Ordinal > 0)
                 {
-                    Debug.Assert(_anonymousTypeMap is object);
-                    return _anonymousTypeMap;
+                    return _synthesizedTypes;
                 }
 
                 Debug.Assert(LazyMetadataSymbols is object);
-                return LazyMetadataSymbols.AnonymousTypes;
-            }
-        }
-
-        internal IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates
-        {
-            get
-            {
-                if (Ordinal > 0)
-                {
-                    Debug.Assert(_anonymousDelegates is object);
-                    return _anonymousDelegates;
-                }
-
-                Debug.Assert(LazyMetadataSymbols is object);
-                return LazyMetadataSymbols.AnonymousDelegates;
-            }
-        }
-
-        internal IReadOnlyDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames
-        {
-            get
-            {
-                if (Ordinal > 0)
-                {
-                    Debug.Assert(_anonymousDelegatesWithIndexedNames is object);
-                    return _anonymousDelegatesWithIndexedNames;
-                }
-
-                Debug.Assert(LazyMetadataSymbols is object);
-                return LazyMetadataSymbols.AnonymousDelegatesWithIndexedNames;
+                return LazyMetadataSymbols.SynthesizedTypes;
             }
         }
 
         internal MetadataReader MetadataReader
-        {
-            get { return this.OriginalMetadata.MetadataReader; }
-        }
+            => OriginalMetadata.MetadataReader;
 
         internal int BlobStreamLength
-        {
-            get { return this.BlobStreamLengthAdded + this.MetadataReader.GetHeapSize(HeapIndex.Blob); }
-        }
+            => BlobStreamLengthAdded + MetadataReader.GetHeapSize(HeapIndex.Blob);
 
         internal int StringStreamLength
-        {
-            get { return this.StringStreamLengthAdded + this.MetadataReader.GetHeapSize(HeapIndex.String); }
-        }
+            => StringStreamLengthAdded + MetadataReader.GetHeapSize(HeapIndex.String);
 
         internal int UserStringStreamLength
-        {
-            get { return this.UserStringStreamLengthAdded + this.MetadataReader.GetHeapSize(HeapIndex.UserString); }
-        }
+            => UserStringStreamLengthAdded + MetadataReader.GetHeapSize(HeapIndex.UserString);
 
         internal int GuidStreamLength
-        {
-            get { return this.GuidStreamLengthAdded + this.MetadataReader.GetHeapSize(HeapIndex.Guid); }
-        }
+            => GuidStreamLengthAdded + MetadataReader.GetHeapSize(HeapIndex.Guid);
 
         private static ImmutableArray<int> CalculateTableSizes(MetadataReader reader, ImmutableArray<int> delta)
         {
@@ -670,13 +577,13 @@ namespace Microsoft.CodeAnalysis.Emit
         internal int GetNextAnonymousTypeIndex(bool fromDelegates = false)
         {
             int nextIndex = 0;
-            foreach (var pair in this.AnonymousTypeMap)
+            foreach (var (typeKey, typeValue) in SynthesizedTypes.AnonymousTypes)
             {
-                if (fromDelegates != pair.Key.IsDelegate)
+                if (fromDelegates != typeKey.IsDelegate)
                 {
                     continue;
                 }
-                int index = pair.Value.UniqueIndex;
+                int index = typeValue.UniqueIndex;
                 if (index >= nextIndex)
                 {
                     nextIndex = index + 1;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/IPEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/IPEDeltaAssemblyBuilder.cs
@@ -2,15 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+namespace Microsoft.CodeAnalysis.Emit;
 
-namespace Microsoft.CodeAnalysis.Emit
+internal interface IPEDeltaAssemblyBuilder
 {
-    internal interface IPEDeltaAssemblyBuilder
-    {
-        void OnCreatedIndices(DiagnosticBag diagnostics);
-        IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> GetAnonymousTypeMap();
-        IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> GetAnonymousDelegates();
-        IReadOnlyDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames();
-    }
+    void OnCreatedIndices(DiagnosticBag diagnostics);
+    SynthesizedTypeMaps GetSynthesizedTypes();
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChange.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChange.cs
@@ -2,27 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 
-internal enum SymbolChange
+namespace Microsoft.CodeAnalysis.Emit
 {
-    /// <summary>
-    /// No change to symbol or members.
-    /// </summary>
-    None = 0,
+    internal enum SymbolChange
+    {
+        /// <summary>
+        /// No change to symbol or members.
+        /// </summary>
+        None = 0,
 
-    /// <summary>
-    /// No change to symbol but may contain changed symbols.
-    /// </summary>
-    ContainsChanges,
+        /// <summary>
+        /// No change to symbol but may contain changed symbols.
+        /// </summary>
+        ContainsChanges,
 
-    /// <summary>
-    /// Symbol updated.
-    /// </summary>
-    Updated,
+        /// <summary>
+        /// Symbol updated.
+        /// </summary>
+        Updated,
 
-    /// <summary>
-    /// Symbol added.
-    /// </summary>
-    Added,
+        /// <summary>
+        /// Symbol added.
+        /// </summary>
+        Added,
+    }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChange.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChange.cs
@@ -2,30 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Roslyn.Utilities;
+namespace Microsoft.CodeAnalysis.Emit;
 
-namespace Microsoft.CodeAnalysis.Emit
+internal enum SymbolChange
 {
-    internal enum SymbolChange
-    {
-        /// <summary>
-        /// No change to symbol or members.
-        /// </summary>
-        None = 0,
+    /// <summary>
+    /// No change to symbol or members.
+    /// </summary>
+    None = 0,
 
-        /// <summary>
-        /// No change to symbol but may contain changed symbols.
-        /// </summary>
-        ContainsChanges,
+    /// <summary>
+    /// No change to symbol but may contain changed symbols.
+    /// </summary>
+    ContainsChanges,
 
-        /// <summary>
-        /// Symbol updated.
-        /// </summary>
-        Updated,
+    /// <summary>
+    /// Symbol updated.
+    /// </summary>
+    Updated,
 
-        /// <summary>
-        /// Symbol added.
-        /// </summary>
-        Added,
-    }
+    /// <summary>
+    /// Symbol added.
+    /// </summary>
+    Added,
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
@@ -104,9 +105,9 @@ namespace Microsoft.CodeAnalysis.Emit
             return result;
         }
 
-        private ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
+        private ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
         {
-            var builder = ImmutableDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
 
             foreach (var (key, value) in anonymousTypeMap)
             {
@@ -118,9 +119,9 @@ namespace Microsoft.CodeAnalysis.Emit
             return builder.ToImmutable();
         }
 
-        private ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates)
+        private ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates)
         {
-            var builder = ImmutableDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
 
             foreach (var (key, value) in anonymousDelegates)
             {
@@ -132,9 +133,9 @@ namespace Microsoft.CodeAnalysis.Emit
             return builder.ToImmutable();
         }
 
-        private ImmutableDictionary<string, AnonymousTypeValue> MapAnonymousDelegatesWithIndexedNames(IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegates)
+        private ImmutableSegmentedDictionary<string, AnonymousTypeValue> MapAnonymousDelegatesWithIndexedNames(IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegates)
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, AnonymousTypeValue>();
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<string, AnonymousTypeValue>();
 
             foreach (var (key, value) in anonymousDelegates)
             {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -61,9 +61,10 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: baseline.StringStreamLengthAdded,
                 userStringStreamLengthAdded: baseline.UserStringStreamLengthAdded,
                 guidStreamLengthAdded: baseline.GuidStreamLengthAdded,
-                anonymousTypeMap: MapAnonymousTypes(baseline.AnonymousTypeMap),
-                anonymousDelegates: MapAnonymousDelegates(baseline.AnonymousDelegates),
-                anonymousDelegatesWithIndexedNames: MapAnonymousDelegatesWithIndexedNames(baseline.AnonymousDelegatesWithIndexedNames),
+                synthesizedTypes: new SynthesizedTypeMaps(
+                    MapAnonymousTypes(baseline.SynthesizedTypes.AnonymousTypes),
+                    MapAnonymousDelegates(baseline.SynthesizedTypes.AnonymousDelegates),
+                    MapAnonymousDelegatesWithIndexedNames(baseline.SynthesizedTypes.AnonymousDelegatesWithIndexedNames)),
                 synthesizedMembers: mappedSynthesizedMembers,
                 deletedMembers: mappedDeletedMembers,
                 addedOrChangedMethods: MapAddedOrChangedMethods(baseline.AddedOrChangedMethods),
@@ -103,46 +104,46 @@ namespace Microsoft.CodeAnalysis.Emit
             return result;
         }
 
-        private IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
+        private ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> MapAnonymousTypes(ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap)
         {
-            var result = new Dictionary<AnonymousTypeKey, AnonymousTypeValue>();
+            var builder = ImmutableDictionary.CreateBuilder<AnonymousTypeKey, AnonymousTypeValue>();
 
             foreach (var (key, value) in anonymousTypeMap)
             {
                 var type = (Cci.ITypeDefinition?)MapDefinition(value.Type);
-                RoslynDebug.Assert(type != null);
-                result.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
+                Debug.Assert(type != null);
+                builder.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
             }
 
-            return result;
+            return builder.ToImmutable();
         }
 
-        private IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(IReadOnlyDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates)
+        private ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> MapAnonymousDelegates(ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> anonymousDelegates)
         {
-            var result = new Dictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>();
+            var builder = ImmutableDictionary.CreateBuilder<SynthesizedDelegateKey, SynthesizedDelegateValue>();
 
             foreach (var (key, value) in anonymousDelegates)
             {
                 var delegateTypeDef = (Cci.ITypeDefinition?)MapDefinition(value.Delegate);
-                RoslynDebug.Assert(delegateTypeDef != null);
-                result.Add(key, new SynthesizedDelegateValue(delegateTypeDef));
+                Debug.Assert(delegateTypeDef != null);
+                builder.Add(key, new SynthesizedDelegateValue(delegateTypeDef));
             }
 
-            return result;
+            return builder.ToImmutable();
         }
 
-        private IReadOnlyDictionary<string, AnonymousTypeValue> MapAnonymousDelegatesWithIndexedNames(IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegates)
+        private ImmutableDictionary<string, AnonymousTypeValue> MapAnonymousDelegatesWithIndexedNames(IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegates)
         {
-            var result = new Dictionary<string, AnonymousTypeValue>();
+            var builder = ImmutableDictionary.CreateBuilder<string, AnonymousTypeValue>();
 
             foreach (var (key, value) in anonymousDelegates)
             {
                 var type = (Cci.ITypeDefinition?)MapDefinition(value.Type);
-                RoslynDebug.Assert(type != null);
-                result.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
+                Debug.Assert(type != null);
+                builder.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
             }
 
-            return result;
+            return builder.ToImmutable();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Emit;
+
+internal readonly struct SynthesizedTypeMaps(
+    ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue>? anonymousTypeMap,
+    ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? anonymousDelegates,
+    ImmutableDictionary<string, AnonymousTypeValue>? anonymousDelegatesWithIndexedNames)
+{
+    public static readonly SynthesizedTypeMaps Empty = new SynthesizedTypeMaps(null, null, null);
+
+    public bool IsEmpty
+        => AnonymousTypes.IsEmpty && AnonymousDelegates.IsEmpty && AnonymousDelegatesWithIndexedNames.IsEmpty;
+
+    /// <summary>
+    /// In C#, this is the set of anonymous types only; in VB, this is the set of anonymous types and delegates.
+    /// </summary>
+    public ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes { get; }
+        = anonymousTypeMap ?? ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue>.Empty;
+
+    /// <summary>
+    /// In C#, the set of anonymous delegates with name fully determined by signature;
+    /// in VB, this set is unused and empty.
+    /// </summary>
+    public ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates { get; }
+        = anonymousDelegates ?? ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>.Empty;
+
+    /// <summary>
+    /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
+    /// Only includes identities that differ between these two.
+    /// </summary>
+    public ImmutableDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames { get; }
+        = anonymousDelegatesWithIndexedNames ?? ImmutableDictionary<string, AnonymousTypeValue>.Empty;
+
+    public bool IsSubsetOf(SynthesizedTypeMaps other)
+        => AnonymousTypes.All(p => other.AnonymousTypes.ContainsKey(p.Key)) &&
+           AnonymousDelegates.All(p => other.AnonymousDelegates.ContainsKey(p.Key)) &&
+           AnonymousDelegatesWithIndexedNames.All(p => other.AnonymousDelegatesWithIndexedNames.ContainsKey(p.Key));
+}

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -4,13 +4,14 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Emit;
 
 internal readonly struct SynthesizedTypeMaps(
-    ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue>? anonymousTypeMap,
-    ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? anonymousDelegates,
-    ImmutableDictionary<string, AnonymousTypeValue>? anonymousDelegatesWithIndexedNames)
+    ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue>? anonymousTypeMap,
+    ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? anonymousDelegates,
+    ImmutableSegmentedDictionary<string, AnonymousTypeValue>? anonymousDelegatesWithIndexedNames)
 {
     public static readonly SynthesizedTypeMaps Empty = new SynthesizedTypeMaps(null, null, null);
 
@@ -20,25 +21,25 @@ internal readonly struct SynthesizedTypeMaps(
     /// <summary>
     /// In C#, this is the set of anonymous types only; in VB, this is the set of anonymous types and delegates.
     /// </summary>
-    public ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes { get; }
-        = anonymousTypeMap ?? ImmutableDictionary<AnonymousTypeKey, AnonymousTypeValue>.Empty;
+    public ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes { get; }
+        = anonymousTypeMap ?? [];
 
     /// <summary>
     /// In C#, the set of anonymous delegates with name fully determined by signature;
     /// in VB, this set is unused and empty.
     /// </summary>
-    public ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates { get; }
-        = anonymousDelegates ?? ImmutableDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>.Empty;
+    public ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates { get; }
+        = anonymousDelegates ?? [];
 
     /// <summary>
     /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
     /// Only includes identities that differ between these two.
     /// </summary>
-    public ImmutableDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames { get; }
-        = anonymousDelegatesWithIndexedNames ?? ImmutableDictionary<string, AnonymousTypeValue>.Empty;
+    public ImmutableSegmentedDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames { get; }
+        = anonymousDelegatesWithIndexedNames ?? [];
 
     public bool IsSubsetOf(SynthesizedTypeMaps other)
-        => AnonymousTypes.All(p => other.AnonymousTypes.ContainsKey(p.Key)) &&
-           AnonymousDelegates.All(p => other.AnonymousDelegates.ContainsKey(p.Key)) &&
-           AnonymousDelegatesWithIndexedNames.All(p => other.AnonymousDelegatesWithIndexedNames.ContainsKey(p.Key));
+        => AnonymousTypes.Keys.All(static (key, other) => other.AnonymousTypes.ContainsKey(key), other) &&
+           AnonymousDelegates.Keys.All(static (key, other) => other.AnonymousDelegates.ContainsKey(key), other) &&
+           AnonymousDelegatesWithIndexedNames.Keys.All(static (key, other) => other.AnonymousDelegatesWithIndexedNames.ContainsKey(key), other);
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -22,21 +22,21 @@ internal readonly struct SynthesizedTypeMaps(
     /// In C#, this is the set of anonymous types only; in VB, this is the set of anonymous types and delegates.
     /// </summary>
     public ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue> AnonymousTypes { get; }
-        = anonymousTypeMap ?? [];
+        = anonymousTypeMap ?? ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue>.Empty;
 
     /// <summary>
     /// In C#, the set of anonymous delegates with name fully determined by signature;
     /// in VB, this set is unused and empty.
     /// </summary>
     public ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue> AnonymousDelegates { get; }
-        = anonymousDelegates ?? [];
+        = anonymousDelegates ?? ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>.Empty;
 
     /// <summary>
     /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
     /// Only includes identities that differ between these two.
     /// </summary>
     public ImmutableSegmentedDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames { get; }
-        = anonymousDelegatesWithIndexedNames ?? [];
+        = anonymousDelegatesWithIndexedNames ?? ImmutableSegmentedDictionary<string, AnonymousTypeValue>.Empty;
 
     public bool IsSubsetOf(SynthesizedTypeMaps other)
         => AnonymousTypes.Keys.All(static (key, other) => other.AnonymousTypes.ContainsKey(key), other) &&

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -116,21 +116,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Return previousGeneration
             End If
 
+            Dim synthesizedTypes = moduleBeingBuilt.GetSynthesizedTypes()
             Dim currentSynthesizedMembers = moduleBeingBuilt.GetAllSynthesizedMembers()
             Dim currentDeletedMembers = moduleBeingBuilt.EncSymbolChanges.GetAllDeletedMembers()
 
             ' Mapping from previous compilation to the current.
-            Dim anonymousTypeMap = moduleBeingBuilt.GetAnonymousTypeMap()
             Dim sourceAssembly = DirectCast(previousGeneration.Compilation, VisualBasicCompilation).SourceAssembly
             Dim sourceContext = New EmitContext(DirectCast(previousGeneration.PEModuleBuilder, PEModuleBuilder), Nothing, New DiagnosticBag(), metadataOnly:=False, includePrivateMembers:=True)
             Dim otherContext = New EmitContext(moduleBeingBuilt, Nothing, New DiagnosticBag(), metadataOnly:=False, includePrivateMembers:=True)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                anonymousTypeMap,
                 sourceAssembly,
                 sourceContext,
                 compilation.SourceAssembly,
                 otherContext,
+                synthesizedTypes,
                 currentSynthesizedMembers,
                 currentDeletedMembers)
 
@@ -139,11 +139,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
             ' TODO can we reuse some data from the previous matcher?
             Dim matcherWithAllSynthesizedMembers = New VisualBasicSymbolMatcher(
-                anonymousTypeMap,
                 sourceAssembly,
                 sourceContext,
                 compilation.SourceAssembly,
                 otherContext,
+                synthesizedTypes,
                 mappedSynthesizedMembers,
                 mappedDeletedMembers)
 

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
             Dim metadataDecoder = DirectCast(metadataSymbols.MetadataDecoder, MetadataDecoder)
             Dim metadataAssembly = DirectCast(metadataDecoder.ModuleSymbol.ContainingAssembly, PEAssemblySymbol)
-            Dim matchToMetadata = New VisualBasicSymbolMatcher(initialBaseline.LazyMetadataSymbols.AnonymousTypes, sourceAssembly, context, metadataAssembly)
+            Dim matchToMetadata = New VisualBasicSymbolMatcher(initialBaseline.LazyMetadataSymbols.SynthesizedTypes, sourceAssembly, context, metadataAssembly)
 
             Dim matchToPrevious As VisualBasicSymbolMatcher = Nothing
             If previousGeneration.Ordinal > 0 Then
@@ -53,11 +53,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Dim previousContext = New EmitContext(DirectCast(previousGeneration.PEModuleBuilder, PEModuleBuilder), Nothing, New DiagnosticBag(), metadataOnly:=False, includePrivateMembers:=True)
 
                 matchToPrevious = New VisualBasicSymbolMatcher(
-                    previousGeneration.AnonymousTypeMap,
                     sourceAssembly:=sourceAssembly,
                     sourceContext:=context,
                     otherAssembly:=previousAssembly,
                     otherContext:=previousContext,
+                    previousGeneration.SynthesizedTypes,
                     otherSynthesizedMembersOpt:=previousGeneration.SynthesizedMembers,
                     otherDeletedMembersOpt:=previousGeneration.DeletedMembers)
             End If
@@ -115,22 +115,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Dim assemblyReferenceIdentityMap As ImmutableDictionary(Of AssemblyIdentity, AssemblyIdentity) = Nothing
             Dim metadataAssembly = metadataCompilation.GetBoundReferenceManager().CreatePEAssemblyForAssemblyMetadata(AssemblyMetadata.Create(originalMetadata), MetadataImportOptions.All, assemblyReferenceIdentityMap)
             Dim metadataDecoder = New MetadataDecoder(metadataAssembly.PrimaryModule)
-            Dim metadataAnonymousTypes = GetAnonymousTypeMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder)
-            ' VB anonymous delegates are handled as anonymous types in the map above
-            Dim anonymousDelegates = SpecializedCollections.EmptyReadOnlyDictionary(Of SynthesizedDelegateKey, SynthesizedDelegateValue)
-            Dim anonymousDelegatesWithIndexedNames = SpecializedCollections.EmptyReadOnlyDictionary(Of String, AnonymousTypeValue)
-            Dim metadataSymbols = New EmitBaseline.MetadataSymbols(metadataAnonymousTypes, anonymousDelegates, anonymousDelegatesWithIndexedNames, metadataDecoder, assemblyReferenceIdentityMap)
+
+            ' VB anonymous delegates are handled as anonymous types.
+            Dim synthesizedTypes = New SynthesizedTypeMaps(
+                GetAnonymousTypeMapFromMetadata(originalMetadata.MetadataReader, metadataDecoder),
+                anonymousDelegates:=Nothing,
+                anonymousDelegatesWithIndexedNames:=Nothing)
+
+            Dim metadataSymbols = New EmitBaseline.MetadataSymbols(synthesizedTypes, metadataDecoder, assemblyReferenceIdentityMap)
 
             Return InterlockedOperations.Initialize(initialBaseline.LazyMetadataSymbols, metadataSymbols)
         End Function
 
         ' friend for testing
-        Friend Overloads Shared Function GetAnonymousTypeMapFromMetadata(reader As MetadataReader, metadataDecoder As MetadataDecoder) As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue)
+        Friend Overloads Shared Function GetAnonymousTypeMapFromMetadata(reader As MetadataReader, metadataDecoder As MetadataDecoder) As ImmutableDictionary(Of AnonymousTypeKey, AnonymousTypeValue)
             ' In general, the anonymous type name Is 'VB$Anonymous' ('Type'|'Delegate') '_' (submission-index '_')? index module-id
             ' but EnC Is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index:
             ' e.g. VB$AnonymousType_123, VB$AnonymousDelegate_123
 
-            Dim result = New Dictionary(Of AnonymousTypeKey, AnonymousTypeValue)
+            Dim builder = ImmutableDictionary.CreateBuilder(Of AnonymousTypeKey, AnonymousTypeValue)
             For Each handle In reader.TypeDefinitions
                 Dim def = reader.GetTypeDefinition(handle)
                 If Not def.Namespace.IsNil Then
@@ -150,15 +153,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     Dim type = DirectCast(metadataDecoder.GetTypeOfToken(handle), NamedTypeSymbol)
                     Dim key = GetAnonymousTypeKey(type)
                     Dim value = New AnonymousTypeValue(name, index, type.GetCciAdapter())
-                    result.Add(key, value)
+                    builder.Add(key, value)
                 ElseIf TryParseAnonymousTypeTemplateName(GeneratedNameConstants.AnonymousDelegateTemplateNamePrefix, name, index) Then
                     Dim type = DirectCast(metadataDecoder.GetTypeOfToken(handle), NamedTypeSymbol)
                     Dim key = GetAnonymousDelegateKey(type)
                     Dim value = New AnonymousTypeValue(name, index, type.GetCciAdapter())
-                    result.Add(key, value)
+                    builder.Add(key, value)
                 End If
             Next
-            Return result
+            Return builder.ToImmutable()
         End Function
 
         Friend Shared Function TryParseAnonymousTypeTemplateName(prefix As String, name As String, <Out()> ByRef index As Integer) As Boolean
@@ -222,21 +225,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Friend Overloads Function GetAnonymousTypeMap() As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue) Implements IPEDeltaAssemblyBuilder.GetAnonymousTypeMap
-            Dim anonymousTypes = Compilation.AnonymousTypeManager.GetAnonymousTypeMap()
+        Friend Overloads Function GetSynthesizedTypes() As SynthesizedTypeMaps Implements IPEDeltaAssemblyBuilder.GetSynthesizedTypes
+            ' VB anonymous delegates are handled as anonymous types
+            Dim result = New SynthesizedTypeMaps(
+                Compilation.AnonymousTypeManager.GetAnonymousTypeMap(),
+                anonymousDelegates:=Nothing,
+                anonymousDelegatesWithIndexedNames:=Nothing)
+
             ' Should contain all entries in previous generation.
-            Debug.Assert(_previousGeneration.AnonymousTypeMap.All(Function(p) anonymousTypes.ContainsKey(p.Key)))
-            Return anonymousTypes
-        End Function
+            Debug.Assert(_previousGeneration.SynthesizedTypes.IsSubsetOf(result))
 
-        Friend Overloads Function GetAnonymousDelegates() As IReadOnlyDictionary(Of SynthesizedDelegateKey, SynthesizedDelegateValue) Implements IPEDeltaAssemblyBuilder.GetAnonymousDelegates
-            ' VB anonymous delegates are handled as anonymous types in the method above
-            Return SpecializedCollections.EmptyReadOnlyDictionary(Of SynthesizedDelegateKey, SynthesizedDelegateValue)
-        End Function
-
-        Friend Overloads Function GetAnonymousDelegatesWithIndexedNames() As IReadOnlyDictionary(Of String, AnonymousTypeValue) Implements IPEDeltaAssemblyBuilder.GetAnonymousDelegatesWithIndexedNames
-            ' VB anonymous delegates are handled as anonymous types in the method above
-            Return SpecializedCollections.EmptyReadOnlyDictionary(Of String, AnonymousTypeValue)
+            Return result
         End Function
 
         Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
@@ -248,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         Friend Overrides Function GetPreviousAnonymousTypes() As ImmutableArray(Of AnonymousTypeKey)
-            Return ImmutableArray.CreateRange(_previousGeneration.AnonymousTypeMap.Keys)
+            Return ImmutableArray.CreateRange(_previousGeneration.SynthesizedTypes.AnonymousTypes.Keys)
         End Function
 
         Friend Overrides Function GetNextAnonymousTypeIndex(fromDelegates As Boolean) As Integer

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -8,6 +8,7 @@ Imports System.Reflection.Metadata
 Imports System.Runtime.InteropServices
 Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.CodeGen
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Symbols
@@ -128,12 +129,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         End Function
 
         ' friend for testing
-        Friend Overloads Shared Function GetAnonymousTypeMapFromMetadata(reader As MetadataReader, metadataDecoder As MetadataDecoder) As ImmutableDictionary(Of AnonymousTypeKey, AnonymousTypeValue)
+        Friend Overloads Shared Function GetAnonymousTypeMapFromMetadata(reader As MetadataReader, metadataDecoder As MetadataDecoder) As ImmutableSegmentedDictionary(Of AnonymousTypeKey, AnonymousTypeValue)
             ' In general, the anonymous type name Is 'VB$Anonymous' ('Type'|'Delegate') '_' (submission-index '_')? index module-id
             ' but EnC Is not supported for modules nor submissions. Hence we only look for type names with no module id and no submission index:
             ' e.g. VB$AnonymousType_123, VB$AnonymousDelegate_123
 
-            Dim builder = ImmutableDictionary.CreateBuilder(Of AnonymousTypeKey, AnonymousTypeValue)
+            Dim builder = ImmutableSegmentedDictionary.CreateBuilder(Of AnonymousTypeKey, AnonymousTypeValue)
             For Each handle In reader.TypeDefinitions
                 Dim def = reader.GetTypeDefinition(handle)
                 If Not def.Namespace.IsNil Then

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -22,25 +22,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private ReadOnly _defs As MatchDefs
         Private ReadOnly _symbols As MatchSymbols
 
-        Public Sub New(anonymousTypeMap As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue),
-                      sourceAssembly As SourceAssemblySymbol,
-                      sourceContext As EmitContext,
-                      otherAssembly As SourceAssemblySymbol,
-                      otherContext As EmitContext,
-                      otherSynthesizedMembersOpt As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
-                      otherDeletedMembersOpt As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)))
+        Public Sub New(sourceAssembly As SourceAssemblySymbol,
+                       sourceContext As EmitContext,
+                       otherAssembly As SourceAssemblySymbol,
+                       otherContext As EmitContext,
+                       synthesizedTypes As SynthesizedTypeMaps,
+                       otherSynthesizedMembersOpt As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
+                       otherDeletedMembersOpt As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)))
 
             _defs = New MatchDefsToSource(sourceContext, otherContext)
-            _symbols = New MatchSymbols(anonymousTypeMap, sourceAssembly, otherAssembly, otherSynthesizedMembersOpt, otherDeletedMembersOpt, New DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)))
+            _symbols = New MatchSymbols(sourceAssembly, otherAssembly, synthesizedTypes, otherSynthesizedMembersOpt, otherDeletedMembersOpt, New DeepTranslator(otherAssembly.GetSpecialType(SpecialType.System_Object)))
         End Sub
 
-        Public Sub New(anonymousTypeMap As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue),
-                      sourceAssembly As SourceAssemblySymbol,
-                      sourceContext As EmitContext,
-                      otherAssembly As PEAssemblySymbol)
+        Public Sub New(synthesizedTypes As SynthesizedTypeMaps,
+                       sourceAssembly As SourceAssemblySymbol,
+                       sourceContext As EmitContext,
+                       otherAssembly As PEAssemblySymbol)
 
             _defs = New MatchDefsToMetadata(sourceContext, otherAssembly)
-            _symbols = New MatchSymbols(anonymousTypeMap, sourceAssembly, otherAssembly, otherSynthesizedMembersOpt:=Nothing, otherDeletedMembers:=Nothing, deepTranslatorOpt:=Nothing)
+            _symbols = New MatchSymbols(sourceAssembly, otherAssembly, synthesizedTypes, otherSynthesizedMembersOpt:=Nothing, otherDeletedMembers:=Nothing, deepTranslatorOpt:=Nothing)
         End Sub
 
         Public Overrides Function MapDefinition(definition As Cci.IDefinition) As Cci.IDefinition
@@ -226,7 +226,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private NotInheritable Class MatchSymbols
             Inherits VisualBasicSymbolVisitor(Of Symbol)
 
-            Private ReadOnly _anonymousTypeMap As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue)
+            Private ReadOnly _synthesizedTypes As SynthesizedTypeMaps
             Private ReadOnly _comparer As SymbolComparer
             Private ReadOnly _matches As ConcurrentDictionary(Of Symbol, Symbol)
 
@@ -241,14 +241,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             ' through all members of a given kind each time a member Is matched.
             Private ReadOnly _otherMembers As ConcurrentDictionary(Of ISymbolInternal, IReadOnlyDictionary(Of String, ImmutableArray(Of ISymbolInternal)))
 
-            Public Sub New(anonymousTypeMap As IReadOnlyDictionary(Of AnonymousTypeKey, AnonymousTypeValue),
-                           sourceAssembly As SourceAssemblySymbol,
+            Public Sub New(sourceAssembly As SourceAssemblySymbol,
                            otherAssembly As AssemblySymbol,
+                           synthesizedTypes As SynthesizedTypeMaps,
                            otherSynthesizedMembersOpt As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
                            otherDeletedMembers As ImmutableDictionary(Of ISymbolInternal, ImmutableArray(Of ISymbolInternal)),
                            deepTranslatorOpt As DeepTranslator)
 
-                _anonymousTypeMap = anonymousTypeMap
+                _synthesizedTypes = synthesizedTypes
                 _sourceAssembly = sourceAssembly
                 _otherAssembly = otherAssembly
                 _otherSynthesizedMembersOpt = otherSynthesizedMembersOpt
@@ -511,7 +511,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Friend Function TryFindAnonymousType(type As AnonymousTypeManager.AnonymousTypeOrDelegateTemplateSymbol, <Out> ByRef otherType As AnonymousTypeValue) As Boolean
                 Debug.Assert(type.ContainingSymbol Is _sourceAssembly.GlobalNamespace)
 
-                Return _anonymousTypeMap.TryGetValue(type.GetAnonymousTypeKey(), otherType)
+                Return _synthesizedTypes.AnonymousTypes.TryGetValue(type.GetAnonymousTypeKey(), otherType)
             End Function
 
             Private Function VisitNamedTypeMember(Of T As Symbol)(member As T, predicate As Func(Of T, T, Boolean)) As Symbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -247,17 +247,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             builder.Free()
         End Sub
 
-        Friend Function GetAnonymousTypeMap() As IReadOnlyDictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
-            Dim result = New Dictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
-            Dim builder = ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol).GetInstance()
-            GetAllCreatedTemplates(builder)
-            For Each template In builder
-                Dim nameAndIndex = template.NameAndIndex
-                Dim key = template.GetAnonymousTypeKey()
-                Dim value = New Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(nameAndIndex.Name, nameAndIndex.Index, template.GetCciAdapter())
-                result.Add(key, value)
-            Next
-            builder.Free()
+        Friend Function GetAnonymousTypeMap() As ImmutableDictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
+            Dim templates = ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol).GetInstance()
+            GetAllCreatedTemplates(templates)
+
+            Dim result = templates.ToImmutableDictionary(
+                keySelector:=Function(template) template.GetAnonymousTypeKey(),
+                elementSelector:=Function(template) New Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()))
+
+            templates.Free()
             Return result
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -8,6 +8,7 @@ Imports System.Collections.Immutable
 Imports System.Diagnostics
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
@@ -247,11 +248,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             builder.Free()
         End Sub
 
-        Friend Function GetAnonymousTypeMap() As ImmutableDictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
+        Friend Function GetAnonymousTypeMap() As ImmutableSegmentedDictionary(Of Microsoft.CodeAnalysis.Emit.AnonymousTypeKey, Microsoft.CodeAnalysis.Emit.AnonymousTypeValue)
             Dim templates = ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol).GetInstance()
             GetAllCreatedTemplates(templates)
 
-            Dim result = templates.ToImmutableDictionary(
+            Dim result = templates.ToImmutableSegmentedDictionary(
                 keySelector:=Function(template) template.GetAnonymousTypeKey(),
                 elementSelector:=Function(template) New Microsoft.CodeAnalysis.Emit.AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()))
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.vb
@@ -303,13 +303,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Friend Shared Function CreateMatcher(fromCompilation As VisualBasicCompilation, toCompilation As VisualBasicCompilation) As VisualBasicSymbolMatcher
             Return New VisualBasicSymbolMatcher(
-                Nothing,
                 fromCompilation.SourceAssembly,
-                Nothing,
+                sourceContext:=Nothing,
                 toCompilation.SourceAssembly,
-                Nothing,
-                Nothing,
-                Nothing)
+                otherContext:=Nothing,
+                synthesizedTypes:=SynthesizedTypeMaps.Empty,
+                otherSynthesizedMembersOpt:=Nothing,
+                otherDeletedMembersOpt:=Nothing)
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -331,7 +331,8 @@ End Class
             Dim reader0 = peModule0.Module.MetadataReader
             Dim decoder0 = New MetadataDecoder(peModule0)
 
-            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Dim synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0)
+            Dim anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes
             Assert.Equal("VB$AnonymousType_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True)))).Name)
             Assert.Equal("VB$AnonymousType_1", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("B", isKey:=False, ignoreCase:=True)))).Name)
             Assert.Equal(2, anonymousTypeMap0.Count)
@@ -355,7 +356,7 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                anonymousTypeMap0,
+                synthesizedTypes0,
                 compilation1.SourceAssembly,
                 emitContext,
                 peAssemblySymbol0)
@@ -401,7 +402,8 @@ End Class
             Dim reader0 = peModule0.Module.MetadataReader
             Dim decoder0 = New MetadataDecoder(peModule0)
 
-            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Dim synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0)
+            Dim anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes
             Assert.Equal("VB$AnonymousType_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True)))).Name)
             Assert.Equal("VB$AnonymousType_1", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("X", isKey:=False, ignoreCase:=True)))).Name)
             Assert.Equal("VB$AnonymousType_2", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(New AnonymousTypeKeyField("Y", isKey:=False, ignoreCase:=True)))).Name)
@@ -426,7 +428,7 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                anonymousTypeMap0,
+                synthesizedTypes0,
                 compilation1.SourceAssembly,
                 emitContext,
                 peAssemblySymbol0)
@@ -472,7 +474,8 @@ End Class
             Dim reader0 = peModule0.Module.MetadataReader
             Dim decoder0 = New MetadataDecoder(peModule0)
 
-            Dim anonymousTypeMap0 = PEDeltaAssemblyBuilder.GetAnonymousTypeMapFromMetadata(reader0, decoder0)
+            Dim synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0)
+            Dim anonymousTypeMap0 = synthesizedTypes0.AnonymousTypes
             Assert.Equal("VB$AnonymousDelegate_0", anonymousTypeMap0(New AnonymousTypeKey(ImmutableArray.Create(
                 New AnonymousTypeKeyField("A", isKey:=False, ignoreCase:=True),
                 New AnonymousTypeKeyField(AnonymousTypeDescriptor.FunctionReturnParameterName, isKey:=False, ignoreCase:=True)), isDelegate:=True)).Name)
@@ -503,7 +506,7 @@ End Class
             Assert.Equal("$VB$Local_x2", x2.Name)
 
             Dim matcher = New VisualBasicSymbolMatcher(
-                anonymousTypeMap0,
+                synthesizedTypes0,
                 compilation1.SourceAssembly,
                 emitContext,
                 peAssemblySymbol0)
@@ -534,14 +537,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -563,14 +559,7 @@ Class C
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("C.x")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -594,14 +583,7 @@ Class C
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("C.x")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -630,14 +612,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -664,14 +639,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -698,14 +666,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -732,14 +693,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of MethodSymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -772,14 +726,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of PropertySymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -810,14 +757,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of PropertySymbol)("C.X")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -842,14 +782,7 @@ End Structure
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("Vector.Coordinates")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -872,14 +805,7 @@ End Structure
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of FieldSymbol)("Vector.Coordinates")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -904,14 +830,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of SourceNamedTypeSymbol)("C.F")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())
@@ -935,14 +854,7 @@ End Class"
             Dim compilation0 = CreateCompilationWithMscorlib40(source0, options:=TestOptions.DebugDll, references:=ValueTupleRefs)
             Dim compilation1 = compilation0.WithSource(source1)
 
-            Dim matcher = New VisualBasicSymbolMatcher(
-                Nothing,
-                compilation1.SourceAssembly,
-                New EmitContext(),
-                compilation0.SourceAssembly,
-                New EmitContext(),
-                Nothing,
-                Nothing)
+            Dim matcher = CreateMatcher(compilation1, compilation0)
 
             Dim member = compilation1.GetMember(Of SourceNamedTypeSymbol)("C.F")
             Dim other = matcher.MapDefinition(member.GetCciAdapter())

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+KeyCollection.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+KeyCollection.cs
@@ -53,6 +53,19 @@ namespace Microsoft.CodeAnalysis.Collections
 
             bool ICollection<TKey>.Remove(TKey item)
                 => throw new NotSupportedException();
+
+            public bool All<TArg>(Func<TKey, TArg, bool> predicate, TArg arg)
+            {
+                foreach (var item in this)
+                {
+                    if (!predicate(item, arg))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+ValueCollection.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedDictionary`2+ValueCollection.cs
@@ -53,6 +53,19 @@ namespace Microsoft.CodeAnalysis.Collections
 
             bool ICollection<TValue>.Remove(TValue item)
                 => throw new NotSupportedException();
+
+            public bool All<TArg>(Func<TValue, TArg, bool> predicate, TArg arg)
+            {
+                foreach (var item in this)
+                {
+                    if (!predicate(item, arg))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
Encapsulate synthesized type maps (anonymousTypeMap, anonymousDelegates, anonymousDelegatesWithIndexedNames) in a new type to simplify passing them around. Switch to ImmutableDictionary.

