### PR TITLE
Document outline updates

### DIFF
--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -96,6 +96,7 @@
                   VirtualizingStackPanel.VirtualizationMode="Recycling"
                   TreeViewItem.SourceUpdated="SymbolTreeItem_SourceUpdated"
                   TreeViewItem.Selected="SymbolTreeItem_Selected"
+                  Visibility="{Binding Visibility, Mode=OneWayToSource}"
                   ItemsSource="{Binding Source={StaticResource DocumentSymbolItems}}"> <!-- Binding to our CollectionViewSource -->
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type self:DocumentSymbolDataViewModel}">

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml
@@ -11,6 +11,7 @@
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:ComponentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             d:DataContext="{d:DesignInstance Type=self:DocumentOutlineViewModel}"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              x:Name="DocumentOutline"
@@ -94,7 +95,7 @@
                   AutomationProperties.Name="{x:Static self:DocumentOutlineStrings.Document_Outline}"
                   VirtualizingStackPanel.IsVirtualizing="True"
                   VirtualizingStackPanel.VirtualizationMode="Recycling"
-                  TreeViewItem.SourceUpdated="SymbolTreeItem_SourceUpdated"
+                  SourceUpdated="SymbolTree_SourceUpdated"
                   TreeViewItem.Selected="SymbolTreeItem_Selected"
                   Visibility="{Binding Visibility, Mode=OneWayToSource}"
                   ItemsSource="{Binding Source={StaticResource DocumentSymbolItems}}"> <!-- Binding to our CollectionViewSource -->

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml.cs
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineView.xaml.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Outlining;
 using InternalUtilities = Microsoft.Internal.VisualStudio.PlatformUI.Utilities;
 using IOleCommandTarget = Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget;
 using OLECMD = Microsoft.VisualStudio.OLE.Interop.OLECMD;
@@ -34,6 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
     {
         private readonly IThreadingContext _threadingContext;
         private readonly IGlobalOptionService _globalOptionService;
+        private readonly IOutliningManagerService _outliningManagerService;
         private readonly VsCodeWindowViewTracker _viewTracker;
         private readonly DocumentOutlineViewModel _viewModel;
         private readonly IVsToolbarTrayHost _toolbarTrayHost;
@@ -44,11 +46,13 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             IVsWindowSearchHostFactory windowSearchHostFactory,
             IThreadingContext threadingContext,
             IGlobalOptionService globalOptionService,
+            IOutliningManagerService outliningManagerService,
             VsCodeWindowViewTracker viewTracker,
             DocumentOutlineViewModel viewModel)
         {
             _threadingContext = threadingContext;
             _globalOptionService = globalOptionService;
+            _outliningManagerService = outliningManagerService;
             _viewTracker = viewTracker;
             _viewModel = viewModel;
 
@@ -289,7 +293,8 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
                 {
                     var textView = _viewTracker.GetActiveView();
                     textView.TryMoveCaretToAndEnsureVisible(
-                        symbolModel.Data.SelectionRangeSpan.TranslateTo(textView.TextSnapshot, SpanTrackingMode.EdgeInclusive).Start);
+                        symbolModel.Data.SelectionRangeSpan.TranslateTo(textView.TextSnapshot, SpanTrackingMode.EdgeInclusive).Start,
+                        _outliningManagerService);
                 }
                 finally
                 {

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineViewModel.cs
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineViewModel.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -63,6 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
 
         // Mutable state.  Should only update on UI thread.
 
+        private Visibility _visibility_doNotAccessDirectly = Visibility.Visible;
         private SortOption _sortOption_doNotAccessDirectly = SortOption.Location;
         private string _searchText_doNotAccessDirectly = "";
         private ImmutableArray<DocumentSymbolDataViewModel> _documentSymbolViewModelItems_doNotAccessDirectly = ImmutableArray<DocumentSymbolDataViewModel>.Empty;
@@ -111,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             _taggerEventSource.Connect();
 
             // queue initial model update
-            _workQueue.AddWork(default(VoidResult));
+            _workQueue.AddWork();
         }
 
         public void Dispose()
