### PR TITLE
Update SBRP dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,9 +6,9 @@
       <Sha>1b64d3c0fad8af67da8f42927ce7306730224c15</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23211.4">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23461.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>01850f2b7bff23e118d1faecb941d770c8e626f2</Sha>
+      <Sha>264d80ed1ee84b458328b2df68f9930deac08bff</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->


### PR DESCRIPTION
The SBRP dependency is out of date by 5 months. This updates it in order to have access to System.Text.Json.7.0.3. This fixes the issue of that showing up as a source-build prebuilt.

Contributes to https://github.com/dotnet/roslyn/issues/69847