### PR TITLE
Fix declaration snippets after `partial` keyword

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
@@ -348,5 +348,66 @@ public class MyClass
 
             await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        [InlineData("public")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public async Task NoAdditionalAccessibilityModifiersIfAfterPartialKeywordTest(string modifier)
+        {
+            var markupBeforeCommit = $$"""
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">{{modifier}} partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                root = true
+
+                [*]
+                # IDE0008: Use explicit type
+                dotnet_style_require_accessibility_modifiers = always
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{modifier}} partial class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        public async Task EnsureCorrectModifierOrderAfterPartialKeywordTest()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                root = true
+
+                [*]
+                # IDE0008: Use explicit type
+                dotnet_style_require_accessibility_modifiers = always
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public partial class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpEnumSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpEnumSnippetCompletionProviderTests.cs
@@ -270,6 +270,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         [WpfTheory]
         [InlineData("abstract")]
+        [InlineData("partial")]
         [InlineData("sealed")]
         [InlineData("static")]
         [InlineData("ref")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
@@ -359,5 +359,66 @@ public struct MyStruct
 
             await VerifyItemIsAbsentAsync(markupBeforeCommit, ItemToCommit);
         }
+
+        [WpfTheory, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        [InlineData("public")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public async Task NoAdditionalAccessibilityModifiersIfAfterPartialKeywordTest(string modifier)
+        {
+            var markupBeforeCommit = $$"""
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">{{modifier}} partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                root = true
+
+                [*]
+                # IDE0008: Use explicit type
+                dotnet_style_require_accessibility_modifiers = always
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = $$"""
+                {{modifier}} partial struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        public async Task EnsureCorrectModifierOrderAfterPartialKeywordTest()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                root = true
+
+                [*]
+                # IDE0008: Use explicit type
+                dotnet_style_require_accessibility_modifiers = always
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public partial struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpClassSnippetProvider.cs
@@ -46,17 +46,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var name = NameGenerator.GenerateUniqueName("MyClass", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-            var classDeclaration = useAccessibility is true
-                ? generator.ClassDeclaration(name, accessibility: Accessibility.Public)
-                : generator.ClassDeclaration(name);
-
-            return classDeclaration;
+            return generator.ClassDeclaration(name);
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpEnumSnippetProvider.cs
@@ -40,17 +40,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var name = NameGenerator.GenerateUniqueName("MyEnum", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-            var classDeclaration = useAccessibility is true
-                ? generator.EnumDeclaration(name, accessibility: Accessibility.Public)
-                : generator.EnumDeclaration(name);
-
-            return classDeclaration;
+            return generator.EnumDeclaration(name);
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpInterfaceSnippetProvider.cs
@@ -42,15 +42,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var name = NameGenerator.GenerateUniqueName("MyInterface", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-            return useAccessibility is true
-                ? generator.InterfaceDeclaration(name, accessibility: Accessibility.Public)
-                : generator.InterfaceDeclaration(name);
+            return generator.InterfaceDeclaration(name);
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpStructSnippetProvider.cs
@@ -44,17 +44,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override ISet<SyntaxKind> ValidModifiers => s_validModifiers;
 
-        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var name = NameGenerator.GenerateUniqueName("MyStruct", name => semanticModel.LookupSymbols(position, name: name).IsEmpty);
-            var classDeclaration = useAccessibility is true
-                ? generator.StructDeclaration(name, accessibility: Accessibility.Public)
-                : generator.StructDeclaration(name);
-
-            return classDeclaration;
+            return generator.StructDeclaration(name);
         }
 
         protected override Func<SyntaxNode?, bool> GetSnippetContainerFunction(ISyntaxFacts syntaxFacts)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractTypeSnippetProvider.cs
@@ -12,20 +12,25 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {
-    internal abstract class AbstractTypeSnippetProvider : AbstractSingleChangeSnippetProvider
+    internal abstract class AbstractTypeSnippetProvider : AbstractSnippetProvider
     {
-        protected abstract Task<bool> HasPrecedingAccessibilityModifiersAsync(Document document, int position, CancellationToken cancellationToken);
         protected abstract void GetTypeDeclarationIdentifier(SyntaxNode node, out SyntaxToken identifier);
-        protected abstract Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, bool useAccessibility, CancellationToken cancellationToken);
+        protected abstract Task<SyntaxNode> GenerateTypeDeclarationAsync(Document document, int position, CancellationToken cancellationToken);
+        protected abstract Task<TextChange?> GetAccessibilityModifiersChangeAsync(Document document, int position, CancellationToken cancellationToken);
 
-        protected override async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
+        protected override async Task<ImmutableArray<TextChange>> GenerateSnippetTextChangesAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            var hasAccessibilityModifiers = await HasPrecedingAccessibilityModifiersAsync(document, position, cancellationToken).ConfigureAwait(false);
-            var useAccessibility = !hasAccessibilityModifiers && await AreAccessibilityModifiersRequiredAsync(document, cancellationToken).ConfigureAwait(false);
+            var typeDeclaration = await GenerateTypeDeclarationAsync(document, position, cancellationToken).ConfigureAwait(false);
 
-            var typeDeclaration = await GenerateTypeDeclarationAsync(document, position, useAccessibility, cancellationToken).ConfigureAwait(false);
+            var mainChange = new TextChange(TextSpan.FromBounds(position, position), typeDeclaration.NormalizeWhitespace().ToFullString());
+            var accessibilityModifiersChange = await GetAccessibilityModifiersChangeAsync(document, position, cancellationToken).ConfigureAwait(false);
 
-            return new TextChange(TextSpan.FromBounds(position, position), typeDeclaration.NormalizeWhitespace().ToFullString());
+            if (accessibilityModifiersChange.HasValue)
+            {
+                return ImmutableArray.Create(accessibilityModifiersChange.Value, mainChange);
+            }
+
+            return ImmutableArray.Create(mainChange);
         }
 
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
@@ -37,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
             return arrayBuilder.ToImmutableArray();
         }
 
-        private static async Task<bool> AreAccessibilityModifiersRequiredAsync(Document document, CancellationToken cancellationToken)
+        protected static async Task<bool> AreAccessibilityModifiersRequiredAsync(Document document, CancellationToken cancellationToken)
         {
             var options = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
             var accessibilityModifiersRequired = options.GetEditorConfigOptionValue(CodeStyleOptions2.AccessibilityModifiersRequired, AccessibilityModifiersRequired.Never);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     case SyntaxKind.InKeyword:
                     case SyntaxKind.RequiredKeyword:
                     case SyntaxKind.FileKeyword:
+                    case SyntaxKind.PartialKeyword:
                         result.Add(token.Kind());
                         positionBeforeModifiers = token.FullSpan.Start;
                         token = token.GetPreviousToken(includeSkipped: true);
@@ -67,6 +68,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         if (token.HasMatchingText(SyntaxKind.FileKeyword))
                         {
                             result.Add(SyntaxKind.FileKeyword);
+                            positionBeforeModifiers = token.FullSpan.Start;
+                            token = token.GetPreviousToken(includeSkipped: true);
+                            continue;
+                        }
+                        if (token.HasMatchingText(SyntaxKind.PartialKeyword))
+                        {
+                            result.Add(SyntaxKind.PartialKeyword);
                             positionBeforeModifiers = token.FullSpan.Start;
                             token = token.GetPreviousToken(includeSkipped: true);
                             continue;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/69600

The idea of a fix is to separate accessibility modifiers generation and main declaration generation into separate text changes. This way we can control what goes where.

Demo:
![devenv_patxlcG8xX](https://github.com/dotnet/roslyn/assets/70431552/1b4cb04f-d967-454e-b913-47af828f6b81)
