### PR TITLE
Prevent infinite lookup cycle through bases of a containing type of an enum or a delegate type.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // force resolution of bases in containing type
                     // to make base resolution errors more deterministic
-                    if ((object)ContainingType != null)
+                    if ((object)ContainingType != null &&
+                        TypeKind is not (TypeKind.Enum or TypeKind.Delegate or TypeKind.Submission))
                     {
                         var tmp = ContainingType.BaseTypeNoUseSiteDiagnostics;
                     }

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -189,11 +189,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case TypeKind.Interface:
                     return GetNextDeclaredBase((NamedTypeSymbol)type, basesBeingResolved, compilation, ref visited);
 
-                default:
-                    // Enums and delegates know their own base types
+                case TypeKind.Dynamic:
+                case TypeKind.Enum:
+                case TypeKind.Delegate:
+                case TypeKind.Array:
+                case TypeKind.Submission:
+                    // Enums, arrays, submissions and delegates know their own base types
                     // intrinsically (and do not include interface lists)
                     // so there is no possibility of a cycle.
                     return type.BaseTypeNoUseSiteDiagnostics;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case TypeKind.Delegate:
                 case TypeKind.Array:
                 case TypeKind.Submission:
+                case TypeKind.Pointer:
+                case TypeKind.FunctionPointer:
                     // Enums, arrays, submissions and delegates know their own base types
                     // intrinsically (and do not include interface lists)
                     // so there is no possibility of a cycle.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3371,6 +3371,233 @@ static class Extension2
             Assert.False(symbols.Where(s => s.Name == "MathMax3").Any());
         }
 
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_02()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal enum AnyEnum
+    {
+        Val
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_03()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal enum AnyEnum
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_04()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal class AnyEnum
+    {
+        static internal int Val;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27),
+                // (10,29): warning CS0649: Field 'AnyClass.AnyEnum.Val' is never assigned to, and will always have its default value 0
+                //         static internal int Val;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "Val").WithArguments("MyNamespace.AnyClass.AnyEnum.Val", "0").WithLocation(10, 29)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_05()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal class AnyEnum
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_06()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal struct AnyEnum
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_07()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal interface AnyEnum
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70027")]
+        public void UsingStatic_08()
+        {
+            var source =
+@"
+using static MyNamespace.AnyClass.AnyEnum.Val;
+
+namespace MyNamespace;
+
+internal class AnyClass : AnyBaseClass
+{
+    internal delegate void AnyEnum();
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static MyNamespace.AnyClass.AnyEnum.Val;").WithLocation(2, 1),
+                // (2,43): error CS0426: The type name 'Val' does not exist in the type 'AnyClass.AnyEnum'
+                // using static MyNamespace.AnyClass.AnyEnum.Val;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInAgg, "Val").WithArguments("Val", "MyNamespace.AnyClass.AnyEnum").WithLocation(2, 43),
+                // (6,27): error CS0246: The type or namespace name 'AnyBaseClass' could not be found (are you missing a using directive or an assembly reference?)
+                // internal class AnyClass : AnyBaseClass
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "AnyBaseClass").WithArguments("AnyBaseClass").WithLocation(6, 27)
+                );
+        }
+
         [Fact, WorkItem(30726, "https://github.com/dotnet/roslyn/issues/30726")]
         public void UsingStaticGenericConstraint()
         {


### PR DESCRIPTION
Fixes #70027.