### PR TITLE
Make completion handler more resilient

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -315,13 +315,15 @@ namespace Roslyn.Test.Utilities
             => CreateTestLspServerAsync(new string[] { markup }, LanguageNames.VisualBasic, mutatingLspWorkspace, initializationOptions);
 
         private protected Task<TestLspServer> CreateTestLspServerAsync(
-            string[] markups, string languageName, bool mutatingLspWorkspace, InitializationOptions? initializationOptions, List<Type>? excludedTypes = null, List<Type>? extraExportedTypes = null)
+            string[] markups, string languageName, bool mutatingLspWorkspace, InitializationOptions? initializationOptions, List<Type>? excludedTypes = null, List<Type>? extraExportedTypes = null, bool commonReferences = true)
         {
             var lspOptions = initializationOptions ?? new InitializationOptions();
 
             var workspace = CreateWorkspace(lspOptions, workspaceKind: null, mutatingLspWorkspace, excludedTypes, extraExportedTypes);
 
-            workspace.InitializeDocuments(TestWorkspace.CreateWorkspaceElement(languageName, files: markups, fileContainingFolders: lspOptions.DocumentFileContainingFolders, sourceGeneratedFiles: lspOptions.SourceGeneratedMarkups), openDocuments: false);
+            workspace.InitializeDocuments(
+                TestWorkspace.CreateWorkspaceElement(languageName, files: markups, fileContainingFolders: lspOptions.DocumentFileContainingFolders, sourceGeneratedFiles: lspOptions.SourceGeneratedMarkups, commonReferences: commonReferences),
+                openDocuments: false);
 
             return CreateTestLspServerAsync(workspace, lspOptions);
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             return builder.ToArray();
         }
 
