### PR TITLE
Properly support (and reject) a limited set of preprocessor directive scenarios for 'use expression body'.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -68,10 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         protected override bool TryConvertToExpressionBody(
             IndexerDeclarationSyntax declaration,
             ExpressionBodyPreference conversionPreference,
+            CancellationToken cancellationToken,
             out ArrowExpressionClauseSyntax arrowExpression,
             out SyntaxToken semicolonToken)
         {
-            return TryConvertToExpressionBodyForBaseProperty(declaration, conversionPreference, out arrowExpression, out semicolonToken);
+            return TryConvertToExpressionBodyForBaseProperty(declaration, conversionPreference, cancellationToken, out arrowExpression, out semicolonToken);
         }
 
         protected override Location GetDiagnosticLocation(IndexerDeclarationSyntax declaration)

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForPropertiesHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyForPropertiesHelper.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -68,10 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         protected override bool TryConvertToExpressionBody(
             PropertyDeclarationSyntax declaration,
             ExpressionBodyPreference conversionPreference,
+            CancellationToken cancellationToken,
             out ArrowExpressionClauseSyntax arrowExpression,
             out SyntaxToken semicolonToken)
         {
-            return TryConvertToExpressionBodyForBaseProperty(declaration, conversionPreference, out arrowExpression, out semicolonToken);
+            return TryConvertToExpressionBodyForBaseProperty(declaration, conversionPreference, cancellationToken, out arrowExpression, out semicolonToken);
         }
 
         protected override Location GetDiagnosticLocation(PropertyDeclarationSyntax declaration)

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 {
@@ -25,9 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         public abstract ArrowExpressionClauseSyntax? GetExpressionBody(SyntaxNode declaration);
         public abstract bool IsRelevantDeclarationNode(SyntaxNode node);
 
-        public abstract bool CanOfferUseExpressionBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer);
+        public abstract bool CanOfferUseExpressionBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer, CancellationToken cancellationToken);
         public abstract bool CanOfferUseBlockBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer, out bool fixesError, [NotNullWhen(true)] out ArrowExpressionClauseSyntax? expressionBody);
-        public abstract SyntaxNode Update(SemanticModel semanticModel, SyntaxNode declaration, bool useExpressionBody);
+        public abstract SyntaxNode Update(SemanticModel semanticModel, SyntaxNode declaration, bool useExpressionBody, CancellationToken cancellationToken);
 
         public abstract Location GetDiagnosticLocation(SyntaxNode declaration);
 

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -67,14 +67,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         public override bool IsRelevantDeclarationNode(SyntaxNode node)
             => node is TDeclaration;
 
-        public override bool CanOfferUseExpressionBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer)
-            => CanOfferUseExpressionBody(preference, (TDeclaration)declaration, forAnalyzer);
+        public override bool CanOfferUseExpressionBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer, CancellationToken cancellationToken)
+            => CanOfferUseExpressionBody(preference, (TDeclaration)declaration, forAnalyzer, cancellationToken);
 
         public override bool CanOfferUseBlockBody(CodeStyleOption2<ExpressionBodyPreference> preference, SyntaxNode declaration, bool forAnalyzer, out bool fixesError, [NotNullWhen(true)] out ArrowExpressionClauseSyntax? expressionBody)
             => CanOfferUseBlockBody(preference, (TDeclaration)declaration, forAnalyzer, out fixesError, out expressionBody);
 
-        public sealed override SyntaxNode Update(SemanticModel semanticModel, SyntaxNode declaration, bool useExpressionBody)
-            => Update(semanticModel, (TDeclaration)declaration, useExpressionBody);
+        public sealed override SyntaxNode Update(SemanticModel semanticModel, SyntaxNode declaration, bool useExpressionBody, CancellationToken cancellationToken)
+            => Update(semanticModel, (TDeclaration)declaration, useExpressionBody, cancellationToken);
 
         public override Location GetDiagnosticLocation(SyntaxNode declaration)
             => GetDiagnosticLocation((TDeclaration)declaration);

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -86,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         }
 
         public bool CanOfferUseExpressionBody(
-            CodeStyleOption2<ExpressionBodyPreference> preference, TDeclaration declaration, bool forAnalyzer)
+            CodeStyleOption2<ExpressionBodyPreference> preference, TDeclaration declaration, bool forAnalyzer, CancellationToken cancellationToken)
         {
             var userPrefersExpressionBodies = preference.Value != ExpressionBodyPreference.Never;
             var analyzerDisabled = preference.Notification.Severity == ReportDiagnostic.Suppress;
@@ -104,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
                     var conversionPreference = forAnalyzer ? preference.Value : ExpressionBodyPreference.WhenPossible;
 
-                    return TryConvertToExpressionBody(declaration, conversionPreference,
+                    return TryConvertToExpressionBody(declaration, conversionPreference, cancellationToken,
                         expressionWhenOnSingleLine: out _, semicolonWhenOnSingleLine: out _);
                 }
             }
