### PR TITLE
Add System.CommandLine to Version.Details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,6 +11,10 @@
       <Sha>01850f2b7bff23e118d1faecb941d770c8e626f2</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
+    </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="System.IO.Pipelines" Version="7.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/roslyn/issues/69847

System.CommandLine is showing up as a source-build prebuilt after the introduction of the BuildHost project: https://github.com/dotnet/roslyn/blob/bc41e82a81ab5a788d741cae00d9adeb993608f9/src/Workspaces/Core/MSBuild.BuildHost/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj#L28

This is because the build is loading the version specified by `SystemCommandLineVersion` and not using the current version of `System.CommandLine` produced by source-build. This is fixed by ensuring that `System.CommandLine` is defined in Version.Details. This allows source-build to override that version with the current version.