### PR TITLE
Add mitigation in 17.7 for cases where local and remote host disagree on source generated files.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Peek/PeekableItemSource.cs
@@ -137,6 +137,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                             workspace, document.Id, item.SourceSpan.Start, cancellationToken).ConfigureAwait(false))
                     {
                         var text = await document.GetTextAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+                        if (text is null)
+                            continue;
+
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);
                         if (document.FilePath != null)
                         {

--- a/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
+++ b/src/EditorFeatures/Core/CodeDefinitionWindow/DefinitionContextTracker.cs
@@ -171,6 +171,9 @@ namespace Microsoft.CodeAnalysis.CodeDefinitionWindow
                     if (await navigationService.CanNavigateToSpanAsync(workspace, item.Document.Id, item.SourceSpan, cancellationToken).ConfigureAwait(false))
                     {
                         var text = await item.Document.GetTextAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                        if (text is null)
+                            continue;
+
                         var linePositionSpan = text.Lines.GetLinePositionSpan(item.SourceSpan);
 
                         if (item.Document.FilePath != null)

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     return ImmutableArray<DocumentHighlights>.Empty;
                 }
 
-                return await result.Value.SelectAsArrayAsync(h => h.RehydrateAsync(solution)).ConfigureAwait(false);
+                var highlights = await result.Value.SelectAsArrayAsync(h => h.RehydrateAsync(solution, cancellationToken)).ConfigureAwait(false);
+                return highlights.WhereNotNull();
             }
 
             return await GetDocumentHighlightsInCurrentProcessAsync(

--- a/src/Features/Core/Portable/NavigateTo/RoslynNavigateToItem.cs
+++ b/src/Features/Core/Portable/NavigateTo/RoslynNavigateToItem.cs
@@ -91,8 +91,14 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
             else
             {
-                var document = await solution.GetRequiredDocumentAsync(
-                    DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                // https://github.com/dotnet/roslyn/issues/69964
+                //
+                // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(
+                    DocumentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                if (document == null)
+                    return null;
+
                 return new NavigateToSearchResult(this, document, activeDocument);
             }
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/AbstractGoToDefinitionHandler.cs
@@ -58,8 +58,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         continue;
                     }
 
+                    var definitionDoc = await definition.Document.GetRequiredDocumentAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                    if (definitionDoc is null)
+                        continue;
+
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
-                        await definition.Document.GetRequiredDocumentAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false),
+                        definitionDoc,
                         definition.SourceSpan,
                         definition.IsStale,
                         cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -86,6 +86,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
             {
                 var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+                if (document is null)
+                    return;
 
                 var location = await ProtocolConversions.TextSpanToLocationAsync(
                     document, result.NavigableItem.SourceSpan, result.NavigableItem.IsStale, _context, cancellationToken).ConfigureAwait(false);

--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
@@ -45,6 +45,9 @@ internal static class OmniSharpNavigateToSearcher
         public async Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
             var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+            if (document is null)
+                return;
+
             var omniSharpResult = new OmniSharpNavigateToSearchResult(
                 result.AdditionalInformation,
                 result.Kind,

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -700,6 +700,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
         public async Task<GraphNode?> CreateNodeAsync(Solution solution, INavigateToSearchResult result, CancellationToken cancellationToken)
         {
             var document = await result.NavigableItem.Document.GetRequiredDocumentAsync(solution, cancellationToken).ConfigureAwait(false);
+            if (document is null)
+                return null;
+
             var project = document.Project;
 
             // If it doesn't belong to a document or project we can navigate to, then ignore entirely.

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioDocumentNavigationService.cs
@@ -103,7 +103,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return true;
             }
 
-            var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
+            var document = await workspace.CurrentSolution.GetRequiredDocumentIncludingSourceGeneratedAsync(
+                documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+            if (document is null)
+                return false;
+
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
             var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -163,6 +163,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 foreach (var item in items)
                 {
                     var document = await item.Document.GetRequiredDocumentAsync(context.Solution, cancellationToken).ConfigureAwait(false);
+                    if (document is null)
+                        continue;
+
                     var location = await ProtocolConversions.TextSpanToLocationAsync(
                         document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
                     locations.AddIfNotNull(location);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -249,7 +249,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         cancellationToken.ThrowIfCancellationRequested();
 
                         Debug.Assert(infos.Count > 0);
-                        var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+
+                        // https://github.com/dotnet/roslyn/issues/69964
+                        //
+                        // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                        var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(
+                            documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                        if (document is null)
+                            continue;
+
                         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                         cachedModels.Add(semanticModel);
 
@@ -276,7 +284,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                        // https://github.com/dotnet/roslyn/issues/69964
+                        //
+                        // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                        var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(
+                            documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                        if (document is null)
+                            continue;
+
                         var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                         cachedModels.Add(semanticModel);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("37");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("38");
 
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 serializableLocations.Options,
                 fallbackOptions,
                 locations,
-                implicitLocations,
+                implicitLocations.WhereNotNull(),
                 referencedSymbols);
         }
     }

--- a/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/LightweightRenameLocations.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 Options,
                 FallbackOptions,
                 Locations,
-                implicitLocations,
+                implicitLocations.WhereNotNull(),
                 referencedSymbols);
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
@@ -44,25 +44,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => project.GetAnalyzerConfigDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
         public static TextDocument GetRequiredTextDocument(this Project project, DocumentId documentId)
-        {
-            var document = project.GetTextDocument(documentId);
-            if (document == null)
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-
-            return document;
-        }
+            => project.GetTextDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
         public static async ValueTask<Document> GetRequiredSourceGeneratedDocumentAsync(this Project project, DocumentId documentId, CancellationToken cancellationToken)
         {
             var document = await project.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
-            if (document is null)
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
-
-            return document;
+            return document ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -271,9 +271,7 @@ namespace Microsoft.CodeAnalysis
         {
             var document = GetDocument(documentId) ?? GetAdditionalDocument(documentId) ?? GetAnalyzerConfigDocument(documentId);
             if (document != null)
-            {
                 return document;
-            }
 
             return await GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
         }
@@ -297,21 +295,26 @@ namespace Microsoft.CodeAnalysis
 
         public async ValueTask<SourceGeneratedDocument?> GetSourceGeneratedDocumentAsync(DocumentId documentId, CancellationToken cancellationToken = default)
         {
+            // Immediately shortcircuit out if we know this is not a doc-id corresponding to an SG document.
+            if (!documentId.IsSourceGenerated)
+                return null;
+
+            // User incorrect called into us with a doc id for a different project.  Ideally we'd throw here, but we've
+            // always been resilient to this misuse since the start of roslyn, so we just quick-bail instead.
+            if (this.Id != documentId.ProjectId)
+                return null;
+
             // Quick check first: if we already have created a SourceGeneratedDocument wrapper, we're good
             if (_idToSourceGeneratedDocumentMap.TryGetValue(documentId, out var sourceGeneratedDocument))
-            {
                 return sourceGeneratedDocument;
-            }
 
             // We'll have to run generators if we haven't already and now try to find it.
             var generatedDocumentStates = await _solution.State.GetSourceGeneratedDocumentStatesAsync(State, cancellationToken).ConfigureAwait(false);
             var generatedDocumentState = generatedDocumentStates.GetState(documentId);
-            if (generatedDocumentState != null)
-            {
-                return GetOrCreateSourceGeneratedDocument(generatedDocumentState);
-            }
+            if (generatedDocumentState is null)
+                return null;
 
-            return null;
+            return GetOrCreateSourceGeneratedDocument(generatedDocumentState);
         }
 
         internal SourceGeneratedDocument GetOrCreateSourceGeneratedDocument(SourceGeneratedDocumentState state)
@@ -327,20 +330,24 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         internal SourceGeneratedDocument? TryGetSourceGeneratedDocumentForAlreadyGeneratedId(DocumentId documentId)
         {
+            // Immediately shortcircuit out if we know this is not a doc-id corresponding to an SG document.
+            if (!documentId.IsSourceGenerated)
+                return null;
+
+            // User incorrect called into us with a doc id for a different project.  Ideally we'd throw here, but we've
+            // always been resilient to this misuse since the start of roslyn, so we just quick-bail instead.
+            if (this.Id != documentId.ProjectId)
+                return null;
+
             // Easy case: do we already have the SourceGeneratedDocument created?
             if (_idToSourceGeneratedDocumentMap.TryGetValue(documentId, out var document))
-            {
                 return document;
-            }
 
             // Trickier case now: it's possible we generated this, but we don't actually have the SourceGeneratedDocument for it, so let's go
             // try to fetch the state.
             var documentState = _solution.State.TryGetSourceGeneratedDocumentStateForAlreadyGeneratedId(documentId);
-
             if (documentState == null)
-            {
                 return null;
-            }
 
             return ImmutableHashMapExtensions.GetOrAdd(ref _idToSourceGeneratedDocumentMap, documentId, s_createSourceGeneratedDocumentFunction, (documentState, this));
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -3,98 +3,109 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis
+namespace Microsoft.CodeAnalysis;
+
+/// <summary>
+/// A small struct that holds the values that define the identity of a source generated document, and don't change
+/// as new generations happen. This is mostly for convenience as we are reguarly working with this combination of values.
+/// </summary>
+internal readonly record struct SourceGeneratedDocumentIdentity
+    : IObjectWritable, IEquatable<SourceGeneratedDocumentIdentity>
 {
-    /// <summary>
-    /// A small struct that holds the values that define the identity of a source generated document, and don't change
-    /// as new generations happen. This is mostly for convenience as we are reguarly working with this combination of values.
-    /// </summary>
-    internal readonly record struct SourceGeneratedDocumentIdentity
-        (DocumentId DocumentId, string HintName, SourceGeneratorIdentity Generator, string FilePath)
-        : IObjectWritable, IEquatable<SourceGeneratedDocumentIdentity>
+    public bool ShouldReuseInSerialization => true;
+
+    public readonly DocumentId DocumentId;
+    public readonly string HintName;
+    public readonly SourceGeneratorIdentity Generator;
+    public readonly string FilePath;
+
+    public SourceGeneratedDocumentIdentity(DocumentId documentId, string hintName, SourceGeneratorIdentity generator, string filePath)
     {
-        public bool ShouldReuseInSerialization => true;
+        Contract.ThrowIfFalse(documentId.IsSourceGenerated);
+        DocumentId = documentId;
+        HintName = hintName;
+        Generator = generator;
+        FilePath = filePath;
+    }
 
-        public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath, AnalyzerReference analyzerReference)
-        {
-            // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
-            // a document by DocumentId can find it after some change has happened that requires generators to run again.
-            // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
-            // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
-            var generatorIdentity = new SourceGeneratorIdentity(generator, analyzerReference);
+    public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath, AnalyzerReference analyzerReference)
+    {
+        // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
+        // a document by DocumentId can find it after some change has happened that requires generators to run again.
+        // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
+        // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
+        var generatorIdentity = new SourceGeneratorIdentity(generator, analyzerReference);
 
-            // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
-            // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
-            var projectIdBytes = projectId.Id.ToByteArray();
+        // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
+        // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
+        var projectIdBytes = projectId.Id.ToByteArray();
 
-            // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
-            // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
-            var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
+        // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
+        // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
+        var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
 
-            using var _ = ArrayBuilder<byte>.GetInstance(capacity: (assemblyNameToHash.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
-            hashInput.AddRange(projectIdBytes);
+        using var _ = ArrayBuilder<byte>.GetInstance(capacity: (assemblyNameToHash.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
+        hashInput.AddRange(projectIdBytes);
 
-            // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
-            // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
-            hashInput.AddRange(Encoding.Unicode.GetBytes(assemblyNameToHash));
-            hashInput.AddRange(0, 0);
-            hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.TypeName));
-            hashInput.AddRange(0, 0);
-            hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
+        // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
+        // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
+        hashInput.AddRange(Encoding.Unicode.GetBytes(assemblyNameToHash));
+        hashInput.AddRange(0, 0);
+        hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.TypeName));
+        hashInput.AddRange(0, 0);
+        hashInput.AddRange(Encoding.Unicode.GetBytes(hintName));
 
-            // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
-            // is it must be collision resistant, and provide enough bits to fill a GUID.
-            using var crytpoAlgorithm = System.Security.Cryptography.SHA256.Create();
-            var hash = crytpoAlgorithm.ComputeHash(hashInput.ToArray());
-            Array.Resize(ref hash, 16);
-            var guid = new Guid(hash);
+        // The particular choice of crypto algorithm here is arbitrary and can be always changed as necessary. The only requirement
+        // is it must be collision resistant, and provide enough bits to fill a GUID.
+        using var crytpoAlgorithm = System.Security.Cryptography.SHA256.Create();
+        var hash = crytpoAlgorithm.ComputeHash(hashInput.ToArray());
+        Array.Resize(ref hash, 16);
+        var guid = new Guid(hash);
 
-            var documentId = DocumentId.CreateFromSerialized(projectId, guid, hintName);
+        var documentId = DocumentId.CreateFromSerialized(projectId, guid, isSourceGenerated: true, hintName);
 
-            return new SourceGeneratedDocumentIdentity(documentId, hintName, generatorIdentity, filePath);
-        }
+        return new SourceGeneratedDocumentIdentity(documentId, hintName, generatorIdentity, filePath);
+    }
 
-        public void WriteTo(ObjectWriter writer)
-        {
-            DocumentId.WriteTo(writer);
+    public void WriteTo(ObjectWriter writer)
+    {
+        DocumentId.WriteTo(writer);
 
-            writer.WriteString(HintName);
-            writer.WriteString(Generator.AssemblyName);
-            writer.WriteString(Generator.AssemblyPath);
-            writer.WriteString(Generator.AssemblyVersion.ToString());
-            writer.WriteString(Generator.TypeName);
-            writer.WriteString(FilePath);
-        }
+        writer.WriteString(HintName);
+        writer.WriteString(Generator.AssemblyName);
+        writer.WriteString(Generator.AssemblyPath);
+        writer.WriteString(Generator.AssemblyVersion.ToString());
+        writer.WriteString(Generator.TypeName);
+        writer.WriteString(FilePath);
+    }
 
-        internal static SourceGeneratedDocumentIdentity ReadFrom(ObjectReader reader)
-        {
-            var documentId = DocumentId.ReadFrom(reader);
+    internal static SourceGeneratedDocumentIdentity ReadFrom(ObjectReader reader)
+    {
+        var documentId = DocumentId.ReadFrom(reader);
 
-            var hintName = reader.ReadString();
-            var generatorAssemblyName = reader.ReadString();
-            var generatorAssemblyPath = reader.ReadString();
-            var generatorAssemblyVersion = Version.Parse(reader.ReadString());
-            var generatorTypeName = reader.ReadString();
-            var filePath = reader.ReadString();
+        var hintName = reader.ReadString();
+        var generatorAssemblyName = reader.ReadString();
+        var generatorAssemblyPath = reader.ReadString();
+        var generatorAssemblyVersion = Version.Parse(reader.ReadString());
+        var generatorTypeName = reader.ReadString();
+        var filePath = reader.ReadString();
 
-            return new SourceGeneratedDocumentIdentity(
-                documentId,
-                hintName,
-                new SourceGeneratorIdentity
-                {
-                    AssemblyName = generatorAssemblyName,
-                    AssemblyPath = generatorAssemblyPath,
-                    AssemblyVersion = generatorAssemblyVersion,
-                    TypeName = generatorTypeName
-                },
-                filePath);
-        }
+        return new SourceGeneratedDocumentIdentity(
+            documentId,
+            hintName,
+            new SourceGeneratorIdentity
+            {
+                AssemblyName = generatorAssemblyName,
+                AssemblyPath = generatorAssemblyPath,
+                AssemblyVersion = generatorAssemblyVersion,
+                TypeName = generatorTypeName
+            },
+            filePath);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
@@ -35,7 +35,14 @@ namespace Microsoft.CodeAnalysis.Remote
             // need to be revisited if we someday support FAR between these languages.
             return RunServiceAsync(solutionChecksum, async solution =>
             {
-                var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                // https://github.com/dotnet/roslyn/issues/69964
+                //
+                // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(
+                    documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                if (document is null)
+                    return ImmutableArray<SerializableDocumentHighlights>.Empty;
+
                 var documentsToSearch = await documentIdsToSearch.SelectAsArrayAsync(id => solution.GetDocumentAsync(id, includeSourceGenerated: true, cancellationToken)).ConfigureAwait(false);
                 var documentsToSearchSet = ImmutableHashSet.CreateRange(documentsToSearch.WhereNotNull());
 

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -42,7 +42,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 //
                 // Tracked by https://github.com/dotnet/roslyn/issues/67065.
                 frozenPartialSemantics = false;
-                var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+
+                // https://github.com/dotnet/roslyn/issues/69964
+                //
+                // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                if (document is null)
+                    return ImmutableArray<InheritanceMarginItem>.Empty;
+
                 var service = document.GetRequiredLanguageService<IInheritanceMarginService>();
                 return await service.GetInheritanceMemberItemsAsync(document, spanToSearch, includeGlobalImports, frozenPartialSemantics, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
@@ -29,8 +29,12 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunServiceAsync(solutionChecksum, async solution =>
             {
-                var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
-                Contract.ThrowIfNull(document);
+                // https://github.com/dotnet/roslyn/issues/69964
+                //
+                // Remove this once we solve root cause issue of the hosts disagreeing on source generated documents.
+                var document = await solution.GetRequiredDocumentIncludingSourceGeneratedAsync(documentId, throwForMissingSourceGenerated: false, cancellationToken).ConfigureAwait(false);
+                if (document is null)
+                    return ImmutableArray<SerializableNavigationBarItem>.Empty;
 
                 if (forceFrozenPartialSemanticsForCrossProcessOperations)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -35,5 +35,20 @@ namespace Roslyn.Utilities
 
             return result.ToImmutableAndClear();
         }
+
+        public static ImmutableArray<T> WhereNotNull<T>(this ImmutableArray<T?> array) where T : struct
+        {
+            var count = array.Count(static t => t != null);
+
+            using var _ = ArrayBuilder<T>.GetInstance(count, out var result);
+
+            foreach (var value in array)
+            {
+                if (value != null)
+                    result.Add(value.Value);
+            }
+
+            return result.ToImmutableAndClear();
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ISolutionExtensions.cs
@@ -50,11 +50,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => solution.GetDocument(documentId) ?? throw CreateDocumentNotFoundException();
 
 #if !CODE_STYLE
+
+        public static ValueTask<Document?> GetRequiredDocumentIncludingSourceGeneratedAsync(
+            this Solution solution,
+            DocumentId documentId,
+            CancellationToken cancellationToken)
+            => GetRequiredDocumentIncludingSourceGeneratedAsync(solution, documentId, throwForMissingSourceGenerated: true, cancellationToken);
+
         public static async ValueTask<Document?> GetRequiredDocumentIncludingSourceGeneratedAsync(
             this Solution solution,
             DocumentId documentId,
-            bool throwForMissingSourceGenerated = true,
-            CancellationToken cancellationToken = default)
+            bool throwForMissingSourceGenerated,
+            CancellationToken cancellationToken)
         {
             var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
We're seeing a lot of crashes in the wild where the local VS workspace and the Remote OOP workspace disagree on what trees are present within each other (for example, in https://github.com/dotnet/roslyn/issues/69234).

When looking at these crashes, we commonly see stuff like:

![image](https://github.com/dotnet/roslyn/assets/4564579/4d16b80c-5fc7-4397-bc7b-4bffc6157cb2)

indicating that this is an issue primarily with SG docs.  Our theory (which we are still collecting data/dumps on) is that there is either a bug in our workspace in terms of how we generate SG docs, or there is a buggy SG out there which doesn't operate deterministically.  In either event, the two hosts could then see a different set of documents, which would then cause these crashes.

To address this, we've made a larger/riskier change in main here https://github.com/dotnet/roslyn/pull/69917 to make it so that the local VS workspace always defers to the remote workspace for SG contents.  This should ensure that there is no way for these systems to be out of sync.

However, we do not want to port a large/risky change like that back to 17.7.  So, instead we're considering mitigating the issue in 17.7 such that the features that are currently affected make themselves resilient to this scenario.  This is not something we want to be in 17.8, so if this is accepted, we will undo this change there and only take the full fix.  

When this flows into main, we will want to keep the first commit, which corresponds to https://github.com/dotnet/roslyn/pull/69952.

We will not want to keep the second commit.