### PR TITLE
Validate that only BoundConversion can have a field typed Conversion

### DIFF
--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -295,7 +295,7 @@ namespace BoundTreeGenerator
                 case TargetLanguage.CSharp:
                     {
                         string abstr = "";
-                        if (node is AbstractNode)
+                        if (node is AbstractNode and not Node)
                             abstr = "abstract ";
                         else if (CanBeSealed(node))
                             abstr = "sealed ";
@@ -307,7 +307,7 @@ namespace BoundTreeGenerator
                 case TargetLanguage.VB:
                     {
                         string abstr = "";
-                        if (node is AbstractNode)
+                        if (node is AbstractNode and not Node)
                             abstr = "MustInherit ";
                         else if (CanBeSealed(node))
                             abstr = "NotInheritable ";
@@ -692,19 +692,15 @@ namespace BoundTreeGenerator
 
         private static IEnumerable<Field> Fields(TreeType node)
         {
-            if (node is Node)
-                return from n in ((Node)node).Fields where !n.Override select n;
-            if (node is AbstractNode)
-                return from n in ((AbstractNode)node).Fields where !n.Override select n;
+            if (node is AbstractNode aNode)
+                return from n in aNode.Fields where !n.Override select n;
             return Enumerable.Empty<Field>();
         }
 
         private static IEnumerable<Field> FieldsIncludingOverrides(TreeType node)
         {
-            if (node is Node)
-                return ((Node)node).Fields;
-            if (node is AbstractNode)
-                return ((AbstractNode)node).Fields;
+            if (node is AbstractNode aNode)
+                return aNode.Fields;
             return Enumerable.Empty<Field>();
         }
 
@@ -897,12 +893,12 @@ namespace BoundTreeGenerator
 
         private void WriteType(TreeType node)
         {
-            if (node is not AbstractNode and not Node)
+            if (node is not AbstractNode)
                 return;
             WriteClassHeader(node);
 
             bool unsealed = !CanBeSealed(node);
-            bool concrete = node is not AbstractNode;
+            bool concrete = node is Node;
             bool hasChildNodes = AllNodeOrNodeListFields(node).Any();
 
             if (unsealed)
@@ -932,7 +928,7 @@ namespace BoundTreeGenerator
         {
             if (!AllFields(node).Any())
                 return;
-            bool emitNew = (!Fields(node).Any()) && !(BaseType(node) is AbstractNode);
+            bool emitNew = (!Fields(node).Any()) && BaseType(node) is Node;
 
             switch (_targetLang)
             {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
@@ -45,7 +45,7 @@ namespace BoundTreeGenerator
         public List<Field> Fields;
     }
 
-    public class Node : TreeType
+    public class Node : AbstractNode
     {
         [XmlAttribute]
         public string Root;
@@ -62,9 +62,6 @@ namespace BoundTreeGenerator
 
         [XmlElement(ElementName = "Kind", Type = typeof(Kind))]
         public List<Kind> Kinds;
-
-        [XmlElement(ElementName = "Field", Type = typeof(Field))]
-        public List<Field> Fields;
     }
 
     public class Kind


### PR DESCRIPTION
Ensure that we don't violate this correctness invariant by validating it in the writer itself.