@@ -115,16 +116,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         protected virtual bool TryConvertToExpressionBody(
             TDeclaration declaration,
             ExpressionBodyPreference conversionPreference,
+            CancellationToken cancellationToken,
             [NotNullWhen(true)] out ArrowExpressionClauseSyntax? expressionWhenOnSingleLine,
             out SyntaxToken semicolonWhenOnSingleLine)
         {
             return TryConvertToExpressionBodyWorker(
-                declaration, conversionPreference,
+                declaration, conversionPreference, cancellationToken,
                 out expressionWhenOnSingleLine, out semicolonWhenOnSingleLine);
         }
 
         private bool TryConvertToExpressionBodyWorker(
-            SyntaxNode declaration, ExpressionBodyPreference conversionPreference,
+            SyntaxNode declaration, ExpressionBodyPreference conversionPreference, CancellationToken cancellationToken,
             [NotNullWhen(true)] out ArrowExpressionClauseSyntax? expressionWhenOnSingleLine, out SyntaxToken semicolonWhenOnSingleLine)
         {
             var body = GetBody(declaration);
@@ -138,17 +140,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             var languageVersion = body.SyntaxTree.Options.LanguageVersion();
 
             return body.TryConvertToArrowExpressionBody(
-                declaration.Kind(), languageVersion, conversionPreference,
+                declaration.Kind(), languageVersion, conversionPreference, cancellationToken,
                 out expressionWhenOnSingleLine, out semicolonWhenOnSingleLine);
         }
 
         protected bool TryConvertToExpressionBodyForBaseProperty(
             BasePropertyDeclarationSyntax declaration,
             ExpressionBodyPreference conversionPreference,
+            CancellationToken cancellationToken,
             [NotNullWhen(true)] out ArrowExpressionClauseSyntax? arrowExpression,
             out SyntaxToken semicolonToken)
         {
-            if (TryConvertToExpressionBodyWorker(declaration, conversionPreference, out arrowExpression, out semicolonToken))
+            if (TryConvertToExpressionBodyWorker(declaration, conversionPreference, cancellationToken, out arrowExpression, out semicolonToken))
             {
                 return true;
             }
@@ -221,11 +224,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             return userPrefersBlockBodies == forAnalyzer || (!forAnalyzer && analyzerDisabled);
         }
 
-        public TDeclaration Update(SemanticModel semanticModel, TDeclaration declaration, bool useExpressionBody)
+        public TDeclaration Update(SemanticModel semanticModel, TDeclaration declaration, bool useExpressionBody, CancellationToken cancellationToken)
         {
             if (useExpressionBody)
             {
-                TryConvertToExpressionBody(declaration, ExpressionBodyPreference.WhenPossible, out var expressionBody, out var semicolonToken);
+                TryConvertToExpressionBody(declaration, ExpressionBodyPreference.WhenPossible, cancellationToken, out var expressionBody, out var semicolonToken);
 
                 var trailingTrivia = semicolonToken.TrailingTrivia
                                                    .Where(t => t.Kind() != SyntaxKind.EndOfLineTrivia)

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaDiagnosticAnalyzer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
             SemanticModel semanticModel, CodeStyleOption2<ExpressionBodyPreference> option,
             LambdaExpressionSyntax declaration, CancellationToken cancellationToken)
         {
-            if (UseExpressionBodyForLambdaHelpers.CanOfferUseExpressionBody(option.Value, declaration, declaration.GetLanguageVersion()))
+            if (UseExpressionBodyForLambdaHelpers.CanOfferUseExpressionBody(option.Value, declaration, declaration.GetLanguageVersion(), cancellationToken))
             {
                 var location = GetDiagnosticLocation(declaration);
 

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBodyForLambda/UseExpressionBodyForLambdaHelpers.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
         }
 
         internal static bool CanOfferUseExpressionBody(
-            ExpressionBodyPreference preference, LambdaExpressionSyntax declaration, LanguageVersion languageVersion)
+            ExpressionBodyPreference preference, LambdaExpressionSyntax declaration, LanguageVersion languageVersion, CancellationToken cancellationToken)
         {
             var userPrefersExpressionBodies = preference != ExpressionBodyPreference.Never;
             if (!userPrefersExpressionBodies)
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
 
             // They don't have an expression body.  See if we could convert the block they 
             // have into one.
-            return TryConvertToExpressionBody(declaration, languageVersion, preference, out _);
+            return TryConvertToExpressionBody(declaration, languageVersion, preference, cancellationToken, out _);
         }
 
         internal static ExpressionSyntax? GetBodyAsExpression(LambdaExpressionSyntax declaration)
@@ -107,11 +107,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
             LambdaExpressionSyntax declaration,
             LanguageVersion languageVersion,
             ExpressionBodyPreference conversionPreference,
+            CancellationToken cancellationToken,
             [NotNullWhen(true)] out ExpressionSyntax? expression)
         {
             var body = declaration.Body as BlockSyntax;
 
-            return body.TryConvertToExpressionBody(languageVersion, conversionPreference, out expression, out _);
+            return body.TryConvertToExpressionBody(languageVersion, conversionPreference, cancellationToken, out expression, out _);
         }
     }
 }

--- a/src/Analyzers/CSharp/CodeFixes/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             var declaration = declarationLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
             var useExpressionBody = diagnostic.Properties.ContainsKey(nameof(UseExpressionBody));
 
-            var updatedDeclaration = helper.Update(semanticModel, declaration, useExpressionBody)
+            var updatedDeclaration = helper.Update(semanticModel, declaration, useExpressionBody, cancellationToken)
                                            .WithAdditionalAnnotations(Formatter.Annotation);
 
             editor.ReplaceNode(declaration, updatedDeclaration);