@@ -129,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
                 IntervalTree<DocumentSymbolDataViewModel>.Empty);
 
         private void OnEventSourceChanged(object sender, TaggerEventArgs e)
-            => _workQueue.AddWork(default(VoidResult), cancelExistingWork: true);
+            => _workQueue.AddWork(cancelExistingWork: true);
 
         /// <summary>
         /// Keeps track if we're currently in the middle of navigating or not.  For example, when the user clicks on an
@@ -173,6 +175,23 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             }
         }
 
+        /// <remarks>This property is bound to the UI. However, it is only read/written by the UI. We only act as
+        /// storage for the value. When this value is true, UI updates are deferred.</remarks>
+        public Visibility Visibility
+        {
+            get
+            {
+                _threadingContext.ThrowIfNotOnUIThread();
+                return _visibility_doNotAccessDirectly;
+            }
+
+            set
+            {
+                _threadingContext.ThrowIfNotOnUIThread();
+                _visibility_doNotAccessDirectly = value;
+            }
+        }
+
         /// <remarks>This property is bound to the UI.  However, it is only read/written by the UI.  We only act as
         /// storage for the value.  When the value changes, the sorting is actually handled by
         /// DocumentSymbolDataViewModelSorter.</remarks>
@@ -208,7 +227,7 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
                 _threadingContext.ThrowIfNotOnUIThread();
                 _searchText_doNotAccessDirectly = value;
 
-                _workQueue.AddWork(default(VoidResult), cancelExistingWork: true);
+                _workQueue.AddWork(cancelExistingWork: true);
             }
         }
 
@@ -250,6 +269,17 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
 
         private async ValueTask ComputeViewStateAsync(CancellationToken cancellationToken)
         {
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            if (_isDisposed)
+                return;
+
+            if (Visibility != Visibility.Visible)
+            {
+                // Retry the update after a delay
+                _workQueue.AddWork(cancelExistingWork: true);
+                return;
+            }
+
             // Do any expensive semantic/computation work in the background.
             await TaskScheduler.Default;
             cancellationToken.ThrowIfCancellationRequested();
@@ -261,6 +291,13 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             if (_isDisposed)
                 return;
+
+            if (Visibility != Visibility.Visible)
+            {
+                // Retry the update after a delay
+                _workQueue.AddWork(cancelExistingWork: true);
+                return;
+            }
 
             var searchText = this.SearchText;
             var sortOption = this.SortOption;
@@ -305,6 +342,13 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             if (_isDisposed)
                 return;
+
+            if (Visibility != Visibility.Visible)
+            {
+                // Retry the update after a delay
+                _workQueue.AddWork(cancelExistingWork: true);
+                return;
+            }
 
             this.LastPresentedViewState = newViewState;
             this.DocumentSymbolViewModelItems = newViewModelItems;

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Outlining;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
 
@@ -264,6 +265,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 var asyncListenerProvider = _languageService.Package.ComponentModel.GetService<IAsynchronousOperationListenerProvider>();
                 var asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.DocumentOutline);
                 var editorAdaptersFactoryService = _languageService.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+                var outliningManagerService = _languageService.Package.ComponentModel.GetService<IOutliningManagerService>();
 
                 // Assert that the previous Document Outline Control and host have been freed. 
                 Contract.ThrowIfFalse(_documentOutlineView is null);
@@ -271,7 +273,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
                 var viewTracker = new VsCodeWindowViewTracker(_codeWindow, threadingContext, editorAdaptersFactoryService);
                 _documentOutlineView = new DocumentOutlineView(
-                    uiShell, windowSearchHostFactory, threadingContext, _globalOptions, viewTracker,
+                    uiShell, windowSearchHostFactory, threadingContext, _globalOptions, outliningManagerService, viewTracker,
                     new DocumentOutlineViewModel(threadingContext, viewTracker, languageServiceBroker, asyncListener));
 
                 _documentOutlineViewHost = new ElementHost


### PR DESCRIPTION
* Only move caret in editor if Document Outline has keyboard focus (Fixes #69292)
* Expand outlining regions if necessary (Fixes #69902)
* Avoid updating the UI if the tree view is not visible (Fixes #69903)