### PR TITLE
Do not show `and` or `or` keywords after arrow of pointer access expression in patterns

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AndKeywordRecommenderTests.cs
@@ -631,5 +631,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 expr is (not []) $$ var x
                 """);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70045")]
+        public async Task TestNotInMemberAccessInPattern1()
+        {
+            await VerifyAbsenceAsync("""
+                int v = 0;
+                if (v is var a and a.$$)
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70045")]
+        public async Task TestNotInMemberAccessInPattern2()
+        {
+            await VerifyAbsenceAsync("""
+                int* v = null;
+                if (v is var a and a->$$)
+                """);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/OrKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/OrKeywordRecommenderTests.cs
@@ -593,5 +593,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                     global::$$
                 """));
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70045")]
+        public async Task TestNotInMemberAccessInPattern1()
+        {
+            await VerifyAbsenceAsync("""
+                int v = 0;
+                if (v is var a and a.$$)
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70045")]
+        public async Task TestNotInMemberAccessInPattern2()
+        {
+            await VerifyAbsenceAsync("""
+                int* v = null;
+                if (v is var a and a->$$)
+                """);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1439,7 +1439,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // For instance:
             // e is { A.$$ }
-            if (leftToken.IsKind(SyntaxKind.DotToken))
+            // e is { A->$$ }
+            if (leftToken.IsKind(SyntaxKind.DotToken) ||
+                leftToken.IsKind(SyntaxKind.MinusGreaterThanToken))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/70045

The normal member access didn't have any problems, but I looked through tests and didn't find the one verifying that, so added it as well.