### PR TITLE
Temp fix to bring vsmac package

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -43,6 +43,7 @@
       "Microsoft.CodeAnalysis.InteractiveHost": "vssdk",
       "Microsoft.CodeAnalysis.VisualBasic.EditorFeatures": "vssdk",
       "Microsoft.CodeAnalysis.EditorFeatures.Wpf": "vssdk",
+      "Microsoft.CodeAnalysis.EditorFeatures.Cocoa": "vssdk",
       "Microsoft.VisualStudio.IntegrationTest.Utilities": "vs-impl",
       "Microsoft.VisualStudio.LanguageServices.DevKit": "npm",
       "Microsoft.CodeAnalysis.LanguageServer": "vs-impl",


### PR DESCRIPTION
This would unblock 17.7 build so that we can ship https://github.com/dotnet/roslyn/pull/69921
It is a temp fix.
In the longer run, because vsmac only lives in 17.6 branch. We should port https://github.com/dotnet/roslyn/pull/69765 to 17.7 and 17.8 branch. Then move the nuget publish data to a different file (branch based, not always read from main)