### PR TITLE
Remove unused member

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpIdeCodeStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpIdeCodeStyleOptions.cs
@@ -37,9 +37,6 @@ internal sealed record class CSharpIdeCodeStyleOptions : IdeCodeStyleOptions, IE
     private static readonly CodeStyleOption2<string> s_defaultModifierOrder =
         new(string.Join(",", s_preferredModifierOrderDefault.Select(SyntaxFacts.GetText)), NotificationOption2.Silent);
 
-    public static readonly CodeStyleOption2<AddImportPlacement> s_outsideNamespacePlacementWithSilentEnforcement =
-        new(AddImportPlacement.OutsideNamespace, NotificationOption2.Silent);
-
     private static readonly CodeStyleOption2<ExpressionBodyPreference> s_whenPossibleWithSilentEnforcement =
         new(ExpressionBodyPreference.WhenPossible, NotificationOption2.Silent);
 


### PR DESCRIPTION
For whatever reason it was `public` therefore it didn't trigger the 'unused member' warning. Verified through 'FAR' in VS that it isn't used anywhere directly.