### PR TITLE
Update msbuild locator to pick up fix to probe more SDK locations

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>8.1.1.7464</ICSharpCodeDecompilerVersion>
     <InputSimulatorPlusVersion>1.0.7</InputSimulatorPlusVersion>
-    <MicrosoftBuildLocatorVersion>1.6.1</MicrosoftBuildLocatorVersion>
+    <MicrosoftBuildLocatorVersion>1.6.10</MicrosoftBuildLocatorVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <!--
       SourceBuild will requires that all dependencies also be source buildable. We are referencing a


### PR DESCRIPTION
VSCode issue - https://github.com/dotnet/vscode-csharp/issues/6335

This new version of the locator will continue probing for SDK locations if it finds a `dotnet` runtime, but no SDKs