### PR TITLE
Fallback gracefully when running on runtimes that only support the Invariant culture

### DIFF
--- a/src/Features/Core/Portable/Completion/PatternMatchHelper.cs
+++ b/src/Features/Core/Portable/Completion/PatternMatchHelper.cs
@@ -18,10 +18,24 @@ namespace Microsoft.CodeAnalysis.Completion
     /// </summary>
     internal sealed class PatternMatchHelper(string pattern) : IDisposable
     {
+        private static readonly CultureInfo EnUSCultureInfo;
+
+        static PatternMatchHelper()
+        {
+            try
+            {
+                EnUSCultureInfo = new("en-US");
+            }
+            catch (CultureNotFoundException)
+            {
+                // See https://github.com/microsoft/vscode-dotnettools/issues/386
+                // This can happen when running on a runtime that is setup for culture invariant mode only.
+                EnUSCultureInfo = CultureInfo.InvariantCulture;
+            }
+        }
+
         private readonly object _gate = new();
         private readonly Dictionary<(CultureInfo, bool includeMatchedSpans), PatternMatcher> _patternMatcherMap = new();
-
-        private static readonly CultureInfo EnUSCultureInfo = new("en-US");
 
         public string Pattern { get; } = pattern;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/386.