### PR TITLE
Use no-op global assembly cache helper when running under .net core

### DIFF
--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/ClrGlobalAssemblyCache.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/ClrGlobalAssemblyCache.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis
 
     /// <summary>
     /// Provides APIs to enumerate and look up assemblies stored in the Global Assembly Cache.
+    /// 
+    /// This resolver only works when running under the .net framework runtime.
     /// </summary>
     internal sealed class ClrGlobalAssemblyCache : GlobalAssemblyCache
     {

--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/DotNetCoreGlobalAssemblyCache.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/DotNetCoreGlobalAssemblyCache.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis;
 /// However it isn't extremely straightforward to implement and we don't need it at this time so leaving it as a no-op.
 /// More info on how this might be possible under a .net core runtime can be found https://github.com/dotnet/core/issues/3048#issuecomment-725781811
 /// </summary>
-internal class DotNetCoreGlobalAssemblyCache : GlobalAssemblyCache
+internal sealed class DotNetCoreGlobalAssemblyCache : GlobalAssemblyCache
 {
     public override IEnumerable<AssemblyIdentity> GetAssemblyIdentities(AssemblyName partialName, ImmutableArray<ProcessorArchitecture> architectureFilter = default)
     {

--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/GlobalAssemblyCache.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -27,7 +25,9 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return new ClrGlobalAssemblyCache();
+                return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains(".NET Framework")
+                    ? new ClrGlobalAssemblyCache()
+                    : new DotNetCoreGlobalAssemblyCache();
             }
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="partialName">Optional partial name.</param>
         /// <param name="architectureFilter">Optional architecture filter.</param>
-        public abstract IEnumerable<AssemblyIdentity> GetAssemblyIdentities(AssemblyName partialName, ImmutableArray<ProcessorArchitecture> architectureFilter = default(ImmutableArray<ProcessorArchitecture>));
+        public abstract IEnumerable<AssemblyIdentity> GetAssemblyIdentities(AssemblyName partialName, ImmutableArray<ProcessorArchitecture> architectureFilter = default);
 
         /// <summary>
         /// Enumerates assemblies in the GAC returning those that match given partial name and
@@ -52,14 +52,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="partialName">The optional partial name.</param>
         /// <param name="architectureFilter">The optional architecture filter.</param>
-        public abstract IEnumerable<AssemblyIdentity> GetAssemblyIdentities(string partialName = null, ImmutableArray<ProcessorArchitecture> architectureFilter = default(ImmutableArray<ProcessorArchitecture>));
+        public abstract IEnumerable<AssemblyIdentity> GetAssemblyIdentities(string? partialName = null, ImmutableArray<ProcessorArchitecture> architectureFilter = default);
 
         /// <summary>
         /// Enumerates assemblies in the GAC returning their simple names.
         /// </summary>
         /// <param name="architectureFilter">Optional architecture filter.</param>
         /// <returns>Unique simple names of GAC assemblies.</returns>
-        public abstract IEnumerable<string> GetAssemblySimpleNames(ImmutableArray<ProcessorArchitecture> architectureFilter = default(ImmutableArray<ProcessorArchitecture>));
+        public abstract IEnumerable<string> GetAssemblySimpleNames(ImmutableArray<ProcessorArchitecture> architectureFilter = default);
 
         /// <summary>
         /// Looks up specified partial assembly name in the GAC and returns the best matching <see cref="AssemblyIdentity"/>.
@@ -69,13 +69,12 @@ namespace Microsoft.CodeAnalysis
         /// <param name="preferredCulture">The optional preferred culture information</param>
         /// <returns>An assembly identity or null, if <paramref name="displayName"/> can't be resolved.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="displayName"/> is null.</exception>
-        public AssemblyIdentity ResolvePartialName(
+        public AssemblyIdentity? ResolvePartialName(
             string displayName,
-            ImmutableArray<ProcessorArchitecture> architectureFilter = default(ImmutableArray<ProcessorArchitecture>),
-            CultureInfo preferredCulture = null)
+            ImmutableArray<ProcessorArchitecture> architectureFilter = default,
+            CultureInfo? preferredCulture = null)
         {
-            string location;
-            return ResolvePartialName(displayName, out location, architectureFilter, preferredCulture);
+            return ResolvePartialName(displayName, out _, architectureFilter, preferredCulture);
         }
 
         /// <summary>
@@ -87,10 +86,10 @@ namespace Microsoft.CodeAnalysis
         /// <param name="preferredCulture">The optional preferred culture information</param>
         /// <returns>An assembly identity or null, if <paramref name="displayName"/> can't be resolved.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="displayName"/> is null.</exception>
-        public abstract AssemblyIdentity ResolvePartialName(
+        public abstract AssemblyIdentity? ResolvePartialName(
             string displayName,
-            out string location,
-            ImmutableArray<ProcessorArchitecture> architectureFilter = default(ImmutableArray<ProcessorArchitecture>),
-            CultureInfo preferredCulture = null);
+            out string? location,
+            ImmutableArray<ProcessorArchitecture> architectureFilter = default,
+            CultureInfo? preferredCulture = null);
     }
 }

