### PR TITLE
[Performance] Reduce array allocations of BadArguments

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -89,21 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ArgsToParamsOpt[arg];
         }
 
-        public int FirstBadArgument
-        {
-            get
-            {
-                for (int i = 0; i < BadArguments.Capacity; i++)
-                {
-                    if (BadArguments[i])
-                    {
-                        return i;
-                    }
-                }
-
-                throw ExceptionUtilities.Unreachable();
-            }
-        }
+        public int FirstBadArgument => BadArguments.TrueBits().First();
 
         // A method may be applicable, but worse than another method.
         public bool IsApplicable

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// For example, if a method overload has 5 parameters and the second parameter is the only bad parameter, then this
         /// BitVector could end up with Capacity being 2 where BadArguments[0] is false and BadArguments[1] is true.
         /// </remarks>
-        public readonly BitVector BadArguments;
+        public readonly BitVector BadArgumentsOpt;
         public readonly ImmutableArray<int> ArgsToParamsOpt;
         public readonly ImmutableArray<TypeParameterDiagnosticInfo> ConstraintFailureDiagnostics;
 
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private MemberAnalysisResult(
             MemberResolutionKind kind,
-            BitVector badArguments = default,
+            BitVector badArgumentsOpt = default,
             ImmutableArray<int> argsToParamsOpt = default,
             ImmutableArray<Conversion> conversionsOpt = default,
             int missingParameter = -1,
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt = default)
         {
             this.Kind = kind;
-            this.BadArguments = badArguments;
+            this.BadArgumentsOpt = badArgumentsOpt;
             this.ArgsToParamsOpt = argsToParamsOpt;
             this.ConversionsOpt = conversionsOpt;
             this.BadParameter = missingParameter;
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ArgsToParamsOpt[arg];
         }
 
-        public int FirstBadArgument => BadArguments.TrueBits().First();
+        public int FirstBadArgument => BadArgumentsOpt.TrueBits().First();
 
         // A method may be applicable, but worse than another method.
         public bool IsApplicable
@@ -182,35 +182,35 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.NameUsedForPositional,
-                badArguments: CreateBadArgumentsWithPosition(argumentPosition));
+                badArgumentsOpt: CreateBadArgumentsWithPosition(argumentPosition));
         }
 
         public static MemberAnalysisResult BadNonTrailingNamedArgument(int argumentPosition)
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.BadNonTrailingNamedArgument,
-                badArguments: CreateBadArgumentsWithPosition(argumentPosition));
+                badArgumentsOpt: CreateBadArgumentsWithPosition(argumentPosition));
         }
 
         public static MemberAnalysisResult NoCorrespondingParameter(int argumentPosition)
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.NoCorrespondingParameter,
-                badArguments: CreateBadArgumentsWithPosition(argumentPosition));
+                badArgumentsOpt: CreateBadArgumentsWithPosition(argumentPosition));
         }
 
         public static MemberAnalysisResult NoCorrespondingNamedParameter(int argumentPosition)
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.NoCorrespondingNamedParameter,
-                badArguments: CreateBadArgumentsWithPosition(argumentPosition));
+                badArgumentsOpt: CreateBadArgumentsWithPosition(argumentPosition));
         }
 
         public static MemberAnalysisResult DuplicateNamedArgument(int argumentPosition)
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.DuplicateNamedArgument,
-                badArguments: CreateBadArgumentsWithPosition(argumentPosition));
+                badArgumentsOpt: CreateBadArgumentsWithPosition(argumentPosition));
         }
 
         internal static BitVector CreateBadArgumentsWithPosition(int argumentPosition)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3708,7 +3708,7 @@ outerDefault:
             // * for a ref or out parameter, the type of the argument is identical to the type of the corresponding 
             //   parameter. After all, a ref or out parameter is an alias for the argument passed.
             ArrayBuilder<Conversion> conversions = null;