--- a/src/Analyzers/CSharp/CodeFixes/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeFixProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
 
             editor.ReplaceNode(
                 originalDeclaration,
-                (current, _) => UseExpressionBodyForLambdaCodeActionHelpers.Update(semanticModel, originalDeclaration, (LambdaExpressionSyntax)current));
+                (current, _) => UseExpressionBodyForLambdaCodeActionHelpers.Update(semanticModel, originalDeclaration, (LambdaExpressionSyntax)current, cancellationToken));
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForMethodsAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForMethodsAnalyzerTests.cs
@@ -517,6 +517,328 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             await TestWithUseExpressionBody(code, fixedCode);
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69783")]
+        public async Task TestDirectives3()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        Console.WriteLine(1);
+                        Console.WriteLine(2);
+                #endif
+                    }
+                }
+                """;
+            await TestWithUseExpressionBody(code, code);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives4()
+        {
+            var code = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        Console.WriteLine(1);
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        Console.WriteLine(1);
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives5()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        throw new System.NotImplementedException();
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        throw new System.NotImplementedException();
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives6()
+        {
+            var code = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        throw new System.NotImplementedException();
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        throw new System.NotImplementedException();
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69783")]
+        public async Task TestDirectives7()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method()
+                    {
+                #if DEBUG
+                #endif
+                        Console.WriteLine(0);
+                    }
+                }
+                """;
+            await TestWithUseExpressionBody(code, code);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69783")]
+        public async Task TestDirectives8()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method()
+                    {
+                        Console.WriteLine(0);
+                #if DEBUG
+                #endif
+                    }
+                }
+                """;
+            await TestWithUseExpressionBody(code, code);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/69783")]
+        public async Task TestDirectives9()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #else
+                        Console.WriteLine(1);
+                #endif
+
+                #if DEBUG
+                #endif
+                    }
+                }
+                """;
+            await TestWithUseExpressionBody(code, code);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives10()
+        {
+            var code = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define DEBUG
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives11()
+        {
+            var code = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define RELEASE
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/17120")]
+        public async Task TestDirectives12()
+        {
+            var code = """
+                #define OTHER
+                using System;
+
+                class Program
+                {
+                    {|IDE0022:void Method()
+                    {
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+                    }|}
+                }
+                """;
+            var fixedCode = """
+                #define OTHER
+                using System;
+
+                class Program
+                {
+                    void Method() =>
+                #if DEBUG
+                        Console.WriteLine(0);
+                #elif RELEASE
+                        Console.WriteLine(1);
+                #else
+                        Console.WriteLine(2);
+                #endif
+
+                }
+                """;
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/20362")]
         public async Task TestOfferToConvertToBlockEvenIfExpressionBodyPreferredIfPriorToCSharp6()
         {

--- a/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAutoPropertyToFullProperty/CSharpConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
 
         protected override (SyntaxNode newGetAccessor, SyntaxNode newSetAccessor) GetNewAccessors(
             CSharpCodeGenerationContextInfo info, SyntaxNode property,
-            string fieldName, SyntaxGenerator generator)
+            string fieldName, SyntaxGenerator generator, CancellationToken cancellationToken)
         {
             // C# might have trivia with the accessors that needs to be preserved.  
             // so we will update the existing accessors instead of creating new ones
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
             var (getAccessor, setAccessor) = GetExistingAccessors(accessorListSyntax);
 
             var getAccessorStatement = generator.ReturnStatement(generator.IdentifierName(fieldName));
-            var newGetter = GetUpdatedAccessor(info, getAccessor, getAccessorStatement);
+            var newGetter = GetUpdatedAccessor(info, getAccessor, getAccessorStatement, cancellationToken);
 
             SyntaxNode newSetter = null;
             if (setAccessor != null)
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
                 var setAccessorStatement = generator.ExpressionStatement(generator.AssignmentStatement(
                     generator.IdentifierName(fieldName),
                     generator.IdentifierName("value")));
-                newSetter = GetUpdatedAccessor(info, setAccessor, setAccessorStatement);
+                newSetter = GetUpdatedAccessor(info, setAccessor, setAccessorStatement, cancellationToken);
             }
 
             return (newGetAccessor: newGetter, newSetAccessor: newSetter);
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
                 accessorListSyntax.Accessors.FirstOrDefault(a => a.Kind() is SyntaxKind.SetAccessorDeclaration or SyntaxKind.InitAccessorDeclaration));
 
         private static SyntaxNode GetUpdatedAccessor(CSharpCodeGenerationContextInfo info,
-            SyntaxNode accessor, SyntaxNode statement)
+            SyntaxNode accessor, SyntaxNode statement, CancellationToken cancellationToken)
         {
             var newAccessor = AddStatement(accessor, statement);
             var accessorDeclarationSyntax = (AccessorDeclarationSyntax)newAccessor;
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAutoPropertyToFullProperty
             }
 
             if (!accessorDeclarationSyntax.Body.TryConvertToArrowExpressionBody(
-                    accessorDeclarationSyntax.Kind(), info.LanguageVersion, preference,
+                    accessorDeclarationSyntax.Kind(), info.LanguageVersion, preference, cancellationToken,
                     out var arrowExpression, out _))
             {
                 return accessorDeclarationSyntax.WithSemicolonToken(default);

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -6,18 +6,17 @@
 
 using System;
 using System.Composition;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.ReplaceMethodWithProperty;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProperty
@@ -40,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             SyntaxEditor editor,
             SemanticModel semanticModel,
             GetAndSetMethods getAndSetMethods,
-            string propertyName, bool nameChanged)
+            string propertyName, bool nameChanged,
+            CancellationToken cancellationToken)
         {
             if (getAndSetMethods.GetMethodDeclaration is not MethodDeclarationSyntax getMethodDeclaration)
             {
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             var newProperty = ConvertMethodsToProperty(
                 (CSharpCodeGenerationOptions)options, languageVersion,
                 semanticModel, editor.Generator,
-                getAndSetMethods, propertyName, nameChanged);
+                getAndSetMethods, propertyName, nameChanged, cancellationToken);
 
             editor.ReplaceNode(getMethodDeclaration, newProperty);
         }
