### PR TITLE
Fix source build trying to consume StreamJsonRpc

### DIFF
--- a/src/Workspaces/Core/MSBuild.BuildHost/IRemoteProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/IRemoteProjectFile.cs
@@ -8,14 +8,19 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.MSBuild.Logging;
+
+#if !DOTNET_BUILD_FROM_SOURCE
 using StreamJsonRpc;
+#endif
 
 namespace Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost;
 
 /// <summary>
-/// A trimmed down interface of <see cref="IProjectFile"/> that is usable for RPC to the build host process and meets all the requirements of being an <see cref="RpcMarshalableAttribute"/> interface.
+/// A trimmed down interface of <see cref="IProjectFile"/> that is usable for RPC to the build host process and meets all the requirements of being an RPC marshable interface.
 /// </summary>
+#if !DOTNET_BUILD_FROM_SOURCE
 [RpcMarshalable]
+#endif
 internal interface IRemoteProjectFile : IDisposable
 {
     Task<ImmutableArray<ProjectFileInfo>> GetProjectFileInfosAsync(CancellationToken cancellationToken);

--- a/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Logging/DiagnosticLogItem.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/MSBuild/Logging/DiagnosticLogItem.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.MSBuild.Logging
 {

--- a/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
   </ItemGroup>

--- a/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
@@ -6,12 +6,24 @@ using System;
 using System.CommandLine;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+
+#if !DOTNET_BUILD_FROM_SOURCE
 using StreamJsonRpc;
+#endif
 
 namespace Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost;
 
 internal static class Program
 {
+#if DOTNET_BUILD_FROM_SOURCE
+
+    internal static void Main()
+    {
+        throw new NotSupportedException("This cannot currently be launched as a process in source build scenarios.");
+    }
+
+#else
+
     internal static async Task Main(string[] args)
     {
         var binaryLogOption = new CliOption<string?>("--binlog") { Required = false };
@@ -50,4 +62,6 @@ internal static class Program
 
         logger.LogInformation("RPC channel closed; process exiting.");
     }
+
+#endif
 }


### PR DESCRIPTION
Right now the use of StreamJsonRpc is only being used for our LSP server which doesn't build in source build anyways. So we can exclude it here for now.

Fixes https://github.com/dotnet/roslyn/issues/69847