### PR TITLE
EnC: Generate correct state mapping for methods containing await foreach

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // non-void return type T, the await-expression is classified as a value of type T.
             TypeSymbol awaitExpressionType = info.GetResult?.ReturnType ?? (hasErrors ? CreateErrorType() : Compilation.DynamicType);
 
-            return new BoundAwaitExpression(node, expression, info, awaitExpressionType, hasErrors);
+            return new BoundAwaitExpression(node, expression, info, debugInfo: default, awaitExpressionType, hasErrors);
         }
 
         internal void ReportBadAwaitDiagnostics(SyntaxNodeOrToken nodeOrToken, BindingDiagnosticBag diagnostics, ref bool hasErrors)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitExpressionDebugInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitExpressionDebugInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp;
 /// The number of async state machine states to reserve.
 /// 
 /// Any time multiple <see cref="BoundAwaitExpression"/>s might be associated with the same syntax node
-/// we need to make sure that the same number state machine states gets allocated for the node,
+/// we need to make sure that the same number of state machine states gets allocated for the node,
 /// regardless of the actual number of <see cref="BoundAwaitExpression"/>s that get emitted.
 /// 
 /// To do so one or more of the emitted <see cref="BoundAwaitExpression"/>s may

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitExpressionDebugInfo.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundAwaitExpressionDebugInfo.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeGen;
+
+namespace Microsoft.CodeAnalysis.CSharp;
+
+/// <summary>
+/// Debug info associated with <see cref="BoundAwaitExpression"/> to support EnC.
+/// </summary>
+/// <param name="AwaitId">The id of the generated await.</param>
+/// <param name="ReservedStateMachineCount">
+/// The number of async state machine states to reserve.
+/// 
+/// Any time multiple <see cref="BoundAwaitExpression"/>s might be associated with the same syntax node
+/// we need to make sure that the same number state machine states gets allocated for the node,
+/// regardless of the actual number of <see cref="BoundAwaitExpression"/>s that get emitted.
+/// 
+/// To do so one or more of the emitted <see cref="BoundAwaitExpression"/>s may
+/// reserve additional dummy state machine states so that the total number of states
+/// (one for each <see cref="BoundAwaitExpression"/> plus total reserved states) is constant
+/// regardless of semantics of the syntax node.
+/// 
+/// E.g. `await foreach` produces at least one and at most two <see cref="BoundAwaitExpression"/>s:
+/// one for MoveNextAsync and the other for DisposeAsync.
+/// 
+/// If the enumerator is async-disposable it produces two <see cref="BoundAwaitExpression"/>s with 
+/// <paramref name="ReservedStateMachineCount"/> set to 0.
+/// 
+/// If the enumerator is not async-disposable it produces a single <see cref="BoundAwaitExpression"/> with 
+/// <paramref name="ReservedStateMachineCount"/> set to 1.
+/// 
+/// The states are only reserved in DEBUG builds.
+/// </param>
+internal readonly record struct BoundAwaitExpressionDebugInfo(AwaitDebugId AwaitId, byte ReservedStateMachineCount);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -690,6 +690,7 @@
 
     <Field Name="Expression" Type="BoundExpression"/>
     <Field Name="AwaitableInfo" Type="BoundAwaitableInfo" Null="disallow"/>
