### PR TITLE
Do not show `nint` and `nuint` in attribute name context

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/NativeIntegerKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NativeIntegerKeywordRecommenderTests.cs
@@ -422,5 +422,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 }
                 """);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70074")]
+        public async Task TestNotInAttribute1()
+        {
+            await VerifyAbsenceAsync("""
+                [$$
+                class C
+                {
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70074")]
+        public async Task TestNotInAttribute2()
+        {
+            await VerifyAbsenceAsync("""
+                class C
+                {
+                    [$$
+                    void M()
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70074")]
+        public async Task TestNotInAttribute3()
+        {
+            await VerifyAbsenceAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        [$$
+                        void L()
+                        {
+                        }
+                    }
+                }
+                """);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractNativeIntegerKeywordRecommender.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         private static bool IsValidContext(CSharpSyntaxContext context)
         {
             if (context.IsTaskLikeTypeContext ||
-                context.IsGenericConstraintContext)
+                context.IsGenericConstraintContext ||
+                context.IsAttributeNameContext)
             {
                 return false;
             }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/70074