### PR TITLE
Relax remote host APIs so they can work on workspace-green nodes

### DIFF
--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceConnection.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceConnection.cs
@@ -140,8 +140,15 @@ internal abstract class RemoteServiceConnection<TService> : IDisposable
     // multiple solution, no callback
 
     public abstract ValueTask<bool> TryInvokeAsync(
+        SolutionState solution1,
+        SolutionState solution2,
+        Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
+
+    public ValueTask<bool> TryInvokeAsync(
         Solution solution1,
         Solution solution2,
         Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(solution1.State, solution2.State, invocation, cancellationToken);
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceConnection.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceConnection.cs
@@ -3,97 +3,145 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.CodeAnalysis.Remote
+namespace Microsoft.CodeAnalysis.Remote;
+
+/// <summary>
+/// Abstracts a connection to a service implementing type <typeparamref name="TService"/>.
+/// </summary>
+/// <typeparam name="TService">Remote interface type of the service.</typeparam>
+internal abstract class RemoteServiceConnection<TService> : IDisposable
+    where TService : class
 {
-    /// <summary>
-    /// Abstracts a connection to a service implementing type <typeparamref name="TService"/>.
-    /// </summary>
-    /// <typeparam name="TService">Remote interface type of the service.</typeparam>
-    internal abstract class RemoteServiceConnection<TService> : IDisposable
-        where TService : class
-    {
-        public abstract void Dispose();
+    public abstract void Dispose();
 
-        // no solution, no callback
+    // no solution, no callback
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Func<TService, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<bool> TryInvokeAsync(
+        Func<TService, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Func<TService, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Func<TService, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
 
-        // no solution, callback
+    // no solution, callback
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<bool> TryInvokeAsync(
+        Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Func<TService, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
 
-        // solution, no callback
+    // solution, no callback
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Solution solution,
-            Func<TService, Checksum, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<bool> TryInvokeAsync(
+        SolutionState solution,
+        Func<TService, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Solution solution,
-            Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        SolutionState solution,
+        Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
 
-        // project, no callback
+    public ValueTask<bool> TryInvokeAsync(
+        Solution solution,
+        Func<TService, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(solution.State, invocation, cancellationToken);
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Project project,
-            Func<TService, Checksum, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Solution solution,
+        Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(solution.State, invocation, cancellationToken);
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Project project,
-            Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    // project, no callback
 
-        // solution, callback
+    public abstract ValueTask<bool> TryInvokeAsync(
+        SolutionState solution,
+        ProjectId projectId,
+        Func<TService, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Solution solution,
-            Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        SolutionState solution,
+        ProjectId projectId,
+        Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Solution solution,
-            Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    public ValueTask<bool> TryInvokeAsync(
+        Project project,
+        Func<TService, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(project.Solution.State, project.Id, invocation, cancellationToken);
 
-        // project, callback
+    public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Project project,
+        Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(project.Solution.State, project.Id, invocation, cancellationToken);
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Project project,
-            Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
+    // solution, callback
 
-        public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
-            Project project,
-            Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
-            CancellationToken cancellationToken);
+    public abstract ValueTask<bool> TryInvokeAsync(
+        SolutionState solution,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 
-        // multiple solution, no callback
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        SolutionState solution,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
 
-        public abstract ValueTask<bool> TryInvokeAsync(
-            Solution solution1,
-            Solution solution2,
-            Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation,
-            CancellationToken cancellationToken);
-    }
+    public ValueTask<bool> TryInvokeAsync(
+        Solution solution,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(solution.State, invocation, cancellationToken);
+
+    public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Solution solution,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(solution.State, invocation, cancellationToken);
+
+    // project, callback
+
+    public abstract ValueTask<bool> TryInvokeAsync(
+        SolutionState solution,
+        ProjectId projectId,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
+
+    public abstract ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        SolutionState solution,
+        ProjectId projectId,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken);
+
+    public ValueTask<bool> TryInvokeAsync(
+        Project project,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(project.Solution.State, project.Id, invocation, cancellationToken);
+
+    public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(
+        Project project,
+        Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken)
+        => TryInvokeAsync(project.Solution.State, project.Id, invocation, cancellationToken);
+
+    // multiple solution, no callback
+
+    public abstract ValueTask<bool> TryInvokeAsync(
+        Solution solution1,
+        Solution solution2,
+        Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation,
+        CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -304,12 +304,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
         // multi-solution, no callback
 
-        public override async ValueTask<bool> TryInvokeAsync(Solution solution1, Solution solution2, Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<bool> TryInvokeAsync(SolutionState solution1, SolutionState solution2, Func<TService, Checksum, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
             try
             {
-                using var scope1 = await _solutionAssetStorage.StoreAssetsAsync(solution1.State, cancellationToken).ConfigureAwait(false);
-                using var scope2 = await _solutionAssetStorage.StoreAssetsAsync(solution2.State, cancellationToken).ConfigureAwait(false);
+                using var scope1 = await _solutionAssetStorage.StoreAssetsAsync(solution1, cancellationToken).ConfigureAwait(false);
+                using var scope2 = await _solutionAssetStorage.StoreAssetsAsync(solution2, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 await invocation(rental.Service, scope1.SolutionChecksum, scope2.SolutionChecksum, cancellationToken).ConfigureAwait(false);
                 return true;

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -3,16 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO.Pipelines;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Extensions;
-using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
@@ -167,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         // solution, no callback
 
-        public override async ValueTask<bool> TryInvokeAsync(Solution solution, Func<TService, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<bool> TryInvokeAsync(SolutionState solution, Func<TService, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
             try
             {
@@ -183,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Solution solution, Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionState solution, Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
             try
             {
@@ -200,11 +195,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         // project, no callback
 
-        public override async ValueTask<bool> TryInvokeAsync(Project project, Func<TService, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<bool> TryInvokeAsync(SolutionState solution, ProjectId projectId, Func<TService, Checksum, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
             try
             {
-                using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
+                using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 await invocation(rental.Service, scope.SolutionChecksum, cancellationToken).ConfigureAwait(false);
                 return true;
@@ -216,11 +211,11 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Project project, Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionState solution, ProjectId projectId, Func<TService, Checksum, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
             try
             {
-                using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
+                using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await invocation(rental.Service, scope.SolutionChecksum, cancellationToken).ConfigureAwait(false);
             }
@@ -233,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         // solution, callback
 
-        public override async ValueTask<bool> TryInvokeAsync(Solution solution, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<bool> TryInvokeAsync(SolutionState solution, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
@@ -252,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Solution solution, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionState solution, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
@@ -271,13 +266,13 @@ namespace Microsoft.CodeAnalysis.Remote
 
         // project, callback
 
-        public override async ValueTask<bool> TryInvokeAsync(Project project, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<bool> TryInvokeAsync(SolutionState solution, ProjectId projectId, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {
-                using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
+                using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 await invocation(rental.Service, scope.SolutionChecksum, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
 
@@ -290,13 +285,13 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Project project, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+        public override async ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(SolutionState solution, ProjectId projectId, Func<TService, Checksum, RemoteServiceCallbackId, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(_callbackDispatcher is not null);
 
             try
             {
-                using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
+                using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, projectId, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await invocation(rental.Service, scope.SolutionChecksum, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
             }
@@ -313,8 +308,8 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             try
             {
-                using var scope1 = await _solutionAssetStorage.StoreAssetsAsync(solution1, cancellationToken).ConfigureAwait(false);
-                using var scope2 = await _solutionAssetStorage.StoreAssetsAsync(solution2, cancellationToken).ConfigureAwait(false);
+                using var scope1 = await _solutionAssetStorage.StoreAssetsAsync(solution1.State, cancellationToken).ConfigureAwait(false);
+                using var scope2 = await _solutionAssetStorage.StoreAssetsAsync(solution2.State, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 await invocation(rental.Service, scope1.SolutionChecksum, scope2.SolutionChecksum, cancellationToken).ConfigureAwait(false);
                 return true;

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -48,18 +48,20 @@ internal partial class SolutionAssetStorage
     /// <summary>
     /// Adds given snapshot into the storage. This snapshot will be available within the returned <see cref="Scope"/>.
     /// </summary>
-    internal ValueTask<Scope> StoreAssetsAsync(Solution solution, CancellationToken cancellationToken)
+    public ValueTask<Scope> StoreAssetsAsync(Solution solution, CancellationToken cancellationToken)
+        => StoreAssetsAsync(solution.State, cancellationToken);
+
+    /// <inheritdoc cref="StoreAssetsAsync(Solution, CancellationToken)"/>
+    public ValueTask<Scope> StoreAssetsAsync(Project project, CancellationToken cancellationToken)
+        => StoreAssetsAsync(project.Solution.State, project.Id, cancellationToken);
+
+    /// <inheritdoc cref="StoreAssetsAsync(Solution, CancellationToken)"/>
+    public ValueTask<Scope> StoreAssetsAsync(SolutionState solution, CancellationToken cancellationToken)
         => StoreAssetsAsync(solution, projectId: null, cancellationToken);
 
-    /// <summary>
-    /// Adds given snapshot into the storage. This snapshot will be available within the returned <see cref="Scope"/>.
-    /// </summary>
-    internal ValueTask<Scope> StoreAssetsAsync(Project project, CancellationToken cancellationToken)
-        => StoreAssetsAsync(project.Solution, project.Id, cancellationToken);
-
-    private async ValueTask<Scope> StoreAssetsAsync(Solution solution, ProjectId? projectId, CancellationToken cancellationToken)
+    /// <inheritdoc cref="StoreAssetsAsync(Solution, CancellationToken)"/>
+    public async ValueTask<Scope> StoreAssetsAsync(SolutionState solutionState, ProjectId? projectId, CancellationToken cancellationToken)
     {
-        var solutionState = solution.State;
         var checksum = projectId == null
             ? await solutionState.GetChecksumAsync(cancellationToken).ConfigureAwait(false)
             : await solutionState.GetChecksumAsync(projectId, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Extracted from teh work to make it so that the VSWorkspace calls out to the OOP server to compute SG documents, instead of doing it itself.  Extracted out to make things easier to review.

The vs workspace will do this inside the compilation-tracker component that is producing compilations.  This component does not work at hte layer of the workspace red-nodes (e.g. Solution/Project/Document), instead it works at the level of the workspace green-nodes (SolutionState/ProjectState/DocumentState).  As such, to be able to call out to OOP we need to ensure that that green state is synchronized over.

Fortunately, that green-state synchronization is *how* the OOP synchronization system already works under teh covers.  So This is just a trivial change of exposing that support directly.  THe existing red-synchronization is still exposed for all features to use, and it just forwards to the underlying green synchronization.