### PR TITLE
Semantic snippets: Follow user's preferred modifier order for type declaration snippets

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
@@ -409,5 +409,140 @@ public class MyClass
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        public async Task EnsureCorrectModifierOrderAfterPartialKeywordTest_InvalidPreferredModifiersList()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = invalid!
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public partial class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBeforeAllOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">sealed unsafe $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = public,sealed,unsafe
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public sealed unsafe class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBeforeAllOthers_NotAllModifiersInTheList()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">sealed unsafe $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = public,sealed
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public sealed unsafe class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBetweenOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">sealed unsafe $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = sealed,public,unsafe
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                sealed public unsafe class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierAfterAllOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">sealed unsafe $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = sealed,unsafe,public
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                sealed unsafe public class MyClass
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
@@ -420,5 +420,140 @@ public struct MyStruct
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/69600")]
+        public async Task EnsureCorrectModifierOrderAfterPartialKeywordTest_InvalidPreferredModifiersList()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">partial $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = invalid!
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public partial struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBeforeAllOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">readonly ref $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = public,readonly,ref
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public readonly ref struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBeforeAllOthers_NotAllModifiersInTheList()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">readonly ref $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = public,readonly
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                public readonly ref struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierBetweenOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">readonly ref $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = readonly,public,ref
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                readonly public ref struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
+
+        [WpfFact]
+        public async Task EnsureCorrectModifierOrderFromOptionsTest_PublicModifierAfterAllOthers()
+        {
+            var markupBeforeCommit = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+                    <Document FilePath="/0/Test0.cs">readonly ref $$</Document>
+                <AnalyzerConfigDocument FilePath="/.editorconfig">
+                [*]
+                dotnet_style_require_accessibility_modifiers = always
+
+                csharp_preferred_modifier_order = readonly,ref,public
+                    </AnalyzerConfigDocument>
+                    </Project>
+                </Workspace>
+                """;
+
+            var expectedCodeAfterCommit = """
+                readonly ref public struct MyStruct
+                {
+                    $$
+                }
+                """;
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -70,6 +69,58 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             return false;
+        }
+
+        public static bool IsPotentialModifier(this SyntaxToken token, out SyntaxKind modifierKind)
+        {
+            var tokenKind = token.Kind();
+            switch (tokenKind)
+            {
+                case SyntaxKind.PublicKeyword:
+                case SyntaxKind.InternalKeyword:
+                case SyntaxKind.ProtectedKeyword:
+                case SyntaxKind.PrivateKeyword:
+                case SyntaxKind.SealedKeyword:
+                case SyntaxKind.AbstractKeyword:
+                case SyntaxKind.StaticKeyword:
+                case SyntaxKind.VirtualKeyword:
+                case SyntaxKind.ExternKeyword:
+                case SyntaxKind.NewKeyword:
+                case SyntaxKind.OverrideKeyword:
+                case SyntaxKind.ReadOnlyKeyword:
+                case SyntaxKind.VolatileKeyword:
+                case SyntaxKind.UnsafeKeyword:
+                case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.RefKeyword:
+                case SyntaxKind.OutKeyword:
+                case SyntaxKind.InKeyword:
+                case SyntaxKind.RequiredKeyword:
+                case SyntaxKind.FileKeyword:
+                case SyntaxKind.PartialKeyword:
+                    modifierKind = tokenKind;
+                    return true;
+                case SyntaxKind.IdentifierToken:
+                    if (token.HasMatchingText(SyntaxKind.AsyncKeyword))
+                    {
+                        modifierKind = SyntaxKind.AsyncKeyword;
+                        return true;
+                    }
+                    if (token.HasMatchingText(SyntaxKind.FileKeyword))
+                    {
+                        modifierKind = SyntaxKind.FileKeyword;
+                        return true;
+                    }
+                    if (token.HasMatchingText(SyntaxKind.PartialKeyword))
+                    {
+                        modifierKind = SyntaxKind.PartialKeyword;
+                        return true;
+                    }
+                    modifierKind = SyntaxKind.None;
+                    return false;
+                default:
+                    modifierKind = SyntaxKind.None;
+                    return false;
+            }
         }
 
         public static bool IsLiteral(this SyntaxToken token)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTokenExtensions.cs
@@ -74,6 +74,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static bool IsPotentialModifier(this SyntaxToken token, out SyntaxKind modifierKind)
         {
             var tokenKind = token.Kind();
+            modifierKind = SyntaxKind.None;
+
             switch (tokenKind)
             {
                 case SyntaxKind.PublicKeyword:
@@ -103,22 +105,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     if (token.HasMatchingText(SyntaxKind.AsyncKeyword))
                     {
                         modifierKind = SyntaxKind.AsyncKeyword;
-                        return true;
                     }
                     if (token.HasMatchingText(SyntaxKind.FileKeyword))
                     {
                         modifierKind = SyntaxKind.FileKeyword;
-                        return true;
                     }
                     if (token.HasMatchingText(SyntaxKind.PartialKeyword))
                     {
                         modifierKind = SyntaxKind.PartialKeyword;
-                        return true;
                     }
-                    modifierKind = SyntaxKind.None;
-                    return false;
+                    return modifierKind != SyntaxKind.None;
                 default:
-                    modifierKind = SyntaxKind.None;
                     return false;
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -30,57 +30,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var result = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer);
             while (true)
             {
-                switch (token.Kind())
+                if (token.IsPotentialModifier(out var modifierKind))
                 {
-                    case SyntaxKind.PublicKeyword:
-                    case SyntaxKind.InternalKeyword:
-                    case SyntaxKind.ProtectedKeyword:
-                    case SyntaxKind.PrivateKeyword:
-                    case SyntaxKind.SealedKeyword:
-                    case SyntaxKind.AbstractKeyword:
-                    case SyntaxKind.StaticKeyword:
-                    case SyntaxKind.VirtualKeyword:
-                    case SyntaxKind.ExternKeyword:
-                    case SyntaxKind.NewKeyword:
-                    case SyntaxKind.OverrideKeyword:
-                    case SyntaxKind.ReadOnlyKeyword:
-                    case SyntaxKind.VolatileKeyword:
-                    case SyntaxKind.UnsafeKeyword:
-                    case SyntaxKind.AsyncKeyword:
-                    case SyntaxKind.RefKeyword:
-                    case SyntaxKind.OutKeyword:
-                    case SyntaxKind.InKeyword:
-                    case SyntaxKind.RequiredKeyword:
-                    case SyntaxKind.FileKeyword:
-                    case SyntaxKind.PartialKeyword:
-                        result.Add(token.Kind());
-                        positionBeforeModifiers = token.FullSpan.Start;
-                        token = token.GetPreviousToken(includeSkipped: true);
-                        continue;
-                    case SyntaxKind.IdentifierToken:
-                        if (token.HasMatchingText(SyntaxKind.AsyncKeyword))
-                        {
-                            result.Add(SyntaxKind.AsyncKeyword);
-                            positionBeforeModifiers = token.FullSpan.Start;
-                            token = token.GetPreviousToken(includeSkipped: true);
-                            continue;
-                        }
-                        if (token.HasMatchingText(SyntaxKind.FileKeyword))
-                        {
-                            result.Add(SyntaxKind.FileKeyword);
-                            positionBeforeModifiers = token.FullSpan.Start;
-                            token = token.GetPreviousToken(includeSkipped: true);
-                            continue;
-                        }
-                        if (token.HasMatchingText(SyntaxKind.PartialKeyword))
-                        {
-                            result.Add(SyntaxKind.PartialKeyword);
-                            positionBeforeModifiers = token.FullSpan.Start;
-                            token = token.GetPreviousToken(includeSkipped: true);
-                            continue;
-                        }
-
-                        break;
+                    result.Add(modifierKind);
+                    positionBeforeModifiers = token.FullSpan.Start;
+                    token = token.GetPreviousToken(includeSkipped: true);
+                    continue;
                 }
 
                 break;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -28,17 +28,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var token = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
             var result = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer);
-            while (true)
+            while (token.IsPotentialModifier(out var modifierKind))
             {
-                if (token.IsPotentialModifier(out var modifierKind))
-                {
-                    result.Add(modifierKind);
-                    positionBeforeModifiers = token.FullSpan.Start;
-                    token = token.GetPreviousToken(includeSkipped: true);
-                    continue;
-                }
-
-                break;
+                result.Add(modifierKind);
+                positionBeforeModifiers = token.FullSpan.Start;
+                token = token.GetPreviousToken(includeSkipped: true);
             }
 
             return result;


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/69874

Since now there are 2 separate text changes for accessibility modifier and declaration itself, it is somewhat trivial to implement preserving user's preferred modifier order for settings/editorconfig. The actual change is like ~20 lines, everithing else is tests + extraction of helper method

Demo:
![devenv_JMXTgxUWE1](https://github.com/dotnet/roslyn/assets/70431552/ee5e9b24-0301-43bd-9b2e-000602a916e7)