### PR TITLE
Lazily populate FileIdentifier fields

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1353,8 +1353,8 @@ symIsHidden:;
                 return false;
             }
 
-            var symbolFileIdentifier = ((NamedTypeSymbol)symbol).AssociatedFileIdentifier.GetValueOrDefault();
-            if (symbolFileIdentifier.FilePathChecksumOpt.IsDefault)
+            var symbolFileIdentifier = ((NamedTypeSymbol)symbol).AssociatedFileIdentifier;
+            if (symbolFileIdentifier is null || symbolFileIdentifier.FilePathChecksumOpt.IsDefault)
             {
                 // the containing file of the file-local type has an ill-formed path.
                 return false;
@@ -1371,7 +1371,7 @@ symIsHidden:;
                     if (binder is BuckStopsHereBinder lastBinder)
                     {
                         // we never expect to bind a file type in a context where the BuckStopsHereBinder lacks an AssociatedFileIdentifier
-                        return lastBinder.AssociatedFileIdentifier.Value;
+                        return lastBinder.AssociatedFileIdentifier;
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1371,7 +1371,7 @@ symIsHidden:;
                     if (binder is BuckStopsHereBinder lastBinder)
                     {
                         // we never expect to bind a file type in a context where the BuckStopsHereBinder lacks an AssociatedFileIdentifier
-                        return lastBinder.AssociatedFileIdentifier;
+                        return lastBinder.AssociatedFileIdentifier ?? throw ExceptionUtilities.Unreachable();
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp;
 
-internal class FileIdentifier
+internal sealed class FileIdentifier
 {
     private static readonly Encoding s_encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -12,7 +12,12 @@ namespace Microsoft.CodeAnalysis.CSharp;
 
 internal sealed class FileIdentifier
 {
-    private record FileIdentifierData(string? EncoderFallbackErrorMessage, string DisplayFilePath, ImmutableArray<byte> FilePathChecksumOpt);
+    private class FileIdentifierData(string? encoderFallbackErrorMessage, string displayFilePath, ImmutableArray<byte> filePathChecksumOpt)
+    {
+        public readonly string? EncoderFallbackErrorMessage = encoderFallbackErrorMessage;
+        public readonly string DisplayFilePath = displayFilePath;
+        public readonly ImmutableArray<byte> FilePathChecksumOpt = filePathChecksumOpt;
+    }
 
     private static readonly Encoding s_encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -26,7 +31,7 @@ internal sealed class FileIdentifier
 
     private FileIdentifier(ImmutableArray<byte> filePathChecksumOpt, string displayFilePath)
     {
-        _data = new FileIdentifierData(EncoderFallbackErrorMessage: null, displayFilePath, filePathChecksumOpt);
+        _data = new FileIdentifierData(encoderFallbackErrorMessage: null, displayFilePath, filePathChecksumOpt);
         _filePath = string.Empty;
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -18,7 +19,7 @@ internal sealed class FileIdentifier
 
     private string? _encoderFallbackErrorMessage;
     private string? _displayFilePath;
-    private ImmutableArray<byte> _filePathChecksumOpt;
+    private StrongBox<ImmutableArray<byte>>? _filePathChecksumOpt;
 
     private FileIdentifier(string filePath)
     {
@@ -27,7 +28,7 @@ internal sealed class FileIdentifier
 
     private FileIdentifier(ImmutableArray<byte> filePathChecksumOpt, string displayFilePath)
     {
-        _filePathChecksumOpt = filePathChecksumOpt;
+        _filePathChecksumOpt = new(filePathChecksumOpt);
         _displayFilePath = displayFilePath;
     }
 
@@ -53,8 +54,7 @@ internal sealed class FileIdentifier
 
             _encoderFallbackErrorMessage = encoderFallbackErrorMessage;
             _displayFilePath = displayFilePath;
-
-            ImmutableInterlocked.InterlockedInitialize(ref _filePathChecksumOpt, hash);
+            _filePathChecksumOpt = new(hash);
 
             Volatile.Write(ref _filePath, null);
         }
@@ -86,7 +86,7 @@ internal sealed class FileIdentifier
         {
             EnsureInitialized();
 
-            return _filePathChecksumOpt;
+            return _filePathChecksumOpt!.Value;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Text;
 
@@ -54,7 +55,8 @@ internal sealed class FileIdentifier
             _displayFilePath = displayFilePath;
 
             ImmutableInterlocked.InterlockedInitialize(ref _filePathChecksumOpt, hash);
-            _filePath = null;
+
+            Volatile.Write(ref _filePath, null);
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -32,13 +32,14 @@ internal struct FileIdentifier
 
     private void EnsureInitialized()
     {
-        if (_filePath is not null)
+        var filePath = _filePath;
+        if (filePath is not null)
         {
             string? encoderFallbackErrorMessage = null;
             ImmutableArray<byte> hash = default;
             try
             {
-                var encodedFilePath = s_encoding.GetBytes(_filePath);
+                var encodedFilePath = s_encoding.GetBytes(filePath);
                 using var hashAlgorithm = SourceHashAlgorithms.CreateDefaultInstance();
                 hash = hashAlgorithm.ComputeHash(encodedFilePath).ToImmutableArray();
             }
@@ -47,7 +48,7 @@ internal struct FileIdentifier
                 encoderFallbackErrorMessage = ex.Message;
             }
 
-            var displayFilePath = GeneratedNames.GetDisplayFilePath(_filePath);
+            var displayFilePath = GeneratedNames.GetDisplayFilePath(filePath);
 
             _encoderFallbackErrorMessage = encoderFallbackErrorMessage;
             _filePathChecksumOpt = hash;

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp;
 
-internal struct FileIdentifier
+internal class FileIdentifier
 {
     private static readonly Encoding s_encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -51,9 +51,9 @@ internal class FileIdentifier
             var displayFilePath = GeneratedNames.GetDisplayFilePath(filePath);
 
             _encoderFallbackErrorMessage = encoderFallbackErrorMessage;
-            _filePathChecksumOpt = hash;
             _displayFilePath = displayFilePath;
 
+            ImmutableInterlocked.InterlockedInitialize(ref _filePathChecksumOpt, hash);
             _filePath = null;
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         }
 
         internal sealed override bool IsFileLocal => _lazyUncommonProperties is { lazyFilePathChecksum: { IsDefault: false }, lazyDisplayFileName: { } };
-        internal sealed override FileIdentifier? AssociatedFileIdentifier
+        internal sealed override FileIdentifier AssociatedFileIdentifier
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 // Therefore we can use `_lazyUncommonProperties` directly to avoid additional computations.
                 // Also important, that computing full uncommon properties here may lead to stack overflow if there is a circular dependency between types in the metadata.
                 return _lazyUncommonProperties is { lazyFilePathChecksum: { IsDefault: false } checksum, lazyDisplayFileName: { } displayFileName }
-                    ? new FileIdentifier { FilePathChecksumOpt = checksum, DisplayFilePath = displayFileName }
+                    ? FileIdentifier.Create(checksum, displayFileName)
                     : null;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         }
 
         internal override bool IsFileLocal => _underlyingType.IsFileLocal;
-        internal override FileIdentifier? AssociatedFileIdentifier => _underlyingType.AssociatedFileIdentifier;
+        internal override FileIdentifier AssociatedFileIdentifier => _underlyingType.AssociatedFileIdentifier;
 
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool IsFileLocal => _underlyingType.IsFileLocal;
-        internal sealed override FileIdentifier? AssociatedFileIdentifier => _underlyingType.AssociatedFileIdentifier;
+        internal sealed override FileIdentifier AssociatedFileIdentifier => _underlyingType.AssociatedFileIdentifier;
 
         internal sealed override NamedTypeSymbol AsNativeInteger() => throw ExceptionUtilities.Unreachable();
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool MangleName => false;
 
         internal sealed override bool IsFileLocal => false;
-        internal sealed override FileIdentifier? AssociatedFileIdentifier => null;
+        internal sealed override FileIdentifier AssociatedFileIdentifier => null;
 
         internal override bool HasCodeAnalysisEmbeddedAttribute => true;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         internal sealed override bool IsFileLocal => false;
-        internal sealed override FileIdentifier? AssociatedFileIdentifier => null;
+        internal sealed override FileIdentifier AssociatedFileIdentifier => null;
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -4367,8 +4367,8 @@ public partial class C
         Assert.Equal("C@<tree 0>", type.ToTestDisplayString());
         var identifier = type.GetSymbol()!.AssociatedFileIdentifier;
         Assert.NotNull(identifier);
-        AssertEx.Equal(expectedChecksum, identifier.GetValueOrDefault().FilePathChecksumOpt);
-        Assert.Empty(identifier.GetValueOrDefault().DisplayFilePath);
+        AssertEx.Equal(expectedChecksum, identifier.FilePathChecksumOpt);
+        Assert.Empty(identifier.DisplayFilePath);
         Assert.True(type.IsFileLocal);
 
         var referencingMetadataComp = CreateCompilation("", new[] { comp.ToMetadataReference() });
@@ -4376,8 +4376,8 @@ public partial class C
         Assert.Equal("C@<tree 0>", type.ToTestDisplayString());
         identifier = type.GetSymbol()!.AssociatedFileIdentifier;
         Assert.NotNull(identifier);
-        AssertEx.Equal(expectedChecksum, identifier.GetValueOrDefault().FilePathChecksumOpt);
-        Assert.Empty(identifier.GetValueOrDefault().DisplayFilePath);
+        AssertEx.Equal(expectedChecksum, identifier.FilePathChecksumOpt);
+        Assert.Empty(identifier.DisplayFilePath);
         Assert.True(type.IsFileLocal);
 
         var referencingImageComp = CreateCompilation("", new[] { comp.EmitToImageReference() });
@@ -4385,8 +4385,8 @@ public partial class C
         Assert.Equal("C@<unknown>", type.ToTestDisplayString());
         identifier = type.GetSymbol()!.AssociatedFileIdentifier;
         Assert.NotNull(identifier);
-        AssertEx.Equal(expectedChecksum, identifier.GetValueOrDefault().FilePathChecksumOpt);
-        Assert.Empty(identifier.GetValueOrDefault().DisplayFilePath);
+        AssertEx.Equal(expectedChecksum, identifier.FilePathChecksumOpt);
+        Assert.Empty(identifier.DisplayFilePath);
         Assert.False(type.IsFileLocal);
     }
 
@@ -4436,8 +4436,8 @@ public partial class C
         Assert.NotNull(identifier);
         AssertEx.Equal(
             new byte[] { 0xE3, 0xB0, 0xC4, 0x42, 0x98, 0xFC, 0x1C, 0x14, 0x9A, 0xFB, 0xF4, 0xC8, 0x99, 0x6F, 0xB9, 0x24, 0x27, 0xAE, 0x41, 0xE4, 0x64, 0x9B, 0x93, 0x4C, 0xA4, 0x95, 0x99, 0x1B, 0x78, 0x52, 0xB8, 0x55 },
-            identifier.GetValueOrDefault().FilePathChecksumOpt);
-        Assert.Empty(identifier.GetValueOrDefault().DisplayFilePath);
+            identifier.FilePathChecksumOpt);
+        Assert.Empty(identifier.DisplayFilePath);
         Assert.True(type.IsFileLocal);
     }
 
@@ -4526,8 +4526,8 @@ public partial class C
         Assert.IsType<RetargetingNamedTypeSymbol>(retargeted);
         Assert.False(retargeted.GetPublicSymbol().IsFileLocal);
 
-        var originalFileIdentifier = classC1.AssociatedFileIdentifier!.Value;
-        var retargetedFileIdentifier = retargeted.AssociatedFileIdentifier!.Value;
+        var originalFileIdentifier = classC1.AssociatedFileIdentifier!;
+        var retargetedFileIdentifier = retargeted.AssociatedFileIdentifier!;
         Assert.Equal(originalFileIdentifier.DisplayFilePath, retargetedFileIdentifier.DisplayFilePath);
         Assert.Equal((IEnumerable<byte>)originalFileIdentifier.FilePathChecksumOpt, (IEnumerable<byte>)retargetedFileIdentifier.FilePathChecksumOpt);
         Assert.Equal(originalFileIdentifier.EncoderFallbackErrorMessage, retargetedFileIdentifier.EncoderFallbackErrorMessage);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             // looking up file-local types. If there is no document name, use an invalid FilePathChecksumOpt.
             FileIdentifier fileIdentifier = methodDebugInfo.ContainingDocumentName is { } documentName
                 ? FileIdentifier.Create(documentName)
-                : new FileIdentifier { EncoderFallbackErrorMessage = null, FilePathChecksumOpt = ImmutableArray<byte>.Empty, DisplayFilePath = string.Empty };
+                : FileIdentifier.Create(filePathChecksumOpt: ImmutableArray<byte>.Empty, displayFilePath: string.Empty);
 
             NamespaceBinder = CreateBinderChain(
                 Compilation,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
         internal override bool IsFileLocal => false;
-        internal override FileIdentifier? AssociatedFileIdentifier => null;
+        internal override FileIdentifier AssociatedFileIdentifier => null;
 
         public override IEnumerable<string> MemberNames
         {


### PR DESCRIPTION
Found while inspecting profiles for turning on/off razor precise semantic tokens. In the code analysis process, I see 1.6% of CPU and 0.4% of allocations spent in MS.CA.C#.FileIdentifier.Create. (which is over half of the CPU time spent in in CreateSemanticModel). I tested this locally by opening the Roslyn sln, waiting several minutes, and saw over 30K FileIdentifier objects created.

One thing I was curious about was which members were being heavily used in this object as there are differing costs associated with populating each of the members. What I found was that, at least for the scenarios I was testing, none of the objects members were being called for any of the 30K FileIdentifier objects, and thus we could lazily populate this object and not likely ever incur those costs.

![image](https://github.com/dotnet/roslyn/assets/6785178/be75b65c-7c3b-4759-8854-36652cdbcab0)

![image](https://github.com/dotnet/roslyn/assets/6785178/586309c7-854b-443b-a68c-998e344d79ac)
