### PR TITLE
[Performance] Avoid 500MB of HashSet enumerator allocations calling `Any`

### DIFF
--- a/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
@@ -30,6 +30,10 @@ namespace Microsoft.CodeAnalysis
             return hashSet.Add(item);
         }
 
+        /// <summary>
+        /// This extension method is added so that it's preferred over LINQ's Any.
+        /// This is more efficient than LINQ, especially in that it avoids the enumerator boxing allocation.
+        /// </summary>
         internal static bool Any<T>(this HashSet<T> hashSet, Func<T, bool> predicate)
         {
             foreach (var item in hashSet)

--- a/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/HashSetExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -27,6 +28,19 @@ namespace Microsoft.CodeAnalysis
             }
 
             return hashSet.Add(item);
+        }
+
+        internal static bool Any<T>(this HashSet<T> hashSet, Func<T, bool> predicate)
+        {
+            foreach (var item in hashSet)
+            {
+                if (predicate(item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
![image](https://github.com/dotnet/roslyn/assets/31348972/e886f6f9-c92c-4061-b39c-23837495e570)

The new extension method is now picked instead of LINQ Any.