### PR TITLE
Add a struct enumerator for WeakList<T>

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
@@ -87,10 +87,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
             Assert.Null(list.GetWeakReference(3).GetTarget());
             Assert.Null(list.GetWeakReference(4).GetTarget());
 
-            var array = list.ToArray();
+            var nonWeakList = new List<object>();
+            foreach (var obj in list)
+                nonWeakList.Add(obj);
 
-            Assert.Equal(1, array.Length);
-            Assert.Same(b.GetReference(), array[0]);
+            Assert.Equal(1, nonWeakList.Count);
+            Assert.Same(b.GetReference(), nonWeakList[0]);
 
             // list was compacted:
             Assert.Equal(1, list.WeakCount);
@@ -123,7 +125,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
 
             b.AssertReleased();
 
-            list.ToArray(); // shrinks, #alive == 0
+            // shrinks, #alive == 0
+            foreach (var obj in list)
+                ;
+
             Assert.Equal(0, list.TestOnly_UnderlyingArray.Length);
             Assert.Equal(0, list.WeakCount);
         }
@@ -151,7 +156,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
 
             b.AssertReleased();
 
-            list.ToArray(); // shrinks, #alive == 0
+            // shrinks, #alive == 0
+            foreach (var obj in list)
+                ;
+
             Assert.Equal(0, list.TestOnly_UnderlyingArray.Length);
             Assert.Equal(0, list.WeakCount);
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Utilities
     /// <summary>
     /// Represents an ordered sequence of weak references.
     /// </summary>
-    internal sealed class WeakList<T> : IEnumerable<T>
+    internal sealed class WeakList<T>
         where T : class
     {
         private WeakReference<T>[] _items;
@@ -158,47 +158,68 @@ namespace Roslyn.Utilities
             _items[_size++] = new WeakReference<T>(item);
         }
 
-        public IEnumerator<T> GetEnumerator()
+        public struct Enumerator
         {
-            int count = _size;
-            int alive = _size;
-            int firstDead = -1;
+            private readonly WeakList<T> _weakList;
+            private int _nextIndex;
+            private readonly int _count;
+            private int _alive;
+            private int _firstDead;
+            private T? _current;
 
-            for (int i = 0; i < count; i++)
+            public Enumerator(WeakList<T> weakList)
             {
-                T? item;
-                if (_items[i].TryGetTarget(out item))
-                {
-                    yield return item;
-                }
-                else
-                {
-                    // object has been collected 
+                _weakList = weakList;
+                _nextIndex = 0;
+                _count = weakList._size;
+                _alive = weakList._size;
+                _firstDead = -1;
+                _current = null;
+            }
 
-                    if (firstDead < 0)
+            public T Current => _current!;
+
+            public bool MoveNext()
+            {
+                while (_nextIndex < _count)
+                {
+                    int currentIndex = _nextIndex++;
+                    if (_weakList._items[currentIndex].TryGetTarget(out var item))
                     {
-                        firstDead = i;
+                        _current = item;
+                        return true;
                     }
+                    else
+                    {
+                        // object has been collected 
 
-                    alive--;
+                        if (_firstDead < 0)
+                        {
+                            _firstDead = currentIndex;
+                        }
+
+                        _alive--;
+                    }
                 }
-            }
 
-            if (alive == 0)
-            {
-                _items = Array.Empty<WeakReference<T>>();
-                _size = 0;
-            }
-            else if (alive < _items.Length / 4)
-            {
-                // If we have just a few items left we shrink the array.
-                Shrink(firstDead, alive);
+                if (_alive == 0)
+                {
+                    _weakList._items = Array.Empty<WeakReference<T>>();
+                    _weakList._size = 0;
+                }
+                else if (_alive < _weakList._items.Length / 4)
+                {
+                    // If we have just a few items left we shrink the array.
+                    _weakList.Shrink(_firstDead, _alive);
+                }
+
+                return false;
             }
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        public Enumerator GetEnumerator()
         {
-            return GetEnumerator();
+            return new Enumerator(this);
         }
 
         internal WeakReference<T>[] TestOnly_UnderlyingArray { get { return _items; } }

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -161,8 +161,8 @@ namespace Roslyn.Utilities
         public struct Enumerator
         {
             private readonly WeakList<T> _weakList;
-            private int _nextIndex;
             private readonly int _count;
+            private int _nextIndex;
             private int _alive;
             private int _firstDead;
             private T? _current;
@@ -183,7 +183,8 @@ namespace Roslyn.Utilities
             {
                 while (_nextIndex < _count)
                 {
-                    int currentIndex = _nextIndex++;
+                    int currentIndex = _nextIndex;
+                    _nextIndex += 1;
                     if (_weakList._items[currentIndex].TryGetTarget(out var item))
                     {
                         _current = item;


### PR DESCRIPTION
In the trace I'm looking at from the CompletionTest.Completion.Totals scenario in speedometer, this is the highest allocating enumerator in Roslyn at 0.4% of all allocations in the codeanalysis process.

![image](https://github.com/dotnet/roslyn/assets/6785178/ad070822-3d1b-42fa-9dad-9c8ae9c28886)
