### PR TITLE
Mark export attributes as Inherited = false

### DIFF
--- a/src/Features/Core/Portable/Completion/ExportCompletionProviderAttribute.cs
+++ b/src/Features/Core/Portable/Completion/ExportCompletionProviderAttribute.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Completion
     /// be found and used by the per language associated <see cref="CompletionService"/>.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class ExportCompletionProviderAttribute(string name, string language) : ExportAttribute(typeof(CompletionProvider))
     {
         public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/BraceMatching/ExportAspNetCoreEmbeddedLanguageBraceMatcherAttribute.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/BraceMatching/ExportAspNetCoreEmbeddedLanguageBraceMatcherAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
     /// Use this attribute to export a <see cref="IAspNetCoreEmbeddedLanguageBraceMatcher"/>.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     internal sealed class ExportAspNetCoreEmbeddedLanguageBraceMatcherAttribute : ExportAttribute
     {
         /// <summary>

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/Classification/ExportAspNetCoreEmbeddedLanguageClassifierAttribute.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/Classification/ExportAspNetCoreEmbeddedLanguageClassifierAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
     /// Use this attribute to export a <see cref="IAspNetCoreEmbeddedLanguageClassifier"/>.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     internal sealed class ExportAspNetCoreEmbeddedLanguageClassifierAttribute : ExportAttribute
     {
         /// <summary>

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/DocumentHighlighting/ExportAspNetCoreEmbeddedLanguageClassifierAttribute.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/DocumentHighlighting/ExportAspNetCoreEmbeddedLanguageClassifierAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
     /// Use this attribute to export a <see cref="IAspNetCoreEmbeddedLanguageDocumentHighlighter"/>.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     internal sealed class ExportAspNetCoreEmbeddedLanguageDocumentHighlighterAttribute : ExportAttribute
     {
         /// <summary>

--- a/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/ExportCodeFixProviderAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// Use this attribute to declare a <see cref="CodeFixProvider"/> implementation so that it can be discovered by the host.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class ExportCodeFixProviderAttribute : ExportAttribute
     {
         private static readonly string[] s_defaultDocumentKinds = new[] { nameof(TextDocumentKind.Document) };

--- a/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/ExportCodeRefactoringProviderAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     /// Use this attribute to declare a <see cref="CodeRefactoringProvider"/> implementation so that it can be discovered by the host.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class ExportCodeRefactoringProviderAttribute : ExportAttribute
     {
         private static readonly string[] s_defaultDocumentKinds = new[] { nameof(TextDocumentKind.Document) };


### PR DESCRIPTION
Closes #69809

These attributes are used to mark MEF exported provider types for various extensions into Roslyn, and not designed to be inherited by the sub-types. https://github.com/dotnet/roslyn-analyzers/issues/6903 tracks adding a meta-analyzer that will flag these attributes applied to abstract types.