@@ -59,11 +59,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
         public static SyntaxNode ConvertMethodsToProperty(
             CSharpCodeGenerationOptions options, LanguageVersion languageVersion,
             SemanticModel semanticModel, SyntaxGenerator generator, GetAndSetMethods getAndSetMethods,
-            string propertyName, bool nameChanged)
+            string propertyName, bool nameChanged, CancellationToken cancellationToken)
         {
             var propertyDeclaration = ConvertMethodsToPropertyWorker(
                 options, languageVersion, semanticModel,
-                generator, getAndSetMethods, propertyName, nameChanged);
+                generator, getAndSetMethods, propertyName, nameChanged, cancellationToken);
 
             var expressionBodyPreference = options.PreferExpressionBodiedProperties.Value;
             if (expressionBodyPreference != ExpressionBodyPreference.Never)
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
                     }
                     else if (getAccessor.Body != null &&
                              getAccessor.Body.TryConvertToArrowExpressionBody(
-                                 propertyDeclaration.Kind(), languageVersion, expressionBodyPreference,
+                                 propertyDeclaration.Kind(), languageVersion, expressionBodyPreference, cancellationToken,
                                  out var arrowExpression, out var semicolonToken))
                     {
                         return propertyDeclaration.WithExpressionBody(arrowExpression)
@@ -112,12 +112,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
         public static PropertyDeclarationSyntax ConvertMethodsToPropertyWorker(
             CSharpCodeGenerationOptions options, LanguageVersion languageVersion,
             SemanticModel semanticModel, SyntaxGenerator generator, GetAndSetMethods getAndSetMethods,
-            string propertyName, bool nameChanged)
+            string propertyName, bool nameChanged, CancellationToken cancellationToken)
         {
             var getMethodDeclaration = (MethodDeclarationSyntax)getAndSetMethods.GetMethodDeclaration;
             var setMethodDeclaration = getAndSetMethods.SetMethodDeclaration as MethodDeclarationSyntax;
-            var getAccessor = CreateGetAccessor(getAndSetMethods, options, languageVersion);
-            var setAccessor = CreateSetAccessor(semanticModel, generator, getAndSetMethods, options, languageVersion);
+            var getAccessor = CreateGetAccessor(getAndSetMethods, options, languageVersion, cancellationToken);
+            var setAccessor = CreateSetAccessor(semanticModel, generator, getAndSetMethods, options, languageVersion, cancellationToken);
 
             var nameToken = GetPropertyName(getMethodDeclaration.Identifier, propertyName, nameChanged);
             var warning = GetWarning(getAndSetMethods);
@@ -160,23 +160,23 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
         }
 
         private static AccessorDeclarationSyntax CreateGetAccessor(
-            GetAndSetMethods getAndSetMethods, CSharpCodeGenerationOptions options, LanguageVersion languageVersion)
+            GetAndSetMethods getAndSetMethods, CSharpCodeGenerationOptions options, LanguageVersion languageVersion, CancellationToken cancellationToken)
         {
             var accessorDeclaration = CreateGetAccessorWorker(getAndSetMethods);
 
             return UseExpressionOrBlockBodyIfDesired(
-                options, languageVersion, accessorDeclaration);
+                options, languageVersion, accessorDeclaration, cancellationToken);
         }
 
         private static AccessorDeclarationSyntax UseExpressionOrBlockBodyIfDesired(
             CSharpCodeGenerationOptions options, LanguageVersion languageVersion,
-            AccessorDeclarationSyntax accessorDeclaration)
+            AccessorDeclarationSyntax accessorDeclaration, CancellationToken cancellationToken)
         {
             var expressionBodyPreference = options.PreferExpressionBodiedAccessors.Value;
             if (accessorDeclaration?.Body != null && expressionBodyPreference != ExpressionBodyPreference.Never)
             {
                 if (accessorDeclaration.Body.TryConvertToArrowExpressionBody(
-                        accessorDeclaration.Kind(), languageVersion, expressionBodyPreference,
+                        accessorDeclaration.Kind(), languageVersion, expressionBodyPreference, cancellationToken,
                         out var arrowExpression, out var semicolonToken))
                 {
                     return accessorDeclaration.WithBody(null)
@@ -229,10 +229,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
 
         private static AccessorDeclarationSyntax CreateSetAccessor(
             SemanticModel semanticModel, SyntaxGenerator generator, GetAndSetMethods getAndSetMethods,
-            CSharpCodeGenerationOptions options, LanguageVersion languageVersion)
+            CSharpCodeGenerationOptions options, LanguageVersion languageVersion, CancellationToken cancellationToken)
         {
             var accessorDeclaration = CreateSetAccessorWorker(semanticModel, generator, getAndSetMethods);
-            return UseExpressionOrBlockBodyIfDesired(options, languageVersion, accessorDeclaration);
+            return UseExpressionOrBlockBodyIfDesired(options, languageVersion, accessorDeclaration, cancellationToken);
         }
 
         private static AccessorDeclarationSyntax CreateSetAccessorWorker(

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
 
             return UseExpressionOrBlockBodyIfDesired(
                 languageVersion, methodDeclaration, expressionBodyPreference,
-                createReturnStatementForExpression: false);
+                createReturnStatementForExpression: false, cancellationToken);
 
             MethodDeclarationSyntax GetSetMethodWorker()
             {
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
 
             return UseExpressionOrBlockBodyIfDesired(
                 languageVersion, methodDeclaration, expressionBodyPreference,
-                createReturnStatementForExpression: true);
+                createReturnStatementForExpression: true, cancellationToken);
 
             MethodDeclarationSyntax GetGetMethodWorker()
             {
@@ -255,12 +255,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             LanguageVersion languageVersion,
             MethodDeclarationSyntax methodDeclaration,
             ExpressionBodyPreference expressionBodyPreference,
-            bool createReturnStatementForExpression)
+            bool createReturnStatementForExpression,
+            CancellationToken cancellationToken)
         {
             if (methodDeclaration.Body != null && expressionBodyPreference != ExpressionBodyPreference.Never)
             {
                 if (methodDeclaration.Body.TryConvertToArrowExpressionBody(
-                        methodDeclaration.Kind(), languageVersion, expressionBodyPreference,
+                        methodDeclaration.Kind(), languageVersion, expressionBodyPreference, cancellationToken,
                         out var arrowExpression, out var semicolonToken))
                 {
                     return methodDeclaration.WithBody(null)

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 if (declaration == null)
                     continue;
 
-                var succeeded = TryComputeRefactoring(context, root, declaration, options, helper);
+                var succeeded = TryComputeRefactoring(context, root, declaration, options, helper, cancellationToken);
                 if (succeeded)
                     return;
             }
@@ -116,13 +116,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
         private static bool TryComputeRefactoring(
             CodeRefactoringContext context, SyntaxNode root, SyntaxNode declaration,
-            CSharpCodeGenerationOptions options, UseExpressionBodyHelper helper)
+            CSharpCodeGenerationOptions options, UseExpressionBodyHelper helper, CancellationToken cancellationToken)
         {
             var document = context.Document;
             var preference = helper.GetExpressionBodyPreference(options);
 
             var succeeded = false;
-            if (helper.CanOfferUseExpressionBody(preference, declaration, forAnalyzer: false))
+            if (helper.CanOfferUseExpressionBody(preference, declaration, forAnalyzer: false, cancellationToken))
             {
                 context.RegisterRefactoring(
                     CodeAction.Create(
@@ -168,15 +168,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var newRoot = GetUpdatedRoot(semanticModel, root, declaration, helper, useExpressionBody);
+            var newRoot = GetUpdatedRoot(semanticModel, root, declaration, helper, useExpressionBody, cancellationToken);
             return document.WithSyntaxRoot(newRoot);
         }
 
         private static SyntaxNode GetUpdatedRoot(
             SemanticModel semanticModel, SyntaxNode root, SyntaxNode declaration,
-            UseExpressionBodyHelper helper, bool useExpressionBody)
+            UseExpressionBodyHelper helper, bool useExpressionBody, CancellationToken cancellationToken)
         {
-            var updatedDeclaration = helper.Update(semanticModel, declaration, useExpressionBody);
+            var updatedDeclaration = helper.Update(semanticModel, declaration, useExpressionBody, cancellationToken);
 
             var parent = declaration is AccessorDeclarationSyntax
                 ? declaration.Parent
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var options = (CSharpCodeGenerationOptions)await document.GetCodeGenerationOptionsAsync(optionsProvider, cancellationToken).ConfigureAwait(false);
-            var declarationsToFix = GetDeclarationsToFix(fixAllSpans, root, helper, useExpressionBody, options);
+            var declarationsToFix = GetDeclarationsToFix(fixAllSpans, root, helper, useExpressionBody, options, cancellationToken);
             await FixDeclarationsAsync(document, editor, root, declarationsToFix.ToImmutableArray(), helper, useExpressionBody, cancellationToken).ConfigureAwait(false);
             return;
 
@@ -211,7 +211,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 SyntaxNode root,
                 UseExpressionBodyHelper helper,
                 bool useExpressionBody,
-                CSharpCodeGenerationOptions options)
+                CSharpCodeGenerationOptions options,
+                CancellationToken cancellationToken)
             {
                 var preference = helper.GetExpressionBodyPreference(options);
                 foreach (var span in fixAllSpans)
@@ -223,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                         if (!helper.IsRelevantDeclarationNode(node) || !helper.SyntaxKinds.Contains(node.Kind()))
                             continue;
 
-                        if (useExpressionBody && helper.CanOfferUseExpressionBody(preference, node, forAnalyzer: false))
+                        if (useExpressionBody && helper.CanOfferUseExpressionBody(preference, node, forAnalyzer: false, cancellationToken))
                         {
                             yield return node;
                         }
@@ -257,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                     var currentDeclaration = currentRoot.GetCurrentNodes(declaration).Single();
 
                     // Fix the current declaration and get updated current root
-                    currentRoot = GetUpdatedRoot(semanticModel, currentRoot, currentDeclaration, helper, useExpressionBody);
+                    currentRoot = GetUpdatedRoot(semanticModel, currentRoot, currentDeclaration, helper, useExpressionBody, cancellationToken);
                 }
 
                 // Finally apply the latest current root to the editor.

--- a/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeRefactoringProvider.cs
@@ -174,13 +174,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             using var resultDisposer = ArrayBuilder<CodeAction>.GetInstance(out var result);
-            if (UseExpressionBodyForLambdaHelpers.CanOfferUseExpressionBody(option, lambdaNode, root.GetLanguageVersion()))
+            if (UseExpressionBodyForLambdaHelpers.CanOfferUseExpressionBody(option, lambdaNode, root.GetLanguageVersion(), cancellationToken))
             {
                 var title = UseExpressionBodyForLambdaHelpers.UseExpressionBodyTitle.ToString();
                 result.Add(CodeAction.Create(
                     title,
-                    c => UpdateDocumentAsync(
-                        document, root, lambdaNode, c),
+                    cancellationToken => UpdateDocumentAsync(document, root, lambdaNode, cancellationToken),
                     title));
             }
 
@@ -190,8 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
                 var title = UseExpressionBodyForLambdaHelpers.UseBlockBodyTitle.ToString();
                 result.Add(CodeAction.Create(
                     title,
-                    c => UpdateDocumentAsync(
-                        document, root, lambdaNode, c),
+                    cancellationToken => UpdateDocumentAsync(document, root, lambdaNode, cancellationToken),
                     title));
             }
 
@@ -205,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
 
             // We're only replacing a single declaration in the refactoring.  So pass 'declaration'
             // as both the 'original' and 'current' declaration.
-            var updatedDeclaration = UseExpressionBodyForLambdaCodeActionHelpers.Update(semanticModel, declaration, declaration);
+            var updatedDeclaration = UseExpressionBodyForLambdaCodeActionHelpers.Update(semanticModel, declaration, declaration, cancellationToken);
 
             var newRoot = root.ReplaceNode(declaration, updatedDeclaration);
             return document.WithSyntaxRoot(newRoot);

--- a/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
     {
         protected abstract Task<string> GetFieldNameAsync(Document document, IPropertySymbol propertySymbol, NamingStylePreferencesProvider fallbackOptions, CancellationToken cancellationToken);
         protected abstract (SyntaxNode newGetAccessor, SyntaxNode newSetAccessor) GetNewAccessors(
-            TCodeGenerationContextInfo info, SyntaxNode property, string fieldName, SyntaxGenerator generator);
+            TCodeGenerationContextInfo info, SyntaxNode property, string fieldName, SyntaxGenerator generator, CancellationToken cancellationToken);
         protected abstract SyntaxNode GetPropertyWithoutInitializer(SyntaxNode property);
         protected abstract SyntaxNode GetInitializerValue(SyntaxNode property);
         protected abstract SyntaxNode ConvertPropertyToExpressionBodyIfDesired(TCodeGenerationContextInfo info, SyntaxNode fullProperty);
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
             // Create full property. If the auto property had an initial value
             // we need to remove it and later add it to the backing field
             var fieldName = await GetFieldNameAsync(document, propertySymbol, fallbackOptions, cancellationToken).ConfigureAwait(false);
-            var (newGetAccessor, newSetAccessor) = GetNewAccessors(info, property, fieldName, generator);
+            var (newGetAccessor, newSetAccessor) = GetNewAccessors(info, property, fieldName, generator, cancellationToken);
             var fullProperty = generator
                 .WithAccessorDeclarations(
                     GetPropertyWithoutInitializer(property),

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/IReplaceMethodWithPropertyService.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         void ReplaceGetMethodWithProperty(
             CodeGenerationOptions options, ParseOptions parseOptions,
             SyntaxEditor editor, SemanticModel semanticModel,
-            GetAndSetMethods getAndSetMethods, string propertyName, bool nameChanged);
+            GetAndSetMethods getAndSetMethods, string propertyName, bool nameChanged, CancellationToken cancellationToken);
 
         void RemoveSetMethod(SyntaxEditor editor, SyntaxNode setMethodDeclaration);
     }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 
                 service.ReplaceGetMethodWithProperty(
                     codeGenerationOptions, parseOptions, editor, semanticModel,
-                    getSetPair, propertyName, nameChanged);
+                    getSetPair, propertyName, nameChanged, cancellationToken);
             }
 
             // Then remove all the set methods.