+    <Field Name="DebugInfo" Type="BoundAwaitExpressionDebugInfo" Null="NotApplicable"/>
   </Node>
 
   <AbstractNode Name="BoundTypeOf" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2136,7 +2136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundAwaitExpression : BoundExpression
     {
-        public BoundAwaitExpression(SyntaxNode syntax, BoundExpression expression, BoundAwaitableInfo awaitableInfo, TypeSymbol type, bool hasErrors = false)
+        public BoundAwaitExpression(SyntaxNode syntax, BoundExpression expression, BoundAwaitableInfo awaitableInfo, BoundAwaitExpressionDebugInfo debugInfo, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.AwaitExpression, syntax, type, hasErrors || expression.HasErrors() || awaitableInfo.HasErrors())
         {
 
@@ -2146,20 +2146,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.Expression = expression;
             this.AwaitableInfo = awaitableInfo;
+            this.DebugInfo = debugInfo;
         }
 
         public new TypeSymbol Type => base.Type!;
         public BoundExpression Expression { get; }
         public BoundAwaitableInfo AwaitableInfo { get; }
+        public BoundAwaitExpressionDebugInfo DebugInfo { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitAwaitExpression(this);
 
-        public BoundAwaitExpression Update(BoundExpression expression, BoundAwaitableInfo awaitableInfo, TypeSymbol type)
+        public BoundAwaitExpression Update(BoundExpression expression, BoundAwaitableInfo awaitableInfo, BoundAwaitExpressionDebugInfo debugInfo, TypeSymbol type)
         {
-            if (expression != this.Expression || awaitableInfo != this.AwaitableInfo || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (expression != this.Expression || awaitableInfo != this.AwaitableInfo || debugInfo != this.DebugInfo || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundAwaitExpression(this.Syntax, expression, awaitableInfo, type, this.HasErrors);
+                var result = new BoundAwaitExpression(this.Syntax, expression, awaitableInfo, debugInfo, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10938,7 +10940,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundAwaitableInfo awaitableInfo = (BoundAwaitableInfo)this.Visit(node.AwaitableInfo);
             TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(expression, awaitableInfo, type);
+            return node.Update(expression, awaitableInfo, node.DebugInfo, type);
         }
         public override BoundNode? VisitTypeOfOperator(BoundTypeOfOperator node)
         {
@@ -12746,12 +12748,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
-                updatedNode = node.Update(expression, awaitableInfo, infoAndType.Type!);
+                updatedNode = node.Update(expression, awaitableInfo, node.DebugInfo, infoAndType.Type!);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(expression, awaitableInfo, node.Type);
+                updatedNode = node.Update(expression, awaitableInfo, node.DebugInfo, node.Type);
             }
             return updatedNode;
         }
@@ -15213,6 +15215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("expression", null, new TreeDumperNode[] { Visit(node.Expression, null) }),
             new TreeDumperNode("awaitableInfo", null, new TreeDumperNode[] { Visit(node.AwaitableInfo, null) }),
+            new TreeDumperNode("debugInfo", node.DebugInfo, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //  _promiseOfValueOrEnd.SetResult(true);
             //  return;
 
-            AddResumableState(_iteratorStateAllocator, node.Syntax, out var stateNumber, out GeneratedLabelSymbol resumeLabel);
+            AddResumableState(_iteratorStateAllocator, node.Syntax, awaitId: default, out var stateNumber, out GeneratedLabelSymbol resumeLabel);
 
             var rewrittenExpression = (BoundExpression)Visit(node.Expression);
             var blockBuilder = ArrayBuilder<BoundStatement>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // if(!($awaiterTemp.IsCompleted)) { ... }
                     F.If(
                         condition: F.Not(GenerateGetIsCompleted(awaiterTemp, isCompletedMethod)),
-                        thenClause: GenerateAwaitForIncompleteTask(awaiterTemp)));
+                        thenClause: GenerateAwaitForIncompleteTask(awaiterTemp, node.DebugInfo)));
             BoundExpression getResultCall = MakeCallMaybeDynamic(
                 F.Local(awaiterTemp),
                 getResult,
@@ -450,9 +450,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return F.Call(F.Local(awaiterTemp), getIsCompletedMethod);
         }
 
-        private BoundBlock GenerateAwaitForIncompleteTask(LocalSymbol awaiterTemp)
+        private BoundBlock GenerateAwaitForIncompleteTask(LocalSymbol awaiterTemp, BoundAwaitExpressionDebugInfo debugInfo)
         {
-            AddResumableState(awaiterTemp.GetDeclaratorSyntax(), out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel);
+            var awaitSyntax = awaiterTemp.GetDeclaratorSyntax();
+            AddResumableState(awaitSyntax, debugInfo.AwaitId, out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel);
 
             TypeSymbol awaiterFieldType = awaiterTemp.Type.IsVerifierReference()
                 ? F.SpecialType(SpecialType.System_Object)
@@ -484,6 +485,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             blockBuilder.Add(
                 GenerateReturn(false));
+
+            if (F.Compilation.Options.EnableEditAndContinue)
+            {
+                for (int i = 0; i < debugInfo.ReservedStateMachineCount; i++)
+                {
+                    AddResumableState(awaitSyntax, new AwaitDebugId((byte)(debugInfo.AwaitId.RelativeStateOrdinal + 1 + i)), out _, out var dummyResumeLabel);
+                    blockBuilder.Add(F.Label(dummyResumeLabel));
+                }
+            }
 
             blockBuilder.Add(
                 F.Label(resumeLabel));

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     <next_state_label>: ;
             //     <hidden sequence point>
             //     this.state = finalizeState;
-            AddResumableState(node.Syntax, out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel);
+            AddResumableState(node.Syntax, awaitId: default, out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel);
             _currentFinallyFrame.AddState(stateNumber);
 
             var rewrittenExpression = (BoundExpression)Visit(node.Expression);
@@ -464,12 +464,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var syntax = statement.Syntax;
 
-            if (slotAllocatorOpt?.TryGetPreviousStateMachineState(syntax, out var finalizeState) != true)
+            if (slotAllocatorOpt?.TryGetPreviousStateMachineState(syntax, awaitId: default, out var finalizeState) != true)
             {
                 finalizeState = _nextFinalizeState--;
             }
 
-            AddStateDebugInfo(syntax, finalizeState);
+            AddStateDebugInfo(syntax, awaitId: default, finalizeState);
 
             var finallyMethod = MakeSynthesizedFinally(finalizeState);
             var newFrame = new IteratorFinallyFrame(_currentFinallyFrame, finalizeState, finallyMethod, _yieldsInTryAnalysis.Labels(statement));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Await.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Await.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -19,9 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return RewriteAwaitExpression((BoundExpression)base.VisitAwaitExpression(node)!, used);
         }
 
-        private BoundExpression RewriteAwaitExpression(SyntaxNode syntax, BoundExpression rewrittenExpression, BoundAwaitableInfo awaitableInfo, TypeSymbol type, bool used)
+        private BoundExpression RewriteAwaitExpression(SyntaxNode syntax, BoundExpression rewrittenExpression, BoundAwaitableInfo awaitableInfo, TypeSymbol type, BoundAwaitExpressionDebugInfo debugInfo, bool used)
         {
-            return RewriteAwaitExpression(new BoundAwaitExpression(syntax, rewrittenExpression, awaitableInfo, type) { WasCompilerGenerated = true }, used);
+            return RewriteAwaitExpression(new BoundAwaitExpression(syntax, rewrittenExpression, awaitableInfo, debugInfo, type) { WasCompilerGenerated = true }, used);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// - interface-based disposal (the enumerator type converts to IDisposable/IAsyncDisposable)
         /// - we need to do a runtime check for IDisposable
         /// </summary>
-        /// <returns>Finall block, or null if none should be emitted.</returns>
+        /// <returns>Finally block, or null if none should be emitted.</returns>
         private BoundBlock? GetDisposalFinallyBlock(
             CSharpSyntaxNode forEachSyntax,
             ForEachEnumeratorInfo enumeratorInfo,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -14,6 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class LocalRewriter
     {
+        private static readonly AwaitDebugId s_moveNextAsyncAwaitId = new AwaitDebugId(RelativeStateOrdinal: 0);
+        private static readonly AwaitDebugId s_disposeAsyncAwaitId = new AwaitDebugId(RelativeStateOrdinal: 1);
+
         /// <summary>
         /// This is the entry point for foreach-loop lowering.  It delegates to
         ///   RewriteEnumeratorForEachStatement
@@ -208,14 +212,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var rewrittenBodyBlock = CreateBlockDeclaringIterationVariables(iterationVariables, iterationVarDecl, rewrittenBody, forEachSyntax);
             BoundExpression rewrittenCondition = SynthesizeCall(
-                    methodArgumentInfo: enumeratorInfo.MoveNextInfo,
-                    syntax: forEachSyntax,
-                    receiver: boundEnumeratorVar,
-                    allowExtensionAndOptionalParameters: isAsync);
+                methodArgumentInfo: enumeratorInfo.MoveNextInfo,
+                syntax: forEachSyntax,
+                receiver: boundEnumeratorVar,
+                allowExtensionAndOptionalParameters: isAsync);
+
+            var disposalFinallyBlock = GetDisposalFinallyBlock(forEachSyntax, enumeratorInfo, enumeratorType, boundEnumeratorVar, out var hasAsyncDisposal);
             if (isAsync)
             {
                 Debug.Assert(awaitableInfo is { GetResult: { } });
-                rewrittenCondition = RewriteAwaitExpression(forEachSyntax, rewrittenCondition, awaitableInfo, awaitableInfo.GetResult.ReturnType, used: true);
+
+                // We need to be sure that when the disposal isn't async we reserve an unused state machine state number for it,
+                // so that await foreach always produces 2 state machine states: one for MoveNextAsync and the other for DisposeAsync.
+                // Otherwise, EnC wouldn't be able to map states when the disposal changes from having async dispose to not, or vice versa.
+                var debugInfo = new BoundAwaitExpressionDebugInfo(s_moveNextAsyncAwaitId, ReservedStateMachineCount: (byte)(hasAsyncDisposal ? 0 : 1));
+
+                rewrittenCondition = RewriteAwaitExpression(forEachSyntax, rewrittenCondition, awaitableInfo, awaitableInfo.GetResult.ReturnType, debugInfo, used: true);
             }
 
             BoundStatement whileLoop = RewriteWhileStatement(
@@ -228,9 +240,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundStatement result;
 
-            if (enumeratorInfo.NeedsDisposal)
+            if (disposalFinallyBlock != null)
             {
-                BoundStatement tryFinally = WrapWithTryFinallyDispose(forEachSyntax, enumeratorInfo, enumeratorType, boundEnumeratorVar, whileLoop);
+                // try {
+                //     while (e.MoveNext()) {
+                //         V v = (V)(T)e.Current;  -OR-  (D1 d1, ...) = (V)(T)e.Current;
+                //         /* loop body */
+                //     }
+                // }
+                // finally {
+                //     /* dispose of e */
+                // }
+                BoundStatement tryFinally = new BoundTryStatement(
+                    forEachSyntax,
+                    tryBlock: new BoundBlock(forEachSyntax, locals: ImmutableArray<LocalSymbol>.Empty, statements: ImmutableArray.Create(whileLoop)),
+                    catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
+                    finallyBlockOpt: disposalFinallyBlock);
 
                 // E e = ((C)(x)).GetEnumerator();
                 // try {
@@ -275,14 +300,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// - interface-based disposal (the enumerator type converts to IDisposable/IAsyncDisposable)
         /// - we need to do a runtime check for IDisposable
         /// </summary>
-        private BoundStatement WrapWithTryFinallyDispose(
+        /// <returns>Finall block, or null if none should be emitted.</returns>
+        private BoundBlock? GetDisposalFinallyBlock(
             CSharpSyntaxNode forEachSyntax,
             ForEachEnumeratorInfo enumeratorInfo,
             TypeSymbol enumeratorType,
             BoundLocal boundEnumeratorVar,
-            BoundStatement rewrittenBody)
+            out bool hasAsyncDisposal)
         {
-            Debug.Assert(enumeratorInfo.NeedsDisposal);
+            hasAsyncDisposal = false;
+
+            if (!enumeratorInfo.NeedsDisposal)
+            {
+                return null;
+            }
 
             NamedTypeSymbol? idisposableTypeSymbol = null;
             bool isImplicit = false;
@@ -295,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // This is a temporary workaround for https://github.com/dotnet/roslyn/issues/39948
                 if (disposeMethod is null)
                 {
-                    return rewrittenBody;
+                    return null;
                 }
 
                 idisposableTypeSymbol = disposeMethod.ContainingType;
@@ -313,7 +344,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                containingType: _factory.CurrentType,
                                                location: enumeratorInfo.Location);
 
-            BoundBlock finallyBlockOpt;
             if (isImplicit || !(enumeratorInfo.PatternDisposeInfo is null))
             {
                 Conversion receiverConversion = enumeratorType.IsStructType() ?
@@ -344,6 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // await /* disposeCall */
                     disposeCallStatement = WrapWithAwait(forEachSyntax, disposeCall, disposeAwaitableInfoOpt);
                     _sawAwaitInExceptionHandler = true;
+                    hasAsyncDisposal = true;
                 }
                 else
                 {
@@ -373,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors: false);
                 }
 
-                finallyBlockOpt = new BoundBlock(forEachSyntax,
+                return new BoundBlock(forEachSyntax,
                     locals: ImmutableArray<LocalSymbol>.Empty,
                     statements: ImmutableArray.Create(alwaysOrMaybeDisposeStmt));
             }
@@ -429,27 +460,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // IDisposable d = e as IDisposable;
                 // if (d != null) d.Dispose();
-                finallyBlockOpt = new BoundBlock(forEachSyntax,
+                return new BoundBlock(forEachSyntax,
                     locals: ImmutableArray.Create(disposableVar),
                     statements: ImmutableArray.Create(disposableVarDecl, ifStmt));
             }
-
-            // try {
-            //     while (e.MoveNext()) {
-            //         V v = (V)(T)e.Current;  -OR-  (D1 d1, ...) = (V)(T)e.Current;
-            //         /* loop body */
-            //     }
-            // }
-            // finally {
-            //     /* dispose of e */
-            // }
-            BoundStatement tryFinally = new BoundTryStatement(forEachSyntax,
-                tryBlock: new BoundBlock(forEachSyntax,
-                    locals: ImmutableArray<LocalSymbol>.Empty,
-                    statements: ImmutableArray.Create<BoundStatement>(rewrittenBody)),
-                catchBlocks: ImmutableArray<BoundCatchBlock>.Empty,
-                finallyBlockOpt: finallyBlockOpt);
-            return tryFinally;
         }
 
         /// <summary>
@@ -459,7 +473,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundStatement WrapWithAwait(SyntaxNode forEachSyntax, BoundExpression disposeCall, BoundAwaitableInfo disposeAwaitableInfoOpt)
         {
             TypeSymbol awaitExpressionType = disposeAwaitableInfoOpt.GetResult?.ReturnType ?? _compilation.DynamicType;
-            var awaitExpr = RewriteAwaitExpression(forEachSyntax, disposeCall, disposeAwaitableInfoOpt, awaitExpressionType, used: false);
+            var debugInfo = new BoundAwaitExpressionDebugInfo(s_disposeAsyncAwaitId, ReservedStateMachineCount: 0);
+            var awaitExpr = RewriteAwaitExpression(forEachSyntax, disposeCall, disposeAwaitableInfoOpt, awaitExpressionType, debugInfo, used: false);
             return new BoundExpressionStatement(forEachSyntax, awaitExpr);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _sawAwaitInExceptionHandler = true;
 
                     TypeSymbol awaitExpressionType = awaitOpt.GetResult?.ReturnType ?? _compilation.DynamicType;
-                    disposeCall = RewriteAwaitExpression(resourceSyntax, disposeCall, awaitOpt, awaitExpressionType, false);
+                    disposeCall = RewriteAwaitExpression(resourceSyntax, disposeCall, awaitOpt, awaitExpressionType, debugInfo: default, used: false);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -722,7 +722,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // the spilling will occur in the enclosing node.
             BoundSpillSequenceBuilder builder = null;
             var expr = VisitExpression(ref builder, node.Expression);
-            return UpdateExpression(builder, node.Update(expr, node.AwaitableInfo, node.Type));
+            return UpdateExpression(builder, node.Update(expr, node.AwaitableInfo, node.DebugInfo, node.Type));
         }
 
         public override BoundNode VisitSpillSequence(BoundSpillSequence node)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -206,22 +206,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 #nullable enable
-        protected void AddResumableState(SyntaxNode awaitOrYieldReturnSyntax, out StateMachineState state, out GeneratedLabelSymbol resumeLabel)
-            => AddResumableState(_resumableStateAllocator, awaitOrYieldReturnSyntax, out state, out resumeLabel);
+        protected void AddResumableState(SyntaxNode awaitOrYieldReturnSyntax, AwaitDebugId awaitId, out StateMachineState state, out GeneratedLabelSymbol resumeLabel)
+            => AddResumableState(_resumableStateAllocator, awaitOrYieldReturnSyntax, awaitId, out state, out resumeLabel);
 
-        protected void AddResumableState(ResumableStateMachineStateAllocator allocator, SyntaxNode awaitOrYieldReturnSyntax, out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel)
+        protected void AddResumableState(ResumableStateMachineStateAllocator allocator, SyntaxNode awaitOrYieldReturnSyntax, AwaitDebugId awaitId, out StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel)
         {
-            stateNumber = allocator.AllocateState(awaitOrYieldReturnSyntax);
-            AddStateDebugInfo(awaitOrYieldReturnSyntax, stateNumber);
+            stateNumber = allocator.AllocateState(awaitOrYieldReturnSyntax, awaitId);
+            AddStateDebugInfo(awaitOrYieldReturnSyntax, awaitId, stateNumber);
             AddState(stateNumber, out resumeLabel);
         }
 
-        protected void AddStateDebugInfo(SyntaxNode node, StateMachineState state)
+        protected void AddStateDebugInfo(SyntaxNode node, AwaitDebugId awaitId, StateMachineState state)
         {
             Debug.Assert(SyntaxBindingUtilities.BindsToResumableStateMachineState(node) || SyntaxBindingUtilities.BindsToTryStatement(node), $"Unexpected syntax: {node.Kind()}");
 
             int syntaxOffset = CurrentMethod.CalculateLocalSyntaxOffset(node.SpanStart, node.SyntaxTree);
-            _stateDebugInfoBuilder.Add(new StateMachineStateDebugInfo(syntaxOffset, state));
+            _stateDebugInfoBuilder.Add(new StateMachineStateDebugInfo(syntaxOffset, awaitId, state));
         }
 
         protected void AddState(StateMachineState stateNumber, out GeneratedLabelSymbol resumeLabel)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/ResumableStateMachineStateAllocator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/ResumableStateMachineStateAllocator.cs
@@ -43,13 +43,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             _nextState = slotAllocator?.GetFirstUnusedStateMachineState(increasing) ?? firstState;
         }
 
-        public StateMachineState AllocateState(SyntaxNode awaitOrYieldReturnSyntax)
+        public StateMachineState AllocateState(SyntaxNode awaitOrYieldReturnSyntax, AwaitDebugId awaitId)
         {
             Debug.Assert(SyntaxBindingUtilities.BindsToResumableStateMachineState(awaitOrYieldReturnSyntax));
 
             int direction = _increasing ? +1 : -1;
 
-            if (_slotAllocator?.TryGetPreviousStateMachineState(awaitOrYieldReturnSyntax, out var state) == true)
+            if (_slotAllocator?.TryGetPreviousStateMachineState(awaitOrYieldReturnSyntax, awaitId, out var state) == true)
             {
 #if DEBUG
                 // two states of the new state machine should not match the same state of the previous machine:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1619,12 +1619,15 @@ class C
 }";
             var expected = new[]
             {
-                // (4,60): error CS8652: The feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // 1.cs(2,2): error CS8370: Feature 'nullable reference types' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // #nullable disable
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "nullable").WithArguments("nullable reference types", "8.0").WithLocation(2, 2),
+                // 0.cs(4,60): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //     async System.Collections.Generic.IAsyncEnumerator<int> M()
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M").WithArguments("async streams", "8.0").WithLocation(4, 60),
-                // (34,2): error CS8652: The feature 'nullable reference types' is not available in C# 7.3. Please use language version 8.0 or greater.
+                // 1.cs(21,2): error CS8370: Feature 'nullable reference types' is not available in C# 7.3. Please use language version 8.0 or greater.
                 // #nullable disable
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "nullable").WithArguments("nullable reference types", "8.0").WithLocation(34, 2)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "nullable").WithArguments("nullable reference types", "8.0").WithLocation(21, 2)
             };
             var comp = CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, parseOptions: TestOptions.Regular7_3);
             comp.VerifyDiagnostics(expected);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -335,48 +335,45 @@ class C
             });
 
             vd.VerifyPdb("C.M", @"
-    <symbols>
-      <files>
-        <file id=""1"" name="""" language=""C#"" />
-      </files>
-      <methods>
-        <method containingType=""C"" name=""M"" parameterNames=""disposable"">
-          <customDebugInfo>
-            <forwardIterator name=""&lt;M&gt;d__3"" />
-            <encLocalSlotMap>
-              <slot kind=""6"" offset=""11"" />
-              <slot kind=""8"" offset=""11"" />
-              <slot kind=""0"" offset=""11"" />
-              <slot kind=""4"" offset=""53"" />
-              <slot kind=""6"" offset=""98"" />
-              <slot kind=""8"" offset=""98"" />
-              <slot kind=""0"" offset=""98"" />
-              <slot kind=""4"" offset=""151"" />
-              <slot kind=""4"" offset=""220"" />
-              <slot kind=""28"" offset=""261"" />
-              <slot kind=""28"" offset=""261"" ordinal=""1"" />
-              <slot kind=""28"" offset=""261"" ordinal=""2"" />
-              <slot kind=""28"" offset=""281"" />
-              <slot kind=""28"" offset=""281"" ordinal=""1"" />
-              <slot kind=""28"" offset=""281"" ordinal=""2"" />
-              <slot kind=""4"" offset=""307"" />
-              <slot kind=""4"" offset=""376"" />
-              <slot kind=""3"" offset=""410"" />
-              <slot kind=""2"" offset=""410"" />
-            </encLocalSlotMap>
-            <encStateMachineStateMap>
-              <state number=""0"" offset=""74"" />
-              <state number=""1"" offset=""172"" />
-              <state number=""2"" offset=""281"" />
-              <state number=""3"" offset=""261"" />
-              <state number=""4"" offset=""241"" />
-              <state number=""5"" offset=""328"" />
-            </encStateMachineStateMap>
-          </customDebugInfo>
-        </method>
-      </methods>
-    </symbols>
-");
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""M"" parameterNames=""disposable"">
+      <customDebugInfo>
+        <forwardIterator name=""&lt;M&gt;d__3"" />
+        <encLocalSlotMap>
+          <slot kind=""6"" offset=""11"" />
+          <slot kind=""8"" offset=""11"" />
+          <slot kind=""0"" offset=""11"" />
+          <slot kind=""4"" offset=""53"" />
+          <slot kind=""6"" offset=""98"" />
+          <slot kind=""8"" offset=""98"" />
+          <slot kind=""0"" offset=""98"" />
+          <slot kind=""4"" offset=""151"" />
+          <slot kind=""4"" offset=""220"" />
+          <slot kind=""28"" offset=""261"" />
+          <slot kind=""28"" offset=""261"" ordinal=""1"" />
+          <slot kind=""28"" offset=""261"" ordinal=""2"" />
+          <slot kind=""28"" offset=""281"" />
+          <slot kind=""28"" offset=""281"" ordinal=""1"" />
+          <slot kind=""28"" offset=""281"" ordinal=""2"" />
+          <slot kind=""4"" offset=""307"" />
+          <slot kind=""4"" offset=""376"" />
+          <slot kind=""3"" offset=""410"" />
+          <slot kind=""2"" offset=""410"" />
+        </encLocalSlotMap>
+        <encStateMachineStateMap>
+          <state number=""0"" offset=""74"" />
+          <state number=""1"" offset=""172"" />
+          <state number=""4"" offset=""241"" />
+          <state number=""3"" offset=""261"" />
+          <state number=""2"" offset=""281"" />
+          <state number=""5"" offset=""328"" />
+        </encStateMachineStateMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options: PdbValidationOptions.ExcludeDocuments);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -2513,7 +2513,7 @@ public class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      262 (0x106)
+  // Code size      273 (0x111)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
@@ -2528,118 +2528,124 @@ public class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_000c
-    IL_000a:  br.s       IL_0011
-    IL_000c:  br         IL_009a
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0017
+    IL_0010:  br.s       IL_001c
+    IL_0012:  br         IL_00a5
+    IL_0017:  br         IL_00a5
     // sequence point: {
-    IL_0011:  nop
+    IL_001c:  nop
     // sequence point: await foreach
-    IL_0012:  nop
+    IL_001d:  nop
     // sequence point: new C()
-    IL_0013:  ldarg.0
-    IL_0014:  newobj     ""C..ctor()""
-    IL_0019:  ldloca.s   V_1
-    IL_001b:  initobj    ""System.Threading.CancellationToken""
-    IL_0021:  ldloc.1
-    IL_0022:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0027:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_001e:  ldarg.0
+    IL_001f:  newobj     ""C..ctor()""
+    IL_0024:  ldloca.s   V_1
+    IL_0026:  initobj    ""System.Threading.CancellationToken""
+    IL_002c:  ldloc.1
+    IL_002d:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0032:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
     // sequence point: <hidden>
-    IL_002c:  br.s       IL_005c
+    IL_0037:  br.s       IL_0067
     // sequence point: var i
-    IL_002e:  ldarg.0
-    IL_002f:  ldarg.0
-    IL_0030:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_0035:  callvirt   ""int C.Enumerator.Current.get""
-    IL_003a:  stfld      ""int C.<Main>d__0.<i>5__2""
+    IL_0039:  ldarg.0
+    IL_003a:  ldarg.0
+    IL_003b:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0040:  callvirt   ""int C.Enumerator.Current.get""
+    IL_0045:  stfld      ""int C.<Main>d__0.<i>5__2""
     // sequence point: {
-    IL_003f:  nop
+    IL_004a:  nop
     // sequence point: Write($""Got({i}) "");
-    IL_0040:  ldstr      ""Got({0}) ""
-    IL_0045:  ldarg.0
-    IL_0046:  ldfld      ""int C.<Main>d__0.<i>5__2""
-    IL_004b:  box        ""int""
-    IL_0050:  call       ""string string.Format(string, object)""
-    IL_0055:  call       ""void System.Console.Write(string)""
-    IL_005a:  nop
+    IL_004b:  ldstr      ""Got({0}) ""
+    IL_0050:  ldarg.0
+    IL_0051:  ldfld      ""int C.<Main>d__0.<i>5__2""
+    IL_0056:  box        ""int""
+    IL_005b:  call       ""string string.Format(string, object)""
+    IL_0060:  call       ""void System.Console.Write(string)""
+    IL_0065:  nop
     // sequence point: }
-    IL_005b:  nop
+    IL_0066:  nop
     // sequence point: in
-    IL_005c:  ldarg.0
-    IL_005d:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_0062:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
-    IL_0067:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_006c:  stloc.2
+    IL_0067:  ldarg.0
+    IL_0068:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_006d:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
+    IL_0072:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_0077:  stloc.2
     // sequence point: <hidden>
-    IL_006d:  ldloca.s   V_2
-    IL_006f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_0074:  brtrue.s   IL_00b6
-    IL_0076:  ldarg.0
-    IL_0077:  ldc.i4.0
-    IL_0078:  dup
-    IL_0079:  stloc.0
-    IL_007a:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0078:  ldloca.s   V_2
+    IL_007a:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_007f:  brtrue.s   IL_00c1
+    IL_0081:  ldarg.0
+    IL_0082:  ldc.i4.0
+    IL_0083:  dup
+    IL_0084:  stloc.0
+    IL_0085:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_007f:  ldarg.0
-    IL_0080:  ldloc.2
-    IL_0081:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_0086:  ldarg.0
-    IL_0087:  stloc.3
-    IL_0088:  ldarg.0
-    IL_0089:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_008e:  ldloca.s   V_2
-    IL_0090:  ldloca.s   V_3
-    IL_0092:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-    IL_0097:  nop
-    IL_0098:  leave.s    IL_0105
+    IL_008a:  ldarg.0
+    IL_008b:  ldloc.2
+    IL_008c:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_0091:  ldarg.0
+    IL_0092:  stloc.3
+    IL_0093:  ldarg.0
+    IL_0094:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0099:  ldloca.s   V_2
+    IL_009b:  ldloca.s   V_3
+    IL_009d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_00a2:  nop
+    IL_00a3:  leave.s    IL_0110
     // async: resume
-    IL_009a:  ldarg.0
-    IL_009b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_00a0:  stloc.2
-    IL_00a1:  ldarg.0
-    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_00a7:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_00ad:  ldarg.0
-    IL_00ae:  ldc.i4.m1
-    IL_00af:  dup
-    IL_00b0:  stloc.0
-    IL_00b1:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b6:  ldarg.0
-    IL_00b7:  ldloca.s   V_2
-    IL_00b9:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_00be:  stfld      ""bool C.<Main>d__0.<>s__3""
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldfld      ""bool C.<Main>d__0.<>s__3""
-    IL_00c9:  brtrue     IL_002e
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00ab:  stloc.2
+    IL_00ac:  ldarg.0
+    IL_00ad:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00b2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00b8:  ldarg.0
+    IL_00b9:  ldc.i4.m1
+    IL_00ba:  dup
+    IL_00bb:  stloc.0
+    IL_00bc:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00c1:  ldarg.0
+    IL_00c2:  ldloca.s   V_2
+    IL_00c4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00c9:  stfld      ""bool C.<Main>d__0.<>s__3""
     IL_00ce:  ldarg.0
-    IL_00cf:  ldnull
-    IL_00d0:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_00d5:  leave.s    IL_00f1
+    IL_00cf:  ldfld      ""bool C.<Main>d__0.<>s__3""
+    IL_00d4:  brtrue     IL_0039
+    IL_00d9:  ldarg.0
+    IL_00da:  ldnull
+    IL_00db:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_00e0:  leave.s    IL_00fc
   }
   catch System.Exception
   {
     // async: catch handler, sequence point: <hidden>
-    IL_00d7:  stloc.s    V_4
-    IL_00d9:  ldarg.0
-    IL_00da:  ldc.i4.s   -2
-    IL_00dc:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00e1:  ldarg.0
-    IL_00e2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_00e7:  ldloc.s    V_4
-    IL_00e9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00ee:  nop
-    IL_00ef:  leave.s    IL_0105
+    IL_00e2:  stloc.s    V_4
+    IL_00e4:  ldarg.0
+    IL_00e5:  ldc.i4.s   -2
+    IL_00e7:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00f2:  ldloc.s    V_4
+    IL_00f4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00f9:  nop
+    IL_00fa:  leave.s    IL_0110
   }
   // sequence point: }
-  IL_00f1:  ldarg.0
-  IL_00f2:  ldc.i4.s   -2
-  IL_00f4:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00fc:  ldarg.0
+  IL_00fd:  ldc.i4.s   -2
+  IL_00ff:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00f9:  ldarg.0
-  IL_00fa:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_00ff:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0104:  nop
-  IL_0105:  ret
-}", sequencePoints: "C+<Main>d__0.MoveNext", source: source + s_IAsyncEnumerable);
+  IL_0104:  ldarg.0
+  IL_0105:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_010f:  nop
+  IL_0110:  ret
+}
+", sequencePoints: "C+<Main>d__0.MoveNext", source: source + s_IAsyncEnumerable);
         }
 
         [Fact]
@@ -4219,7 +4225,7 @@ class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      272 (0x110)
+  // Code size      283 (0x11b)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
@@ -4234,124 +4240,129 @@ class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_000c
-    IL_000a:  br.s       IL_0011
-    IL_000c:  br         IL_0096
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0017
+    IL_0010:  br.s       IL_001c
+    IL_0012:  br         IL_00a1
+    IL_0017:  br         IL_00a1
     // sequence point: {
-    IL_0011:  nop
+    IL_001c:  nop
     // sequence point: ICollection<int> c = new Collection<int>();
-    IL_0012:  ldarg.0
-    IL_0013:  newobj     ""Collection<int>..ctor()""
-    IL_0018:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_001d:  ldarg.0
+    IL_001e:  newobj     ""Collection<int>..ctor()""
+    IL_0023:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
     // sequence point: await foreach
-    IL_001d:  nop
+    IL_0028:  nop
     // sequence point: c
-    IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-    IL_0025:  ldloca.s   V_1
-    IL_0027:  initobj    ""System.Threading.CancellationToken""
-    IL_002d:  ldloc.1
-    IL_002e:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0033:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_0029:  ldarg.0
+    IL_002a:  ldarg.0
+    IL_002b:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_0030:  ldloca.s   V_1
+    IL_0032:  initobj    ""System.Threading.CancellationToken""
+    IL_0038:  ldloc.1
+    IL_0039:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_003e:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
     // sequence point: <hidden>
-    IL_0038:  br.s       IL_0058
+    IL_0043:  br.s       IL_0063
     // sequence point: var i
-    IL_003a:  ldarg.0
-    IL_003b:  ldarg.0
-    IL_003c:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_0041:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
-    IL_0046:  stfld      ""int C.<Main>d__0.<i>5__3""
+    IL_0045:  ldarg.0
+    IL_0046:  ldarg.0
+    IL_0047:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_004c:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
+    IL_0051:  stfld      ""int C.<Main>d__0.<i>5__3""
     // sequence point: {
-    IL_004b:  nop
-    // sequence point: Write($""Got "");
-    IL_004c:  ldstr      ""Got ""
-    IL_0051:  call       ""void System.Console.Write(string)""
     IL_0056:  nop
+    // sequence point: Write($""Got "");
+    IL_0057:  ldstr      ""Got ""
+    IL_005c:  call       ""void System.Console.Write(string)""
+    IL_0061:  nop
     // sequence point: }
-    IL_0057:  nop
+    IL_0062:  nop
     // sequence point: in
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_005e:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
-    IL_0063:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_0068:  stloc.2
+    IL_0063:  ldarg.0
+    IL_0064:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_0069:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
+    IL_006e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_0073:  stloc.2
     // sequence point: <hidden>
-    IL_0069:  ldloca.s   V_2
-    IL_006b:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_0070:  brtrue.s   IL_00b2
-    IL_0072:  ldarg.0
-    IL_0073:  ldc.i4.0
-    IL_0074:  dup
-    IL_0075:  stloc.0
-    IL_0076:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0074:  ldloca.s   V_2
+    IL_0076:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_007b:  brtrue.s   IL_00bd
+    IL_007d:  ldarg.0
+    IL_007e:  ldc.i4.0
+    IL_007f:  dup
+    IL_0080:  stloc.0
+    IL_0081:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_007b:  ldarg.0
-    IL_007c:  ldloc.2
-    IL_007d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_0082:  ldarg.0
-    IL_0083:  stloc.3
-    IL_0084:  ldarg.0
-    IL_0085:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_008a:  ldloca.s   V_2
-    IL_008c:  ldloca.s   V_3
-    IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-    IL_0093:  nop
-    IL_0094:  leave.s    IL_010f
+    IL_0086:  ldarg.0
+    IL_0087:  ldloc.2
+    IL_0088:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_008d:  ldarg.0
+    IL_008e:  stloc.3
+    IL_008f:  ldarg.0
+    IL_0090:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0095:  ldloca.s   V_2
+    IL_0097:  ldloca.s   V_3
+    IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_009e:  nop
+    IL_009f:  leave.s    IL_011a
     // async: resume
-    IL_0096:  ldarg.0
-    IL_0097:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_009c:  stloc.2
-    IL_009d:  ldarg.0
-    IL_009e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_00a3:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_00a9:  ldarg.0
-    IL_00aa:  ldc.i4.m1
-    IL_00ab:  dup
-    IL_00ac:  stloc.0
-    IL_00ad:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldloca.s   V_2
-    IL_00b5:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_00ba:  stfld      ""bool C.<Main>d__0.<>s__4""
-    IL_00bf:  ldarg.0
-    IL_00c0:  ldfld      ""bool C.<Main>d__0.<>s__4""
-    IL_00c5:  brtrue     IL_003a
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a7:  stloc.2
+    IL_00a8:  ldarg.0
+    IL_00a9:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00ae:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldc.i4.m1
+    IL_00b6:  dup
+    IL_00b7:  stloc.0
+    IL_00b8:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00bd:  ldarg.0
+    IL_00be:  ldloca.s   V_2
+    IL_00c0:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00c5:  stfld      ""bool C.<Main>d__0.<>s__4""
     IL_00ca:  ldarg.0
-    IL_00cb:  ldnull
-    IL_00cc:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_00d1:  leave.s    IL_00f4
+    IL_00cb:  ldfld      ""bool C.<Main>d__0.<>s__4""
+    IL_00d0:  brtrue     IL_0045
+    IL_00d5:  ldarg.0
+    IL_00d6:  ldnull
+    IL_00d7:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_00dc:  leave.s    IL_00ff
   }
   catch System.Exception
   {
     // async: catch handler, sequence point: <hidden>
-    IL_00d3:  stloc.s    V_4
-    IL_00d5:  ldarg.0
-    IL_00d6:  ldc.i4.s   -2
-    IL_00d8:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00dd:  ldarg.0
-    IL_00de:  ldnull
-    IL_00df:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-    IL_00e4:  ldarg.0
-    IL_00e5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_00ea:  ldloc.s    V_4
-    IL_00ec:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00f1:  nop
-    IL_00f2:  leave.s    IL_010f
+    IL_00de:  stloc.s    V_4
+    IL_00e0:  ldarg.0
+    IL_00e1:  ldc.i4.s   -2
+    IL_00e3:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00e8:  ldarg.0
+    IL_00e9:  ldnull
+    IL_00ea:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_00ef:  ldarg.0
+    IL_00f0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00f5:  ldloc.s    V_4
+    IL_00f7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00fc:  nop
+    IL_00fd:  leave.s    IL_011a
   }
   // sequence point: }
-  IL_00f4:  ldarg.0
-  IL_00f5:  ldc.i4.s   -2
-  IL_00f7:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00ff:  ldarg.0
+  IL_0100:  ldc.i4.s   -2
+  IL_0102:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00fc:  ldarg.0
-  IL_00fd:  ldnull
-  IL_00fe:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-  IL_0103:  ldarg.0
-  IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_0109:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_010e:  nop
-  IL_010f:  ret
+  IL_0107:  ldarg.0
+  IL_0108:  ldnull
+  IL_0109:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+  IL_010e:  ldarg.0
+  IL_010f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_0114:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0119:  nop
+  IL_011a:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -6744,7 +6744,7 @@ class C
 
             var diff1 = compilation1.EmitDifference(
                     generation0,
-                    [SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)]);
+                    ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
@@ -7009,7 +7009,7 @@ class C
                 NonDisposableAsyncEnumeratorDefinition + CommonAsyncStreamsTypes, options: (CSharpParseOptions)source0.Tree.Options, filename: "AsyncStreams.cs");
 
             var compilation0 = CreateCompilationWithTasksExtensions(new[] { source0.Tree, asyncStreamsTree }, options: ComSafeDebugDll);
-            var compilation1 = compilation0.WithSource([source1.Tree, asyncStreamsTree]);
+            var compilation1 = compilation0.WithSource(new[] { source1.Tree, asyncStreamsTree });
 
             var v0 = CompileAndVerify(compilation0);
             v0.VerifyDiagnostics();
@@ -7183,7 +7183,7 @@ class C
 
             var diff1 = compilation1.EmitDifference(
                     generation0,
-                    [SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)]);
+                    ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -6418,6 +6418,897 @@ class C
         }
 
         [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69805")]
+        public void UpdateAwaitForEach_AsyncDisposableEnumerator()
+        {
+            var source0 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task F()
+    {
+        <N:0>await foreach (var x in Iterator())</N:0>
+        {
+            Body(1);
+        }
+
+        End();
+    }
+
+    IAsyncEnumerable<int> Iterator() => null;
+    static void Body(int x) {}
+    static void End() { }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task F()
+    {
+        <N:0>await foreach (var x in Iterator())</N:0>
+        {
+            Body(2);
+        }
+
+        End();
+    }
+
+    IAsyncEnumerable<int> Iterator() => null;
+    static void Body(int x) { }
+    static void End() { }
+}");
+            var asyncStreamsTree = Parse(
+                AsyncStreamsTypes, options: (CSharpParseOptions)source0.Tree.Options, filename: "AsyncStreams.cs");
+
+            var compilation0 = CreateCompilationWithTasksExtensions(new[] { source0.Tree, asyncStreamsTree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource([source1.Tree, asyncStreamsTree]);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            v0.VerifyPdb("C.F", @"
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""F"">
+      <customDebugInfo>
+        <forwardIterator name=""&lt;F&gt;d__0"" />
+        <encLocalSlotMap>
+          <slot kind=""5"" offset=""16"" />
+          <slot kind=""22"" offset=""16"" />
+          <slot kind=""23"" offset=""16"" />
+          <slot kind=""0"" offset=""16"" />
+          <slot kind=""28"" offset=""16"" />
+        </encLocalSlotMap>
+        <encStateMachineStateMap>
+          <state number=""0"" offset=""16"" />
+          <state number=""1"" offset=""16"" />
+        </encStateMachineStateMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options: PdbValidationOptions.ExcludeDocuments);
+
+            v0.VerifyMethodBody("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+{
+  // Code size      477 (0x1dd)
+  .maxstack  3
+  .locals init (int V_0,
+                System.Threading.CancellationToken V_1,
+                System.Runtime.CompilerServices.ValueTaskAwaiter<bool> V_2,
+                System.Threading.Tasks.ValueTask<bool> V_3,
+                C.<F>d__0 V_4,
+                object V_5,
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
+                System.Threading.Tasks.ValueTask V_7,
+                System.Exception V_8)
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    // sequence point: <hidden>
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_0048
+    IL_0014:  br         IL_0143
+    // sequence point: {
+    IL_0019:  nop
+    // sequence point: await foreach
+    IL_001a:  nop
+    // sequence point: Iterator()
+    IL_001b:  ldarg.0
+    IL_001c:  ldarg.0
+    IL_001d:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0022:  call       ""System.Collections.Generic.IAsyncEnumerable<int> C.Iterator()""
+    IL_0027:  ldloca.s   V_1
+    IL_0029:  initobj    ""System.Threading.CancellationToken""
+    IL_002f:  ldloc.1
+    IL_0030:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0035:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    // sequence point: <hidden>
+    IL_003a:  ldarg.0
+    IL_003b:  ldnull
+    IL_003c:  stfld      ""object C.<F>d__0.<>s__2""
+    IL_0041:  ldarg.0
+    IL_0042:  ldc.i4.0
+    IL_0043:  stfld      ""int C.<F>d__0.<>s__3""
+    // sequence point: <hidden>
+    IL_0048:  nop
+    .try
+    {
+      // sequence point: <hidden>
+      IL_0049:  ldloc.0
+      IL_004a:  brfalse.s  IL_004e
+      IL_004c:  br.s       IL_0050
+      IL_004e:  br.s       IL_00b1
+      // sequence point: <hidden>
+      IL_0050:  br.s       IL_006c
+      // sequence point: var x
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+      IL_0059:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
+      IL_005e:  stfld      ""int C.<F>d__0.<x>5__4""
+      // sequence point: {
+      IL_0063:  nop
+      // sequence point: Body(1);
+      IL_0064:  ldc.i4.1
+      IL_0065:  call       ""void C.Body(int)""
+      IL_006a:  nop
+      // sequence point: }
+      IL_006b:  nop
+      // sequence point: in
+      IL_006c:  ldarg.0
+      IL_006d:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+      IL_0072:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
+      IL_0077:  stloc.3
+      IL_0078:  ldloca.s   V_3
+      IL_007a:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
+      IL_007f:  stloc.2
+      // sequence point: <hidden>
+      IL_0080:  ldloca.s   V_2
+      IL_0082:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
+      IL_0087:  brtrue.s   IL_00cd
+      IL_0089:  ldarg.0
+      IL_008a:  ldc.i4.0
+      IL_008b:  dup
+      IL_008c:  stloc.0
+      IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+      // async: yield
+      IL_0092:  ldarg.0
+      IL_0093:  ldloc.2
+      IL_0094:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_0099:  ldarg.0
+      IL_009a:  stloc.s    V_4
+      IL_009c:  ldarg.0
+      IL_009d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+      IL_00a2:  ldloca.s   V_2
+      IL_00a4:  ldloca.s   V_4
+      IL_00a6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<F>d__0)""
+      IL_00ab:  nop
+      IL_00ac:  leave      IL_01dc
+      // async: resume
+      IL_00b1:  ldarg.0
+      IL_00b2:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_00b7:  stloc.2
+      IL_00b8:  ldarg.0
+      IL_00b9:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_00be:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
+      IL_00c4:  ldarg.0
+      IL_00c5:  ldc.i4.m1
+      IL_00c6:  dup
+      IL_00c7:  stloc.0
+      IL_00c8:  stfld      ""int C.<F>d__0.<>1__state""
+      IL_00cd:  ldarg.0
+      IL_00ce:  ldloca.s   V_2
+      IL_00d0:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
+      IL_00d5:  stfld      ""bool C.<F>d__0.<>s__5""
+      IL_00da:  ldarg.0
+      IL_00db:  ldfld      ""bool C.<F>d__0.<>s__5""
+      IL_00e0:  brtrue     IL_0052
+      // sequence point: <hidden>
+      IL_00e5:  leave.s    IL_00f3
+    }
+    catch object
+    {
+      // sequence point: <hidden>
+      IL_00e7:  stloc.s    V_5
+      IL_00e9:  ldarg.0
+      IL_00ea:  ldloc.s    V_5
+      IL_00ec:  stfld      ""object C.<F>d__0.<>s__2""
+      IL_00f1:  leave.s    IL_00f3
+    }
+    // sequence point: <hidden>
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_00f9:  brfalse.s  IL_0168
+    IL_00fb:  ldarg.0
+    IL_00fc:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_0101:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_0106:  stloc.s    V_7
+    IL_0108:  ldloca.s   V_7
+    IL_010a:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_010f:  stloc.s    V_6
+    // sequence point: <hidden>
+    IL_0111:  ldloca.s   V_6
+    IL_0113:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0118:  brtrue.s   IL_0160
+    IL_011a:  ldarg.0
+    IL_011b:  ldc.i4.1
+    IL_011c:  dup
+    IL_011d:  stloc.0
+    IL_011e:  stfld      ""int C.<F>d__0.<>1__state""
+    // async: yield
+    IL_0123:  ldarg.0
+    IL_0124:  ldloc.s    V_6
+    IL_0126:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_012b:  ldarg.0
+    IL_012c:  stloc.s    V_4
+    IL_012e:  ldarg.0
+    IL_012f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_0134:  ldloca.s   V_6
+    IL_0136:  ldloca.s   V_4
+    IL_0138:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<F>d__0)""
+    IL_013d:  nop
+    IL_013e:  leave      IL_01dc
+    // async: resume
+    IL_0143:  ldarg.0
+    IL_0144:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_0149:  stloc.s    V_6
+    IL_014b:  ldarg.0
+    IL_014c:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_0151:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_0157:  ldarg.0
+    IL_0158:  ldc.i4.m1
+    IL_0159:  dup
+    IL_015a:  stloc.0
+    IL_015b:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0160:  ldloca.s   V_6
+    IL_0162:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_0167:  nop
+    // sequence point: <hidden>
+    IL_0168:  ldarg.0
+    IL_0169:  ldfld      ""object C.<F>d__0.<>s__2""
+    IL_016e:  stloc.s    V_5
+    IL_0170:  ldloc.s    V_5
+    IL_0172:  brfalse.s  IL_0191
+    IL_0174:  ldloc.s    V_5
+    IL_0176:  isinst     ""System.Exception""
+    IL_017b:  stloc.s    V_8
+    IL_017d:  ldloc.s    V_8
+    IL_017f:  brtrue.s   IL_0184
+    IL_0181:  ldloc.s    V_5
+    IL_0183:  throw
+    IL_0184:  ldloc.s    V_8
+    IL_0186:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_018b:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0190:  nop
+    IL_0191:  ldarg.0
+    IL_0192:  ldfld      ""int C.<F>d__0.<>s__3""
+    IL_0197:  pop
+    IL_0198:  ldarg.0
+    IL_0199:  ldnull
+    IL_019a:  stfld      ""object C.<F>d__0.<>s__2""
+    IL_019f:  ldarg.0
+    IL_01a0:  ldnull
+    IL_01a1:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    // sequence point: End();
+    IL_01a6:  call       ""void C.End()""
+    IL_01ab:  nop
+    IL_01ac:  leave.s    IL_01c8
+  }
+  catch System.Exception
+  {
+    // sequence point: <hidden>
+    IL_01ae:  stloc.s    V_8
+    IL_01b0:  ldarg.0
+    IL_01b1:  ldc.i4.s   -2
+    IL_01b3:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_01b8:  ldarg.0
+    IL_01b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_01be:  ldloc.s    V_8
+    IL_01c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_01c5:  nop
+    IL_01c6:  leave.s    IL_01dc
+  }
+  // sequence point: }
+  IL_01c8:  ldarg.0
+  IL_01c9:  ldc.i4.s   -2
+  IL_01cb:  stfld      ""int C.<F>d__0.<>1__state""
+  // sequence point: <hidden>
+  IL_01d0:  ldarg.0
+  IL_01d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_01d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01db:  nop
+  IL_01dc:  ret
+}
+");
+
+            var diff1 = compilation1.EmitDifference(
+                    generation0,
+                    [SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)]);
+
+            diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+{
+  // Code size      477 (0x1dd)
+  .maxstack  3
+  .locals init (int V_0,
+                System.Threading.CancellationToken V_1,
+                System.Runtime.CompilerServices.ValueTaskAwaiter<bool> V_2,
+                System.Threading.Tasks.ValueTask<bool> V_3,
+                C.<F>d__0 V_4,
+                object V_5,
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
+                System.Threading.Tasks.ValueTask V_7,
+                System.Exception V_8)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_0048
+    IL_0014:  br         IL_0143
+    IL_0019:  nop
+    IL_001a:  nop
+    IL_001b:  ldarg.0
+    IL_001c:  ldarg.0
+    IL_001d:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0022:  call       ""System.Collections.Generic.IAsyncEnumerable<int> C.Iterator()""
+    IL_0027:  ldloca.s   V_1
+    IL_0029:  initobj    ""System.Threading.CancellationToken""
+    IL_002f:  ldloc.1
+    IL_0030:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0035:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_003a:  ldarg.0
+    IL_003b:  ldnull
+    IL_003c:  stfld      ""object C.<F>d__0.<>s__2""
+    IL_0041:  ldarg.0
+    IL_0042:  ldc.i4.0
+    IL_0043:  stfld      ""int C.<F>d__0.<>s__3""
+    IL_0048:  nop
+    .try
+    {
+      IL_0049:  ldloc.0
+      IL_004a:  brfalse.s  IL_004e
+      IL_004c:  br.s       IL_0050
+      IL_004e:  br.s       IL_00b1
+      IL_0050:  br.s       IL_006c
+      IL_0052:  ldarg.0
+      IL_0053:  ldarg.0
+      IL_0054:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+      IL_0059:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
+      IL_005e:  stfld      ""int C.<F>d__0.<x>5__4""
+      IL_0063:  nop
+      IL_0064:  ldc.i4.2
+      IL_0065:  call       ""void C.Body(int)""
+      IL_006a:  nop
+      IL_006b:  nop
+      IL_006c:  ldarg.0
+      IL_006d:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+      IL_0072:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
+      IL_0077:  stloc.3
+      IL_0078:  ldloca.s   V_3
+      IL_007a:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
+      IL_007f:  stloc.2
+      IL_0080:  ldloca.s   V_2
+      IL_0082:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
+      IL_0087:  brtrue.s   IL_00cd
+      IL_0089:  ldarg.0
+      IL_008a:  ldc.i4.0
+      IL_008b:  dup
+      IL_008c:  stloc.0
+      IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+      IL_0092:  ldarg.0
+      IL_0093:  ldloc.2
+      IL_0094:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_0099:  ldarg.0
+      IL_009a:  stloc.s    V_4
+      IL_009c:  ldarg.0
+      IL_009d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+      IL_00a2:  ldloca.s   V_2
+      IL_00a4:  ldloca.s   V_4
+      IL_00a6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<F>d__0)""
+      IL_00ab:  nop
+      IL_00ac:  leave      IL_01dc
+      IL_00b1:  ldarg.0
+      IL_00b2:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_00b7:  stloc.2
+      IL_00b8:  ldarg.0
+      IL_00b9:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+      IL_00be:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
+      IL_00c4:  ldarg.0
+      IL_00c5:  ldc.i4.m1
+      IL_00c6:  dup
+      IL_00c7:  stloc.0
+      IL_00c8:  stfld      ""int C.<F>d__0.<>1__state""
+      IL_00cd:  ldarg.0
+      IL_00ce:  ldloca.s   V_2
+      IL_00d0:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
+      IL_00d5:  stfld      ""bool C.<F>d__0.<>s__5""
+      IL_00da:  ldarg.0
+      IL_00db:  ldfld      ""bool C.<F>d__0.<>s__5""
+      IL_00e0:  brtrue     IL_0052
+      IL_00e5:  leave.s    IL_00f3
+    }
+    catch object
+    {
+      IL_00e7:  stloc.s    V_5
+      IL_00e9:  ldarg.0
+      IL_00ea:  ldloc.s    V_5
+      IL_00ec:  stfld      ""object C.<F>d__0.<>s__2""
+      IL_00f1:  leave.s    IL_00f3
+    }
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_00f9:  brfalse.s  IL_0168
+    IL_00fb:  ldarg.0
+    IL_00fc:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_0101:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_0106:  stloc.s    V_7
+    IL_0108:  ldloca.s   V_7
+    IL_010a:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_010f:  stloc.s    V_6
+    IL_0111:  ldloca.s   V_6
+    IL_0113:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0118:  brtrue.s   IL_0160
+    IL_011a:  ldarg.0
+    IL_011b:  ldc.i4.1
+    IL_011c:  dup
+    IL_011d:  stloc.0
+    IL_011e:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0123:  ldarg.0
+    IL_0124:  ldloc.s    V_6
+    IL_0126:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_012b:  ldarg.0
+    IL_012c:  stloc.s    V_4
+    IL_012e:  ldarg.0
+    IL_012f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_0134:  ldloca.s   V_6
+    IL_0136:  ldloca.s   V_4
+    IL_0138:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<F>d__0)""
+    IL_013d:  nop
+    IL_013e:  leave      IL_01dc
+    IL_0143:  ldarg.0
+    IL_0144:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_0149:  stloc.s    V_6
+    IL_014b:  ldarg.0
+    IL_014c:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<F>d__0.<>u__2""
+    IL_0151:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_0157:  ldarg.0
+    IL_0158:  ldc.i4.m1
+    IL_0159:  dup
+    IL_015a:  stloc.0
+    IL_015b:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0160:  ldloca.s   V_6
+    IL_0162:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_0167:  nop
+    IL_0168:  ldarg.0
+    IL_0169:  ldfld      ""object C.<F>d__0.<>s__2""
+    IL_016e:  stloc.s    V_5
+    IL_0170:  ldloc.s    V_5
+    IL_0172:  brfalse.s  IL_0191
+    IL_0174:  ldloc.s    V_5
+    IL_0176:  isinst     ""System.Exception""
+    IL_017b:  stloc.s    V_8
+    IL_017d:  ldloc.s    V_8
+    IL_017f:  brtrue.s   IL_0184
+    IL_0181:  ldloc.s    V_5
+    IL_0183:  throw
+    IL_0184:  ldloc.s    V_8
+    IL_0186:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_018b:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0190:  nop
+    IL_0191:  ldarg.0
+    IL_0192:  ldfld      ""int C.<F>d__0.<>s__3""
+    IL_0197:  pop
+    IL_0198:  ldarg.0
+    IL_0199:  ldnull
+    IL_019a:  stfld      ""object C.<F>d__0.<>s__2""
+    IL_019f:  ldarg.0
+    IL_01a0:  ldnull
+    IL_01a1:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_01a6:  call       ""void C.End()""
+    IL_01ab:  nop
+    IL_01ac:  leave.s    IL_01c8
+  }
+  catch System.Exception
+  {
+    IL_01ae:  stloc.s    V_8
+    IL_01b0:  ldarg.0
+    IL_01b1:  ldc.i4.s   -2
+    IL_01b3:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_01b8:  ldarg.0
+    IL_01b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_01be:  ldloc.s    V_8
+    IL_01c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_01c5:  nop
+    IL_01c6:  leave.s    IL_01dc
+  }
+  IL_01c8:  ldarg.0
+  IL_01c9:  ldc.i4.s   -2
+  IL_01cb:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_01d0:  ldarg.0
+  IL_01d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_01d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01db:  nop
+  IL_01dc:  ret
+}");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/69805")]
+        public void UpdateAwaitForEach_NonDisposableEnumerator()
+        {
+            var source0 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task F()
+    {
+        <N:0>await foreach (var x in Iterator())</N:0>
+        {
+            Body(1);
+        }
+
+        End();
+    }
+
+    IAsyncEnumerable<int> Iterator() => null;
+    static void Body(int x) {}
+    static void End() { }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    async Task F()
+    {
+        <N:0>await foreach (var x in Iterator())</N:0>
+        {
+            Body(2);
+        }
+
+        End();
+    }
+
+    IAsyncEnumerable<int> Iterator() => null;
+    static void Body(int x) { }
+    static void End() { }
+}");
+            var asyncStreamsTree = Parse(
+                NonDisposableAsyncEnumeratorDefinition + CommonAsyncStreamsTypes, options: (CSharpParseOptions)source0.Tree.Options, filename: "AsyncStreams.cs");
+
+            var compilation0 = CreateCompilationWithTasksExtensions(new[] { source0.Tree, asyncStreamsTree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource([source1.Tree, asyncStreamsTree]);
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            // Both states are allocated eventhough only a single await is emitted:
+            v0.VerifyPdb("C.F", @"
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""F"">
+      <customDebugInfo>
+        <forwardIterator name=""&lt;F&gt;d__0"" />
+        <encLocalSlotMap>
+          <slot kind=""5"" offset=""16"" />
+          <slot kind=""0"" offset=""16"" />
+          <slot kind=""28"" offset=""16"" />
+        </encLocalSlotMap>
+        <encStateMachineStateMap>
+          <state number=""0"" offset=""16"" />
+          <state number=""1"" offset=""16"" />
+        </encStateMachineStateMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options: PdbValidationOptions.ExcludeDocuments);
+
+            v0.VerifyMethodBody("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+{
+  // Code size      266 (0x10a)
+  .maxstack  3
+  .locals init (int V_0,
+                System.Threading.CancellationToken V_1,
+                System.Runtime.CompilerServices.ValueTaskAwaiter<bool> V_2,
+                System.Threading.Tasks.ValueTask<bool> V_3,
+                C.<F>d__0 V_4,
+                System.Exception V_5)
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    // sequence point: <hidden>
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0017
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br         IL_0098
+    IL_0017:  br.s       IL_0098
+    // sequence point: {
+    IL_0019:  nop
+    // sequence point: await foreach
+    IL_001a:  nop
+    // sequence point: Iterator()
+    IL_001b:  ldarg.0
+    IL_001c:  ldarg.0
+    IL_001d:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0022:  call       ""System.Collections.Generic.IAsyncEnumerable<int> C.Iterator()""
+    IL_0027:  ldloca.s   V_1
+    IL_0029:  initobj    ""System.Threading.CancellationToken""
+    IL_002f:  ldloc.1
+    IL_0030:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0035:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    // sequence point: <hidden>
+    IL_003a:  br.s       IL_0056
+    // sequence point: var x
+    IL_003c:  ldarg.0
+    IL_003d:  ldarg.0
+    IL_003e:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_0043:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
+    IL_0048:  stfld      ""int C.<F>d__0.<x>5__2""
+    // sequence point: {
+    IL_004d:  nop
+    // sequence point: Body(1);
+    IL_004e:  ldc.i4.1
+    IL_004f:  call       ""void C.Body(int)""
+    IL_0054:  nop
+    // sequence point: }
+    IL_0055:  nop
+    // sequence point: in
+    IL_0056:  ldarg.0
+    IL_0057:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_005c:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
+    IL_0061:  stloc.3
+    IL_0062:  ldloca.s   V_3
+    IL_0064:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
+    IL_0069:  stloc.2
+    // sequence point: <hidden>
+    IL_006a:  ldloca.s   V_2
+    IL_006c:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
+    IL_0071:  brtrue.s   IL_00b4
+    IL_0073:  ldarg.0
+    IL_0074:  ldc.i4.0
+    IL_0075:  dup
+    IL_0076:  stloc.0
+    IL_0077:  stfld      ""int C.<F>d__0.<>1__state""
+    // async: yield
+    IL_007c:  ldarg.0
+    IL_007d:  ldloc.2
+    IL_007e:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_0083:  ldarg.0
+    IL_0084:  stloc.s    V_4
+    IL_0086:  ldarg.0
+    IL_0087:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  ldloca.s   V_4
+    IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<F>d__0)""
+    IL_0095:  nop
+    IL_0096:  leave.s    IL_0109
+    // async: resume
+    IL_0098:  ldarg.0
+    IL_0099:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_009e:  stloc.2
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_00a5:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.m1
+    IL_00ad:  dup
+    IL_00ae:  stloc.0
+    IL_00af:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldloca.s   V_2
+    IL_00b7:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
+    IL_00bc:  stfld      ""bool C.<F>d__0.<>s__3""
+    IL_00c1:  ldarg.0
+    IL_00c2:  ldfld      ""bool C.<F>d__0.<>s__3""
+    IL_00c7:  brtrue     IL_003c
+    IL_00cc:  ldarg.0
+    IL_00cd:  ldnull
+    IL_00ce:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    // sequence point: End();
+    IL_00d3:  call       ""void C.End()""
+    IL_00d8:  nop
+    IL_00d9:  leave.s    IL_00f5
+  }
+  catch System.Exception
+  {
+    // sequence point: <hidden>
+    IL_00db:  stloc.s    V_5
+    IL_00dd:  ldarg.0
+    IL_00de:  ldc.i4.s   -2
+    IL_00e0:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00e5:  ldarg.0
+    IL_00e6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_00eb:  ldloc.s    V_5
+    IL_00ed:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00f2:  nop
+    IL_00f3:  leave.s    IL_0109
+  }
+  // sequence point: }
+  IL_00f5:  ldarg.0
+  IL_00f6:  ldc.i4.s   -2
+  IL_00f8:  stfld      ""int C.<F>d__0.<>1__state""
+  // sequence point: <hidden>
+  IL_00fd:  ldarg.0
+  IL_00fe:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_0103:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0108:  nop
+  IL_0109:  ret
+}");
+
+            var diff1 = compilation1.EmitDifference(
+                    generation0,
+                    [SemanticEdit.Create(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)]);
+
+            diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
+{
+  // Code size      266 (0x10a)
+  .maxstack  3
+  .locals init (int V_0,
+                System.Threading.CancellationToken V_1,
+                System.Runtime.CompilerServices.ValueTaskAwaiter<bool> V_2,
+                System.Threading.Tasks.ValueTask<bool> V_3,
+                C.<F>d__0 V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  br.s       IL_000c
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  beq.s      IL_0017
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br         IL_0098
+    IL_0017:  br.s       IL_0098
+    IL_0019:  nop
+    IL_001a:  nop
+    IL_001b:  ldarg.0
+    IL_001c:  ldarg.0
+    IL_001d:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0022:  call       ""System.Collections.Generic.IAsyncEnumerable<int> C.Iterator()""
+    IL_0027:  ldloca.s   V_1
+    IL_0029:  initobj    ""System.Threading.CancellationToken""
+    IL_002f:  ldloc.1
+    IL_0030:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0035:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_003a:  br.s       IL_0056
+    IL_003c:  ldarg.0
+    IL_003d:  ldarg.0
+    IL_003e:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_0043:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
+    IL_0048:  stfld      ""int C.<F>d__0.<x>5__2""
+    IL_004d:  nop
+    IL_004e:  ldc.i4.2
+    IL_004f:  call       ""void C.Body(int)""
+    IL_0054:  nop
+    IL_0055:  nop
+    IL_0056:  ldarg.0
+    IL_0057:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_005c:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
+    IL_0061:  stloc.3
+    IL_0062:  ldloca.s   V_3
+    IL_0064:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
+    IL_0069:  stloc.2
+    IL_006a:  ldloca.s   V_2
+    IL_006c:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
+    IL_0071:  brtrue.s   IL_00b4
+    IL_0073:  ldarg.0
+    IL_0074:  ldc.i4.0
+    IL_0075:  dup
+    IL_0076:  stloc.0
+    IL_0077:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_007c:  ldarg.0
+    IL_007d:  ldloc.2
+    IL_007e:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_0083:  ldarg.0
+    IL_0084:  stloc.s    V_4
+    IL_0086:  ldarg.0
+    IL_0087:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  ldloca.s   V_4
+    IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<F>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<F>d__0)""
+    IL_0095:  nop
+    IL_0096:  leave.s    IL_0109
+    IL_0098:  ldarg.0
+    IL_0099:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_009e:  stloc.2
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<F>d__0.<>u__1""
+    IL_00a5:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.m1
+    IL_00ad:  dup
+    IL_00ae:  stloc.0
+    IL_00af:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldloca.s   V_2
+    IL_00b7:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
+    IL_00bc:  stfld      ""bool C.<F>d__0.<>s__3""
+    IL_00c1:  ldarg.0
+    IL_00c2:  ldfld      ""bool C.<F>d__0.<>s__3""
+    IL_00c7:  brtrue     IL_003c
+    IL_00cc:  ldarg.0
+    IL_00cd:  ldnull
+    IL_00ce:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<F>d__0.<>s__1""
+    IL_00d3:  call       ""void C.End()""
+    IL_00d8:  nop
+    IL_00d9:  leave.s    IL_00f5
+  }
+  catch System.Exception
+  {
+    IL_00db:  stloc.s    V_5
+    IL_00dd:  ldarg.0
+    IL_00de:  ldc.i4.s   -2
+    IL_00e0:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00e5:  ldarg.0
+    IL_00e6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+    IL_00eb:  ldloc.s    V_5
+    IL_00ed:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00f2:  nop
+    IL_00f3:  leave.s    IL_0109
+  }
+  IL_00f5:  ldarg.0
+  IL_00f6:  ldc.i4.s   -2
+  IL_00f8:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00fd:  ldarg.0
+  IL_00fe:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_0103:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0108:  nop
+  IL_0109:  ret
+}
+");
+        }
+
+        [Fact]
         public void HoistedVariables_MultipleGenerations()
         {
             var source0 = MarkedSource(@"

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -767,9 +767,6 @@ class C
 
             v0.VerifyPdb("C.M", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -783,14 +780,15 @@ class C
           <slot kind=""23"" offset=""66"" />
         </encLocalSlotMap>
         <encStateMachineStateMap>
-          <state number=""0"" offset=""66"" />
           <state number=""1"" offset=""46"" />
+          <state number=""0"" offset=""66"" />
         </encStateMachineStateMap>
       </customDebugInfo>
     </method>
   </methods>
 </symbols>
-");
+", options: PdbValidationOptions.ExcludeDocuments);
+
             v0.VerifyLocalSignature("C.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 .locals init (int V_0,
               object V_1,
@@ -860,9 +858,6 @@ class C
 
             v0.VerifyPdb("C.M", @"
 <symbols>
-  <files>
-    <file id=""1"" name="""" language=""C#"" />
-  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -876,14 +871,15 @@ class C
           <slot kind=""23"" offset=""65"" />
         </encLocalSlotMap>
         <encStateMachineStateMap>
-          <state number=""0"" offset=""65"" />
           <state number=""1"" offset=""45"" />
+          <state number=""0"" offset=""65"" />
         </encStateMachineStateMap>
       </customDebugInfo>
     </method>
   </methods>
 </symbols>
-");
+", options: PdbValidationOptions.ExcludeDocuments);
+
             v0.VerifyLocalSignature("C.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 .locals init (int V_0,
               object V_1,

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
                 localSlots: [],
                 closures: [],
                 lambdas: [],
-                stateMachineStates: 
+                stateMachineStates:
                 [
                     new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(2), (StateMachineState)0),
                     new StateMachineStateDebugInfo(syntaxOffset: 0x30, new AwaitDebugId(0), (StateMachineState)5),

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
@@ -297,18 +297,17 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
 
             var info = new EditAndContinueMethodDebugInformation(
                 methodOrdinal: 1,
-                localSlots: [],
-                closures: [],
-                lambdas: [],
-                stateMachineStates:
-                [
+                localSlots: ImmutableArray<LocalSlotDebugInfo>.Empty,
+                closures: ImmutableArray<ClosureDebugInfo>.Empty,
+                lambdas: ImmutableArray<LambdaDebugInfo>.Empty,
+                stateMachineStates: ImmutableArray.Create(
                     new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(2), (StateMachineState)0),
                     new StateMachineStateDebugInfo(syntaxOffset: 0x30, new AwaitDebugId(0), (StateMachineState)5),
                     new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(0), (StateMachineState)1),
                     new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(0), (StateMachineState)3),
                     new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(1), (StateMachineState)2),
-                    new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(1), (StateMachineState)4),
-                ]);
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(1), (StateMachineState)4)
+                ));
 
             info.SerializeStateMachineStates(cmw);
 
