### PR TITLE
Handle property without accessors in `Binder.ReceiverIsSubjectToCloning`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1197,7 +1197,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 #nullable enable
 
         internal ThreeState ReceiverIsSubjectToCloning(BoundExpression? receiver, PropertySymbol property)
-            => ReceiverIsSubjectToCloning(receiver, property.GetMethod ?? property.SetMethod);
+        {
+            var method = property.GetMethod ?? property.SetMethod;
+
+            // Property might be missing accessors in invalid code.
+            if (method is null)
+            {
+                return ThreeState.False;
+            }
+
+            return ReceiverIsSubjectToCloning(receiver, method);
+        }
 
         internal ThreeState ReceiverIsSubjectToCloning(BoundExpression? receiver, MethodSymbol method)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/69997.