### PR TITLE
Update Microsoft.DevDiv.Optimization.Data.PowerShell to 1.0803

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,7 +97,7 @@
     <MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>3.3.0</MicrosoftCodeAnalysisAnalyzerUtilitiesVersion>
     <MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>3.3.4-beta1.22504.1</MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion>
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>
-    <MicrosoftDevDivOptimizationDataPowerShellVersion>1.0.339</MicrosoftDevDivOptimizationDataPowerShellVersion>
+    <MicrosoftDevDivOptimizationDataPowerShellVersion>1.0.803</MicrosoftDevDivOptimizationDataPowerShellVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -333,7 +333,7 @@ function GetIbcDropName() {
     }
 
     # Bring in the ibc tools
-    $packagePath = Join-Path (Get-PackageDir "Microsoft.DevDiv.Optimization.Data.PowerShell") "lib\net461"
+    $packagePath = Join-Path (Get-PackageDir "Microsoft.DevDiv.Optimization.Data.PowerShell") "lib\net472"
     Import-Module (Join-Path $packagePath "Optimization.Data.PowerShell.dll")
 
     # Find the matching drop


### PR DESCRIPTION
Microsoft.DevDiv.Optimization.Data.PowerShell 1.0.339 has a dependencies 
-> Microsoft.VisualStudio.Services.InteractiveClient (≥ 16.150.0-preview) -> Microsoft.VisualStudio.Services.InteractiveClient 16.150.0-preview -> Microsoft.IdentityModel.Clients.ActiveDirectory (≥ 3.17.2)
And ` Microsoft.IdentityModel.Clients.ActiveDirectory` is deprecated, it will soon block our signed CI.

Update this to 1.0803, it updates the dependency to Microsoft.VisualStudio.Services.InteractiveClient (≥ 19.210.0-preview)
 -> Microsoft.Identity.Client  (New package)