-            ArrayBuilder<int> badArguments = null;
+            BitVector badArguments = default;
             for (int argumentPosition = 0; argumentPosition < paramCount; argumentPosition++)
             {
                 BoundExpression argument = arguments.Argument(argumentPosition);
@@ -3723,8 +3723,12 @@ outerDefault:
                     }
                     else
                     {
-                        badArguments = badArguments ?? ArrayBuilder<int>.GetInstance();
-                        badArguments.Add(argumentPosition);
+                        if (badArguments == default)
+                        {
+                            badArguments = BitVector.Create(paramCount);
+                        }
+
+                        badArguments[argumentPosition] = true;
                         conversion = Conversion.NoConversion;
                     }
                 }
@@ -3777,15 +3781,19 @@ outerDefault:
                         // lambda binding in particular, for instance, with LINQ expressions.
                         // Note that BuildArgumentsForErrorRecovery will still bind some number
                         // of overloads for the semantic model.
-                        Debug.Assert(badArguments == null);
+                        Debug.Assert(badArguments == default);
                         Debug.Assert(conversions == null);
-                        return MemberAnalysisResult.BadArgumentConversions(argsToParameters, ImmutableArray.Create(argumentPosition), ImmutableArray.Create(conversion));
+                        return MemberAnalysisResult.BadArgumentConversions(argsToParameters, MemberAnalysisResult.CreateBadArgumentsWithPosition(argumentPosition), ImmutableArray.Create(conversion));
                     }
 
                     if (!conversion.Exists)
                     {
-                        badArguments ??= ArrayBuilder<int>.GetInstance();
-                        badArguments.Add(argumentPosition);
+                        if (badArguments == default)
+                        {
+                            badArguments = BitVector.Create(paramCount);
+                        }
+
+                        badArguments[argumentPosition] = true;
                     }
                 }
 
@@ -3800,7 +3808,7 @@ outerDefault:
                     conversions.Add(conversion);
                 }
 
-                if (badArguments != null && !completeResults)
+                if (badArguments != default && !completeResults)
                 {
                     break;
                 }
@@ -3808,9 +3816,9 @@ outerDefault:
 
             MemberAnalysisResult result;
             var conversionsArray = conversions != null ? conversions.ToImmutableAndFree() : default(ImmutableArray<Conversion>);
