### PR TITLE
Override ChecksumSynchronizer.AddIfNeeded to not allocate an enumerator

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/ChecksumSynchronizer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -114,7 +115,25 @@ namespace Microsoft.CodeAnalysis.Remote
                         AddIfNeeded(checksums, checksum);
                         continue;
                     case ChecksumCollection checksumCollection:
-                        AddIfNeeded(checksums, checksumCollection);
+                        AddIfNeeded(checksums, checksumCollection.Children);
+                        continue;
+                }
+
+                throw ExceptionUtilities.UnexpectedValue(checksumOrCollection);
+            }
+        }
+
+        private void AddIfNeeded(HashSet<Checksum> checksums, ImmutableArray<object> checksumOrCollections)
+        {
+            foreach (var checksumOrCollection in checksumOrCollections)
+            {
+                switch (checksumOrCollection)
+                {
+                    case Checksum checksum:
+                        AddIfNeeded(checksums, checksum);
+                        continue;
+                    case ChecksumCollection checksumCollection:
+                        AddIfNeeded(checksums, checksumCollection.Children);
                         continue;
                 }
 


### PR DESCRIPTION
In the trace I'm looking at from the CompletionTest.Completion.Totals scenario in speedometer, this is the 4th highest allocating enumerator in Roslyn at 0.2% of all allocations in the codeanalysis process. (Note, it is actually 0.3%, but to get rid of the remaining enumerator allocations would likely require duplicating a lot more code in this class)

![image](https://github.com/dotnet/roslyn/assets/6785178/cfe2952d-d9ed-4bc7-a539-49bda67a6645)
