### PR TITLE
Use .NET 8 crossgen2's opt-cross-module option

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -317,7 +317,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- We should try to keep this version in sync with the version of app-local runtime in VS. -->
-    <MicrosoftNetCoreAppRuntimePackagesVersion>8.0.0-preview.5.23280.8</MicrosoftNetCoreAppRuntimePackagesVersion>
-    <MicrosoftWindowsDesktopAppRuntimePackagesVersion>8.0.0-preview.5.23302.2</MicrosoftWindowsDesktopAppRuntimePackagesVersion>
+    <MicrosoftNetCoreAppRuntimePackagesVersion>8.0.0-rc.1.23419.4</MicrosoftNetCoreAppRuntimePackagesVersion>
+    <MicrosoftWindowsDesktopAppRuntimePackagesVersion>8.0.0-rc.1.23420.5</MicrosoftWindowsDesktopAppRuntimePackagesVersion>
   </PropertyGroup>
 </Project>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/CoreComponents.Shared.targets
@@ -109,6 +109,7 @@
       <_RspFileLines Include="--out:$(_R2ROptimizeAssemblyOutputPath)" />
       <_RspFileLines Include="--targetarch:$(TargetArch)" />
       <_RspFileLines Include="--optimize" />
+      <_RspFileLines Include="--opt-cross-module:*" />
       <_RspFileLines Include="@(_RuntimeLibraries->'--reference:%(FullPath)')" />
       <_RspFileLines Include="@(_CrossgenTargetsAsDependencies->'--reference:%(FullPath)')" />
       <_RspFileLines Include="@(_NonCrossgenTargetsAsDependencies->'--reference:%(FullPath)')" />


### PR DESCRIPTION
This would reduce jitting in our ServiceHub process by 10% across all RPS tests

Validation insertion:
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/497420