### PR TITLE
Avoid `null` type of pattern expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -703,10 +703,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // input value among many constant tests.
                         convertedExpression = operand;
                     }
-                    else if (conversion.ConversionKind == ConversionKind.ImplicitNullToPointer ||
-                        (conversion.ConversionKind == ConversionKind.NoConversion && convertedExpression.Type?.IsErrorType() == true))
+                    else if (conversion.ConversionKind == ConversionKind.NoConversion && convertedExpression.Type?.IsErrorType() == true)
                     {
                         convertedExpression = operand;
+                    }
+                    else if (conversion.ConversionKind == ConversionKind.ImplicitNullToPointer)
+                    {
+                        constantValue = operand.ConstantValueOpt;
+                        return convertedExpression;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests4.cs
@@ -3470,6 +3470,24 @@ class Program
                 );
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70048")]
+        public void Pointer_RelationalPattern()
+        {
+            var source = """
+                class C
+                {
+                    unsafe void M(void* p)
+                    {
+                        if (p is < null) { }
+                    }
+                }
+                """;
+            CreateCompilation(source, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+                // (5,18): error CS8781: Relational patterns may not be used for a value of type 'void*'.
+                //         if (p is < null) { }
+                Diagnostic(ErrorCode.ERR_UnsupportedTypeForRelationalPattern, "< null").WithArguments("void*").WithLocation(5, 18));
+        }
+
         [Fact]
         public void UnmatchedInput_06()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70048.