--- a/src/Features/VisualBasic/Portable/ConvertAutoPropertyToFullProperty/VisualBasicConvertAutoPropertyToFullProperty.vb
+++ b/src/Features/VisualBasic/Portable/ConvertAutoPropertyToFullProperty/VisualBasicConvertAutoPropertyToFullProperty.vb
@@ -36,10 +36,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertAutoPropertyToFullProperty
         End Function
 
         Protected Overrides Function GetNewAccessors(
-            info As VisualBasicCodeGenerationContextInfo,
-            propertyNode As SyntaxNode,
-            fieldName As String,
-            generator As SyntaxGenerator) As (newGetAccessor As SyntaxNode, newSetAccessor As SyntaxNode)
+                info As VisualBasicCodeGenerationContextInfo,
+                propertyNode As SyntaxNode,
+                fieldName As String,
+                generator As SyntaxGenerator,
+                cancellationToken As CancellationToken) As (newGetAccessor As SyntaxNode, newSetAccessor As SyntaxNode)
 
             Dim returnStatement = New SyntaxList(Of StatementSyntax)(DirectCast(generator.ReturnStatement(
                 generator.IdentifierName(fieldName)), StatementSyntax))

--- a/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
@@ -2,17 +2,16 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 Imports System.Composition
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeActions
+Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.ReplaceMethodWithProperty
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
-Imports Microsoft.CodeAnalysis.CodeGeneration
-Imports System.Threading
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.ReplaceMethodWithProperty
     <ExportLanguageService(GetType(IReplaceMethodWithPropertyService), LanguageNames.VisualBasic), [Shared]>

