### PR TITLE
Reduce work done in operator overload syntax classifier.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 {
@@ -22,6 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 
         public override void AddClassifications(
            SyntaxNode syntax,
+           TextSpan textSpan,
            SemanticModel semanticModel,
            ClassificationOptions options,
            SegmentedList<ClassifiedSpan> result,

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
@@ -22,6 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
     {
         public override void AddClassifications(
             SyntaxNode syntax,
+            TextSpan textSpan,
             SemanticModel semanticModel,
             ClassificationOptions options,
             SegmentedList<ClassifiedSpan> result,

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/OperatorOverloadSyntaxClassifier.cs
@@ -23,17 +23,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
         public override void AddClassifications(
             SyntaxNode syntax,
+            TextSpan textSpan,
             SemanticModel semanticModel,
             ClassificationOptions options,
             SegmentedList<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
-            var symbolInfo = semanticModel.GetSymbolInfo(syntax, cancellationToken);
-            if (symbolInfo.Symbol is IMethodSymbol methodSymbol
-                && methodSymbol.MethodKind == MethodKind.UserDefinedOperator)
+            if (syntax.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
-                var operatorSpan = GetOperatorTokenSpan(syntax);
-                if (!operatorSpan.IsEmpty)
+                return;
+            }
+
+            var operatorSpan = GetOperatorTokenSpan(syntax);
+            if (!operatorSpan.IsEmpty && operatorSpan.IntersectsWith(textSpan))
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(syntax, cancellationToken);
+                if (symbolInfo.Symbol is IMethodSymbol methodSymbol
+                    && methodSymbol.MethodKind == MethodKind.UserDefinedOperator)
                 {
                     result.Add(new ClassifiedSpan(operatorSpan, ClassificationTypeNames.OperatorOverloaded));
                 }

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/SyntaxTokenClassifier.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
@@ -25,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 
         public override void AddClassifications(
             SyntaxToken lessThanToken,
+            TextSpan textSpan,
             SemanticModel semanticModel,
             ClassificationOptions options,
             SegmentedList<ClassifiedSpan> result,

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/UsingDirectiveSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/UsingDirectiveSyntaxClassifier.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 {
@@ -17,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
     {
         public override void AddClassifications(
             SyntaxNode syntax,
+            TextSpan textSpan,
             SemanticModel semanticModel,
             ClassificationOptions options,
             SegmentedList<ClassifiedSpan> result,

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.Worker.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     _cancellationToken.ThrowIfCancellationRequested();
 
                     list.Clear();
-                    classifier.AddClassifications(syntax, _semanticModel, _options, list, _cancellationToken);
+                    classifier.AddClassifications(syntax, _textSpan, _semanticModel, _options, list, _cancellationToken);
                     AddClassifications(list);
                 }
             }
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     _cancellationToken.ThrowIfCancellationRequested();
 
                     list.Clear();
-                    classifier.AddClassifications(syntax, _semanticModel, _options, list, _cancellationToken);
+                    classifier.AddClassifications(syntax, _textSpan, _semanticModel, _options, list, _cancellationToken);
                     AddClassifications(list);
                 }
 

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassifier.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification.Classifiers
 {
@@ -18,11 +19,11 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         protected static string? GetClassificationForType(ITypeSymbol type)
             => type.GetClassification();
 
-        public virtual void AddClassifications(SyntaxNode syntax, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public virtual void AddClassifications(SyntaxNode syntax, TextSpan textSpan, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
         }
 
-        public virtual void AddClassifications(SyntaxToken syntax, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public virtual void AddClassifications(SyntaxToken syntax, TextSpan textSpan, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassifier.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification.Classifiers
 {
@@ -24,11 +25,11 @@ namespace Microsoft.CodeAnalysis.Classification.Classifiers
         /// <summary>
         /// This method will be called for all nodes that match the types specified by the <see cref="SyntaxNodeTypes"/> property.
         /// </summary>
-        void AddClassifications(SyntaxNode node, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
+        void AddClassifications(SyntaxNode node, TextSpan textSpan, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
 
         /// <summary>
         /// This method will be called for all tokens that match the kinds specified by the <see cref="SyntaxTokenKinds"/> property.
         /// </summary>
-        void AddClassifications(SyntaxToken token, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
+        void AddClassifications(SyntaxToken token, TextSpan textSpan, SemanticModel semanticModel, ClassificationOptions options, SegmentedList<ClassifiedSpan> result, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/IdentifierNameSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/IdentifierNameSyntaxClassifier.vb
@@ -7,6 +7,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.Collections
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Public Overrides ReadOnly Property SyntaxNodeTypes As ImmutableArray(Of Type) = ImmutableArray.Create(GetType(IdentifierNameSyntax))
 
-        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
+        Public Overrides Sub AddClassifications(syntax As SyntaxNode, textSpan As TextSpan, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
             Dim identifierName = DirectCast(syntax, IdentifierNameSyntax)
             Dim identifier = identifierName.Identifier
             If CaseInsensitiveComparison.Equals(identifier.ValueText, s_awaitText) Then

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/ImportAliasClauseSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/ImportAliasClauseSyntaxClassifier.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
@@ -16,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Public Overrides ReadOnly Property SyntaxNodeTypes As ImmutableArray(Of Type) = ImmutableArray.Create(GetType(ImportAliasClauseSyntax))
 
-        Public Overrides Sub AddClassifications(syntax As SyntaxNode, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
+        Public Overrides Sub AddClassifications(syntax As SyntaxNode, textSpan As TextSpan, semanticModel As SemanticModel, options As ClassificationOptions, result As SegmentedList(Of ClassifiedSpan), cancellationToken As CancellationToken)
             ClassifyImportAliasClauseSyntax(DirectCast(syntax, ImportAliasClauseSyntax), semanticModel, result, cancellationToken)
         End Sub
 

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -23,6 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification.Classifiers
 
         Public Overrides Sub AddClassifications(
                 syntax As SyntaxNode,
+                textSpan As TextSpan,
                 semanticModel As SemanticModel,
                 options As ClassificationOptions,
                 result As SegmentedList(Of ClassifiedSpan),


### PR DESCRIPTION
This shows up as 15% of CPU in the code analysis process in a profile provided by DavidW where semantic token requests are performing poorly.

Roslyn classification walks down the tree, finding AssignmentExpressionSyntax nodes and performing semantic binding on the nodes (expensive).

Two optimizations to short-circuit before performing the binding: 1) Per Cyrus, this operation doesn't need to occur on simple assignments (the most common case of AssignmentExpressionSyntax nodes) 2) Check whether the requested range intersects the location where the classification would actually be reported.