### PR TITLE
Add inline parameter hints keywords to VSPackage.resx

### DIFF
--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -144,6 +144,11 @@
   <data name="306" xml:space="preserve">
     <value>Underline reassigned variables;
 Display inline hints;
+Display inline parameter name hints;
+Display inline type hints;
+Color hints;
+Show hints;
+Suppress hints;
 Show diagnostics for closed files;
 Colorize regular expression; 
 Highlight related components under cursor; 


### PR DESCRIPTION
Had trouble finding the checkbox for inline parameter hints using Tools/Options search. I believe this would help.