### PR TITLE
Bring LSP pull diagnostic range-computation more in line with how our squiggle tagger does things.

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "8.0.100-preview.7.23376.3",

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
@@ -110,13 +110,13 @@ internal abstract partial class AbstractDiagnosticsTaggerProvider<TTag>
                 var diagnostics = await _analyzerService.GetDiagnosticsForSpanAsync(
                     document,
                     requestedSpan.Span.ToTextSpan(),
-                    diagnosticKind: _diagnosticKind,
+                    _diagnosticKind,
                     includeSuppressedDiagnostics: true,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
 
                 foreach (var diagnosticData in diagnostics)
                 {
-                    if (_callback.IncludeDiagnostic(diagnosticData) && !diagnosticData.IsSuppressed)
+                    if (!diagnosticData.IsSuppressed && _callback.IncludeDiagnostic(diagnosticData))
                     {
                         var diagnosticSpans = _callback.GetLocationsToTag(diagnosticData)
                             .Select(loc => loc.UnmappedFileSpan.GetClampedTextSpan(sourceText).ToSnapshotSpan(snapshot));

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -10,13 +10,10 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
-internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosticSource
+internal abstract class AbstractDocumentDiagnosticSource<TDocument>(TDocument document) : IDiagnosticSource
     where TDocument : TextDocument
 {
-    public TDocument Document { get; }
-
-    public AbstractDocumentDiagnosticSource(TDocument document)
-        => Document = document;
+    public TDocument Document { get; } = document;
 
     public ProjectOrDocumentId GetId() => new(Document.Id);
     public Project GetProject() => Document.Project;
@@ -30,4 +27,7 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
 
     public abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, CancellationToken cancellationToken);
+
+    public TextDocument? GetTextDocument()
+        => this.Document;
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +20,8 @@ internal interface IDiagnosticSource
     ProjectOrDocumentId GetId();
     TextDocumentIdentifier? GetDocumentIdentifier();
     string ToDisplayString();
+
+    TextDocument? GetTextDocument();
 
     Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
@@ -35,4 +35,6 @@ internal sealed record class ProjectDiagnosticSource(Project Project, Func<Diagn
     }
 
     public string ToDisplayString() => Project.Name;
+
+    public TextDocument? GetTextDocument() => null;
 }


### PR DESCRIPTION
We're currently seeing scenarios where squiggles are showing up in LSP in teh wrong location.  This is an attempt to eliminate potential deviations in our code from how we do things in our own normal squiggle tagging (where we do not see the same problem).  This is not certain to fix the issue, but it eliminates certain possibilities.  