### PR TITLE
Add support for reading runsettings passed by the client

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -147,6 +147,9 @@
   <data name="Failed_0_Passed_1_Skipped_2_Total_3_Duration_4" xml:space="preserve">
     <value>Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</value>
   </data>
+  <data name="Failed_to_read_runsettings_file_at_0:1" xml:space="preserve">
+    <value>Failed to read .runsettings file at {0}:{1}</value>
+  </data>
   <data name="Found_0_tests_in_1" xml:space="preserve">
     <value>Found {0} tests in {1}</value>
   </data>
@@ -161,6 +164,9 @@
   </data>
   <data name="Running_tests" xml:space="preserve">
     <value>Running tests...</value>
+  </data>
+  <data name="Runsettings_file_does_not_exist_at_0" xml:space="preserve">
+    <value>.runsettings file does not exist at {0}</value>
   </data>
   <data name="Show_csharp_logs" xml:space="preserve">
     <value>Show C# logs</value>
@@ -191,5 +197,8 @@
   </data>
   <data name="There_were_problems_loading_your_projects_See_log_for_details" xml:space="preserve">
     <value>There were problems loading your projects. See log for details.</value>
+  </data>
+  <data name="Using_runsettings_file_at_0" xml:space="preserve">
+    <value>Using .runsettings file at {0}</value>
   </data>
 </root>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Testing;
+using Microsoft.Extensions.Logging;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -17,10 +18,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Testing;
 [Method(RunTestsMethodName)]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer testDiscoverer, TestRunner testRunner, ServerConfiguration serverConfiguration)
+internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer testDiscoverer, TestRunner testRunner, ServerConfiguration serverConfiguration, ILoggerFactory loggerFactory)
     : ILspServiceDocumentRequestHandler<RunTestsParams, RunTestsPartialResult[]>
 {
     private const string RunTestsMethodName = "textDocument/runTests";
+
+    private readonly ILogger _logger = loggerFactory.CreateLogger<RunTestsHandler>();
 
     public bool MutatesSolutionState => false;
 
@@ -59,11 +62,13 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             }
         });
 
-        var testCases = await testDiscoverer.DiscoverTestsAsync(request.Range, context.Document, projectOutputPath, progress, vsTestConsoleWrapper, cancellationToken);
+        var runSettingsPath = request.RunSettingsPath;
+        var runSettings = await GetRunSettingsAsync(runSettingsPath, progress, cancellationToken);
+        var testCases = await testDiscoverer.DiscoverTestsAsync(request.Range, context.Document, projectOutputPath, runSettings, progress, vsTestConsoleWrapper, cancellationToken);
         if (!testCases.IsEmpty)
         {
             var clientLanguageServerManager = context.GetRequiredLspService<IClientLanguageServerManager>();
-            await testRunner.RunTestsAsync(testCases, progress, vsTestConsoleWrapper, request.AttachDebugger, clientLanguageServerManager, cancellationToken);
+            await testRunner.RunTestsAsync(testCases, progress, vsTestConsoleWrapper, request.AttachDebugger, runSettings, clientLanguageServerManager, cancellationToken);
         }
 
         return progress.GetValues() ?? Array.Empty<RunTestsPartialResult>();
@@ -159,5 +164,35 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             Microsoft.Extensions.Logging.LogLevel.None => TraceLevel.Off,
             _ => throw new InvalidOperationException($"Unexpected log level {serverConfiguration.MinimumLogLevel}"),
         };
+    }
+
+    private async Task<string?> GetRunSettingsAsync(string? runSettingsPath, BufferedProgress<RunTestsPartialResult> progress, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(runSettingsPath))
+        {
+            return null;
+        }
+
+        if (!File.Exists(runSettingsPath))
+        {
+            var message = string.Format(LanguageServerResources.Runsettings_file_does_not_exist_at_0, runSettingsPath);
+            progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
+            return null;
+        }
+
+        try
+        {
+            var contents = await File.ReadAllTextAsync(runSettingsPath, cancellationToken);
+            var message = string.Format(LanguageServerResources.Using_runsettings_file_at_0, runSettingsPath);
+            progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
+            _logger.LogTrace($".runsettings:{Environment.NewLine}{contents}");
+            return contents;
+        }
+        catch (Exception ex)
+        {
+            var message = string.Format(LanguageServerResources.Failed_to_read_runsettings_file_at_0_1, runSettingsPath, ex);
+            progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
+            return null;
+        }
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -173,13 +173,6 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             return null;
         }
 
-        if (!File.Exists(runSettingsPath))
-        {
-            var message = string.Format(LanguageServerResources.Runsettings_file_does_not_exist_at_0, runSettingsPath);
-            progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
-            return null;
-        }
-
         try
         {
             var contents = await File.ReadAllTextAsync(runSettingsPath, cancellationToken);
@@ -188,11 +181,17 @@ internal class RunTestsHandler(DotnetCliHelper dotnetCliHelper, TestDiscoverer t
             _logger.LogTrace($".runsettings:{Environment.NewLine}{contents}");
             return contents;
         }
+        catch (FileNotFoundException)
+        {
+            var message = string.Format(LanguageServerResources.Runsettings_file_does_not_exist_at_0, runSettingsPath);
+            progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
+        }
         catch (Exception ex)
         {
             var message = string.Format(LanguageServerResources.Failed_to_read_runsettings_file_at_0_1, runSettingsPath, ex);
             progress.Report(new(LanguageServerResources.Discovering_tests, message, Progress: null));
-            return null;
         }
+
+        return null;
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
@@ -34,6 +34,7 @@ internal partial class TestDiscoverer(ILoggerFactory loggerFactory)
         LSP.Range range,
         Document document,
         string projectOutputPath,
+        string? runSettings,
         BufferedProgress<RunTestsPartialResult> progress,
         VsTestConsoleWrapper vsTestConsoleWrapper,
         CancellationToken cancellationToken)