--- a/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceMethodWithProperty/VisualBasicReplaceMethodWithPropertyService.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.ReplaceMethodWithProperty
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService
 Imports Microsoft.CodeAnalysis.CodeGeneration
+Imports System.Threading
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.ReplaceMethodWithProperty
     <ExportLanguageService(GetType(IReplaceMethodWithPropertyService), LanguageNames.VisualBasic), [Shared]>
@@ -35,12 +36,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.ReplaceMethodWithP
         End Sub
 
         Public Sub ReplaceGetMethodWithProperty(
-            options As CodeGenerationOptions,
-            parseOptions As ParseOptions,
-            editor As SyntaxEditor,
-            semanticModel As SemanticModel,
-            getAndSetMethods As GetAndSetMethods,
-            propertyName As String, nameChanged As Boolean) Implements IReplaceMethodWithPropertyService.ReplaceGetMethodWithProperty
+                options As CodeGenerationOptions,
+                parseOptions As ParseOptions,
+                editor As SyntaxEditor,
+                semanticModel As SemanticModel,
+                getAndSetMethods As GetAndSetMethods,
+                propertyName As String, nameChanged As Boolean,
+                cancellationToken As CancellationToken) Implements IReplaceMethodWithPropertyService.ReplaceGetMethodWithProperty
 
             Dim getMethodDeclaration = TryCast(getAndSetMethods.GetMethodDeclaration, MethodStatementSyntax)
             If getMethodDeclaration Is Nothing Then

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return false;
 
             static bool IsAnyCodeDirective(SyntaxTrivia trivia)
-                => trivia.Kind() is SyntaxKind.IfDirectiveTrivia or SyntaxKind.ElifDirectiveTrivia or SyntaxKind.ElseDirectiveTrivia or SyntaxKind.EndIfDirectiveTrivia;
+                => trivia.GetStructure() is ConditionalDirectiveTriviaSyntax;
 
             // We can have an ifdef'ed section around the statement, as long as each segment of the ifdef
             // contains an expression-statement or throw-statement.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