-        private async static Task<CompletionChange> GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(CompletionService completionService, Document document, CompletionItem completionItem, CancellationToken cancellationToken)
+        private static async Task<CompletionChange> GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(CompletionService completionService, Document document, CompletionItem completionItem, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/AbstractLspCompletionResultCreationService.cs
@@ -11,8 +11,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Completion.Providers.Snippets;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             Contract.ThrowIfTrue(item.IsComplexTextEdit);
             Contract.ThrowIfNull(lspItem.Label);
 
-            var completionChange = await completionService.GetChangeAsync(document, item, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var completionChange = await GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(completionService, document, item, cancellationToken).ConfigureAwait(false);
             var change = completionChange.TextChange;
 
             // If the change's span is different from default, then the item should be mark as IsComplexTextEdit.
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             CancellationToken cancellationToken)
         {
             Debug.Assert(selectedItem.Flags.IsExpanded());
-            var completionChange = await completionService.GetChangeAsync(document, selectedItem, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var completionChange = await GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(completionService, document, selectedItem, cancellationToken).ConfigureAwait(false);
 
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             using var _ = ArrayBuilder<LSP.TextEdit>.GetInstance(out var builder);
@@ -414,6 +414,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
             return builder.ToArray();
         }
 
+        private async static Task<CompletionChange> GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(CompletionService completionService, Document document, CompletionItem completionItem, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await completionService.GetChangeAsync(document, completionItem, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+            {
+                // In case of exception, we simply return DisplayText with default span as the change.
+                return CompletionChange.Create(new TextChange(completionItem.Span, completionItem.DisplayText));
+            }
+        }
+
         public static async Task<(LSP.TextEdit edit, bool isSnippetString, int? newPosition)> GenerateComplexTextEditAsync(
             Document document,
             CompletionService completionService,
@@ -424,7 +437,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Completion
         {
             Debug.Assert(selectedItem.IsComplexTextEdit);
 
-            var completionChange = await completionService.GetChangeAsync(document, selectedItem, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var completionChange = await GetCompletionChangeOrDisplayNameInCaseOfExceptionAsync(completionService, document, selectedItem, cancellationToken).ConfigureAwait(false);
             var completionChangeSpan = completionChange.TextChange.Span;
             var newText = completionChange.TextChange.NewText;
             Contract.ThrowIfNull(newText);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -803,10 +803,7 @@ public class C
             extraExportedTypes: new[] { typeof(CSharpLspThrowExceptionOnChangeCompletionService.Factory) }.ToList());
 
         var mockService = testLspServer.TestWorkspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService<CompletionService>() as CSharpLspThrowExceptionOnChangeCompletionService;
-
-
         var builder = ImmutableArray.CreateBuilder<CodeAnalysis.Completion.CompletionItem>();
-
         builder.Add(CodeAnalysis.Completion.CompletionItem.Create("SimpleItem"));
 
         var importItem = CodeAnalysis.Completion.CompletionItem.Create("ExpandedItem");

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -736,4 +736,136 @@ public class C
         foreach (var item in results.Items)
             Assert.Null(item.CommitCharacters);
     }
+
+    private sealed class CSharpLspThrowExceptionOnChangeCompletionService : CompletionService
+    {
+        private CSharpLspThrowExceptionOnChangeCompletionService(SolutionServices services, IAsynchronousOperationListenerProvider listenerProvider) : base(services, listenerProvider)
+        {
+        }
+
+        public override string Language => LanguageNames.CSharp;
+
+        internal override CompletionRules GetRules(CodeAnalysis.Completion.CompletionOptions options)
+            => CompletionRules.Default;
+
+        internal override bool ShouldTriggerCompletion(
+            Project project, LanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger,
+            CodeAnalysis.Completion.CompletionOptions options, OptionSet passThroughOptions, ImmutableHashSet<string> roles = null)
+        {
+            return true;
+        }
+
+        public ImmutableArray<CodeAnalysis.Completion.CompletionItem> ReturnedItems { get; set; } = ImmutableArray<CodeAnalysis.Completion.CompletionItem>.Empty;
+
+        public (int defaultItemCount, int nonDefaultItemCount) ItemCounts { get; set; }
+
+        internal override async Task<CodeAnalysis.Completion.CompletionList> GetCompletionsAsync(
+            Document document, int caretPosition, CodeAnalysis.Completion.CompletionOptions options, OptionSet passThroughOptions,
+            CompletionTrigger trigger = default, ImmutableHashSet<string> roles = null, CancellationToken cancellationToken = default)
+        {
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var defaultItemSpan = GetDefaultCompletionListSpan(text, caretPosition);
+
+            return CodeAnalysis.Completion.CompletionList.Create(defaultItemSpan, ReturnedItems);
+        }
+
+        public override Task<CompletionChange> GetChangeAsync(Document document, CodeAnalysis.Completion.CompletionItem item, char? commitCharacter = null, CancellationToken cancellationToken = default)
+        {
+            Assert.Contains(item, ReturnedItems);
+            throw new Exception("GetChangeAsync throws");
+        }
+
+        [ExportLanguageServiceFactory(typeof(CompletionService), LanguageNames.CSharp, ServiceLayer.Test), Shared]
+        internal sealed class Factory : ILanguageServiceFactory
+        {
+            private readonly IAsynchronousOperationListenerProvider _listenerProvider;
+
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public Factory(IAsynchronousOperationListenerProvider listenerProvider)
+            {
+                _listenerProvider = listenerProvider;
+            }
+
+            public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+            {
+                return new CSharpLspThrowExceptionOnChangeCompletionService(languageServices.LanguageServices.SolutionServices, _listenerProvider);
+            }
+        }
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestHandleExceptionFromGetCompletionChange(bool mutatingLspWorkspace)
+    {
+        var markup = "Item {|caret:|}";
+        await using var testLspServer = await CreateTestLspServerAsync(new[] { markup }, LanguageNames.CSharp, mutatingLspWorkspace,
+            new InitializationOptions { ClientCapabilities = DefaultClientCapabilities, CallInitialized = true },
+            extraExportedTypes: new[] { typeof(CSharpLspThrowExceptionOnChangeCompletionService.Factory) }.ToList());
+
+        var mockService = testLspServer.TestWorkspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService<CompletionService>() as CSharpLspThrowExceptionOnChangeCompletionService;
+
+
+        var builder = ImmutableArray.CreateBuilder<CodeAnalysis.Completion.CompletionItem>();
+
+        builder.Add(CodeAnalysis.Completion.CompletionItem.Create("SimpleItem"));
+
+        var importItem = CodeAnalysis.Completion.CompletionItem.Create("ExpandedItem");
+        importItem.Flags |= CodeAnalysis.Completion.CompletionItemFlags.Expanded;
+        builder.Add(importItem);
+
+        builder.Add(CodeAnalysis.Completion.CompletionItem.Create("ComplexItem", isComplexTextEdit: true));
+
+        mockService.ReturnedItems = builder.ToImmutable();
+
+        var caret = testLspServer.GetLocations("caret").Single();
+        var completionParams = new LSP.CompletionParams()
+        {
+            TextDocument = CreateTextDocumentIdentifier(caret.Uri),
+            Position = caret.Range.Start,
+            Context = new LSP.CompletionContext()
+            {
+                TriggerKind = LSP.CompletionTriggerKind.Invoked,
+            }
+        };
+
+        var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+
+        // getting and resolving completions should not throw
+        var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
+        foreach (var item in results.Items)
+        {
+            item.Data = results.ItemDefaults.Data;
+            var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, item, CancellationToken.None).ConfigureAwait(false);
+
+            if (item.Label == "SimpleItem")
+            {
+                Assert.Null(item.TextEditText);
+                Assert.Null(resolvedItem.AdditionalTextEdits);
+                Assert.Null(resolvedItem.Command);
+            }
+            else if (item.Label == "ExpandedItem")
+            {
+                Assert.Null(item.TextEditText);
+                Assert.Null(resolvedItem.AdditionalTextEdits);
+                Assert.Null(resolvedItem.Command);
+            }
+            else if (item.Label == "ComplexItem")
+            {
+                Assert.Equal("", item.TextEditText);
+                Assert.Null(item.TextEdit);
+                Assert.Null(resolvedItem.AdditionalTextEdits);
+
+                Assert.Equal(nameof(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand), resolvedItem.Command.Title);
+                Assert.Equal(DefaultLspCompletionResultCreationService.CompleteComplexEditCommand, resolvedItem.Command.CommandIdentifier);
+
+                Assert.Equal(completionParams.TextDocument.Uri, ProtocolConversions.CreateAbsoluteUri((string)resolvedItem.Command.Arguments[0]));
+
+                var expectedEdit = new TextEdit { Range = new LSP.Range { Start = new(0, 5), End = new(0, 5) }, NewText = "ComplexItem" };
+                AssertJsonEquals(expectedEdit, resolvedItem.Command.Arguments[1]);
+
+                Assert.Equal(false, resolvedItem.Command.Arguments[2]);
+                Assert.Equal((long)-1, resolvedItem.Command.Arguments[3]);
+            }
+        }
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
@@ -35,11 +35,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static SyntaxNode CreateNewNotImplementedException(SyntaxGenerator codeDefinitionFactory, Compilation compilation)
         {
-            var notImplementedExceptionTypeSyntax = compilation.NotImplementedExceptionType() is INamedTypeSymbol symbol ?
-                codeDefinitionFactory.TypeExpression(symbol, addImport: false) :
-                codeDefinitionFactory.QualifiedName(
-                    codeDefinitionFactory.IdentifierName(nameof(System)),
-                    codeDefinitionFactory.IdentifierName(nameof(NotImplementedException)));
+            var notImplementedExceptionTypeSyntax = compilation.NotImplementedExceptionType() is INamedTypeSymbol symbol
+                ? codeDefinitionFactory.TypeExpression(symbol, addImport: false)
+                : codeDefinitionFactory.QualifiedName(codeDefinitionFactory.IdentifierName(nameof(System)), codeDefinitionFactory.IdentifierName(nameof(NotImplementedException)));
 
             return codeDefinitionFactory.ObjectCreationExpression(
                             notImplementedExceptionTypeSyntax,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editing;
@@ -22,20 +23,28 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this SyntaxGenerator codeDefinitionFactory, Compilation compilation)
         {
             return codeDefinitionFactory.ThrowStatement(
-               CreateNotImplementedException(codeDefinitionFactory, compilation));
+               CreateNewNotImplementedException(codeDefinitionFactory, compilation));
         }
 
         public static SyntaxNode CreateThrowNotImplementedExpression(
             this SyntaxGenerator codeDefinitionFactory, Compilation compilation)
         {
             return codeDefinitionFactory.ThrowExpression(
-               CreateNotImplementedException(codeDefinitionFactory, compilation));
+               CreateNewNotImplementedException(codeDefinitionFactory, compilation));
         }
 
-        private static SyntaxNode CreateNotImplementedException(SyntaxGenerator codeDefinitionFactory, Compilation compilation)
-            => codeDefinitionFactory.ObjectCreationExpression(
-                    codeDefinitionFactory.TypeExpression(compilation.NotImplementedExceptionType(), addImport: false),
-                    SpecializedCollections.EmptyList<SyntaxNode>());
+        private static SyntaxNode CreateNewNotImplementedException(SyntaxGenerator codeDefinitionFactory, Compilation compilation)
+        {
+            var notImplementedExceptionTypeSyntax = compilation.NotImplementedExceptionType() is INamedTypeSymbol symbol ?
+                codeDefinitionFactory.TypeExpression(symbol, addImport: false) :
+                codeDefinitionFactory.QualifiedName(
+                    codeDefinitionFactory.IdentifierName(nameof(System)),
+                    codeDefinitionFactory.IdentifierName(nameof(NotImplementedException)));
+
+            return codeDefinitionFactory.ObjectCreationExpression(
+                            notImplementedExceptionTypeSyntax,
+                            SpecializedCollections.EmptyList<SyntaxNode>());
+        }
 
         public static ImmutableArray<SyntaxNode> CreateThrowNotImplementedStatementBlock(
             this SyntaxGenerator codeDefinitionFactory, Compilation compilation)


### PR DESCRIPTION
This contains two individual fixes. 
1. A general defense against unknown errors when resolving completion changes in LSP handler.
2. Fix override completion to not throw if for some reason we can't find System.NotImplementedExcetpion type in the compilation (i.e. the error in https://github.com/dotnet/vscode-csharp/issues/6048)