### PR TITLE
Initialize usage of ProjectDependencyGraph.Empty to start with a null reverseReferencesMap

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -56,10 +56,13 @@ namespace Microsoft.CodeAnalysis
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap;
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap;
 
+        // Intentionally created with a null reverseReferencesMap. Doing so indicates _lazyReverseReferencesMap
+        //  shouldn't be calculated until reverse reference information is requested. Once this information
+        //  has been calculated, forks of this PDG will calculate their new reverse references in a non-lazy fashion.
         internal static readonly ProjectDependencyGraph Empty = new(
             ImmutableHashSet<ProjectId>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
-            null,
+            reverseReferencesMap: null,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
             ImmutableArray<ProjectId>.Empty,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -56,9 +56,11 @@ namespace Microsoft.CodeAnalysis
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _transitiveReferencesMap;
         private ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>> _reverseTransitiveReferencesMap;
 
-        // Intentionally created with a null reverseReferencesMap. Doing so indicates _lazyReverseReferencesMap
-        //  shouldn't be calculated until reverse reference information is requested. Once this information
-        //  has been calculated, forks of this PDG will calculate their new reverse references in a non-lazy fashion.
+        /// <remarks>
+        ///   Intentionally created with a null reverseReferencesMap. Doing so indicates _lazyReverseReferencesMap
+        ///    shouldn't be calculated until reverse reference information is requested. Once this information
+        ///    has been calculated, forks of this PDG will calculate their new reverse references in a non-lazy fashion.
+        /// </remarks>
         internal static readonly ProjectDependencyGraph Empty = new(
             ImmutableHashSet<ProjectId>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly ProjectDependencyGraph Empty = new(
             ImmutableHashSet<ProjectId>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
-            ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
+            null,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
             ImmutableDictionary<ProjectId, ImmutableHashSet<ProjectId>>.Empty,
             ImmutableArray<ProjectId>.Empty,


### PR DESCRIPTION
Initialize usage of ProjectDependencyGraph.Empty to start with a null reverseReferencesMap

This map is intended to be delay calculated, but because of the way the static Empty object is created, it was causing all subsequent operations on the graph to immediately calculate their effect on the dependency graph's reverse references mapping.

Without this change, when opening Roslyn.slnI was seeing over 99% of ProjectDependencyGraph ctor calls with a populated reverseReferencesMap. With this change, it's around 15%.