### PR TITLE
Fix 'make member readonly' with inline array fields

### DIFF
--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -1405,7 +1405,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan1()
     {
         await new VerifyCS.Test
@@ -1437,7 +1437,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan2()
     {
         await new VerifyCS.Test
@@ -1471,7 +1471,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan2_A()
     {
         await new VerifyCS.Test
@@ -1505,7 +1505,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan3()
     {
         await new VerifyCS.Test
@@ -1563,7 +1563,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan3_A()
     {
         await new VerifyCS.Test
@@ -1621,7 +1621,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan4()
     {
         await new VerifyCS.Test
@@ -1679,7 +1679,7 @@ public sealed class MakeStructMemberReadOnlyTests
         }.RunAsync();
     }
 
-    [Fact]
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/70116")]
     public async Task TestInlineArraySpan4_A()
     {
         await new VerifyCS.Test

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -1404,4 +1404,336 @@ public sealed class MakeStructMemberReadOnlyTests
             """,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestInlineArraySpan1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void RecalculateHash()
+            	{
+            		SHA1.HashData(Data, Hash);
+            	}
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void RecalculateHash()
+            	{
+                    TakesSpan(Data);
+            	}
+
+                readonly void TakesSpan(Span<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan2_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void RecalculateHash()
+            	{
+                    TakesSpan(this.Data);
+            	}
+
+                readonly void TakesSpan(Span<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void [|RecalculateHash|]()
+            	{
+                    TakesReadOnlySpan(Data);
+            	}
+
+                readonly void TakesReadOnlySpan(ReadOnlySpan<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            FixedCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public readonly void RecalculateHash()
+            	{
+                    TakesReadOnlySpan(Data);
+            	}
+
+                readonly void TakesReadOnlySpan(ReadOnlySpan<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan3_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void [|RecalculateHash|]()
+            	{
+                    TakesReadOnlySpan(this.Data);
+            	}
+
+                readonly void TakesReadOnlySpan(ReadOnlySpan<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            FixedCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public readonly void RecalculateHash()
+            	{
+                    TakesReadOnlySpan(this.Data);
+            	}
+
+                readonly void TakesReadOnlySpan(ReadOnlySpan<byte> bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void [|RecalculateHash|]()
+            	{
+                    TakesByteArray(Data);
+            	}
+
+                readonly void TakesByteArray(ByteArray20 bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            FixedCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public readonly void RecalculateHash()
+            	{
+                    TakesByteArray(Data);
+            	}
+
+                readonly void TakesByteArray(ByteArray20 bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInlineArraySpan4_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public void [|RecalculateHash|]()
+            	{
+                    TakesByteArray(this.Data);
+            	}
+
+                readonly void TakesByteArray(ByteArray20 bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            FixedCode = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using System.Security.Cryptography;
+
+            public struct Repro
+            {
+            	public ByteArray20 Data;
+            	public ByteArray20 Hash;
+
+                public readonly void RecalculateHash()
+            	{
+                    TakesByteArray(this.Data);
+            	}
+
+                readonly void TakesByteArray(ByteArray20 bytes) { }
+
+                [InlineArray(20)]
+            	public struct ByteArray20
+            	{
+            		private byte _byte;
+            	}
+            }
+            """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -377,6 +377,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 }
             }
 
+            // An inline array passed as a Span<T> can be written into by the callee, despite no ref at the callsite.  e.g.:
+            //
+            // void Mutate(Span<byte> bytes);
+            // Mutate(this.inlineArray)
+            if (expression.Parent is ArgumentSyntax)
+            {
+                var expressionTypes = semanticModel.GetTypeInfo(expression, cancellationToken);
+                if (expressionTypes.ConvertedType.IsSpan() &&
+                    expressionTypes.Type.IsInlineArray())
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -73,14 +73,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 {
                     // We have either `var x = (stackalloc byte[8])` or `Span<byte> x = (stackalloc byte[8])`.  The former
                     // is not safe to remove. the latter is.
-                    if (semanticModel.GetTypeInfo(varDecl.Type, cancellationToken).Type is
-                        {
-                            Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                            ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true }
-                        })
-                    {
+                    if (semanticModel.GetTypeInfo(varDecl.Type, cancellationToken).Type.IsSpanOrReadOnlySpan())
                         return !varDecl.Type.IsVar;
-                    }
                 }
 
                 return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -729,5 +729,25 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             return symbol;
         }
+
+        public static bool IsSpanOrReadOnlySpan([NotNullWhen(true)] this ITypeSymbol? type)
+            => type is INamedTypeSymbol
+            {
+                Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                TypeArguments.Length : 1,
+                ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true }
+            };
+
+        public static bool IsSpan([NotNullWhen(true)] this ITypeSymbol? type)
+            => type is INamedTypeSymbol
+            {
+                Name: nameof(Span<int>),
+                TypeArguments.Length: 1,
+                ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true }
+            };
+
+        public static bool IsInlineArray([NotNullWhen(true)] this ITypeSymbol? type)
+            => type is INamedTypeSymbol namedType &&
+               namedType.OriginalDefinition.GetAttributes().Any(static a => a.AttributeClass?.SpecialType == SpecialType.System_Runtime_CompilerServices_InlineArrayAttribute);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => type is INamedTypeSymbol
             {
                 Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                TypeArguments.Length : 1,
+                TypeArguments.Length: 1,
                 ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true }
             };
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70116