### PR TITLE
Allow Razor to format a new document it wants to create

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 vsServerCapabilities.Experimental ??= new Dictionary<string, bool>();
                 var experimental = (Dictionary<string, bool>)vsServerCapabilities.Experimental;
                 experimental[SimplifyMethodHandler.SimplifyMethodMethodName] = true;
+                experimental[FormatNewFileHandler.FormatNewFileMethodName] = true;
 
                 var regexExpression = string.Join("|", InlineCompletionsHandler.BuiltInSnippets);
                 var regex = new Regex(regexExpression, RegexOptions.Compiled | RegexOptions.Singleline, TimeSpan.FromSeconds(1));

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
 
 [ExportCSharpVisualBasicStatelessLspService(typeof(FormatNewFileHandler)), Shared]
 [Method(FormatNewFileMethodName)]
-internal class FormatNewFileHandler : ILspServiceRequestHandler<FormatNewFileParams, string?>
+internal sealed class FormatNewFileHandler : ILspServiceRequestHandler<FormatNewFileParams, string?>
 {
     public const string FormatNewFileMethodName = "roslyn/formatNewFile";
     private readonly IGlobalOptionService _globalOptions;
@@ -51,11 +51,11 @@ internal class FormatNewFileHandler : ILspServiceRequestHandler<FormatNewFilePar
         var fileLoader = new SourceTextLoader(source, filePath);
         var documentId = DocumentId.CreateNewId(project.Id);
         var solution = project.Solution.AddDocument(
-                DocumentInfo.Create(
-                    documentId,
-                    name: filePath,
-                    loader: fileLoader,
-                    filePath: filePath));
+            DocumentInfo.Create(
+                documentId,
+                name: filePath,
+                loader: fileLoader,
+                filePath: filePath));
 
         var document = solution.GetRequiredDocument(documentId);
 

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileHandler.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeCleanup;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.RemoveUnnecessaryImports;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+
+[ExportCSharpVisualBasicStatelessLspService(typeof(FormatNewFileHandler)), Shared]
+[Method(FormatNewFileMethodName)]
+internal class FormatNewFileHandler : ILspServiceRequestHandler<FormatNewFileParams, string?>
+{
+    public const string FormatNewFileMethodName = "roslyn/formatNewFile";
+    private readonly IGlobalOptionService _globalOptions;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public FormatNewFileHandler(IGlobalOptionService globalOptions)
+    {
+        _globalOptions = globalOptions;
+    }
+
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public async Task<string?> HandleRequestAsync(FormatNewFileParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        var project = context.Solution?.GetProject(request.Project);
+
+        if (project is null)
+        {
+            return null;
+        }
+
+        // Create a document in-memory to represent the file Razor wants to add
+        var filePath = ProtocolConversions.GetDocumentFilePathFromUri(request.Document.Uri);
+        var source = SourceText.From(request.Contents);
+        var fileLoader = new SourceTextLoader(source, filePath);
+        var documentId = DocumentId.CreateNewId(project.Id);
+        var solution = project.Solution.AddDocument(
+                DocumentInfo.Create(
+                    documentId,
+                    name: filePath,
+                    loader: fileLoader,
+                    filePath: filePath));
+
+        var document = solution.GetRequiredDocument(documentId);
+
+        // Run the new document formatting service, to make sure the right namespace type is used, among other things
+        var formattingService = document.GetLanguageService<INewDocumentFormattingService>();
+        if (formattingService is not null)
+        {
+            var hintDocument = project.Documents.FirstOrDefault();
+            var cleanupOptions = await document.GetCodeCleanupOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+            document = await formattingService.FormatNewDocumentAsync(document, hintDocument, cleanupOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Unlike normal new file formatting, Razor also wants to remove unnecessary usings
+        var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+        var removeImportsService = document.GetLanguageService<IRemoveUnnecessaryImportsService>();
+        if (removeImportsService is not null)
+        {
+            document = await removeImportsService.RemoveUnnecessaryImportsAsync(document, syntaxFormattingOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Now format the document so indentation etc. is correct
+        var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+        var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        root = Formatter.Format(root, solution.Services, syntaxFormattingOptions, cancellationToken);
+
+        return root.ToFullString();
+    }
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileParams.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileParams.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+
+[DataContract]
+internal record FormatNewFileParams
+{
+    [DataMember(Name = "document")]
+    public required TextDocumentIdentifier Document { get; set; }
+
+    [DataMember(Name = "project")]
+    public required TextDocumentIdentifier Project { get; set; }
+
+    [DataMember(Name = "contents")]
+    public required string Contents { get; set; }
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileParams.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/Razor/FormatNewFileParams.cs
@@ -8,14 +8,14 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
 
 [DataContract]
-internal record FormatNewFileParams
+internal sealed record FormatNewFileParams
 {
     [DataMember(Name = "document")]
-    public required TextDocumentIdentifier Document { get; set; }
+    public required TextDocumentIdentifier Document { get; init; }
 
     [DataMember(Name = "project")]
-    public required TextDocumentIdentifier Project { get; set; }
+    public required TextDocumentIdentifier Project { get; init; }
 
     [DataMember(Name = "contents")]
-    public required string Contents { get; set; }
+    public required string Contents { get; init; }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/FormatNewFile/FormatNewFileTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/FormatNewFile/FormatNewFileTests.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.Razor;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SimplifyMethod
+{
+    public class FormatNewFileTests(ITestOutputHelper? testOutputHelper) : AbstractLanguageServerProtocolTests(testOutputHelper)
+    {
+        [Theory, CombinatorialData]
+        public async Task TestFormatNewFileAsync(bool mutatingLspWorkspace)
+        {
+            var markup =
+                """
+                // This is a file header
+
+                using System;
+                using System.Threading.Tasks;
+
+                namespace test;
+
+                class Goo
+                {
+                    public void M()
+                    {
+                    }
+                }
+                """;
+
+            var input = """
+                using System;
+
+                namespace test;
+
+                public partial class MyComponent
+                {
+                }
+                """;
+
+            var expected = """
+                // This is a file header
+                
+                namespace test
+                {
+                    public partial class MyComponent
+                    {
+                    }
+                }
+                """;
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+            var newFilePath = "C:\\MyComponent.razor.cs";
+
+            var result = await RunHandlerAsync(testLspServer, newFilePath, input);
+            AssertEx.EqualOrDiff(expected, result);
+        }
+
+        private static async Task<string?> RunHandlerAsync(TestLspServer testLspServer, string newFilePath, string input)
+        {
+            var project = testLspServer.GetCurrentSolution().Projects.First();
+            Contract.ThrowIfNull(project.FilePath);
+
+            var parameters = new FormatNewFileParams()
+            {
+                Project = new TextDocumentIdentifier
+                {
+                    Uri = ProtocolConversions.CreateAbsoluteUri(project.FilePath)
+                },
+                Document = new TextDocumentIdentifier
+                {
+                    Uri = ProtocolConversions.CreateAbsoluteUri(newFilePath)
+                },
+                Contents = input
+            };
+
+            return await testLspServer.ExecuteRequestAsync<FormatNewFileParams, string?>(FormatNewFileHandler.FormatNewFileMethodName, parameters, CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/4330

Goes with https://github.com/dotnet/razor/pull/9263 and https://github.com/dotnet/vscode-csharp/pull/6329

Adds a custom endpoint so Razor can get access to the `INewDocumentFormattingService`, as well as remove and sort usings, and format the new document with the current C# format options.