### PR TITLE
Fix issue with stale cached data in LSP pull diagnostics

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly TextDocument _document;
             private readonly SourceText _text;
 
-            private readonly IEnumerable<StateSet> _stateSets;
+            private readonly ImmutableArray<StateSet> _stateSets;
             private readonly CompilationWithAnalyzers? _compilationWithAnalyzers;
 
             private readonly TextSpan? _range;
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly Func<string, bool>? _shouldIncludeDiagnostic;
             private readonly bool _includeCompilerDiagnostics;
             private readonly Func<string, IDisposable?>? _addOperationScope;
-            private readonly bool _cacheFullDocumentDiagnostics;
             private readonly bool _isExplicit;
             private readonly bool _logPerformanceInfo;
             private readonly bool _incrementalAnalysis;
@@ -103,15 +102,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var stateSets = owner._stateManager
-                                     .GetOrCreateStateSets(document.Project).Where(s => DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(s.Analyzer, document.Project, owner.GlobalOptions));
+                    .GetOrCreateStateSets(document.Project)
+                    .Where(s => DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(s.Analyzer, document.Project, owner.GlobalOptions))
+                    .ToImmutableArray();
 
                 var ideOptions = owner.AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(document.Project);
-
-                // We want to cache computed full document diagnostics in LatestDiagnosticsForSpanGetter
-                // only in LSP pull diagnostics mode. In LSP push diagnostics mode,
-                // the background analysis from solution crawler handles caching these diagnostics and
-                // updating the error list simultaneously.
-                var cacheFullDocumentDiagnostics = owner.AnalyzerService.GlobalOptions.IsLspPullDiagnostics();
 
                 // Note that some callers, such as diagnostic tagger, might pass in a range equal to the entire document span.
                 // We clear out range for such cases as we are computing full document diagnostics.
@@ -132,14 +127,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 return new LatestDiagnosticsForSpanGetter(
                     owner, compilationWithAnalyzers, document, text, stateSets, shouldIncludeDiagnostic, includeCompilerDiagnostics,
-                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priorityProvider, cacheFullDocumentDiagnostics,
+                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priorityProvider,
                     isExplicit, logPerformanceInfo, incrementalAnalysis, diagnosticKinds);
             }
 
             private static async Task<CompilationWithAnalyzers?> GetOrCreateCompilationWithAnalyzersAsync(
                 Project project,
                 IdeAnalyzerOptions ideOptions,
-                IEnumerable<StateSet> stateSets,
+                ImmutableArray<StateSet> stateSets,
                 bool includeSuppressedDiagnostics,
                 CancellationToken cancellationToken)
             {
@@ -179,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 CompilationWithAnalyzers? compilationWithAnalyzers,
                 TextDocument document,
                 SourceText text,
-                IEnumerable<StateSet> stateSets,
+                ImmutableArray<StateSet> stateSets,
                 Func<string, bool>? shouldIncludeDiagnostic,
                 bool includeCompilerDiagnostics,
                 TextSpan? range,
@@ -187,7 +182,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 Func<string, IDisposable?>? addOperationScope,
                 bool includeSuppressedDiagnostics,
                 ICodeActionRequestPriorityProvider priorityProvider,
-                bool cacheFullDocumentDiagnostics,
                 bool isExplicit,
                 bool logPerformanceInfo,
                 bool incrementalAnalysis,
@@ -205,7 +199,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _addOperationScope = addOperationScope;
                 _includeSuppressedDiagnostics = includeSuppressedDiagnostics;
                 _priorityProvider = priorityProvider;
-                _cacheFullDocumentDiagnostics = cacheFullDocumentDiagnostics;
                 _isExplicit = isExplicit;
                 _logPerformanceInfo = logPerformanceInfo;
                 _incrementalAnalysis = incrementalAnalysis;
@@ -456,13 +449,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var diagnostics = diagnosticsMap[analyzerWithState.Analyzer];
                     builder.AddRange(diagnostics.Where(ShouldInclude));
-
-                    // Save the computed diagnostics if caching is enabled and diagnostics were computed for the entire document.
-                    if (_cacheFullDocumentDiagnostics && !span.HasValue)
-                    {
-                        var data = new DocumentAnalysisData(version, _text.Lines.Count, diagnostics);
-                        analyzerWithState.State.Save(executor.AnalysisScope.Kind, data);
-                    }
                 }
 
                 if (incrementalAnalysis)


### PR DESCRIPTION
Observed while dogfooding.  Removing this code has been smoke tested to confirm it fixes the issue.  ~~Currently investigating to make sure the removal of this code doesn't regress the original bug it was trying to fix.~~

Have confirmed that https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1618061 (the original bug you were fixing @mavasani ) still has the right behavior after this change.