### PR TITLE
Allow Razor to not supply dynamic file info if they don't want to.

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorDynamicFileInfoProvider.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDynamicFileInfoProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         /// <param name="projectId"><see cref="ProjectId"/> this file belongs to</param>
         /// <param name="projectFilePath">full path to project file (ex, csproj)</param>
         /// <param name="filePath">full path to non source file (ex, cshtml)</param>
-        Task<RazorDynamicFileInfo> GetDynamicFileInfoAsync(ProjectId projectId, string? projectFilePath, string filePath, CancellationToken cancellationToken);
+        Task<RazorDynamicFileInfo?> GetDynamicFileInfoAsync(ProjectId projectId, string? projectFilePath, string filePath, CancellationToken cancellationToken);
 
         /// <summary>
         /// let provider know certain file has been removed

--- a/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
@@ -18,7 +18,7 @@ Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDocumentPropertiesService.Diag
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDocumentServiceProvider
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDocumentServiceProvider.GetService<TService>() -> TService?
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider
-Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider.GetDynamicFileInfoAsync(Microsoft.CodeAnalysis.ProjectId! projectId, string? projectFilePath, string! filePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo!>!
+Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider.GetDynamicFileInfoAsync(Microsoft.CodeAnalysis.ProjectId! projectId, string? projectFilePath, string! filePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo?>!
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider.RemoveDynamicFileInfoAsync(Microsoft.CodeAnalysis.ProjectId! projectId, string? projectFilePath, string! filePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider.Updated -> System.EventHandler<string!>!
 Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorLanguageServerFactoryWrapper

--- a/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
@@ -40,6 +40,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             }
 
             var result = await _innerDynamicFileInfoProvider.Value.GetDynamicFileInfoAsync(projectId, projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
+            // This might not be a file/project Razor is interested in
+            if (result is null)
+            {
+                return null;
+            }
+
             var serviceProvider = new RazorDocumentServiceProviderWrapper(result.DocumentServiceProvider);
             var razorDocumentPropertiesService = result.DocumentServiceProvider.GetService<IRazorDocumentPropertiesService>();
             var designTimeOnly = razorDocumentPropertiesService?.DesignTimeOnly ?? false;


### PR DESCRIPTION
Allow a better fix on the Razor side for [AB#1878509](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1878509)

Right now I've worked around the bug, but without being able to return null here, we end up adding an empty `Goo.cshtml.g.cs` file to an F# project. This way we can decide in future if we want to support that scenario :)

NOTE: I'm doing this on the basis of it not being a binary breaking change, but if I'm wrong about that (`RazorDynamicFileInfo` is a class) then let me know.