### PR TITLE
[Performance] Avoid 1GB of Enumerator boxing allocations

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -3156,7 +3156,7 @@ OuterBreak:
             // Not using builder.AddRange here because the dictionary values enumerator is a struct, and calling AddRange will have to box the enumerator.
             // Instead, we increase the builder capacity, then loop over the values.
             // Also, we don't access candidates.Values to avoid realizing the Dictionary's internal ValueCollection (it's created lazily when Values is accessed)
-            builder.Count += candidates.Count;
+            builder.EnsureCapacity(builder.Count + candidates.Count);
             foreach (var (_, value) in candidates)
             {
                 builder.Add(value);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -3153,7 +3153,14 @@ OuterBreak:
 
         private static void GetAllCandidates(Dictionary<TypeWithAnnotations, TypeWithAnnotations> candidates, ArrayBuilder<TypeWithAnnotations> builder)
         {
-            builder.AddRange(candidates.Values);
+            // Not using builder.AddRange here because the dictionary values enumerator is a struct, and calling AddRange will have to box the enumeartor.
+            // Instead, we increase the builder capacity, then loop over the values.
+            var values = candidates.Values;
+            builder.Count += values.Count;
+            foreach (var value in values)
+            {
+                builder.Add(value);
+            }
         }
 
         private static void AddAllCandidates(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -3155,9 +3155,9 @@ OuterBreak:
         {
             // Not using builder.AddRange here because the dictionary values enumerator is a struct, and calling AddRange will have to box the enumeartor.
             // Instead, we increase the builder capacity, then loop over the values.
-            var values = candidates.Values;
-            builder.Count += values.Count;
-            foreach (var value in values)
+            // Also, we don't access candidates.Values to avoid realizing the Dictionary's internal ValueCollection (it's created lazily when Values is accessed)
+            builder.Count += candidates.Count;
+            foreach (var (_, value) in candidates)
             {
                 builder.Add(value);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -3153,7 +3153,7 @@ OuterBreak:
 
         private static void GetAllCandidates(Dictionary<TypeWithAnnotations, TypeWithAnnotations> candidates, ArrayBuilder<TypeWithAnnotations> builder)
         {
-            // Not using builder.AddRange here because the dictionary values enumerator is a struct, and calling AddRange will have to box the enumeartor.
+            // Not using builder.AddRange here because the dictionary values enumerator is a struct, and calling AddRange will have to box the enumerator.
             // Instead, we increase the builder capacity, then loop over the values.
             // Also, we don't access candidates.Values to avoid realizing the Dictionary's internal ValueCollection (it's created lazily when Values is accessed)
             builder.Count += candidates.Count;


### PR DESCRIPTION
![image](https://github.com/dotnet/roslyn/assets/31348972/1c2cc3ae-27a5-4350-a8bb-370e1ce7f0fd)

This is during a ~1.5 minute trace. 1GB of enumerator allocations appears to be a lot.

In addition, there are ~250MB allocations of ValueCollection. This is eliminated by avoiding the access to `Dictionary<TKey,TValue>.Values`

![image](https://github.com/dotnet/roslyn/assets/31348972/7e5ce01f-b7ee-44e0-bfcf-e998e07e4bf7)