@@ -316,19 +315,19 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
             AssertEx.Equal(new byte[] { 0x06, 0x00, 0x02, 0x10, 0x04, 0x10, 0x00, 0x10, 0x06, 0x20, 0x08, 0x20, 0x0A, 0x30 }, bytes);
 
             var deserialized = EditAndContinueMethodDebugInformation.Create(
-                compressedSlotMap: [],
-                compressedLambdaMap: [],
+                compressedSlotMap: ImmutableArray<byte>.Empty,
+                compressedLambdaMap: ImmutableArray<byte>.Empty,
                 compressedStateMachineStateMap: bytes).StateMachineStates;
 
-            AssertEx.Equal(
-            [
+            AssertEx.Equal(new[]
+            {
                 new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(0), (StateMachineState)1),
                 new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(1), (StateMachineState)2),
                 new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(2), (StateMachineState)0),
                 new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(0), (StateMachineState)3),
                 new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(1), (StateMachineState)4),
                 new StateMachineStateDebugInfo(syntaxOffset: 0x30, new AwaitDebugId(0), (StateMachineState)5),
-            ], deserialized);
+            }, deserialized);
         }
 
         [Fact]
@@ -336,9 +335,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
         {
             // not sorted:
             Assert.Throws<InvalidDataException>(() => EditAndContinueMethodDebugInformation.Create(
-                compressedSlotMap: [],
-                compressedLambdaMap: [],
-                compressedStateMachineStateMap: [0x06, 0x00, 0x02, 0x20, 0x04, 0x10, 0x00, 0x10, 0x06, 0x20, 0x08, 0x20, 0x0A, 0x30]));
+                compressedSlotMap: ImmutableArray<byte>.Empty,
+                compressedLambdaMap: ImmutableArray<byte>.Empty,
+                compressedStateMachineStateMap: ImmutableArray.Create<byte>(0x06, 0x00, 0x02, 0x20, 0x04, 0x10, 0x00, 0x10, 0x06, 0x20, 0x08, 0x20, 0x0A, 0x30)));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
@@ -4,19 +4,15 @@
 
 #nullable disable
 
