### PR TITLE
Bail out from remove unused member analyzer for ??= operator

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
-using Microsoft.CodeAnalysis.RemoveUnusedMembers;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
@@ -3097,12 +3095,13 @@ class MyClass
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/32842")]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/66975")]
         public async Task FieldIsNotRead_NullCoalesceAssignment()
         {
             var code = """
                 public class MyClass
                 {
-                    private MyClass {|IDE0052:_field|};
+                    private MyClass _field;
                     public void M() => _field ??= new MyClass();
                 }
                 """;

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -342,8 +342,11 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                         // Note that the increment operation '_f1++' is child of an expression statement, which drops the result of the increment.
                         // while the increment operation '_f2++' is child of a return statement, which uses the result of the increment.
                         // For the above test, '_f1' can be safely removed without affecting the semantics of the program, while '_f2' cannot be removed.
+                        // Additionally, we special case ICoalesceAssignmentOperation (??=) and treat it as a read-write,
+                        // see https://github.com/dotnet/roslyn/issues/66975 for more details
 
-                        if (memberReference?.Parent?.Parent is IExpressionStatementOperation)
+                        if (memberReference?.Parent?.Parent is IExpressionStatementOperation &&
+                            memberReference.Parent is not ICoalesceAssignmentOperation)
                         {
                             valueUsageInfo = ValueUsageInfo.Write;
 


### PR DESCRIPTION
Fixes #66975
See https://github.com/dotnet/roslyn/issues/66975#issuecomment-1438835655 for details