### PR TITLE
Modify the test to cover the scenario

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpRename.cs
@@ -645,6 +645,8 @@ class p$$rogram
         [IdeFact, WorkItem("https://github.com/dotnet/roslyn/issues/68880")]
         public async Task VerifyTextSync()
         {
+            var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(HangMitigatingCancellationToken);
+            globalOptions.SetGlobalOption(InlineRenameUIOptionsStorage.UseInlineAdornment, true);
             await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "Program.cs",
 @"
 public class Class2
@@ -663,15 +665,18 @@ public class Class2
 {
     public int Fi$$;
 }", HangMitigatingCancellationToken);
+            await TestServices.InlineRename.VerifyStringInFlyout("Fi", HangMitigatingCancellationToken);
             await TestServices.Input.SendWithoutActivateAsync(new InputKey[] { "e", "l", "d", "3", "2", "1" }, HangMitigatingCancellationToken);
 
             await TestServices.Workspace.WaitForRenameAsync(HangMitigatingCancellationToken);
+
             await TestServices.EditorVerifier.TextEqualsAsync(
                 @"
 public class Class2
 {
     public int Field321$$;
 }", HangMitigatingCancellationToken);
+            await TestServices.InlineRename.VerifyStringInFlyout("Field321", HangMitigatingCancellationToken);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InlineRenameInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InlineRenameInProcess.cs
@@ -2,12 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Editor.Implementation.InlineRename;
+using Microsoft.CodeAnalysis.Editor.InlineRename;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Extensibility.Testing;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 using WindowsInput.Native;
+using Xunit;
 
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
@@ -36,6 +42,25 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
         {
             await TestServices.Input.SendWithoutActivateAsync(new InputKey[] { (VirtualKeyCode.VK_O, VirtualKeyCode.MENU) }, cancellationToken);
             await TestServices.Workspace.WaitForRenameAsync(cancellationToken);
+        }
+
+        public async Task VerifyStringInFlyout(string expected, CancellationToken cancellationToken)
+        {
+            var optionService = await GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);
+            var isRenameFlyoutEnabled = optionService.GetOption(InlineRenameUIOptionsStorage.UseInlineAdornment);
+            if (!isRenameFlyoutEnabled)
+            {
+                Contract.Fail("Inline rename flyout is disabled");
+                return;
+            }
+
+            var vsTextManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+            var vsTextView = await vsTextManager.GetActiveViewAsync(JoinableTaskFactory, cancellationToken);
+            var testViewHost = await vsTextView.GetTextViewHostAsync(JoinableTaskFactory, cancellationToken);
+            var renameAdornmentLayer = testViewHost.TextView.GetAdornmentLayer(InlineRenameAdornmentProvider.AdornmentLayerName);
+            var inlineRenameFlyout = (RenameFlyout)renameAdornmentLayer.Elements.Single().Adornment;
+            var actualStringInTextBox = inlineRenameFlyout.IdentifierTextBox.Text;
+            Assert.Equal(expected, actualStringInTextBox);
         }
     }
 }


### PR DESCRIPTION
Modify the test in https://github.com/dotnet/roslyn/pull/69708
It is a bug that only affects the new UI, but by default, the rename Integration test is testing the old UI.