-extern alias PDB;
-
 using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Emit;
-using PDB::Microsoft.CodeAnalysis;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -292,6 +288,57 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
 
             AssertEx.Equal(closures, deserialized.Closures);
             AssertEx.Equal(lambdas, deserialized.Lambdas);
+        }
+
+        [Fact]
+        public void StateMachineStateDebugInfo()
+        {
+            var cmw = new BlobBuilder();
+
+            var info = new EditAndContinueMethodDebugInformation(
+                methodOrdinal: 1,
+                localSlots: [],
+                closures: [],
+                lambdas: [],
+                stateMachineStates: 
+                [
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(2), (StateMachineState)0),
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x30, new AwaitDebugId(0), (StateMachineState)5),
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(0), (StateMachineState)1),
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(0), (StateMachineState)3),
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(1), (StateMachineState)2),
+                    new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(1), (StateMachineState)4),
+                ]);
+
+            info.SerializeStateMachineStates(cmw);
+
+            var bytes = cmw.ToImmutableArray();
+            AssertEx.Equal(new byte[] { 0x06, 0x00, 0x02, 0x10, 0x04, 0x10, 0x00, 0x10, 0x06, 0x20, 0x08, 0x20, 0x0A, 0x30 }, bytes);
+
+            var deserialized = EditAndContinueMethodDebugInformation.Create(
+                compressedSlotMap: [],
+                compressedLambdaMap: [],
+                compressedStateMachineStateMap: bytes).StateMachineStates;
+
+            AssertEx.Equal(
+            [
+                new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(0), (StateMachineState)1),
+                new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(1), (StateMachineState)2),
+                new StateMachineStateDebugInfo(syntaxOffset: 0x10, new AwaitDebugId(2), (StateMachineState)0),
+                new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(0), (StateMachineState)3),
+                new StateMachineStateDebugInfo(syntaxOffset: 0x20, new AwaitDebugId(1), (StateMachineState)4),
+                new StateMachineStateDebugInfo(syntaxOffset: 0x30, new AwaitDebugId(0), (StateMachineState)5),
+            ], deserialized);
+        }
+
+        [Fact]
+        public void StateMachineStateDebugInfo_BadData()
+        {
+            // not sorted:
+            Assert.Throws<InvalidDataException>(() => EditAndContinueMethodDebugInformation.Create(
+                compressedSlotMap: [],
+                compressedLambdaMap: [],
+                compressedStateMachineStateMap: [0x06, 0x00, 0x02, 0x20, 0x04, 0x10, 0x00, 0x10, 0x06, 0x20, 0x08, 0x20, 0x0A, 0x30]));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeGen/AwaitDebugId.cs
+++ b/src/Compilers/Core/Portable/CodeGen/AwaitDebugId.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CodeGen;
+
+/// <summary>
+/// Identifies a specific await within a set of awaits generated for a syntax node. 
+/// 
+/// If multiple await expressions are produced for the same syntax node EnC needs to know how they map to specific async calls.
+/// For example, `await foreach` generates two awaits -- one for MoveNextAsync (<paramref name="RelativeStateOrdinal"/> is 0)
+/// and the other for DisposeAsync (<paramref name="RelativeStateOrdinal"/> is 1).
+/// </summary>
+internal readonly record struct AwaitDebugId(byte RelativeStateOrdinal);

--- a/src/Compilers/Core/Portable/CodeGen/DebugId.cs
+++ b/src/Compilers/Core/Portable/CodeGen/DebugId.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
     /// For user defined methods the ordinal is included in Custom Debug Information record attached to the method.
     /// </remarks>
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    internal struct DebugId : IEquatable<DebugId>
+    internal readonly struct DebugId : IEquatable<DebugId>
     {
         public const int UndefinedOrdinal = -1;
 

--- a/src/Compilers/Core/Portable/CodeGen/StateMachineStateDebugInfo.cs
+++ b/src/Compilers/Core/Portable/CodeGen/StateMachineStateDebugInfo.cs
@@ -9,16 +9,11 @@ using Microsoft.CodeAnalysis.Emit;
 
 namespace Microsoft.CodeAnalysis.CodeGen;
 
-internal readonly struct StateMachineStateDebugInfo
+internal readonly struct StateMachineStateDebugInfo(int syntaxOffset, AwaitDebugId awaitId, StateMachineState stateNumber)
 {
-    public readonly int SyntaxOffset;
-    public readonly StateMachineState StateNumber;
-
-    public StateMachineStateDebugInfo(int syntaxOffset, StateMachineState stateNumber)
-    {
-        SyntaxOffset = syntaxOffset;
-        StateNumber = stateNumber;
-    }
+    public readonly int SyntaxOffset = syntaxOffset;
+    public readonly AwaitDebugId AwaitId = awaitId;
+    public readonly StateMachineState StateNumber = stateNumber;
 }
 
 /// <summary>

--- a/src/Compilers/Core/Portable/CodeGen/VariableSlotAllocator.cs
+++ b/src/Compilers/Core/Portable/CodeGen/VariableSlotAllocator.cs
@@ -92,12 +92,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// For a given node associated with entering a state of a state machine in the new compilation,
         /// returns the ordinal of the corresponding state in the previous version of the state machine.
         /// </summary>
+        /// <param name="syntax">Await expression, await foreach statement, yield return statement, or try block syntax node.</param>
         /// <returns>
         /// True if there is a corresponding node in the previous code version that matches the given <paramref name="syntax"/>.
         /// </returns>
-        /// <remarks>
-        /// <paramref name="syntax"/> is an await expression, yield return statement, or try block syntax node.
-        /// </remarks>
-        public abstract bool TryGetPreviousStateMachineState(SyntaxNode syntax, out StateMachineState state);
+        public abstract bool TryGetPreviousStateMachineState(SyntaxNode syntax, AwaitDebugId awaitId, out StateMachineState state);
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<Cci.ITypeReference, int>? awaiterMap = null;
             IReadOnlyDictionary<int, KeyValuePair<DebugId, int>>? lambdaMap = null;
             IReadOnlyDictionary<int, DebugId>? closureMap = null;
-            IReadOnlyDictionary<int, StateMachineState>? stateMachineStateMap = null;
+            IReadOnlyDictionary<(int syntaxOffset, AwaitDebugId debugId), StateMachineState>? stateMachineStateMap = null;
             StateMachineState? firstUnusedIncreasingStateMachineState = null;
             StateMachineState? firstUnusedDecreasingStateMachineState = null;
 
@@ -388,11 +388,11 @@ namespace Microsoft.CodeAnalysis.Emit
 
         private static void MakeStateMachineStateMap(
             ImmutableArray<StateMachineStateDebugInfo> debugInfos,
-            out IReadOnlyDictionary<int, StateMachineState>? map)
+            out IReadOnlyDictionary<(int syntaxOffset, AwaitDebugId debugId), StateMachineState>? map)
         {
             map = debugInfos.IsDefault ?
                 null :
-                debugInfos.ToDictionary(entry => entry.SyntaxOffset, entry => entry.StateNumber);
+                debugInfos.ToDictionary(entry => (entry.SyntaxOffset, entry.AwaitId), entry => entry.StateNumber);
         }
 
         private static void GetStateMachineFieldMapFromPreviousCompilation(

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Emit
         private readonly IReadOnlyDictionary<EncHoistedLocalInfo, int>? _hoistedLocalSlots;
         private readonly int _awaiterCount;
         private readonly IReadOnlyDictionary<Cci.ITypeReference, int>? _awaiterMap;
-        private readonly IReadOnlyDictionary<int, StateMachineState>? _stateMachineStateMap; // SyntaxOffset -> State Ordinal
+        private readonly IReadOnlyDictionary<(int syntaxOffset, AwaitDebugId awaitId), StateMachineState>? _stateMachineStateMap;
         private readonly StateMachineState? _firstUnusedDecreasingStateMachineState;
         private readonly StateMachineState? _firstUnusedIncreasingStateMachineState;
 
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<EncHoistedLocalInfo, int>? hoistedLocalSlots,
             int awaiterCount,
             IReadOnlyDictionary<Cci.ITypeReference, int>? awaiterMap,
-            IReadOnlyDictionary<int, StateMachineState>? stateMachineStateMap,
+            IReadOnlyDictionary<(int syntaxOffset, AwaitDebugId awaitId), StateMachineState>? stateMachineStateMap,
             StateMachineState? firstUnusedIncreasingStateMachineState,
             StateMachineState? firstUnusedDecreasingStateMachineState,
             LambdaSyntaxFacts lambdaSyntaxFacts)
@@ -332,11 +332,11 @@ namespace Microsoft.CodeAnalysis.Emit
         public override StateMachineState? GetFirstUnusedStateMachineState(bool increasing)
             => increasing ? _firstUnusedIncreasingStateMachineState : _firstUnusedDecreasingStateMachineState;
 
-        public override bool TryGetPreviousStateMachineState(SyntaxNode syntax, out StateMachineState state)
+        public override bool TryGetPreviousStateMachineState(SyntaxNode syntax, AwaitDebugId awaitId, out StateMachineState state)
         {
             if (_stateMachineStateMap != null &&
                 TryGetPreviousSyntaxOffset(syntax, out int syntaxOffset) &&
-                _stateMachineStateMap.TryGetValue(syntaxOffset, out state))
+                _stateMachineStateMap.TryGetValue((syntaxOffset, awaitId), out state))
             {
                 return true;
             }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinueMethodDebugInformation.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinueMethodDebugInformation.cs
@@ -321,18 +321,34 @@ namespace Microsoft.CodeAnalysis.Emit
 
                 try
                 {
-                    int count = blobReader.ReadCompressedInteger();
+                    var count = blobReader.ReadCompressedInteger();
                     if (count > 0)
                     {
-                        int syntaxOffsetBaseline = -blobReader.ReadCompressedInteger();
+                        var syntaxOffsetBaseline = -blobReader.ReadCompressedInteger();
+                        var lastSyntaxOffset = int.MinValue;
+                        int relativeOrdinal = 0;
 
                         while (count > 0)
                         {
-                            int stateNumber = blobReader.ReadCompressedSignedInteger();
-                            int syntaxOffset = syntaxOffsetBaseline + blobReader.ReadCompressedInteger();
+                            var stateNumber = blobReader.ReadCompressedSignedInteger();
+                            var syntaxOffset = syntaxOffsetBaseline + blobReader.ReadCompressedInteger();
 
-                            mapBuilder.Add(new StateMachineStateDebugInfo(syntaxOffset, (StateMachineState)stateNumber));
+                            // The entries are ordered by syntax offset.
+                            // The relative ordinal is the index of the entry relative to the last entry with a different syntax offset.
+                            if (syntaxOffset < lastSyntaxOffset)
+                            {
+                                throw CreateInvalidDataException(compressedStateMachineStates, blobReader.Offset);
+                            }
+
+                            relativeOrdinal = (syntaxOffset == lastSyntaxOffset) ? relativeOrdinal + 1 : 0;
+                            if (relativeOrdinal > byte.MaxValue)
+                            {
+                                throw CreateInvalidDataException(compressedStateMachineStates, blobReader.Offset);
+                            }
+
+                            mapBuilder.Add(new StateMachineStateDebugInfo(syntaxOffset, new AwaitDebugId((byte)relativeOrdinal), (StateMachineState)stateNumber));
                             count--;
+                            lastSyntaxOffset = syntaxOffset;
                         }
                     }
                 }
@@ -356,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 int syntaxOffsetBaseline = Math.Min(StateMachineStates.Min(state => state.SyntaxOffset), 0);
                 writer.WriteCompressedInteger(-syntaxOffsetBaseline);
 
-                foreach (StateMachineStateDebugInfo state in StateMachineStates)
+                foreach (StateMachineStateDebugInfo state in StateMachineStates.OrderBy(s => s.SyntaxOffset).ThenBy(s => s.AwaitId.RelativeStateOrdinal))
                 {
                     writer.WriteCompressedSignedInteger((int)state.StateNumber);
                     writer.WriteCompressedInteger(state.SyntaxOffset - syntaxOffsetBaseline);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinueMethodDebugInformation.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinueMethodDebugInformation.cs
@@ -321,17 +321,17 @@ namespace Microsoft.CodeAnalysis.Emit
 
                 try
                 {
-                    var count = blobReader.ReadCompressedInteger();
+                    int count = blobReader.ReadCompressedInteger();
                     if (count > 0)
                     {
-                        var syntaxOffsetBaseline = -blobReader.ReadCompressedInteger();
-                        var lastSyntaxOffset = int.MinValue;
+                        int syntaxOffsetBaseline = -blobReader.ReadCompressedInteger();
+                        int lastSyntaxOffset = int.MinValue;
                         int relativeOrdinal = 0;
 
                         while (count > 0)
                         {
-                            var stateNumber = blobReader.ReadCompressedSignedInteger();
-                            var syntaxOffset = syntaxOffsetBaseline + blobReader.ReadCompressedInteger();
+                            int stateNumber = blobReader.ReadCompressedSignedInteger();
+                            int syntaxOffset = syntaxOffsetBaseline + blobReader.ReadCompressedInteger();
 
                             // The entries are ordered by syntax offset.
                             // The relative ordinal is the index of the entry relative to the last entry with a different syntax offset.

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -233,25 +233,42 @@ namespace System
 }
 ";
 
-        protected const string AsyncStreamsTypes = @"
+        protected const string NonDisposableAsyncEnumeratorDefinition = @"
+#nullable disable
+
 namespace System.Collections.Generic
 {
-    public interface IAsyncEnumerable<out T>
+    public interface IAsyncEnumerator<out T>
     {
-        IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken token = default);
+        System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
+        T Current { get; }
     }
+}
+";
 
+        protected const string DisposableAsyncEnumeratorDefinition = @"
+#nullable disable
+
+namespace System.Collections.Generic
+{
     public interface IAsyncEnumerator<out T> : System.IAsyncDisposable
     {
         System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
         T Current { get; }
     }
 }
-namespace System
+" + IAsyncDisposableDefinition;
+
+        protected const string AsyncStreamsTypes = DisposableAsyncEnumeratorDefinition + CommonAsyncStreamsTypes;
+
+        protected const string CommonAsyncStreamsTypes = @"
+#nullable disable
+
+namespace System.Collections.Generic
 {
-    public interface IAsyncDisposable
+    public interface IAsyncEnumerable<out T>
     {
-        System.Threading.Tasks.ValueTask DisposeAsync();
+        IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken token = default);
     }
 }
 
@@ -265,8 +282,6 @@ namespace System.Runtime.CompilerServices
         }
     }
 }
