### PR TITLE
Localize 17.8

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -85,11 +85,11 @@ stages:
     demands: ImageOverride -equals windows.vs2022preview.amd64
 
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.7') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.8') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: roslyn
-        MirrorBranch: release/dev17.7
+        MirrorBranch: release/dev17.8
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-ROSLYN'
 


### PR DESCRIPTION
It's time to update the localization branch.
Set the branch to 17.8.
Target release/dev17.7 so 17.7 build won't trigger the LOC job.
Later bot should flow this to 17.8 and main.
