### PR TITLE
Add support for navigating to the definition of the target label of a `goto`

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -3531,7 +3531,7 @@ namespace System
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
         Public Async Function TestCSharpGoToDefinition_GotoLabel01() As Task
             Dim workspace =
 <Workspace>
@@ -3560,7 +3560,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
         Public Async Function TestCSharpGoToDefinition_GotoSwitchDefaultLabel01() As Task
             Dim workspace =
 <Workspace>
@@ -3588,7 +3588,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
         Public Async Function TestCSharpGoToDefinition_GotoSwitchDefaultLabel02() As Task
             Dim workspace =
 <Workspace>
@@ -3616,7 +3616,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
         Public Async Function TestCSharpGoToDefinition_GotoSwitchCaseLabel01() As Task
             Dim workspace =
 <Workspace>
@@ -3644,7 +3644,7 @@ class Program
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
         Public Async Function TestCSharpGoToDefinition_GotoSwitchCaseLabel02() As Task
             Dim workspace =
 <Workspace>

--- a/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/CSharpGoToDefinitionTests.vb
@@ -3530,5 +3530,146 @@ namespace System
 
             Await TestAsync(workspace)
         End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        Public Async Function TestCSharpGoToDefinition_GotoLabel01() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#">
+        <Document>
+class Program
+{
+    public void Compare(string[] a, string[] b)
+    {
+        foreach (var x in a)
+        {
+            foreach (var y in b)
+            {
+                if (x.Length > y.Length)
+                    $$goto end;
+            }
+        }
+    [||]end:
+        ;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        Public Async Function TestCSharpGoToDefinition_GotoSwitchDefaultLabel01() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#">
+        <Document>
+class Program
+{
+    public void Method(int argument)
+    {
+        switch (argument)
+        {
+            case 1:
+                $$goto default;
+            case 2:
+                goto case 1;
+            [||]default:
+                break;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        Public Async Function TestCSharpGoToDefinition_GotoSwitchDefaultLabel02() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#">
+        <Document>
+class Program
+{
+    public void Method(int argument)
+    {
+        switch (argument)
+        {
+            case 1:
+                goto $$default;
+            case 2:
+                goto case 1;
+            [||]default:
+                break;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        Public Async Function TestCSharpGoToDefinition_GotoSwitchCaseLabel01() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#">
+        <Document>
+class Program
+{
+    public void Method(int argument)
+    {
+        switch (argument)
+        {
+            [||]case 1:
+                goto default;
+            case 2:
+                $$goto case 1;
+            default:
+                break;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/37842")>
+        Public Async Function TestCSharpGoToDefinition_GotoSwitchCaseLabel02() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#">
+        <Document>
+class Program
+{
+    public void Method(int argument)
+    {
+        switch (argument)
+        {
+            [||]case 1:
+                goto default;
+            case 2:
+                goto $$case 1;
+            default:
+                break;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/VisualBasicGoToDefinitionTests.vb
@@ -1565,5 +1565,93 @@ end class
 
             Await TestAsync(workspace)
         End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
+        Public Async Function TestVisualBasicGoToDefinition_GoToLabel01() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Using System
+
+Public Class C
+    Public Sub Method(parameter As Integer)
+
+        If parameter = 1 Then
+            $$GoTo label
+        End If
+
+        Console.WriteLine(parameter)
+
+[||]label:
+        Return
+
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
+        Public Async Function TestVisualBasicGoToDefinition_GoToLabel02() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Using System
+
+Public Class C
+    Public Sub Method(parameter As Integer)
+
+        If parameter = 1 Then
+            $$GoTo 150
+        End If
+
+        Console.WriteLine(parameter)
+
+[||]150:
+        Return
+
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69916")>
+        Public Async Function TestVisualBasicGoToDefinition_GoToLabel03() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Using System
+
+Public Class C
+    Public Sub Method(parameter As Integer)
+
+        If parameter = 1 Then
+            $$GoTo 150
+        End If
+
+        Console.WriteLine(parameter)
+
+label:
+[||]150:
+        Return
+
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -75,15 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
                 case SyntaxKind.DefaultKeyword:
                 case SyntaxKind.CaseKeyword:
                     {
-                        var foundAccessibleLabel = TryFindAccessibleLabel(node);
-                        if (foundAccessibleLabel is null)
-                            return null;
-
-                        var symbol = semanticModel.GetDeclaredSymbol(foundAccessibleLabel);
-                        if (symbol is null)
-                            return null;
-
-                        return symbol.Locations.FirstOrDefault()?.SourceSpan.Start ?? 0;
+                        return TryFindAccessibleLabel(node)?.SpanStart;
                     }
             }
 

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -76,6 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
                 case SyntaxKind.CaseKeyword:
                     {
                         var foundAccessibleLabel = TryFindAccessibleLabel(node);
+                        if (foundAccessibleLabel is null)
                             return null;
 
                         var symbol = semanticModel.GetDeclaredSymbol(foundAccessibleLabel);
@@ -137,36 +138,18 @@ namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
                 return node;
             }
 
-            SyntaxNode? TryFindAccessibleLabel(SyntaxNode? node)
+            SyntaxNode? TryFindAccessibleLabel(SyntaxNode node)
             {
-                var statement = node?.FirstAncestorOrSelf<GotoStatementSyntax>();
+                var statement = node.FirstAncestorOrSelf<GotoStatementSyntax>();
                 if (statement is null)
-                {
                     return null;
-                }
 
-                var gotoOperation = semanticModel.GetOperation(statement) as IBranchOperation;
+                if (semanticModel.GetOperation(statement) is not IBranchOperation gotoOperation)
+                    return null;
+
                 Debug.Assert(gotoOperation is { BranchKind: BranchKind.GoTo });
                 var target = gotoOperation.Target;
-
-                var expression = statement.Expression;
-                string? name = null;
-                switch (expression)
-                {
-                    case IdentifierNameSyntax identifier:
-                        name = identifier.Identifier.ValueText;
-                        break;
-                }
-
-                var availableLabels = semanticModel.LookupLabels(node!.SpanStart, name);
-
-                if (availableLabels.Contains(target))
-                {
-                    var syntax = target.DeclaringSyntaxReferences.First().GetSyntax();
-                    return syntax;
-                }
-
-                return null;
+                return target.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
             }
         }
     }

--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -76,16 +76,11 @@ namespace Microsoft.CodeAnalysis.CSharp.GoToDefinition
                 case SyntaxKind.CaseKeyword:
                     {
                         var foundAccessibleLabel = TryFindAccessibleLabel(node);
-                        if (foundAccessibleLabel is null)
-                        {
                             return null;
-                        }
 
                         var symbol = semanticModel.GetDeclaredSymbol(foundAccessibleLabel);
                         if (symbol is null)
-                        {
                             return null;
-                        }
 
                         return symbol.Locations.FirstOrDefault()?.SourceSpan.Start ?? 0;
                     }

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
@@ -61,9 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
             Select Case node.Kind()
                 Case SyntaxKind.GoToStatement
                     Dim goToStatement = DirectCast(node, GoToStatementSyntax)
-                    Dim labelToken = goToStatement.Label.LabelToken
-                    Dim labelIdentifier As String = labelToken.ValueText
-
+                    Dim labelIdentifier = goToStatement.Label.LabelToken.ValueText
                     If labelIdentifier Is Nothing Then
                         Return Nothing
                     End If

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
 
             Dim labelTarget = TryGetLabelTarget(semanticModel, node)
             If labelTarget IsNot Nothing Then
-                Return labelTarget.GetFirstToken().Span.Start
+                Return labelTarget.SpanStart
             End If
 
             Return Nothing

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
@@ -50,28 +50,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
                 Return exitTarget.GetLastToken().Span.End
             End If
 
-            Dim labelTarget = TryGetLabelTarget(semanticModel, node)
-            If labelTarget IsNot Nothing Then
-                Return labelTarget.SpanStart
+            If node.IsKind(SyntaxKind.GoToStatement) Then
+                Dim goToStatement = DirectCast(node, GoToStatementSyntax)
+
+                Dim gotoOperation = DirectCast(semanticModel.GetOperation(goToStatement), IBranchOperation)
+                If gotoOperation Is Nothing Then
+                    Return Nothing
+                End If
+
+                Debug.Assert(gotoOperation.BranchKind = BranchKind.GoTo)
+                Dim target = gotoOperation.Target
+                Return target.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()?.SpanStart
             End If
-
-            Return Nothing
-        End Function
-
-        Private Shared Function TryGetLabelTarget(semanticModel As SemanticModel, node As SyntaxNode) As SyntaxNode
-            Select Case node.Kind()
-                Case SyntaxKind.GoToStatement
-                    Dim goToStatement = DirectCast(node, GoToStatementSyntax)
-
-                    Dim gotoOperation = DirectCast(semanticModel.GetOperation(goToStatement), IBranchOperation)
-                    If gotoOperation Is Nothing Then
-                        Return Nothing
-                    End If
-
-                    Debug.Assert(gotoOperation.BranchKind = BranchKind.GoTo)
-                    Dim target = gotoOperation.Target
-                    Return target.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
-            End Select
 
             Return Nothing
         End Function

--- a/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
+++ b/src/Features/VisualBasic/Portable/GoToDefinition/VisualBasicGoToDefinitionSymbolService.vb
@@ -5,6 +5,7 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.GoToDefinition
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Operations
 Imports Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -61,18 +62,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GoToDefinition
             Select Case node.Kind()
                 Case SyntaxKind.GoToStatement
                     Dim goToStatement = DirectCast(node, GoToStatementSyntax)
-                    Dim labelIdentifier = goToStatement.Label.LabelToken.ValueText
-                    If labelIdentifier Is Nothing Then
+
+                    Dim gotoOperation = DirectCast(semanticModel.GetOperation(goToStatement), IBranchOperation)
+                    If gotoOperation Is Nothing Then
                         Return Nothing
                     End If
 
-                    Dim labels = semanticModel.LookupLabels(node.SpanStart, labelIdentifier)
-                    If labels.Length = 0 Then
-                        Return Nothing
-                    End If
-
-                    Dim label = labels.First()
-                    Return label.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
+                    Debug.Assert(gotoOperation.BranchKind = BranchKind.GoTo)
+                    Dim target = gotoOperation.Target
+                    Return target.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()
             End Select
 
             Return Nothing


### PR DESCRIPTION
Closes #69916 

Adds support for both C# and VB. Using go to navigation on the keywords `goto`, `case` and `default` in a go to statement will navigate to the definition of the target label.