### PR TITLE
Optimize allocations in TextReader.ReadToEnd utilized by SourceText.From

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/TextFactory/TextFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TextFactory/TextFactoryService.cs
@@ -32,7 +32,9 @@ namespace Microsoft.CodeAnalysis.Host
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return SourceText.From(reader.ReadToEnd(), encoding, checksumAlgorithm);
+            return (reader is TextReaderWithLength textReaderWithLength)
+                ? SourceText.From(textReaderWithLength, textReaderWithLength.Length, encoding, checksumAlgorithm)
+                : SourceText.From(reader.ReadToEnd(), encoding, checksumAlgorithm);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/TextFactory/TextFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TextFactory/TextFactoryService.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.Host
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return (reader is TextReaderWithLength textReaderWithLength)
-                ? SourceText.From(textReaderWithLength, textReaderWithLength.Length, encoding, checksumAlgorithm)
-                : SourceText.From(reader.ReadToEnd(), encoding, checksumAlgorithm);
+            return SourceText.From(reader.ReadToEnd(), encoding, checksumAlgorithm);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/TextReaderWithLength.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/TextReaderWithLength.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
@@ -11,5 +9,18 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     internal abstract class TextReaderWithLength(int length) : TextReader
     {
         public int Length { get; } = length;
+
+        public override string ReadToEnd()
+        {
+#if NETCOREAPP
+            return string.Create(Length, this, static (chars, state) => state.Read(chars));
+#else
+            var chars = new char[Length];
+
+            var read = base.Read(chars, 0, Length);
+
+            return new string(chars, 0, read);
+#endif                
+        }
     }
 }


### PR DESCRIPTION
The profile I'm looking currently shows 9.4% of allocation in our codeanalysis process under SourceText.From. These allocations occur during the TextReader.ReadToEnd call. Fortunately, Roslyn is already passing in a TextReader that knows it's length, and thus we can optimize this path.

In netfx, this should at least get rid of the extra sizing allocations done during TextReader.ReadToEnd as it appends to it's internal stringbuilder. So, this should see a reduction of about 20% of the allocations in this codepath.

In netcore (which is the case for this profile), we do better as this essentially gets rid of all allocations except for the equivalent of the StringBuilder.ToString call. So, this should see a reduction of about 2/3 of the allocations of this codepath.

![image](https://github.com/dotnet/roslyn/assets/6785178/68486fa6-4355-4737-b7e3-a5d70ad960ce)