### PR TITLE
Include a bit in DocumentId to indicate if it corresponds to a SG document or not

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("37");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("38");
 
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
@@ -44,25 +44,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => project.GetAnalyzerConfigDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
         public static TextDocument GetRequiredTextDocument(this Project project, DocumentId documentId)
-        {
-            var document = project.GetTextDocument(documentId);
-            if (document == null)
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-
-            return document;
-        }
+            => project.GetTextDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
         public static async ValueTask<Document> GetRequiredSourceGeneratedDocumentAsync(this Project project, DocumentId documentId, CancellationToken cancellationToken)
         {
             var document = await project.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
-            if (document is null)
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-
-            return document;
+            return document ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis
     /// An identifier that can be used to retrieve the same <see cref="Document"/> across versions of the
     /// workspace.
     /// </summary>
-    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     [DataContract]
+    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public sealed class DocumentId : IEquatable<DocumentId>, IObjectWritable
     {
         [DataMember(Order = 0)]
@@ -24,12 +24,15 @@ namespace Microsoft.CodeAnalysis
         [DataMember(Order = 1)]
         public Guid Id { get; }
         [DataMember(Order = 2)]
+        internal bool IsSourceGenerated { get; }
+        [DataMember(Order = 3)]
         private readonly string? _debugName;
 
-        private DocumentId(ProjectId projectId, Guid guid, string? debugName)
+        private DocumentId(ProjectId projectId, Guid guid, bool isSourceGenerated, string? debugName)
         {
             this.ProjectId = projectId;
             this.Id = guid;
+            this.IsSourceGenerated = isSourceGenerated;
             _debugName = debugName;
         }
 
@@ -39,28 +42,20 @@ namespace Microsoft.CodeAnalysis
         /// <param name="projectId">The project id this document id is relative to.</param>
         /// <param name="debugName">An optional name to make this id easier to recognize while debugging.</param>
         public static DocumentId CreateNewId(ProjectId projectId, string? debugName = null)
-        {
-            if (projectId == null)
-            {
-                throw new ArgumentNullException(nameof(projectId));
-            }
-
-            return new DocumentId(projectId, Guid.NewGuid(), debugName);
-        }
+            => CreateFromSerialized(projectId, Guid.NewGuid(), isSourceGenerated: false, debugName);
 
         public static DocumentId CreateFromSerialized(ProjectId projectId, Guid id, string? debugName = null)
+            => CreateFromSerialized(projectId, id, isSourceGenerated: true, debugName);
+
+        internal static DocumentId CreateFromSerialized(ProjectId projectId, Guid id, bool isSourceGenerated, string? debugName)
         {
             if (projectId == null)
-            {
                 throw new ArgumentNullException(nameof(projectId));
-            }
 
             if (id == Guid.Empty)
-            {
                 throw new ArgumentException(nameof(id));
-            }
 
-            return new DocumentId(projectId, id, debugName);
+            return new DocumentId(projectId, id, isSourceGenerated, debugName);
         }
 
         internal string? DebugName => _debugName;
@@ -78,7 +73,7 @@ namespace Microsoft.CodeAnalysis
         {
             // Technically, we don't need to check project id.
             return
-                other is object &&
+                other is not null &&
                 this.Id == other.Id &&
                 this.ProjectId == other.ProjectId;
         }
@@ -100,6 +95,7 @@ namespace Microsoft.CodeAnalysis
 
             writer.WriteGuid(Id);
             writer.WriteString(DebugName);
+            writer.WriteBoolean(IsSourceGenerated);
         }
 
         internal static DocumentId ReadFrom(ObjectReader reader)
@@ -108,8 +104,9 @@ namespace Microsoft.CodeAnalysis
 
             var guid = reader.ReadGuid();
             var debugName = reader.ReadString();
+            var isSourceGenerated = reader.ReadBoolean();
 
-            return CreateFromSerialized(projectId, guid, debugName);
+            return CreateFromSerialized(projectId, guid, isSourceGenerated, debugName);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -92,19 +92,17 @@ namespace Microsoft.CodeAnalysis
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
             ProjectId.WriteTo(writer);
-
             writer.WriteGuid(Id);
-            writer.WriteString(DebugName);
             writer.WriteBoolean(IsSourceGenerated);
+            writer.WriteString(DebugName);
         }
 
         internal static DocumentId ReadFrom(ObjectReader reader)
         {
             var projectId = ProjectId.ReadFrom(reader);
-
             var guid = reader.ReadGuid();
-            var debugName = reader.ReadString();
             var isSourceGenerated = reader.ReadBoolean();
+            var debugName = reader.ReadString();
 
             return CreateFromSerialized(projectId, guid, isSourceGenerated, debugName);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
             => CreateFromSerialized(projectId, Guid.NewGuid(), isSourceGenerated: false, debugName);
 
         public static DocumentId CreateFromSerialized(ProjectId projectId, Guid id, string? debugName = null)
-            => CreateFromSerialized(projectId, id, isSourceGenerated: true, debugName);
+            => CreateFromSerialized(projectId, id, isSourceGenerated: false, debugName);
 
         internal static DocumentId CreateFromSerialized(ProjectId projectId, Guid id, bool isSourceGenerated, string? debugName)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -295,7 +295,13 @@ namespace Microsoft.CodeAnalysis
 
         public async ValueTask<SourceGeneratedDocument?> GetSourceGeneratedDocumentAsync(DocumentId documentId, CancellationToken cancellationToken = default)
         {
+            // Immediately shortcircuit out if we know this is not a doc-id corresponding to an SG document.
             if (!documentId.IsSourceGenerated)
+                return null;
+
+            // User incorrect called into us with a doc id for a different project.  Ideally we'd throw here, but we've
+            // always been resilient to this misuse since the start of roslyn, so we just quick-bail instead.
+            if (this.Id != documentId.ProjectId)
                 return null;
 
             // Quick check first: if we already have created a SourceGeneratedDocument wrapper, we're good
@@ -324,7 +330,13 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         internal SourceGeneratedDocument? TryGetSourceGeneratedDocumentForAlreadyGeneratedId(DocumentId documentId)
         {
+            // Immediately shortcircuit out if we know this is not a doc-id corresponding to an SG document.
             if (!documentId.IsSourceGenerated)
+                return null;
+
+            // User incorrect called into us with a doc id for a different project.  Ideally we'd throw here, but we've
+            // always been resilient to this misuse since the start of roslyn, so we just quick-bail instead.
+            if (this.Id != documentId.ProjectId)
                 return null;
 
             // Easy case: do we already have the SourceGeneratedDocument created?

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -3,98 +3,109 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis
+namespace Microsoft.CodeAnalysis;
+
+/// <summary>
+/// A small struct that holds the values that define the identity of a source generated document, and don't change
+/// as new generations happen. This is mostly for convenience as we are reguarly working with this combination of values.
+/// </summary>
+internal readonly record struct SourceGeneratedDocumentIdentity
+    : IObjectWritable, IEquatable<SourceGeneratedDocumentIdentity>
 {
-    /// <summary>
-    /// A small struct that holds the values that define the identity of a source generated document, and don't change
-    /// as new generations happen. This is mostly for convenience as we are reguarly working with this combination of values.
-    /// </summary>
-    internal readonly record struct SourceGeneratedDocumentIdentity
-        (DocumentId DocumentId, string HintName, SourceGeneratorIdentity Generator, string FilePath)
-        : IObjectWritable, IEquatable<SourceGeneratedDocumentIdentity>
+    public bool ShouldReuseInSerialization => true;
+
+    public readonly DocumentId DocumentId;
+    public readonly string HintName;
+    public readonly SourceGeneratorIdentity Generator;
+    public readonly string FilePath;
+
+    public SourceGeneratedDocumentIdentity(DocumentId documentId, string hintName, SourceGeneratorIdentity generator, string filePath)
     {
-        public bool ShouldReuseInSerialization => true;
+        Contract.ThrowIfFalse(documentId.IsSourceGenerated);
+        DocumentId = documentId;
+        HintName = hintName;
+        Generator = generator;
+        FilePath = filePath;
+    }
 
-        public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath, AnalyzerReference analyzerReference)
-        {
-            // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
-            // a document by DocumentId can find it after some change has happened that requires generators to run again.
-            // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
-            // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
-            var generatorIdentity = new SourceGeneratorIdentity(generator, analyzerReference);
+    public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath, AnalyzerReference analyzerReference)
+    {
+        // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
+        // a document by DocumentId can find it after some change has happened that requires generators to run again.
+        // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
+        // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
+        var generatorIdentity = new SourceGeneratorIdentity(generator, analyzerReference);
 
-            // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
-            // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
-            var projectIdBytes = projectId.Id.ToByteArray();
+        // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
+        // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
+        var projectIdBytes = projectId.Id.ToByteArray();
 
-            // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
-            // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
-            var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
+        // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
+        // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
+        var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
 
-            using var _ = ArrayBuilder<byte>.GetInstance(capacity: (assemblyNameToHash.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
-            hashInput.AddRange(projectIdBytes);
+        using var _ = ArrayBuilder<byte>.GetInstance(capacity: (assemblyNameToHash.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
+        hashInput.AddRange(projectIdBytes);
 
-            // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
-            // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
-            hashInput.AddRange(Encoding.Unicode.GetBytes(assemblyNameToHash));
-            hashInput.AddRange(0, 0);
-            hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.TypeName));
-            hashInput.AddRange(0, 0);
-            hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
+        // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
+        // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
+        hashInput.AddRange(Encoding.Unicode.GetBytes(assemblyNameToHash));
+        hashInput.AddRange(0, 0);
+        hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.TypeName));
+        hashInput.AddRange(0, 0);
+        hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
 
-            // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
-            // is it must be collision resistant, and provide enough bits to fill a GUID.
-            using var crytpoAlgorithm = System.Security.Cryptography.SHA256.Create();
-            var hash = crytpoAlgorithm.ComputeHash(hashInput.ToArray());
-            Array.Resize(ref hash, 16);
-            var guid = new Guid(hash);
+        // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
+        // is it must be collision resistant, and provide enough bits to fill a GUID.
+        using var crytpoAlgorithm = System.Security.Cryptography.SHA256.Create();
+        var hash = crytpoAlgorithm.ComputeHash(hashInput.ToArray());
+        Array.Resize(ref hash, 16);
+        var guid = new Guid(hash);
 
-            var documentId = DocumentId.CreateFromSerialized(projectId, guid, hintName);
+        var documentId = DocumentId.CreateFromSerialized(projectId, guid, isSourceGenerated: true, hintName);
 
-            return new SourceGeneratedDocumentIdentity(documentId, hintName, generatorIdentity, filePath);
-        }
+        return new SourceGeneratedDocumentIdentity(documentId, hintName, generatorIdentity, filePath);
+    }
 
-        public void WriteTo(ObjectWriter writer)
-        {
-            DocumentId.WriteTo(writer);
+    public void WriteTo(ObjectWriter writer)
+    {
+        DocumentId.WriteTo(writer);
 
-            writer.WriteString(HintName);
-            writer.WriteString(Generator.AssemblyName);
-            writer.WriteString(Generator.AssemblyPath);
-            writer.WriteString(Generator.AssemblyVersion.ToString());
-            writer.WriteString(Generator.TypeName);
-            writer.WriteString(FilePath);
-        }
+        writer.WriteString(HintName);
+        writer.WriteString(Generator.AssemblyName);
+        writer.WriteString(Generator.AssemblyPath);
+        writer.WriteString(Generator.AssemblyVersion.ToString());
+        writer.WriteString(Generator.TypeName);
+        writer.WriteString(FilePath);
+    }
 
-        internal static SourceGeneratedDocumentIdentity ReadFrom(ObjectReader reader)
-        {
-            var documentId = DocumentId.ReadFrom(reader);
+    internal static SourceGeneratedDocumentIdentity ReadFrom(ObjectReader reader)
+    {
+        var documentId = DocumentId.ReadFrom(reader);
 
-            var hintName = reader.ReadString();
-            var generatorAssemblyName = reader.ReadString();
-            var generatorAssemblyPath = reader.ReadString();
-            var generatorAssemblyVersion = Version.Parse(reader.ReadString());
-            var generatorTypeName = reader.ReadString();
-            var filePath = reader.ReadString();
+        var hintName = reader.ReadString();
+        var generatorAssemblyName = reader.ReadString();
+        var generatorAssemblyPath = reader.ReadString();
+        var generatorAssemblyVersion = Version.Parse(reader.ReadString());
+        var generatorTypeName = reader.ReadString();
+        var filePath = reader.ReadString();
 
-            return new SourceGeneratedDocumentIdentity(
-                documentId,
-                hintName,
-                new SourceGeneratorIdentity
-                {
-                    AssemblyName = generatorAssemblyName,
-                    AssemblyPath = generatorAssemblyPath,
-                    AssemblyVersion = generatorAssemblyVersion,
-                    TypeName = generatorTypeName
-                },
-                filePath);
-        }
+        return new SourceGeneratedDocumentIdentity(
+            documentId,
+            hintName,
+            new SourceGeneratorIdentity
+            {
+                AssemblyName = generatorAssemblyName,
+                AssemblyPath = generatorAssemblyPath,
+                AssemblyVersion = generatorAssemblyVersion,
+                TypeName = generatorTypeName
+            },
+            filePath);
     }
 }


### PR DESCRIPTION
Currently, the IDE has to always go down an expensive path when asked for teh Document corresponding to a particular DocumentId.  This is because we don't know if the doc-id refers to a real user-documetn or a potential SG document.  As such, if we don't find the real document, we have to go generate all the SG docs, even if they may not match teh doc id either.

This changes the internal representation of a DocId to include if it was synthesized to correspond to an SG doc or not.  If not, we can shortcircuit those calls immediately, returning that no doc was found at all after hte fast user-code lookup.  If it is an sg doc id, then we do go and do the more expensive work like we did before.  