### PR TITLE
Colorize unbound `partial` identifier as a keyword

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -2640,6 +2640,118 @@ Operators.Equals,
 Keyword("async"));
         }
 
+        [Theory, CombinatorialData]
+        public async Task TestPartialInIncompleteMember1(TestHost testHost)
+        {
+            await TestAsync("""
+                class C
+                {
+                    [|partial|]
+                }
+                """,
+                testHost,
+                Keyword("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestPartialInIncompleteMember2(TestHost testHost)
+        {
+            await TestAsync("""
+                class C
+                {
+                    [|public partial|]
+                }
+                """,
+                testHost,
+                Keyword("public"),
+                Keyword("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestPartialInIncompleteMember1_PartialTypeIsDefined(TestHost testHost)
+        {
+            await TestAsync("""
+                class partial
+                {
+                }
+
+                class C
+                {
+                    [|partial|]
+                }
+                """,
+                testHost,
+                Class("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestPartialInIncompleteMember2_PartialTypeIsDefined(TestHost testHost)
+        {
+            await TestAsync("""
+                class partial
+                {
+                }
+
+                class C
+                {
+                    [|public partial|]
+                }
+                """,
+                testHost,
+                Keyword("public"),
+                Class("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestTopLevelPartial1(TestHost testHost)
+        {
+            await TestAsync("""
+                partial
+                """,
+                testHost,
+                Keyword("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestTopLevelPartial2(TestHost testHost)
+        {
+            await TestAsync("""
+                public partial
+                """,
+                testHost,
+                Keyword("public"),
+                Keyword("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestTopLevelPartial1_PartialTypeIsDefined(TestHost testHost)
+        {
+            await TestAsync("""
+                class partial
+                {
+                }
+
+                [|partial|]
+                """,
+                testHost,
+                Class("partial"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestTopLevelPartial2_PartialTypeIsDefined(TestHost testHost)
+        {
+            await TestAsync("""
+                class partial
+                {
+                }
+
+                [|public partial|]
+                """,
+                testHost,
+                Keyword("public"),
+                Class("partial"));
+        }
+
         /// <seealso cref="SemanticClassifierTests.LocalFunctionUse"/>
         /// <seealso cref="SyntacticClassifierTests.LocalFunctionDeclaration"/>
         [Theory, CombinatorialData]

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -61,7 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                 TryClassifyFromIdentifier(name, symbolInfo, result) ||
                 TryClassifyValueIdentifier(name, symbolInfo, result) ||
                 TryClassifyNameOfIdentifier(name, symbolInfo, result) ||
-                TryClassifyAsyncIdentifier(name, symbolInfo, result);
+                TryClassifyAsyncIdentifier(name, symbolInfo, result) ||
+                TryClassifyPartialIdentifier(name, symbolInfo, result);
         }
 
         private bool TryClassifySymbol(
@@ -371,6 +372,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             // reference an actual symbol with that name.
             if (symbol is null &&
                 name is IdentifierNameSyntax { Identifier.Text: "async" })
+            {
+                result.Add(new(name.Span, ClassificationTypeNames.Keyword));
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryClassifyPartialIdentifier(NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
+        {
+            if (symbolInfo.GetAnySymbol() is null &&
+                name is IdentifierNameSyntax { Identifier.Text: "partial" })
             {
                 result.Add(new(name.Span, ClassificationTypeNames.Keyword));
                 return true;

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -60,9 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                 TryClassifySymbol(name, symbolInfo, semanticModel, result, cancellationToken) ||
                 TryClassifyFromIdentifier(name, symbolInfo, result) ||
                 TryClassifyValueIdentifier(name, symbolInfo, result) ||
-                TryClassifyNameOfIdentifier(name, symbolInfo, result) ||
-                TryClassifyAsyncIdentifier(name, symbolInfo, result) ||
-                TryClassifyPartialIdentifier(name, symbolInfo, result);
+                TryClassifySomeContextualKeywordIdentifiersAsKeywords(name, symbolInfo, result);
         }
 
         private bool TryClassifySymbol(
@@ -348,42 +346,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             return false;
         }
 
-        private static bool TryClassifyNameOfIdentifier(
-            NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
+        private static bool TryClassifySomeContextualKeywordIdentifiersAsKeywords(NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
         {
-            if (name is IdentifierNameSyntax identifierName &&
-                identifierName.Identifier.IsKindOrHasMatchingText(SyntaxKind.NameOfKeyword) &&
-                symbolInfo.GetAnySymbol() is null)
-            {
-                result.Add(new ClassifiedSpan(identifierName.Identifier.Span, ClassificationTypeNames.Keyword));
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool TryClassifyAsyncIdentifier(NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
-        {
-            var symbol = symbolInfo.GetAnySymbol();
-
-            // Simple approach, if the user ever types 'async' and it doesn't actually bind to anything, presume that
-            // they intend to use it as a keyword and are about to create an async symbol.  This works for all error
-            // cases, while not conflicting with the extremely rare case where 'async' might actually be used to
-            // reference an actual symbol with that name.
-            if (symbol is null &&
-                name is IdentifierNameSyntax { Identifier.Text: "async" })
-            {
-                result.Add(new(name.Span, ClassificationTypeNames.Keyword));
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool TryClassifyPartialIdentifier(NameSyntax name, SymbolInfo symbolInfo, SegmentedList<ClassifiedSpan> result)
-        {
+            // Simple approach, if the user ever types one of identifiers from the list and it doesn't actually bind to anything, presume that
+            // they intend to use it as a keyword. This works for all error
+            // cases, while not conflicting with the extremely rare case where such identifiers might actually be used to
+            // reference actual symbols with that names.
             if (symbolInfo.GetAnySymbol() is null &&
-                name is IdentifierNameSyntax { Identifier.Text: "partial" })
+                name is IdentifierNameSyntax { Identifier.Text: "async" or "nameof" or "partial" })
             {
                 result.Add(new(name.Span, ClassificationTypeNames.Keyword));
                 return true;


### PR DESCRIPTION
Noticed while working at https://github.com/dotnet/roslyn/pull/69874

The change is pretty much the same as https://github.com/dotnet/roslyn/pull/60558