### PR TITLE
Switch PatternMatcher to use a TemporaryArray instead of ArrayBuilder.

### DIFF
--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -499,7 +499,8 @@ namespace Microsoft.CodeAnalysis.PatternMatching
             var patternHumpCount = patternHumps.Count;
             var candidateHumpCount = candidateHumps.Count;
 
-            using var _ = ArrayBuilder<TextSpan>.GetInstance(out var matchSpans);
+            using var matchSpans = TemporaryArray<TextSpan>.Empty;
+
             while (true)
             {
                 // Let's consider our termination cases
@@ -510,7 +511,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
 
                     var matchCount = matchSpans.Count;
                     matchedSpans = _includeMatchedSpans
-                        ? new NormalizedTextSpanCollection(matchSpans).ToImmutableArray()
+                        ? new NormalizedTextSpanCollection(matchSpans.ToImmutableAndClear()).ToImmutableArray()
                         : ImmutableArray<TextSpan>.Empty;
 
                     var camelCaseResult = new CamelCaseResult(firstMatch == 0, contiguous.Value, matchCount, null);


### PR DESCRIPTION
The customer completion profile that I'm looking at shows 5.6% of allocations and 0.7% of CPU in VS during the completion request period are due to allocations in ArrayBuilder.AllocateSlow.

Simple testing on my machine shows > 20,000 roughly concurrent calls to TryUpperCaseCamelCaseMatch, only six of which end up with a non-empty matchedSpans (of size 2 in my test scenario). Instead of hitting some allocations in ArrayBuilder due to such heavy concurrent usage, instead just TemporaryArray which uses stack space for the common case of small arrays.