-using System.Diagnostics.CodeAnalysis;
-using System.Collections.Immutable;
-using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/DirectiveSyntaxExtensions.cs
@@ -3,15 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ConstructorGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ConstructorGenerator.cs
@@ -61,19 +61,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 body: hasNoBody ? null : GenerateBlock(constructor),
                 semicolonToken: hasNoBody ? SyntaxFactory.Token(SyntaxKind.SemicolonToken) : default);
 
-            declaration = UseExpressionBodyIfDesired(info, declaration);
+            declaration = UseExpressionBodyIfDesired(info, declaration, cancellationToken);
 
             return AddFormatterAndCodeGeneratorAnnotationsTo(
                 ConditionallyAddDocumentationCommentTo(declaration, constructor, info, cancellationToken));
         }
 
         private static ConstructorDeclarationSyntax UseExpressionBodyIfDesired(
-            CSharpCodeGenerationContextInfo info, ConstructorDeclarationSyntax declaration)
+            CSharpCodeGenerationContextInfo info, ConstructorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             if (declaration.ExpressionBody == null)
             {
                 if (declaration.Body?.TryConvertToArrowExpressionBody(
-                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedConstructors.Value,
+                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedConstructors.Value, cancellationToken,
                     out var expressionBody, out var semicolonToken) == true)
                 {
                     return declaration.WithBody(null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ConversionGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/ConversionGenerator.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             CSharpCodeGenerationContextInfo info,
             CancellationToken cancellationToken)
         {
-            var declaration = GenerateConversionDeclarationWorker(method, destination, info);
+            var declaration = GenerateConversionDeclarationWorker(method, destination, info, cancellationToken);
             return AddFormatterAndCodeGeneratorAnnotationsTo(AddAnnotationsTo(method,
                 ConditionallyAddDocumentationCommentTo(declaration, method, info, cancellationToken)));
         }
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private static ConversionOperatorDeclarationSyntax GenerateConversionDeclarationWorker(
             IMethodSymbol method,
             CodeGenerationDestination destination,
-            CSharpCodeGenerationContextInfo info)
+            CSharpCodeGenerationContextInfo info,
+            CancellationToken cancellationToken)
         {
             var hasNoBody = !info.Context.GenerateMethodBodies || method.IsExtern;
 
@@ -73,18 +74,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 expressionBody: null,
                 semicolonToken: hasNoBody ? SyntaxFactory.Token(SyntaxKind.SemicolonToken) : new SyntaxToken());
 
-            declaration = UseExpressionBodyIfDesired(info, declaration);
+            declaration = UseExpressionBodyIfDesired(info, declaration, cancellationToken);
 
             return declaration;
         }
 
         private static ConversionOperatorDeclarationSyntax UseExpressionBodyIfDesired(
-            CSharpCodeGenerationContextInfo info, ConversionOperatorDeclarationSyntax declaration)
+            CSharpCodeGenerationContextInfo info, ConversionOperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             if (declaration.ExpressionBody == null)
             {
                 if (declaration.Body?.TryConvertToArrowExpressionBody(
-                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedOperators.Value,
+                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedOperators.Value, cancellationToken,
                     out var expressionBody, out var semicolonToken) == true)
                 {
                     return declaration.WithBody(null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/OperatorGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/OperatorGenerator.cs
@@ -43,20 +43,20 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return reusableSyntax;
             }
 
-            var declaration = GenerateOperatorDeclarationWorker(method, destination, info);
-            declaration = UseExpressionBodyIfDesired(info, declaration);
+            var declaration = GenerateOperatorDeclarationWorker(method, destination, info, cancellationToken);
+            declaration = UseExpressionBodyIfDesired(info, declaration, cancellationToken);
 
             return AddAnnotationsTo(method,
                 ConditionallyAddDocumentationCommentTo(declaration, method, info, cancellationToken));
         }
 
         private static OperatorDeclarationSyntax UseExpressionBodyIfDesired(
-            CSharpCodeGenerationContextInfo info, OperatorDeclarationSyntax declaration)
+            CSharpCodeGenerationContextInfo info, OperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             if (declaration.ExpressionBody == null)
             {
                 if (declaration.Body?.TryConvertToArrowExpressionBody(
-                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedOperators.Value,
+                    declaration.Kind(), info.LanguageVersion, info.Options.PreferExpressionBodiedOperators.Value, cancellationToken,
                     out var expressionBody, out var semicolonToken) == true)
                 {
                     return declaration.WithBody(null)
@@ -71,7 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private static OperatorDeclarationSyntax GenerateOperatorDeclarationWorker(
             IMethodSymbol method,
             CodeGenerationDestination destination,
-            CSharpCodeGenerationContextInfo info)
+            CSharpCodeGenerationContextInfo info,
+            CancellationToken cancellationToken)
         {
             var hasNoBody = !info.Context.GenerateMethodBodies || method.IsExtern || method.IsAbstract;
 
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 expressionBody: null,
                 semicolonToken: hasNoBody ? SyntaxFactory.Token(SyntaxKind.SemicolonToken) : new SyntaxToken());
 
-            operatorDecl = UseExpressionBodyIfDesired(info, operatorDecl);
+            operatorDecl = UseExpressionBodyIfDesired(info, operatorDecl, cancellationToken);
             return operatorDecl;
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             {
                 if (declaration.Initializer == null)
                 {
-                    if (TryGetExpressionBody( 
+                    if (TryGetExpressionBody(
                             declaration, info.LanguageVersion, info.Options.PreferExpressionBodiedProperties.Value, cancellationToken,
                             out var expressionBody, out var semicolonToken))
                     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/PropertyGenerator.cs
@@ -78,8 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
 
             var declaration = property.IsIndexer
-                ? GenerateIndexerDeclaration(property, destination, info)
-                : GeneratePropertyDeclaration(property, destination, info);
+                ? GenerateIndexerDeclaration(property, destination, info, cancellationToken)
+                : GeneratePropertyDeclaration(property, destination, info, cancellationToken);
 
             return ConditionallyAddDocumentationCommentTo(declaration, property, info, cancellationToken);
         }
@@ -87,7 +87,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private static MemberDeclarationSyntax GenerateIndexerDeclaration(
             IPropertySymbol property,
             CodeGenerationDestination destination,
-            CSharpCodeGenerationContextInfo info)
+            CSharpCodeGenerationContextInfo info,
+            CancellationToken cancellationToken)
         {
             var explicitInterfaceSpecifier = GenerateExplicitInterfaceSpecifier(property.ExplicitInterfaceImplementations);
 
@@ -97,8 +98,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     type: GenerateTypeSyntax(property),
                     explicitInterfaceSpecifier: explicitInterfaceSpecifier,
                     parameterList: ParameterGenerator.GenerateBracketedParameterList(property.Parameters, explicitInterfaceSpecifier != null, info),
-                    accessorList: GenerateAccessorList(property, destination, info));
-            declaration = UseExpressionBodyIfDesired(info, declaration);
+                    accessorList: GenerateAccessorList(property, destination, info, cancellationToken));
+            declaration = UseExpressionBodyIfDesired(info, declaration, cancellationToken);
 
             return AddFormatterAndCodeGeneratorAnnotationsTo(
                 AddAnnotationsTo(property, declaration));
@@ -106,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static MemberDeclarationSyntax GeneratePropertyDeclaration(
            IPropertySymbol property, CodeGenerationDestination destination,
-           CSharpCodeGenerationContextInfo info)
+           CSharpCodeGenerationContextInfo info, CancellationToken cancellationToken)
         {
             var initializer = CodeGenerationPropertyInfo.GetInitializer(property) is ExpressionSyntax initializerNode
                 ? SyntaxFactory.EqualsValueClause(initializerNode)
@@ -114,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             var explicitInterfaceSpecifier = GenerateExplicitInterfaceSpecifier(property.ExplicitInterfaceImplementations);
 
-            var accessorList = GenerateAccessorList(property, destination, info);
+            var accessorList = GenerateAccessorList(property, destination, info, cancellationToken);
 
             var propertyDeclaration = SyntaxFactory.PropertyDeclaration(
                 attributeLists: AttributeGenerator.GenerateAttributeLists(property.GetAttributes(), info),
@@ -127,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 initializer: initializer,
                 semicolonToken: initializer is null ? default : SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
-            propertyDeclaration = UseExpressionBodyIfDesired(info, propertyDeclaration);
+            propertyDeclaration = UseExpressionBodyIfDesired(info, propertyDeclaration, cancellationToken);
 
             return AddFormatterAndCodeGeneratorAnnotationsTo(
                 AddAnnotationsTo(property, propertyDeclaration));
@@ -152,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static bool TryGetExpressionBody(
-            BasePropertyDeclarationSyntax baseProperty, LanguageVersion languageVersion, ExpressionBodyPreference preference,
+            BasePropertyDeclarationSyntax baseProperty, LanguageVersion languageVersion, ExpressionBodyPreference preference, CancellationToken cancellationToken,
             [NotNullWhen(true)] out ArrowExpressionClauseSyntax? arrowExpression, out SyntaxToken semicolonToken)
         {
             var accessorList = baseProperty.AccessorList;
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration))
                 {
                     return TryGetArrowExpressionBody(
-                        baseProperty.Kind(), accessor, languageVersion, preference,
+                        baseProperty.Kind(), accessor, languageVersion, preference, cancellationToken,
                         out arrowExpression, out semicolonToken);
                 }
             }
@@ -174,14 +175,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static PropertyDeclarationSyntax UseExpressionBodyIfDesired(
-            CSharpCodeGenerationContextInfo info, PropertyDeclarationSyntax declaration)
+            CSharpCodeGenerationContextInfo info, PropertyDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             if (declaration.ExpressionBody == null)
             {
                 if (declaration.Initializer == null)
                 {
-                    if (TryGetExpressionBody(
-                            declaration, info.LanguageVersion, info.Options.PreferExpressionBodiedProperties.Value,
+                    if (TryGetExpressionBody( 
+                            declaration, info.LanguageVersion, info.Options.PreferExpressionBodiedProperties.Value, cancellationToken,
                             out var expressionBody, out var semicolonToken))
                     {
                         declaration = declaration.WithAccessorList(null)
@@ -195,12 +196,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         private static IndexerDeclarationSyntax UseExpressionBodyIfDesired(
-            CSharpCodeGenerationContextInfo info, IndexerDeclarationSyntax declaration)
+            CSharpCodeGenerationContextInfo info, IndexerDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
             if (declaration.ExpressionBody == null)
             {
                 if (TryGetExpressionBody(
-                        declaration, info.LanguageVersion, info.Options.PreferExpressionBodiedIndexers.Value,
+                        declaration, info.LanguageVersion, info.Options.PreferExpressionBodiedIndexers.Value, cancellationToken,
                         out var expressionBody, out var semicolonToken))
                 {
                     declaration = declaration.WithAccessorList(null)
@@ -261,8 +262,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var setAccessorKind = property.SetMethod?.IsInitOnly == true ? SyntaxKind.InitAccessorDeclaration : SyntaxKind.SetAccessorDeclaration;
             var accessors = new[]
             {
-                GenerateAccessorDeclaration(property, property.GetMethod, SyntaxKind.GetAccessorDeclaration, destination, info),
-                GenerateAccessorDeclaration(property, property.SetMethod, setAccessorKind, destination, info),
+                GenerateAccessorDeclaration(property, property.GetMethod, SyntaxKind.GetAccessorDeclaration, destination, info, cancellationToken),
+                GenerateAccessorDeclaration(property, property.SetMethod, setAccessorKind, destination, info, cancellationToken),
             };
 
             return accessors[0] == null && accessors[1] == null


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69783