### PR TITLE
Update LanguageServerHost to use NamedPipe

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -175,10 +175,10 @@ static CliRootCommand CreateCommandLineParser()
         Required = false
     };
 
-    var pipeNameOption = new CliOption<string?>("--pipe")
+    var pipeNameOption = new CliOption<string>("--pipe")
     {
-        Description = "The name of the pipe to use for RPC with the parent process. If omitted, STDIN/STDOUT is used.",
-        Required = false
+        Description = "The name of the pipe to use for RPC with the parent process.",
+        Required = true
     };
 
     var rootCommand = new CliRootCommand()

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -101,7 +101,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueMethodDebugInfoReader.IgnoreCaseWhenComparingDocumentNames = Path.DirectorySeparatorChar == '\\';
 
     // Named pipe server is actually created from the client, so here we create a client stream.
-    var pipeServer = new NamedPipeClientStream(serverName: ".", GetPlatformPipeConnectionString(serverConfiguration.PipeName), PipeDirection.InOut, PipeOptions.CurrentUserOnly);
+    var pipeServer = new NamedPipeClientStream(serverName: ".", serverConfiguration.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
     await pipeServer.ConnectAsync(cancellationToken);
 
     var server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, loggerFactory.CreateLogger(nameof(LanguageServerHost)));
@@ -221,21 +221,5 @@ static CliRootCommand CreateCommandLineParser()
     });
 
     return rootCommand;
-}
-
-static string GetPlatformPipeConnectionString(string pipeName)
-{
-    var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-    if (isWindows)
-    {
-        return @"\\.\" + pipeName;
-    }
-    else
-    {
-        // For Linux-type systems, the "pipe" is actually a shared file.
-        // Point to the same file as on the client
-        var pipeFile = pipeName + ".sock";
-        return Path.Combine(Path.GetTempPath(), pipeFile);
-    }
 }
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -44,7 +44,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
             LoggerFactory.Create(builder =>
             {
                 builder.SetMinimumLevel(serverConfiguration.MinimumLogLevel);
-                builder.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+                builder.AddConsole();
                 // The console logger outputs control characters on unix for colors which don't render correctly in VSCode.
                 builder.AddSimpleConsole(formatterOptions => formatterOptions.ColorBehavior = LoggerColorBehavior.Disabled);
             })
@@ -101,7 +101,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueMethodDebugInfoReader.IgnoreCaseWhenComparingDocumentNames = Path.DirectorySeparatorChar == '\\';
 
     // Named pipe server is actually created from the client, so here we create a client stream.
-    var pipeServer = new NamedPipeClientStream(".", GetDotNetPipeConnectionString(serverConfiguration.PipeName), PipeDirection.InOut, PipeOptions.Asynchronous);
+    var pipeServer = new NamedPipeClientStream(serverName: ".", GetDotNetPipeConnectionString(serverConfiguration.PipeName), PipeDirection.InOut, PipeOptions.Asynchronous);
     await pipeServer.ConnectAsync(cancellationToken);
 
     var server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, loggerFactory.CreateLogger(nameof(LanguageServerHost)));

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -101,7 +101,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
     Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueMethodDebugInfoReader.IgnoreCaseWhenComparingDocumentNames = Path.DirectorySeparatorChar == '\\';
 
     // Named pipe server is actually created from the client, so here we create a client stream.
-    var pipeServer = new NamedPipeClientStream(serverName: ".", GetPlatformPipeConnectionString(serverConfiguration.PipeName), PipeDirection.InOut, PipeOptions.Asynchronous);
+    var pipeServer = new NamedPipeClientStream(serverName: ".", GetPlatformPipeConnectionString(serverConfiguration.PipeName), PipeDirection.InOut, PipeOptions.CurrentUserOnly);
     await pipeServer.ConnectAsync(cancellationToken);
 
     var server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, loggerFactory.CreateLogger(nameof(LanguageServerHost)));

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/ServerConfigurationFactory.cs
@@ -49,4 +49,5 @@ internal record class ServerConfiguration(
     string? SessionId,
     string? SharedDependenciesPath,
     IEnumerable<string> ExtensionAssemblyPaths,
-    string ExtensionLogDirectory);
+    string ExtensionLogDirectory,
+    string PipeName);


### PR DESCRIPTION
Current communication between client and the Rolsyn language server is writing to STDOUT. This makes the connection vulnerable to any code in the process writing to stdout stream and corrupting the data. 

We have seen at least one bug with this problem: https://github.com/microsoft/vscode-dotnettools/issues/333

The fix it to use a named pipe to communicate. Two things to note about this...
- The named pipe connection is created by the client. It's a little confusing, but the language client creates the named pipe server, and the language server actually creates a named pipe client. 
- The connection string format for .NET code is different than the connection string format for nodejs. We pass the named pipe name only, and then construct the appropriate connection string. If you try to use the same connection string it will fail silently. 