### PR TITLE
Update LanguageServerHost to use NamedPipeServerStream

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/NamedPipeInformation.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/NamedPipeInformation.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+namespace Microsoft.CodeAnalysis.LanguageServer;
 
 [DataContract]
 internal record NamedPipeInformation(

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -5,17 +5,18 @@
 using System.Collections.Immutable;
 using System.CommandLine;
 using System.Diagnostics;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Contracts.Telemetry;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices;
-using Microsoft.CodeAnalysis.LanguageServer.BrokeredServices.Services.HelloWorld;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.LanguageServer.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Logging;
 using Microsoft.CodeAnalysis.LanguageServer.StarredSuggestions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using Newtonsoft.Json;
 
 // Setting the title can fail if the process is run without a window, such
 // as when launched detached from nodejs
@@ -34,6 +35,8 @@ return await parser.Parse(args).InvokeAsync(CancellationToken.None);
 
 static async Task RunAsync(ServerConfiguration serverConfiguration, CancellationToken cancellationToken)
 {
+    const string NamedPipeKey = "NamedPipeInformation";
+
     // Before we initialize the LSP server we can't send LSP log messages.
     // Create a console logger as a fallback to use before the LSP server starts.
     using var loggerFactory = LoggerFactory.Create(builder =>
@@ -44,7 +47,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
             LoggerFactory.Create(builder =>
             {
                 builder.SetMinimumLevel(serverConfiguration.MinimumLogLevel);
-                builder.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+                builder.AddConsole();
                 // The console logger outputs control characters on unix for colors which don't render correctly in VSCode.
                 builder.AddSimpleConsole(formatterOptions => formatterOptions.ColorBehavior = LoggerColorBehavior.Disabled);
             })
@@ -96,11 +99,22 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
 
     var serviceBrokerFactory = exportProvider.GetExportedValue<ServiceBrokerFactory>();
     StarredCompletionAssemblyHelper.InitializeInstance(serverConfiguration.StarredCompletionsPath, loggerFactory, serviceBrokerFactory);
-
     // TODO: Remove, the path should match exactly. Workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1830914.
     Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueMethodDebugInfoReader.IgnoreCaseWhenComparingDocumentNames = Path.DirectorySeparatorChar == '\\';
 
-    var server = new LanguageServerHost(Console.OpenStandardInput(), Console.OpenStandardOutput(), exportProvider, loggerFactory.CreateLogger(nameof(LanguageServerHost)));
+    var languageServerLogger = loggerFactory.CreateLogger(nameof(LanguageServerHost));
+
+    var (clientPipeName, serverPipeName) = CreateNewPipeNames();
+    var pipeServer = new NamedPipeServerStream(serverPipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly | PipeOptions.Asynchronous);
+
+    // Send the named pipe connection info to the client 
+    var clientPipeTransmissionInformation = new KeyValuePair<string, string>(NamedPipeKey, clientPipeName);
+    languageServerLogger.LogInformation(JsonConvert.SerializeObject(clientPipeTransmissionInformation));
+
+    // Wait for connection from client
+    await pipeServer.WaitForConnectionAsync(cancellationToken);
+
+    var server = new LanguageServerHost(pipeServer, pipeServer, exportProvider, languageServerLogger);
     server.Start();
 
     try
@@ -206,7 +220,24 @@ static CliRootCommand CreateCommandLineParser()
 
         return RunAsync(serverConfiguration, cancellationToken);
     });
-
     return rootCommand;
 }
 
+static (string clientPipe, string serverPipe) CreateNewPipeNames()
+{
+    // On windows, .NET and Nodejs use different formats for the pipe name
+    const string WINDOWS_NODJS_PREFIX = @"\\.\pipe\";
+    const string WINDOWS_DOTNET_PREFIX = @"\\.\";
+
+    var pipeName = Guid.NewGuid().ToString();
+
+    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? (WINDOWS_NODJS_PREFIX + pipeName, WINDOWS_DOTNET_PREFIX + pipeName)
+        : (GetUnixTypePipeName(pipeName), GetUnixTypePipeName(pipeName));
+}
+
+static string GetUnixTypePipeName(string pipeName)
+{
+    // Unix-type pipes are actually writing to a file
+    return Path.Combine(Path.GetTempPath(), pipeName + ".sock");
+}

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.LanguageServer.StarredSuggestions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Newtonsoft.Json;
-using Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 // Setting the title can fail if the process is run without a window, such
 // as when launched detached from nodejs

--- a/src/Features/LanguageServer/Protocol/Handler/NamedPipeInformation.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/NamedPipeInformation.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+[DataContract]
+internal record NamedPipeInformation(
+    [property: DataMember(Name = "pipeName")] string PipeName);


### PR DESCRIPTION
Current communication between client and the Rolsyn language server is writing to STDOUT. This makes the connection vulnerable to any code in the process writing to stdout stream and corrupting the data.

We have seen at least one bug with this problem: https://github.com/microsoft/vscode-dotnettools/issues/333

The fix it to use a named pipe to communicate. 
- Client (e.g. VS Code) will kick off this server process
- Create the NamedPipeServerStream. Specify [CurrentUserOnly flag ](https://learn.microsoft.com/en-us/dotnet/api/system.io.pipes.pipeoptions?view=net-7.0), **which indicates that the pipe can only be connected to a client created by the same user.**  
- Pass the name of the pipe back to the client, who will connect 
- When the client connects, send the stream objects to Json-RPC

A note about names... 
- Unix-type systems use a file name to create the connection. 
- Windows systems use a pipe name. The format for the name is different in .NET code and Nodejs code. 

This has been tested on both windows and mac. 