--- a/src/Scripting/Core/Hosting/Resolvers/DotNetCoreGlobalAssemblyCache.cs
+++ b/src/Scripting/Core/Hosting/Resolvers/DotNetCoreGlobalAssemblyCache.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection;
+
+namespace Microsoft.CodeAnalysis;
+
+/// <summary>
+/// Implements a no-op wrapper to search the global assembly cache when running under a .net core runtime.
+/// At some point we may wish to get information about assemblies in the GAC under a .net core runtime - for example
+/// if we're loading a .net framework project in vscode and want to find the actual assembly to decompile.
+/// 
+/// However it isn't extremely straightforward to implement and we don't need it at this time so leaving it as a no-op.
+/// More info on how this might be possible under a .net core runtime can be found https://github.com/dotnet/core/issues/3048#issuecomment-725781811
+/// </summary>
+internal class DotNetCoreGlobalAssemblyCache : GlobalAssemblyCache
+{
+    public override IEnumerable<AssemblyIdentity> GetAssemblyIdentities(AssemblyName partialName, ImmutableArray<ProcessorArchitecture> architectureFilter = default)
+    {
+        return ImmutableArray<AssemblyIdentity>.Empty;
+    }
+
+    public override IEnumerable<AssemblyIdentity> GetAssemblyIdentities(string? partialName = null, ImmutableArray<ProcessorArchitecture> architectureFilter = default)
+    {
+        return ImmutableArray<AssemblyIdentity>.Empty;
+    }
+
+    public override IEnumerable<string> GetAssemblySimpleNames(ImmutableArray<ProcessorArchitecture> architectureFilter = default)
+    {
+        return ImmutableArray<string>.Empty;
+    }
+
+    public override AssemblyIdentity? ResolvePartialName(string displayName, out string? location, ImmutableArray<ProcessorArchitecture> architectureFilter = default, CultureInfo? preferredCulture = null)
+    {
+        location = null;
+        return null;
+    }
+}
+

--- a/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
+++ b/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
@@ -45,6 +45,9 @@
     <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\MonoGlobalAssemblyCache.cs">
       <Link>Hosting\Resolvers\MonoGlobalAssemblyCache.cs</Link>
     </Compile>
+    <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\DotNetCoreGlobalAssemblyCache.cs">
+      <Link>Hosting\Resolvers\DotNetCoreGlobalAssemblyCache.cs</Link>
+    </Compile>
     <Compile Update="ScriptingResources.Designer.cs" GenerateSource="true" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Should fix https://github.com/dotnet/vscode-csharp/issues/6235

The `ClrGlobalAssemblyCache.cs` is used to find the implementation location of .net framework based assemblies that might be in the global assembly cache in order to decompile them.  

`ClrGlobalAssemblyCache.cs` is not valid to use as-is when running in a .net core runtime - it is not valid to [DllImport("clr")] - in fact this generally throws a dll not found exception (it gets caught and reported as a NFW).  I'm guessing in the above issue it managed to get a bit farther before throwing.

The solution here is to avoid calling `ClrGlobalAssemblyCache` when in .net core.  I replaced it with a no-op implementation.  While at some point it may be valuable to support decompiling .net framework assemblies in vscode, its not a high priority scenario and its not entirely clear on how that would be implemnted.