-
-#nullable disable
 
 namespace System.Threading.Tasks.Sources
 {

--- a/src/Compilers/VisualBasic/Portable/CodeGen/ResumableStateMachineStateAllocator.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/ResumableStateMachineStateAllocator.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim direction = If(_increasing, +1, -1)
             Dim state As StateMachineState
 
-            If _slotAllocator?.TryGetPreviousStateMachineState(awaitOrYieldReturnSyntax, state) = True Then
+            If _slotAllocator?.TryGetPreviousStateMachineState(awaitOrYieldReturnSyntax, awaitId:=Nothing, state) = True Then
 #If DEBUG Then
                 ' two states of the new state machine should not match the same state of the previous machine
                 Debug.Assert(Not _matchedStates(state * direction))

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -161,7 +161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If _tryBlockSyntaxForNextFinalizerState IsNot Nothing Then
                     If SlotAllocatorOpt Is Nothing OrElse
-                       Not SlotAllocatorOpt.TryGetPreviousStateMachineState(_tryBlockSyntaxForNextFinalizerState, _currentFinalizerState) Then
+                       Not SlotAllocatorOpt.TryGetPreviousStateMachineState(_tryBlockSyntaxForNextFinalizerState, awaitId:=Nothing, _currentFinalizerState) Then
                         _currentFinalizerState = _nextFinalizerState
                         _nextFinalizerState = CType(_nextFinalizerState - 1, StateMachineState)
                     End If
@@ -179,7 +179,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                              SyntaxBindingUtilities.BindsToTryStatement(node), $"Unexpected syntax: {node.Kind()}")
 
                 Dim syntaxOffset = CurrentMethod.CalculateLocalSyntaxOffset(node.SpanStart, node.SyntaxTree)
