### PR TITLE
Make ManagedToolTask.PathToManagedTool virtual

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </remarks>
         protected bool IsManagedTool => string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName;
 
-        internal string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
+        protected virtual string PathToManagedTool => Utilities.GenerateFullPathToTool(ToolName);
 
         private string PathToManagedToolWithoutExtension
         {


### PR DESCRIPTION
I was trying to use the MSBuild task outside of MSBuild to take advantage of the compiler server, but I was using the code inside a Native AOT application, so Assembly.Location is not available. Right now there's no way to use the code otherwise. This is a minimal change that I came up with that would allow more extensibility while not meaningfully changing the public surface area.