-            if (badArguments != null)
+            if (badArguments != default)
             {
-                result = MemberAnalysisResult.BadArgumentConversions(argsToParameters, badArguments.ToImmutableAndFree(), conversionsArray);
+                result = MemberAnalysisResult.BadArgumentConversions(argsToParameters, badArguments, conversionsArray);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3781,7 +3781,7 @@ outerDefault:
                         // lambda binding in particular, for instance, with LINQ expressions.
                         // Note that BuildArgumentsForErrorRecovery will still bind some number
                         // of overloads for the semantic model.
-                        Debug.Assert(badArguments == default);
+                        Debug.Assert(badArguments.IsNull);
                         Debug.Assert(conversions == null);
                         return MemberAnalysisResult.BadArgumentConversions(argsToParameters, MemberAnalysisResult.CreateBadArgumentsWithPosition(argumentPosition), ImmutableArray.Create(conversion));
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3788,9 +3788,9 @@ outerDefault:
 
                     if (!conversion.Exists)
                     {
-                        if (badArguments == default)
+                        if (badArguments.IsNull)
                         {
-                            badArguments = BitVector.Create(paramCount);
+                            badArguments = BitVector.Create(argumentPosition + 1);
                         }
 
                         badArguments[argumentPosition] = true;
@@ -3808,7 +3808,7 @@ outerDefault:
                     conversions.Add(conversion);
                 }
 
-                if (badArguments != default && !completeResults)
+                if (!badArguments.IsNull && !completeResults)
                 {
                     break;
                 }
@@ -3816,7 +3816,7 @@ outerDefault:
 
             MemberAnalysisResult result;
             var conversionsArray = conversions != null ? conversions.ToImmutableAndFree() : default(ImmutableArray<Conversion>);
-            if (badArguments != default)
+            if (!badArguments.IsNull)
             {
                 result = MemberAnalysisResult.BadArgumentConversions(argsToParameters, badArguments, conversionsArray);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3725,7 +3725,7 @@ outerDefault:
                     {
                         if (badArguments.IsNull)
                         {
-                            badArguments = BitVector.Create(paramCount);
+                            badArguments = BitVector.Create(argumentPosition + 1);
                         }
 
                         badArguments[argumentPosition] = true;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3723,7 +3723,7 @@ outerDefault:
                     }
                     else
                     {
-                        if (badArguments == default)
+                        if (badArguments.IsNull)
                         {
                             badArguments = BitVector.Create(paramCount);
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -6,8 +6,8 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     case MemberResolutionKind.NoCorrespondingNamedParameter:
                         if (supportedInPriorityOrder[noCorrespondingNamedParameterPriority].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[noCorrespondingNamedParameterPriority].Result.BadArgumentsOpt[0])
+                            result.Result.FirstBadArgument > supportedInPriorityOrder[noCorrespondingNamedParameterPriority].Result.FirstBadArgument)
                         {
                             supportedInPriorityOrder[noCorrespondingNamedParameterPriority] = result;
                         }
@@ -420,14 +420,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     case MemberResolutionKind.NameUsedForPositional:
                         if (supportedInPriorityOrder[nameUsedForPositionalPriority].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[nameUsedForPositionalPriority].Result.BadArgumentsOpt[0])
+                            result.Result.FirstBadArgument > supportedInPriorityOrder[nameUsedForPositionalPriority].Result.FirstBadArgument)
                         {
                             supportedInPriorityOrder[nameUsedForPositionalPriority] = result;
                         }
                         break;
                     case MemberResolutionKind.BadNonTrailingNamedArgument:
                         if (supportedInPriorityOrder[badNonTrailingNamedArgumentPriority].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[badNonTrailingNamedArgumentPriority].Result.BadArgumentsOpt[0])
+                            result.Result.FirstBadArgument > supportedInPriorityOrder[badNonTrailingNamedArgumentPriority].Result.FirstBadArgument)
                         {
                             supportedInPriorityOrder[badNonTrailingNamedArgumentPriority] = result;
                         }
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case MemberResolutionKind.DuplicateNamedArgument:
                         {
                             if (supportedInPriorityOrder[duplicateNamedArgumentPriority].IsNull ||
-                            result.Result.BadArgumentsOpt[0] > supportedInPriorityOrder[duplicateNamedArgumentPriority].Result.BadArgumentsOpt[0])
+                            result.Result.FirstBadArgument > supportedInPriorityOrder[duplicateNamedArgumentPriority].Result.FirstBadArgument)
                             {
                                 supportedInPriorityOrder[duplicateNamedArgumentPriority] = result;
                             }
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (firstSupported.Member is FunctionPointerMethodSymbol
                     && firstSupported.Result.Kind == MemberResolutionKind.NoCorrespondingNamedParameter)
                 {
-                    int badArg = firstSupported.Result.BadArgumentsOpt[0];
+                    int badArg = firstSupported.Result.FirstBadArgument;
                     Debug.Assert(arguments.Names[badArg].HasValue);
                     Location badName = arguments.Names[badArg].GetValueOrDefault().Location;
                     diagnostics.Add(ErrorCode.ERR_FunctionPointersCannotBeCalledWithNamedArguments, badName);
@@ -771,7 +771,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments arguments,
             ImmutableArray<Symbol> symbols)
         {
-            int badArg = bad.Result.BadArgumentsOpt[0];
+            int badArg = bad.Result.FirstBadArgument;
             // We would not have gotten this error had there not been a named argument.
             Debug.Assert(arguments.Names.Count > badArg);
             Debug.Assert(arguments.Names[badArg].HasValue);
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments arguments,
             ImmutableArray<Symbol> symbols)
         {
-            int badArg = bad.Result.BadArgumentsOpt[0];
+            int badArg = bad.Result.FirstBadArgument;
             // We would not have gotten this error had there not been a named argument.
             Debug.Assert(arguments.Names.Count > badArg);
             Debug.Assert(arguments.Names[badArg].HasValue);
@@ -807,9 +807,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void ReportDuplicateNamedArgument(MemberResolutionResult<TMember> result, BindingDiagnosticBag diagnostics, AnalyzedArguments arguments)
         {
-            Debug.Assert(result.Result.BadArgumentsOpt.Length == 1);
-            Debug.Assert(arguments.Names[result.Result.BadArgumentsOpt[0]].HasValue);
-            (string name, Location location) = arguments.Names[result.Result.BadArgumentsOpt[0]].GetValueOrDefault();
+            Debug.Assert(result.Result.BadArguments.TrueBits().Any());
+            Debug.Assert(arguments.Names[result.Result.FirstBadArgument].HasValue);
+            (string name, Location location) = arguments.Names[result.Result.FirstBadArgument].GetValueOrDefault();
             Debug.Assert(name != null);
 
             // CS: Named argument '{0}' cannot be specified multiple times
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // call was inapplicable because there was a bad name, that's a candidate
             // for the "best" overload.
 
-            int badArg = bad.Result.BadArgumentsOpt[0];
+            int badArg = bad.Result.FirstBadArgument;
             // We would not have gotten this error had there not been a named argument.
             Debug.Assert(arguments.Names.Count > badArg);
             Debug.Assert(arguments.Names[badArg].HasValue);
@@ -1106,7 +1106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_BadArgTypesForCollectionAdd, location, symbols, method);
             }
 
-            foreach (var arg in badArg.Result.BadArgumentsOpt)
+            foreach (var arg in badArg.Result.BadArguments.TrueBits())
             {
                 ReportBadArgumentError(diagnostics, binder, name, arguments, symbols, badArg, method, arg);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void ReportDuplicateNamedArgument(MemberResolutionResult<TMember> result, BindingDiagnosticBag diagnostics, AnalyzedArguments arguments)
         {
-            Debug.Assert(result.Result.BadArguments.TrueBits().Count() == 1);
+            Debug.Assert(result.Result.BadArgumentsOpt.TrueBits().Count() == 1);
             Debug.Assert(arguments.Names[result.Result.FirstBadArgument].HasValue);
             (string name, Location location) = arguments.Names[result.Result.FirstBadArgument].GetValueOrDefault();
             Debug.Assert(name != null);
@@ -1106,7 +1106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_BadArgTypesForCollectionAdd, location, symbols, method);
             }
 
-            foreach (var arg in badArg.Result.BadArguments.TrueBits())
+            foreach (var arg in badArg.Result.BadArgumentsOpt.TrueBits())
             {
                 ReportBadArgumentError(diagnostics, binder, name, arguments, symbols, badArg, method, arg);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void ReportDuplicateNamedArgument(MemberResolutionResult<TMember> result, BindingDiagnosticBag diagnostics, AnalyzedArguments arguments)
         {
-            Debug.Assert(result.Result.BadArguments.TrueBits().Any());
+            Debug.Assert(result.Result.BadArguments.TrueBits().Count() == 1);
             Debug.Assert(arguments.Names[result.Result.FirstBadArgument].HasValue);
             (string name, Location location) = arguments.Names[result.Result.FirstBadArgument].GetValueOrDefault();
             Debug.Assert(name != null);


### PR DESCRIPTION
Fixes #69969

This moves BadArguments from int array to a BitVector. This will eliminate allocations for most cases.

So, instead of having an array containing the indices of the bad arguments, we now create a BitVector whose true bits represent the bad arguments. This will eliminate the allocations pointed out in the linked issue.

The BitVector is not going to allocate for the vast majority of cases.