### PR TITLE
Change AssemblyData.AvailableSymbols to ImmutableArray instead of IEnumerable

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -862,7 +862,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private abstract class AssemblyDataForMetadataOrCompilation : AssemblyData
             {
-                private List<AssemblySymbol>? _assemblies;
+                private ImmutableArray<AssemblySymbol> _assemblies;
                 private readonly AssemblyIdentity _identity;
                 private readonly ImmutableArray<AssemblyIdentity> _referencedAssemblies;
                 private readonly bool _embedInteropTypes;
@@ -890,25 +890,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                public override IEnumerable<AssemblySymbol> AvailableSymbols
+                public override ImmutableArray<AssemblySymbol> AvailableSymbols
                 {
                     get
                     {
-                        if (_assemblies == null)
+                        if (_assemblies.IsDefault)
                         {
-                            _assemblies = new List<AssemblySymbol>();
+                            var builder = ArrayBuilder<AssemblySymbol>.GetInstance();
 
                             // This should be done lazy because while we creating
                             // instances of this type, creation of new SourceAssembly symbols
                             // might change the set of available AssemblySymbols.
-                            AddAvailableSymbols(_assemblies);
+                            AddAvailableSymbols(builder);
+
+                            _assemblies = builder.ToImmutableAndFree();
                         }
 
                         return _assemblies;
                     }
                 }
 
-                protected abstract void AddAvailableSymbols(List<AssemblySymbol> assemblies);
+                protected abstract void AddAvailableSymbols(ArrayBuilder<AssemblySymbol> builder);
 
                 public override ImmutableArray<AssemblyIdentity> AssemblyReferences
                 {
@@ -1010,7 +1012,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                protected override void AddAvailableSymbols(List<AssemblySymbol> assemblies)
+                protected override void AddAvailableSymbols(ArrayBuilder<AssemblySymbol> assemblies)
                 {
                     // accessing cached symbols requires a lock
                     lock (SymbolCacheAndReferenceManagerStateGuard)
@@ -1123,7 +1125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new RetargetingAssemblySymbol(Compilation.SourceAssembly, this.IsLinked);
                 }
 
-                protected override void AddAvailableSymbols(List<AssemblySymbol> assemblies)
+                protected override void AddAvailableSymbols(ArrayBuilder<AssemblySymbol> assemblies)
                 {
                     assemblies.Add(Compilation.Assembly);
 

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyData.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// The sequence of AssemblySymbols the Binder can choose from.
             /// </summary>
-            public abstract IEnumerable<TAssemblySymbol> AvailableSymbols { get; }
+            public abstract ImmutableArray<TAssemblySymbol> AvailableSymbols { get; }
 
             /// <summary>
             /// Check if provided AssemblySymbol is created for assembly described by this instance. 

--- a/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/AssemblyDataForAssemblyBeingBuilt.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public override IEnumerable<TAssemblySymbol> AvailableSymbols
+            public override ImmutableArray<TAssemblySymbol> AvailableSymbols
             {
                 get
                 {

--- a/src/Compilers/Core/Portable/ReferenceManager/Compilation_MetadataCache.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/Compilation_MetadataCache.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis
         /// Adds cached retargeting symbols into the given list.
         /// <see cref="CommonReferenceManager.SymbolCacheAndReferenceManagerStateGuard"/> must be locked while calling this method.
         /// </summary>
-        internal void AddRetargetingAssemblySymbolsNoLock<T>(List<T> result) where T : IAssemblySymbolInternal
+        internal void AddRetargetingAssemblySymbolsNoLock<T>(ArrayBuilder<T> result) where T : IAssemblySymbolInternal
         {
             foreach (var symbol in _retargetingAssemblySymbols)
             {


### PR DESCRIPTION
This allows the enumeration done in CommonReferenceManager.ReuseAssemblySymbols to be done without allocation.

In the trace I'm looking at from the CompletionTest.Completion.Totals scenario in speedometer, this is the 3rd highest allocating enumerator in Roslyn at 0.4% of all allocations in the codeanalysis process.

![image](https://github.com/dotnet/roslyn/assets/6785178/d4f31a0b-daa8-400f-81b9-fdee6b4cbfdf)

Note that this particular codepath wasn't able to resolve symbols well. Piecing that together with a trace from my machine, gave a better picture of what was leading to this enumerator allocation:

![image](https://github.com/dotnet/roslyn/assets/6785178/03a804f9-1921-48ea-908a-397fbd265b94)