-                _stateDebugInfoBuilder.Add(New StateMachineStateDebugInfo(syntaxOffset, state))
+                _stateDebugInfoBuilder.Add(New StateMachineStateDebugInfo(syntaxOffset, awaitId:=Nothing, state))
             End Sub
 
             Protected Sub AddState(stateNumber As Integer, <Out> ByRef resumeLabel As GeneratedLabelSymbol)

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -213,9 +213,6 @@ End Module
 
             compilation.VerifyPdb("Module1.F",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1" name="F" parameterNames="a">
             <customDebugInfo>
@@ -226,13 +223,10 @@ End Module
             </customDebugInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments)
 
             compilation.VerifyPdb("Module1+VB$StateMachine_1_F.MoveNext",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_1_F" name="MoveNext">
             <customDebugInfo>
@@ -246,18 +240,6 @@ End Module
                     <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x7" hidden="true" document="1"/>
-                <entry offset="0xe" startLine="11" startColumn="5" endLine="11" endColumn="68" document="1"/>
-                <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="25" document="1"/>
-                <entry offset="0x1e" hidden="true" document="1"/>
-                <entry offset="0x7a" startLine="13" startColumn="9" endLine="13" endColumn="17" document="1"/>
-                <entry offset="0x7e" hidden="true" document="1"/>
-                <entry offset="0x86" hidden="true" document="1"/>
-                <entry offset="0xa3" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
-                <entry offset="0xad" hidden="true" document="1"/>
-            </sequencePoints>
             <scope startOffset="0x0" endOffset="0xbb">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -267,38 +249,32 @@ End Module
             </asyncInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments Or PdbValidationOptions.ExcludeSequencePoints)
 
             compilation.VerifyPdb("Module1.Test",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1" name="Test">
             <customDebugInfo>
                 <forwardIterator name="VB$StateMachine_2_Test"/>
                 <encStateMachineStateMap>
+                    <state number="8" offset="0"/>
+                    <state number="2" offset="8"/>
                     <state number="0" offset="38"/>
                     <state number="1" offset="94"/>
-                    <state number="2" offset="8"/>
-                    <state number="3" offset="171"/>
-                    <state number="4" offset="163"/>
-                    <state number="5" offset="155"/>
-                    <state number="6" offset="205"/>
                     <state number="7" offset="125"/>
-                    <state number="8" offset="0"/>
+                    <state number="5" offset="155"/>
+                    <state number="4" offset="163"/>
+                    <state number="3" offset="171"/>
+                    <state number="6" offset="205"/>
                 </encStateMachineStateMap>
             </customDebugInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments)
 
             compilation.VerifyPdb("Module1+VB$StateMachine_2_Test.MoveNext",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_2_Test" name="MoveNext">
             <customDebugInfo>
@@ -318,26 +294,6 @@ End Module
                     <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x7" hidden="true" document="1"/>
-                <entry offset="0x5d" startLine="16" startColumn="5" endLine="16" endColumn="34" document="1"/>
-                <entry offset="0x5e" startLine="17" startColumn="9" endLine="23" endColumn="34" document="1"/>
-                <entry offset="0x70" hidden="true" document="1"/>
-                <entry offset="0xf1" hidden="true" document="1"/>
-                <entry offset="0x176" hidden="true" document="1"/>
-                <entry offset="0x1f0" hidden="true" document="1"/>
-                <entry offset="0x269" hidden="true" document="1"/>
-                <entry offset="0x2e2" hidden="true" document="1"/>
-                <entry offset="0x363" hidden="true" document="1"/>
-                <entry offset="0x3e4" hidden="true" document="1"/>
-                <entry offset="0x463" hidden="true" document="1"/>
-                <entry offset="0x4bf" startLine="24" startColumn="5" endLine="24" endColumn="17" document="1"/>
-                <entry offset="0x4c1" hidden="true" document="1"/>
-                <entry offset="0x4c9" hidden="true" document="1"/>
-                <entry offset="0x4e6" startLine="24" startColumn="5" endLine="24" endColumn="17" document="1"/>
-                <entry offset="0x4f0" hidden="true" document="1"/>
-            </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4fd">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -355,13 +311,10 @@ End Module
             </asyncInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments Or PdbValidationOptions.ExcludeSequencePoints)
 
             compilation.VerifyPdb("Module1.S",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1" name="S">
             <customDebugInfo>
@@ -372,13 +325,10 @@ End Module
             </customDebugInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments)
 
             compilation.VerifyPdb("Module1+VB$StateMachine_3_S.MoveNext",
 <symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_3_S" name="MoveNext">
             <customDebugInfo>
@@ -390,18 +340,6 @@ End Module
                     <slot kind="temp"/>
                 </encLocalSlotMap>
             </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" hidden="true" document="1"/>
-                <entry offset="0x7" hidden="true" document="1"/>
-                <entry offset="0xe" startLine="26" startColumn="5" endLine="26" endColumn="18" document="1"/>
-                <entry offset="0xf" startLine="27" startColumn="9" endLine="27" endColumn="25" document="1"/>
-                <entry offset="0x1d" hidden="true" document="1"/>
-                <entry offset="0x78" startLine="28" startColumn="5" endLine="28" endColumn="12" document="1"/>
-                <entry offset="0x7a" hidden="true" document="1"/>
-                <entry offset="0x82" hidden="true" document="1"/>
-                <entry offset="0x9f" startLine="28" startColumn="5" endLine="28" endColumn="12" document="1"/>
-                <entry offset="0xa9" hidden="true" document="1"/>
-            </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb6">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
             </scope>
@@ -412,7 +350,7 @@ End Module
             </asyncInfo>
         </method>
     </methods>
-</symbols>)
+</symbols>, options:=PdbValidationOptions.ExcludeDocuments Or PdbValidationOptions.ExcludeSequencePoints)
         End Sub
 
         <WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 return false;
             }
 
-            public override bool TryGetPreviousStateMachineState(SyntaxNode awaitOrYieldSyntax, out StateMachineState state)
+            public override bool TryGetPreviousStateMachineState(SyntaxNode syntax, AwaitDebugId awaitId, out StateMachineState state)
             {
                 state = 0;
                 return false;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Return False
             End Function
 
-            Public Overrides Function TryGetPreviousStateMachineState(awaitOrYieldSyntax As SyntaxNode, ByRef state As StateMachineState) As Boolean
+            Public Overrides Function TryGetPreviousStateMachineState(syntax As SyntaxNode, awaitId As AwaitDebugId, ByRef state As StateMachineState) As Boolean
                 state = 0
                 Return False
             End Function


### PR DESCRIPTION
`await foreach` emits two async calls: `MoveNextAsync` and `DisposeAsync`. Both are associated with the same syntax node (offset), which caused a collision in a syntax offset to state number map. 

The PR adds general support for language features that emit multiple awaits for a single syntax node. Currently that's only `await foreach` in C#, but in future it may be other new language features.

Each await associated with the same syntax node needs to be assigned a unique relative state ordinal. This number is then included in the key of the mapping.

Fixes https://github.com/dotnet/roslyn/issues/69805