### PR TITLE
Change commented-code priority to always beat semantic classification

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
@@ -18,6 +18,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal sealed class ClassificationTypeFormatDefinitions
     {
+        // Note:
+        //
+        // Classification of syntax and semantics happens on different cadences.  For that reason, prioritize the
+        // classification of everything 'semantic' to come 'after' 'comment' classification.  That way, if a user
+        // comments something out, they'll see things snap to the commented state immediately, instead of having to wait
+        // for semantic-classification to finish and return no items for that region.
+
         #region Preprocessor Text
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.PreprocessorText)]
@@ -116,6 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.OperatorOverloaded)]
         [Name(ClassificationTypeNames.OperatorOverloaded)]
         [Order(After = PredefinedClassificationTypeNames.Operator)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class OperatorOverloadedFormatDefinition : ClassificationFormatDefinition
@@ -132,6 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ReassignedVariable)]
         [Name(ClassificationTypeNames.ReassignedVariable)]
         [Order(After = Priority.High)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(false)]
         [ExcludeFromCodeCoverage]
         private class ReassignedVariableFormatDefinition : ClassificationFormatDefinition
@@ -151,6 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.StaticSymbol)]
         [Name(ClassificationTypeNames.StaticSymbol)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class SymbolStaticFormatDefinition : ClassificationFormatDefinition
@@ -191,6 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeClassesFormatDefinition : ClassificationFormatDefinition
@@ -211,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeRecordsFormatDefinition : ClassificationFormatDefinition
@@ -230,6 +242,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeRecordStructsFormatDefinition : ClassificationFormatDefinition
@@ -249,6 +262,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeDelegatesFormatDefinition : ClassificationFormatDefinition
@@ -269,6 +283,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeEnumsFormatDefinition : ClassificationFormatDefinition
@@ -289,6 +304,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeInterfacesFormatDefinition : ClassificationFormatDefinition
@@ -309,6 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         private class UserTypeModulesFormatDefinition : ClassificationFormatDefinition
         {
@@ -328,6 +345,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeStructuresFormatDefinition : ClassificationFormatDefinition
@@ -348,6 +366,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeTypeParametersFormatDefinition : ClassificationFormatDefinition
@@ -369,6 +388,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersFieldNameFormatDefinition : ClassificationFormatDefinition
@@ -386,6 +406,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersEnumMemberNameFormatDefinition : ClassificationFormatDefinition
@@ -403,6 +424,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersConstantNameFormatDefinition : ClassificationFormatDefinition
@@ -420,6 +442,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersLocalNameFormatDefinition : ClassificationFormatDefinition
@@ -437,6 +460,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersParameterNameFormatDefinition : ClassificationFormatDefinition
@@ -454,6 +478,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersMethodNameFormatDefinition : ClassificationFormatDefinition
@@ -471,6 +496,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersExtensionMethodNameFormatDefinition : ClassificationFormatDefinition
@@ -488,6 +514,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersPropertyNameFormatDefinition : ClassificationFormatDefinition
@@ -504,6 +531,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.EventName)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersEventNameFormatDefinition : ClassificationFormatDefinition
@@ -520,6 +548,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.NamespaceName)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersNamespaceNameFormatDefinition : ClassificationFormatDefinition
@@ -537,6 +566,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersLabelNameFormatDefinition : ClassificationFormatDefinition
@@ -736,6 +766,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.TestCode)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class TestCodeFormatDefinition : ClassificationFormatDefinition
@@ -754,6 +785,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.TestCodeMarkdown)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class TestCodeMarkdownFormatDefinition : ClassificationFormatDefinition
@@ -774,6 +806,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexComment)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexCommentFormatDefinition : ClassificationFormatDefinition
@@ -792,6 +825,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexCharacterClass)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexCharacterClassFormatDefinition : ClassificationFormatDefinition
@@ -810,6 +844,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexAnchor)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexAnchorFormatDefinition : ClassificationFormatDefinition
@@ -828,6 +863,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexQuantifier)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexQuantifierFormatDefinition : ClassificationFormatDefinition
@@ -846,6 +882,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexGrouping)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexGroupingFormatDefinition : ClassificationFormatDefinition
@@ -864,6 +901,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexAlternation)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexAlternationFormatDefinition : ClassificationFormatDefinition
@@ -882,6 +920,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexText)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexTextFormatDefinition : ClassificationFormatDefinition
@@ -900,6 +939,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexSelfEscapedCharacter)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexSelfEscapedCharacterFormatDefinition : ClassificationFormatDefinition
@@ -922,6 +962,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexOtherEscape)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexOtherEscapeFormatDefinition : ClassificationFormatDefinition
@@ -943,6 +984,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonComment)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonCommentFormatDefinition : ClassificationFormatDefinition
@@ -957,6 +999,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonNumber)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonNumberFormatDefinition : ClassificationFormatDefinition
@@ -971,6 +1014,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonString)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonStringFormatDefinition : ClassificationFormatDefinition
@@ -985,6 +1029,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonKeyword)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonKeywordFormatDefinition : ClassificationFormatDefinition
@@ -999,6 +1044,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonText)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonTextFormatDefinition : ClassificationFormatDefinition
@@ -1013,6 +1059,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonOperator)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonOperatorFormatDefinition : ClassificationFormatDefinition
@@ -1027,6 +1074,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonPunctuation)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonPunctuationFormatDefinition : ClassificationFormatDefinition
@@ -1041,6 +1089,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonObject)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonObjectFormatDefinition : ClassificationFormatDefinition
@@ -1055,6 +1104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonArray)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonArrayFormatDefinition : ClassificationFormatDefinition
@@ -1069,6 +1119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonPropertyName)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonPropertyNameFormatDefinition : ClassificationFormatDefinition
@@ -1083,6 +1134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonConstructorName)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
+        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonConstructorNameFormatDefinition : ClassificationFormatDefinition


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69881

This fixes an issue we've been receiving feedback on, where a user comments out code, but sees stale 'semantic classifications' for a short while before those classifications 'snap' to the commented-out (green-code) state.

This is due to us having different classifiers for syntactic/semantic classifications.  Semantic classification is already setup to just run at a different cadence (syntactic is practically synchronous and often on the UI thread).  While semantic is on a forced delay due to its cost.  This means when you classified you could have the fresh syntactic classifications for the comments, and the stale semantic ones for that region.

Previously, this wasn't an issue as the platform itself was picking the comment classification as the freshly generated tags.  However, changes/fixes at the platform level to actually respect classification-tag ordering (humorously, asked for by roslyn wrt to tagging in LSP with text-mate vs LSP servers) caused this to now be a problem as the comment tag was overridden by the semantic tags.

The fix here is to take a page from something we've already done in tagging, which is to consider comment classification as superceding all of hte rest of our classification tag types.  This ensures that commented out cost 'insta-snaps' to the right state, and you don't observe staleness. 