### PR TITLE
Create a brokered service to delegate loading of projects to us

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LanguageServerProjectSystemServiceTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LanguageServerProjectSystemServiceTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Remote.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Extensions.Logging;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+public class LanguageServerProjectSystemServiceTests
+{
+    [Fact]
+    public async Task FetchServiceAndLoadProject()
+    {
+        AsynchronousOperationListenerProvider.Enable(true);
+
+        using var exportProvider = await LanguageServerTestComposition.CreateExportProviderAsync(new LoggerFactory(), includeDevKitComponents: false);
+        await exportProvider.GetExportedValue<ServiceBrokerFactory>().CreateAsync();
+
+        // Right now the language service indirectly relies on having an initialized configuration
+        // TODO: we shouldn't have to do this in unit tests
+        exportProvider.GetExportedValue<ServerConfigurationFactory>().InitializeConfiguration(new ServerConfiguration(
+            LaunchDebugger: false,
+            MinimumLogLevel: LogLevel.Trace,
+            StarredCompletionsPath: null,
+            TelemetryLevel: null,
+            SessionId: null,
+            SharedDependenciesPath: null,
+            ExtensionAssemblyPaths: SpecializedCollections.EmptyEnumerable<string>(),
+            ExtensionLogDirectory: ""));
+
+        var workspaceFactory = exportProvider.GetExportedValue<LanguageServerWorkspaceFactory>();
+
+        await using var brokeredServiceFactory = new BrokeredServiceProxy<ILanguageServerProjectSystemService>(exportProvider, LanguageServerProjectSystemServiceDescriptor.ServiceDescriptor);
+        var languageServerProjectSystemService = await brokeredServiceFactory.GetServiceAsync();
+
+        // Try loading a trivial project
+        using var tempRoot = new TempRoot();
+        var tempFile = tempRoot.CreateFile("TestProject", ".csproj");
+        tempFile.WriteAllText("<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net7.0</TargetFramework></PropertyGroup></Project>");
+
+        using var loadedProject = await languageServerProjectSystemService.LoadProjectAsync(tempFile.Path, ImmutableDictionary<string, string>.Empty, CancellationToken.None);
+
+        await exportProvider.GetExportedValue<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
+
+        Assert.NotEmpty(workspaceFactory.Workspace.CurrentSolution.Projects);
+    }
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/BrokeredServiceProxy.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/BrokeredServiceProxy.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Nerdbank.Streams;
 using StreamJsonRpc;
 
@@ -20,6 +23,18 @@ internal sealed class BrokeredServiceProxy<T> : IAsyncDisposable where T : class
     private JsonRpc? _serverRpc;
     private JsonRpc? _clientRpc;
     private T? _clientFactoryProxy;
+
+    public BrokeredServiceProxy(ExportProvider exportProvider, ServiceJsonRpcDescriptor serviceDescriptor)
+        : this((T)exportProvider
+                  .GetExports<IExportedBrokeredService, ExportedBrokeredServiceMetadata>()
+                  .Single(service => service.Metadata.ServiceName.Single() == serviceDescriptor.Moniker.Name).Value)
+    {
+    }
+
+    private class ExportedBrokeredServiceMetadata
+    {
+        public required IEnumerable<string> ServiceName { get; init; }
+    }
 
     public BrokeredServiceProxy(T service)
     {

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -4,10 +4,8 @@
 
 using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
-using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Shell.ServiceBroker;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 
@@ -20,12 +18,7 @@ public class WorkspaceProjectFactoryServiceTests
         await exportProvider.GetExportedValue<ServiceBrokerFactory>().CreateAsync();
 
         var workspaceFactory = exportProvider.GetExportedValue<LanguageServerWorkspaceFactory>();
-        var workspaceProjectFactoryServiceInstance = (WorkspaceProjectFactoryService)exportProvider
-            .GetExportedValues<IExportedBrokeredService>()
-            .Single(service => service.Descriptor == WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor);
-
-        await using var brokeredServiceFactory = new BrokeredServiceProxy<IWorkspaceProjectFactoryService>(
-            workspaceProjectFactoryServiceInstance);
+        await using var brokeredServiceFactory = new BrokeredServiceProxy<IWorkspaceProjectFactoryService>(exportProvider, WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor);
 
         var workspaceProjectFactoryService = await brokeredServiceFactory.GetServiceAsync();
         using var workspaceProject = await workspaceProjectFactoryService.CreateAndAddProjectAsync(

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
-using Microsoft.CodeAnalysis.LanguageServer.Logging;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
 using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Shell.ServiceBroker;

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/WorkspaceProjectFactoryServiceTests.cs
@@ -18,9 +18,10 @@ public class WorkspaceProjectFactoryServiceTests
         await exportProvider.GetExportedValue<ServiceBrokerFactory>().CreateAsync();
 
         var workspaceFactory = exportProvider.GetExportedValue<LanguageServerWorkspaceFactory>();
-        await using var brokeredServiceFactory = new BrokeredServiceProxy<IWorkspaceProjectFactoryService>(exportProvider, WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor);
 
+        await using var brokeredServiceFactory = new BrokeredServiceProxy<IWorkspaceProjectFactoryService>(exportProvider, WorkspaceProjectFactoryServiceDescriptor.ServiceDescriptor);
         var workspaceProjectFactoryService = await brokeredServiceFactory.GetServiceAsync();
+
         using var workspaceProject = await workspaceProjectFactoryService.CreateAndAddProjectAsync(
             new WorkspaceProjectCreationInfo(LanguageNames.CSharp, "DisplayName", FilePath: null, new Dictionary<string, string>()),
             CancellationToken.None);
@@ -45,6 +46,6 @@ public class WorkspaceProjectFactoryServiceTests
         if (OperatingSystem.IsWindows())
             return Path.Combine("Z:\\", relativePath);
         else
-            return Path.Combine("//", relativePath);
+            return Path.Combine("/", relativePath);
     }
 }

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/LoadedProjectSystemProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/LoadedProjectSystemProject.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Remote.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
+
+internal sealed class LoadedProjectSystemProject : ILoadedProjectSystemProject
+{
+    public void Dispose()
+    {
+        // TODO: implement this
+    }
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProject.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
 
 internal class WorkspaceProject : IWorkspaceProject
 {

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProjectFactoryService.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProjectFactoryService.cs
@@ -9,13 +9,14 @@ using Microsoft.CodeAnalysis.Remote.ProjectSystem;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
+
 #pragma warning disable RS0030 // This is intentionally using System.ComponentModel.Composition for compatibility with MEF service broker.
 /// <summary>
 /// An implementation of the brokered service <see cref="IWorkspaceProjectFactoryService"/> that just maps calls to the underlying project system.
 /// </summary>
 [ExportBrokeredService("Microsoft.VisualStudio.LanguageServices.WorkspaceProjectFactoryService", null, Audience = ServiceAudience.Local)]
-internal class WorkspaceProjectFactoryService : IWorkspaceProjectFactoryService, IExportedBrokeredService
+internal sealed class WorkspaceProjectFactoryService : IWorkspaceProjectFactoryService, IExportedBrokeredService
 {
     private readonly LanguageServerWorkspaceFactory _workspaceFactory;
     private readonly ProjectInitializationHandler _projectInitializationHandler;

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProjectSystemService.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BrokeredServices/WorkspaceProjectSystemService.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Remote.ProjectSystem;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.BrokeredServices;
+
+#pragma warning disable RS0030 // This is intentionally using System.ComponentModel.Composition for compatibility with MEF service broker.
+/// <summary>
+/// An implementation of the brokered service <see cref="ILanguageServerProjectSystemService"/> that just maps calls to the underlying project system.
+/// </summary>
+[ExportBrokeredService("Microsoft.VisualStudio.LanguageServices.LanguageServerProjectSystemService", null, Audience = ServiceAudience.Local)]
+internal sealed class LanguageServerProjectSystemService : ILanguageServerProjectSystemService, IExportedBrokeredService
+{
+    private readonly LanguageServerProjectSystem _projectSystem;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public LanguageServerProjectSystemService(LanguageServerProjectSystem projectSystem, ProjectInitializationHandler projectInitializationHandler)
+    {
+        _projectSystem = projectSystem;
+    }
+
+    ServiceRpcDescriptor IExportedBrokeredService.Descriptor => LanguageServerProjectSystemServiceDescriptor.ServiceDescriptor;
+
+    Task IExportedBrokeredService.InitializeAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    async Task<ILoadedProjectSystemProject> ILanguageServerProjectSystemService.LoadProjectAsync(string projectFilePath, ImmutableDictionary<string, string> buildProperties, CancellationToken cancellationToken)
+    {
+        // TODO: pass through the build properties, which we don't have support for yet
+        await _projectSystem.OpenProjectsAsync(ImmutableArray.Create(projectFilePath));
+
+        // TODO: pass something along here so we can unload
+        return new LoadedProjectSystemProject();
+    }
+}
+#pragma warning restore RS0030 // Do not used banned APIs

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -5,11 +5,9 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DebugConfiguration;
-using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace.ProjectTelemetry;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
-using Microsoft.Extensions.Logging;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectInitializationHandler.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectInitializationHandler.cs
@@ -44,9 +44,12 @@ internal class ProjectInitializationHandler : IDisposable
 
     public static async Task SendProjectInitializationCompleteNotificationAsync()
     {
-        Contract.ThrowIfNull(LanguageServerHost.Instance, "We don't have an LSP channel yet to send this request through.");
-        var languageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();
-        await languageServerManager.SendNotificationAsync(ProjectInitializationCompleteName, CancellationToken.None);
+        // This could be null in unit tests, since we don't have an LSP channel connected for that
+        if (LanguageServerHost.Instance != null)
+        {
+            var languageServerManager = LanguageServerHost.Instance.GetRequiredLspService<IClientLanguageServerManager>();
+            await languageServerManager.SendNotificationAsync(ProjectInitializationCompleteName, CancellationToken.None);
+        }
     }
 
     public async Task SubscribeToInitializationCompleteAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/ProjectSystem/ILanguageServerProjectSystemService.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/ILanguageServerProjectSystemService.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Remote.ProjectSystem;
+
+internal interface ILanguageServerProjectSystemService
+{
+    Task<ILoadedProjectSystemProject> LoadProjectAsync(string projectFilePath, ImmutableDictionary<string, string> buildProperties, CancellationToken cancellationToken);
+}

--- a/src/Workspaces/Remote/Core/ProjectSystem/ILoadedProjectSystemProject.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/ILoadedProjectSystemProject.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using StreamJsonRpc;
+
+namespace Microsoft.CodeAnalysis.Remote.ProjectSystem;
+
+/// <summary>
+/// A marker interface that represents a loaded project from the <see cref="ILanguageServerProjectSystemService"/>. At this point you can't do anything with this other
+/// than dispose it, which indicates you want the project to be unloaded.
+/// </summary>
+[RpcMarshalable]
+internal interface ILoadedProjectSystemProject : IDisposable
+{
+}

--- a/src/Workspaces/Remote/Core/ProjectSystem/LanguageServerProjectSystemServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/LanguageServerProjectSystemServiceDescriptor.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Remote.ProjectSystem
+{
+    internal static class LanguageServerProjectSystemServiceDescriptor
+    {
+        public const string ServiceName = "LanguageServerProjectSystemService";
+        public static readonly ServiceDescriptor ServiceDescriptor = ServiceDescriptor.CreateInProcServiceDescriptor(ServiceDescriptors.ComponentName, ServiceName, suffix: "", ServiceDescriptors.GetFeatureDisplayName);
+    }
+}


### PR DESCRIPTION
Implementing unloading support is going to require a bit more refactoring, but this should at least unblock the DevKit folks who need to call this.