@@ -56,8 +57,7 @@ internal partial class TestDiscoverer(ILoggerFactory loggerFactory)
         var stopwatch = SharedStopwatch.StartNew();
 
         // The async APIs for vs test are broken (current impl ends up just hanging), so we must use the sync API instead.
-        // TODO - run settings.  https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1799066/
-        var discoveryTask = Task.Run(() => vsTestConsoleWrapper.DiscoverTests(SpecializedCollections.SingletonEnumerable(projectOutputPath), discoverySettings: null, discoveryHandler), cancellationToken);
+        var discoveryTask = Task.Run(() => vsTestConsoleWrapper.DiscoverTests(SpecializedCollections.SingletonEnumerable(projectOutputPath), discoverySettings: runSettings, discoveryHandler), cancellationToken);
         cancellationToken.Register(() => vsTestConsoleWrapper.CancelDiscovery());
         await discoveryTask;
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="new">Failed:    {0}, Passed:    {1}, Skipped:    {2}, Total:    {3}, Duration: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_runsettings_file_at_0:1">
+        <source>Failed to read .runsettings file at {0}:{1}</source>
+        <target state="new">Failed to read .runsettings file at {0}:{1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Found_0_tests_in_1">
         <source>Found {0} tests in {1}</source>
         <target state="new">Found {0} tests in {1}</target>
@@ -75,6 +80,11 @@
       <trans-unit id="Running_tests">
         <source>Running tests...</source>
         <target state="new">Running tests...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Runsettings_file_does_not_exist_at_0">
+        <source>.runsettings file does not exist at {0}</source>
+        <target state="new">.runsettings file does not exist at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Show_csharp_logs">
@@ -125,6 +135,11 @@
       <trans-unit id="There_were_problems_loading_your_projects_See_log_for_details">
         <source>There were problems loading your projects. See log for details.</source>
         <target state="new">There were problems loading your projects. See log for details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Using_runsettings_file_at_0">
+        <source>Using .runsettings file at {0}</source>
+        <target state="new">Using .runsettings file at {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -137,6 +137,9 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         var testContainerMembers = members.Where(member => testContainerNodes.Contains(member.Node));
 
         // Create code lenses for all test methods.
+
+        // The client will fill this in if applicable.
+        string? runSettingsPath = null;
         foreach (var member in testMethodMembers)
         {
             var range = ProtocolConversions.TextSpanToRange(member.Span, text);
@@ -146,7 +149,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
                 Command = new LSP.Command
                 {
                     CommandIdentifier = RunTestsCommandIdentifier,
-                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: false) },
+                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: false, runSettingsPath) },
                     Title = FeaturesResources.Run_Test
                 }
             };
@@ -157,7 +160,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
                 Command = new LSP.Command
                 {
                     CommandIdentifier = RunTestsCommandIdentifier,
-                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: true) },
+                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: true, runSettingsPath) },
                     Title = FeaturesResources.Debug_Test
                 }
             };
@@ -176,7 +179,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
                 Command = new LSP.Command
                 {
                     CommandIdentifier = RunTestsCommandIdentifier,
-                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: false) },
+                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: false, runSettingsPath) },
                     Title = FeaturesResources.Run_All_Tests
                 }
             };
@@ -187,7 +190,7 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
                 Command = new LSP.Command
                 {
                     CommandIdentifier = RunTestsCommandIdentifier,
-                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: true) },
+                    Arguments = new object[] { new RunTestsParams(textDocumentIdentifier, range, AttachDebugger: true, runSettingsPath) },
                     Title = FeaturesResources.Debug_All_Tests
                 }
             };

--- a/src/Features/LanguageServer/Protocol/Handler/Testing/RunTestsParams.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Testing/RunTestsParams.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Testing;
 internal record RunTestsParams(
     [property: DataMember(Name = "textDocument")] TextDocumentIdentifier TextDocument,
     [property: DataMember(Name = "range")] VisualStudio.LanguageServer.Protocol.Range Range,
-    [property: DataMember(Name = "attachDebugger")] bool AttachDebugger
+    [property: DataMember(Name = "attachDebugger")] bool AttachDebugger,
+    [property: DataMember(Name = "runSettingsPath")] string? RunSettingsPath
 ) : IPartialResultParams<RunTestsPartialResult>
 {
     [DataMember(Name = Methods.PartialResultTokenName)]


### PR DESCRIPTION
This is the final (known) change for https://github.com/dotnet/vscode-csharp/issues/5719

Adds support for passing runsettings to vstest.
Client side PR: