### PR TITLE
Remove diagnostic source name field

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -396,7 +396,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 // would get automatically serialized.
                 var diagnostic = new LSP.VSDiagnostic
                 {
-                    Source = "Roslyn",
                     Code = diagnosticData.Id,
                     CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(diagnosticData.GetValidHelpLinkUri()),
                     Message = diagnosticData.Message,


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6347

<img width="423" alt="image" src="https://github.com/dotnet/vscode-csharp/assets/5749229/d3fc4330-7afc-47d5-893d-876b924a2b28">