### PR TITLE
Allow only ordinary member method calls to be intercepted

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -13,6 +13,34 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class BoundExpression
     {
+        public SimpleNameSyntax? InterceptableNameSyntax
+        {
+            get
+            {
+                // When this assertion fails, it means a new syntax is being used which corresponds to a BoundCall.
+                // The developer needs to determine how this new syntax should interact with interceptors (produce an error, permit intercepting the call, etc...)
+                Debug.Assert(this.WasCompilerGenerated || this.Syntax is InvocationExpressionSyntax or ConstructorInitializerSyntax or PrimaryConstructorBaseTypeSyntax { ArgumentList: { } },
+                    $"Unexpected syntax kind for BoundCall: {this.Syntax.Kind()}");
+
+                if (this.WasCompilerGenerated || this.Syntax is not InvocationExpressionSyntax syntax)
+                {
+                    return null;
+                }
+
+                // If a qualified name is used as a valid receiver of an invocation syntax at some point,
+                // we probably want to treat it similarly to a MemberAccessExpression.
+                // However, we don't expect to encounter it.
+                Debug.Assert(syntax.Expression is not QualifiedNameSyntax);
+
+                return syntax.Expression switch
+                {
+                    MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+                    SimpleNameSyntax name => name,
+                    _ => null
+                };
+            }
+        }
+
         internal BoundExpression WithSuppression(bool suppress = true)
         {
             if (this.IsSuppressed == suppress)
@@ -238,34 +266,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return this.Method;
-            }
-        }
-
-        public Location? InterceptableLocation
-        {
-            get
-            {
-                // When this assertion fails, it means a new syntax is being used which corresponds to a BoundCall.
-                // The developer needs to determine how this new syntax should interact with interceptors (produce an error, permit intercepting the call, etc...)
-                Debug.Assert(this.WasCompilerGenerated || this.Syntax is InvocationExpressionSyntax or ConstructorInitializerSyntax or PrimaryConstructorBaseTypeSyntax { ArgumentList: { } },
-                    $"Unexpected syntax kind for BoundCall: {this.Syntax.Kind()}");
-
-                if (this.WasCompilerGenerated || this.Syntax is not InvocationExpressionSyntax syntax)
-                {
-                    return null;
-                }
-
-                // If a qualified name is used as a valid receiver of an invocation syntax at some point,
-                // we probably want to treat it similarly to a MemberAccessExpression.
-                // However, we don't expect to encounter it.
-                Debug.Assert(syntax.Expression is not QualifiedNameSyntax);
-
-                return syntax.Expression switch
-                {
-                    MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Location,
-                    SimpleNameSyntax name => name.Location,
-                    _ => null
-                };
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7604,8 +7604,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InterceptorGlobalNamespace" xml:space="preserve">
     <value>An interceptor cannot be declared in the global namespace.</value>
   </data>
-  <data name="ERR_InterceptorCannotInterceptDelegateInvocation" xml:space="preserve">
-    <value>An interceptor cannot intercept a delegate invocation.</value>
+  <data name="ERR_InterceptableMethodMustBeOrdinary" xml:space="preserve">
+    <value>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</value>
   </data>
   <data name="ERR_InterceptorContainingTypeCannotBeGeneric" xml:space="preserve">
     <value>Method '{0}' cannot be used as an interceptor because its containing type has type parameters.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7604,6 +7604,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InterceptorGlobalNamespace" xml:space="preserve">
     <value>An interceptor cannot be declared in the global namespace.</value>
   </data>
+  <data name="ERR_InterceptorCannotInterceptDelegateInvocation" xml:space="preserve">
+    <value>An interceptor cannot intercept a delegate invocation.</value>
+  </data>
   <data name="ERR_InterceptorContainingTypeCannotBeGeneric" xml:space="preserve">
     <value>Method '{0}' cannot be used as an interceptor because its containing type has type parameters.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2273,6 +2273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpectedInterpolatedString = 9205,
 
         ERR_InterceptorGlobalNamespace = 9206,
+        ERR_InterceptorCannotInterceptDelegateInvocation = 9207,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2273,7 +2273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpectedInterpolatedString = 9205,
 
         ERR_InterceptorGlobalNamespace = 9206,
-        ERR_InterceptorCannotInterceptDelegateInvocation = 9207,
+        ERR_InterceptableMethodMustBeOrdinary = 9207,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -613,6 +613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_SymbolDefinedInAssembly:
                 case ErrorCode.ERR_InterceptorArityNotCompatible:
                 case ErrorCode.ERR_InterceptorCannotBeGeneric:
+                case ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation:
                     // Update src\EditorFeatures\CSharp\LanguageServer\CSharpLspBuildOnlyDiagnostics.cs
                     // whenever new values are added here.
                     return true;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -613,7 +613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_SymbolDefinedInAssembly:
                 case ErrorCode.ERR_InterceptorArityNotCompatible:
                 case ErrorCode.ERR_InterceptorCannotBeGeneric:
-                case ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation:
+                case ErrorCode.ERR_InterceptableMethodMustBeOrdinary:
                     // Update src\EditorFeatures\CSharp\LanguageServer\CSharpLspBuildOnlyDiagnostics.cs
                     // whenever new values are added here.
                     return true;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -195,6 +195,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!node.HasErrors, "nodes with errors should not be lowered");
 
             BoundExpression? expr = node as BoundExpression;
+#if DEBUG
+            if (expr?.Syntax is InvocationExpressionSyntax)
+            {
+                // If this assertion fails, it means new lowering-layer checks are needed for interceptors.
+                // e.g. if the call syntax is being intercepted, an error should be reported
+                Debug.Assert(expr is BoundCall or BoundFunctionPointerInvocation);
+            }
+#endif
             if (expr != null)
             {
                 return VisitExpressionImpl(expr);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -195,15 +195,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!node.HasErrors, "nodes with errors should not be lowered");
 
             BoundExpression? expr = node as BoundExpression;
-#if DEBUG
-            if (expr?.Syntax is InvocationExpressionSyntax)
-            {
-                // If this assertion fails, it means new lowering-layer checks are needed for interceptors.
-                // e.g. if the call syntax is being intercepted, an error should be reported
-                Debug.Assert(expr is BoundCall or BoundFunctionPointerInvocation, $"{expr.GetType().Name} was not expected to have a Syntax of type InvocationExpressionSyntax");
-
-            }
-#endif
             if (expr != null)
             {
                 return VisitExpressionImpl(expr);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -200,7 +200,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If this assertion fails, it means new lowering-layer checks are needed for interceptors.
                 // e.g. if the call syntax is being intercepted, an error should be reported
-                Debug.Assert(expr is BoundCall or BoundFunctionPointerInvocation);
+                Debug.Assert(expr is BoundCall or BoundFunctionPointerInvocation, $"{expr.GetType().Name} was not expected to have a Syntax of type InvocationExpressionSyntax");
+
             }
 #endif
             if (expr != null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -178,6 +178,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            if (receiverOpt is { Type.TypeKind: TypeKind.Delegate })
+            {
+                this._diagnostics.Add(ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation, attributeLocation);
+                return;
+            }
+
             var containingMethod = this._factory.CurrentFunction;
             Debug.Assert(containingMethod is not null);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -139,14 +139,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref ImmutableArray<BoundExpression> arguments,
             ref ImmutableArray<RefKind> argumentRefKindsOpt,
             bool invokedAsExtensionMethod,
-            Location? interceptableLocation)
+            Syntax.SimpleNameSyntax? nameSyntax)
         {
+            var interceptableLocation = nameSyntax?.Location;
             if (this._compilation.TryGetInterceptor(interceptableLocation) is not var (attributeLocation, interceptor))
             {
                 // The call was not intercepted.
                 return;
             }
 
+            Debug.Assert(nameSyntax != null);
             Debug.Assert(interceptableLocation != null);
             Debug.Assert(interceptor.IsDefinition);
             Debug.Assert(!interceptor.ContainingType.IsGenericType);
@@ -178,9 +180,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (receiverOpt is { Type.TypeKind: TypeKind.Delegate })
+            if (method.MethodKind is not MethodKind.Ordinary)
             {
-                this._diagnostics.Add(ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation, attributeLocation);
+                this._diagnostics.Add(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, attributeLocation, nameSyntax.Identifier.ValueText);
                 return;
             }
 
@@ -391,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ref temps,
                     invokedAsExtensionMethod);
 
-                InterceptCallAndAdjustArguments(ref method, ref rewrittenReceiver, ref rewrittenArguments, ref argRefKindsOpt, invokedAsExtensionMethod, node.InterceptableLocation);
+                InterceptCallAndAdjustArguments(ref method, ref rewrittenReceiver, ref rewrittenArguments, ref argRefKindsOpt, invokedAsExtensionMethod, node.InterceptableNameSyntax);
                 var rewrittenCall = MakeCall(node, node.Syntax, rewrittenReceiver, method, rewrittenArguments, argRefKindsOpt, node.ResultKind, node.Type, temps.ToImmutableAndFree());
 
                 if (Instrument)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FunctionPointerInvocation.cs
@@ -35,6 +35,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(discardedReceiver is null);
 
+            if (node.InterceptableNameSyntax is { } nameSyntax && this._compilation.TryGetInterceptor(nameSyntax.Location) is var (attributeLocation, _))
+            {
+                this._diagnostics.Add(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, attributeLocation, nameSyntax.Identifier.ValueText);
+            }
+
             rewrittenArgs = MakeArguments(
                 node.Syntax,
                 rewrittenArgs,

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Vlastnosti instance v rozhraních nemůžou mít inicializátory.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Operátor nameof nelze zachytit.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Instanzeigenschaften in Schnittstellen können keine Initialisierer aufweisen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Ein nameof-Operator kann nicht abgefangen werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Las propiedades de la instancia en las interfaces no pueden tener inicializadores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">No se puede interceptar un operador nameof.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Les propriétés d'instance dans les interfaces ne peuvent pas avoir d'initialiseurs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Un opérateur nameof ne peut pas être intercepté.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Le proprietà di istanza nelle interfacce non possono avere inizializzatori.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Impossibile intercettare un operatore nameof.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">nameof 演算子はインターセプトできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -942,6 +942,11 @@
         <target state="translated">インターフェイス内のインスタンス プロパティは初期化子を持つことができません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -942,6 +942,11 @@
         <target state="translated">인터페이스의 인스턴스 속성은 이니셜라이저를 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">nameof 연산자는 가로챌 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Właściwości wystąpienia w interfejsach nie mogą mieć inicjatorów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Nie można przechwycić operatora nameof.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Um operador nameof não pode ser interceptado.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -942,6 +942,11 @@
         <target state="translated">As propriedades da instância nas interfaces não podem ter inicializadores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Свойства экземпляра в интерфейсах не могут иметь инициализаторы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Имя оператора не может быть перехвачено.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -942,6 +942,11 @@
         <target state="translated">Arabirimlerdeki örnek özelliklerinin başlatıcıları olamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">Nameof işleci engellenemez.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">无法截获 nameof 运算符。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -942,6 +942,11 @@
         <target state="translated">接口中的实例属性不能具有初始值设定项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -942,6 +942,11 @@
         <target state="translated">介面中的執行個體屬性不可有初始設定式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptableMethodMustBeOrdinary">
+        <source>Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</source>
+        <target state="new">Cannot intercept '{0}' because it is not an invocation of an ordinary member method.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorArityNotCompatible">
         <source>Method '{0}' must be non-generic or have arity {1} to match '{2}'.</source>
         <target state="new">Method '{0}' must be non-generic or have arity {1} to match '{2}'.</target>
@@ -950,11 +955,6 @@
       <trans-unit id="ERR_InterceptorCannotBeGeneric">
         <source>Method '{0}' must be non-generic to match '{1}'.</source>
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
-        <source>An interceptor cannot intercept a delegate invocation.</source>
-        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -952,6 +952,11 @@
         <target state="new">Method '{0}' must be non-generic to match '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterceptorCannotInterceptDelegateInvocation">
+        <source>An interceptor cannot intercept a delegate invocation.</source>
+        <target state="new">An interceptor cannot intercept a delegate invocation.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterceptorCannotInterceptNameof">
         <source>A nameof operator cannot be intercepted.</source>
         <target state="translated">無法攔截 nameof 運算子。</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterceptorsTests.cs
@@ -1307,12 +1307,12 @@ public class InterceptorsTests : CSharpTestBase
             """;
         var compilation = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors);
         compilation.VerifyEmitDiagnostics(
-            // Program.cs(22,6): error CS9207: An interceptor cannot intercept a delegate invocation.
+            // Program.cs(22,6): error CS9207: Cannot intercept 'action' because it is not an invocation of an ordinary member method.
             //     [InterceptsLocation("Program.cs", 11, 9)]
-            Diagnostic(ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation, @"InterceptsLocation(""Program.cs"", 11, 9)").WithLocation(22, 6),
-            // Program.cs(23,6): error CS9207: An interceptor cannot intercept a delegate invocation.
+            Diagnostic(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 11, 9)").WithArguments("action").WithLocation(22, 6),
+            // Program.cs(23,6): error CS9207: Cannot intercept 'action' because it is not an invocation of an ordinary member method.
             //     [InterceptsLocation("Program.cs", 16, 14)]
-            Diagnostic(ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation, @"InterceptsLocation(""Program.cs"", 16, 14)").WithLocation(23, 6));
+            Diagnostic(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 16, 14)").WithArguments("action").WithLocation(23, 6));
     }
 
     [Fact]
@@ -1782,6 +1782,91 @@ public class InterceptorsTests : CSharpTestBase
             // Program.cs(21,10): error CS9146: An interceptor method must be an ordinary member method.
             //         [InterceptsLocation("Program.cs", 13, 8)] // 3
             Diagnostic(ErrorCode.ERR_InterceptorMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 13, 8)").WithLocation(21, 10)
+            );
+    }
+
+    [Fact]
+    public void InterceptableMethod_BadMethodKind_01()
+    {
+        var source = """
+            using System.Runtime.CompilerServices;
+
+            class Program
+            {
+                public static unsafe void Main()
+                {
+                    // property
+                    _ = Prop;
+
+                    // constructor
+                    new Program();
+                }
+
+                public static int Prop { get; }
+
+                [InterceptsLocation("Program.cs", 8, 13)] // 1
+                [InterceptsLocation("Program.cs", 11, 9)] // 2, 'new'
+                [InterceptsLocation("Program.cs", 11, 13)] // 3, 'Program'
+                static void Interceptor1() { }
+            }
+            """;
+        var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors, options: TestOptions.UnsafeDebugExe);
+        comp.VerifyDiagnostics(
+            // Program.cs(16,6): error CS9151: Possible method name 'Prop' cannot be intercepted because it is not being invoked.
+            //     [InterceptsLocation("Program.cs", 8, 13)] // 1
+            Diagnostic(ErrorCode.ERR_InterceptorNameNotInvoked, @"InterceptsLocation(""Program.cs"", 8, 13)").WithArguments("Prop").WithLocation(16, 6),
+            // Program.cs(17,6): error CS9141: The provided line and character number does not refer to an interceptable method name, but rather to token 'new'.
+            //     [InterceptsLocation("Program.cs", 11, 9)] // 2, 'new'
+            Diagnostic(ErrorCode.ERR_InterceptorPositionBadToken, @"InterceptsLocation(""Program.cs"", 11, 9)").WithArguments("new").WithLocation(17, 6),
+            // Program.cs(18,6): error CS9151: Possible method name 'Program' cannot be intercepted because it is not being invoked.
+            //     [InterceptsLocation("Program.cs", 11, 13)] // 3, 'Program'
+            Diagnostic(ErrorCode.ERR_InterceptorNameNotInvoked, @"InterceptsLocation(""Program.cs"", 11, 13)").WithArguments("Program").WithLocation(18, 6)
+            );
+    }
+
+    [Fact]
+    public void InterceptableMethod_BadMethodKind_02()
+    {
+        var source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class Program
+            {
+                public static unsafe void Main()
+                {
+                    // delegate
+                    Action a = () => throw null!;
+                    a();
+
+                    // local function
+                    void local() => throw null!;
+                    local();
+
+                    // fnptr invoke
+                    delegate*<void> fnptr = &Interceptor1;
+                    fnptr();
+                }
+
+                public static int Prop { get; }
+
+                [InterceptsLocation("Program.cs", 10, 9)] // 1
+                [InterceptsLocation("Program.cs", 14, 9)] // 2
+                [InterceptsLocation("Program.cs", 18, 9)] // 3
+                static void Interceptor1() { }
+            }
+            """;
+        var comp = CreateCompilation(new[] { (source, "Program.cs"), s_attributesSource }, parseOptions: RegularWithInterceptors, options: TestOptions.UnsafeDebugExe);
+        comp.VerifyEmitDiagnostics(
+            // Program.cs(23,6): error CS9207: Cannot intercept 'a' because it is not an invocation of an ordinary member method.
+            //     [InterceptsLocation("Program.cs", 10, 9)] // 1
+            Diagnostic(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 10, 9)").WithArguments("a").WithLocation(23, 6),
+            // Program.cs(24,6): error CS9207: Cannot intercept 'local' because it is not an invocation of an ordinary member method.
+            //     [InterceptsLocation("Program.cs", 14, 9)] // 2
+            Diagnostic(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 14, 9)").WithArguments("local").WithLocation(24, 6),
+            // Program.cs(25,6): error CS9207: Cannot intercept 'fnptr' because it is not an invocation of an ordinary member method.
+            //     [InterceptsLocation("Program.cs", 18, 9)] // 3
+            Diagnostic(ErrorCode.ERR_InterceptableMethodMustBeOrdinary, @"InterceptsLocation(""Program.cs"", 18, 9)").WithArguments("fnptr").WithLocation(25, 6)
             );
     }
 

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2970,7 +2970,7 @@ class Program
                     case ErrorCode.ERR_SymbolDefinedInAssembly:
                     case ErrorCode.ERR_InterceptorArityNotCompatible:
                     case ErrorCode.ERR_InterceptorCannotBeGeneric:
-                    case ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation:
+                    case ErrorCode.ERR_InterceptableMethodMustBeOrdinary:
                         Assert.True(isBuildOnly, $"Check failed for ErrorCode.{errorCode}");
                         break;
 

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2970,6 +2970,7 @@ class Program
                     case ErrorCode.ERR_SymbolDefinedInAssembly:
                     case ErrorCode.ERR_InterceptorArityNotCompatible:
                     case ErrorCode.ERR_InterceptorCannotBeGeneric:
+                    case ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation:
                         Assert.True(isBuildOnly, $"Check failed for ErrorCode.{errorCode}");
                         break;
 

--- a/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
@@ -57,7 +57,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServer
         "CS9160", // ErrorCode.ERR_InterceptorCannotInterceptNameof
         "CS9163", // ErrorCode.ERR_SymbolDefinedInAssembly
         "CS9177", // ErrorCode.ERR_InterceptorArityNotCompatible
-        "CS9178" // ErrorCode.ERR_InterceptorCannotBeGeneric
+        "CS9178", // ErrorCode.ERR_InterceptorCannotBeGeneric
+        "CS9207" // ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation
         )]
     [Shared]
     internal sealed class CSharpLspBuildOnlyDiagnostics : ILspBuildOnlyDiagnostics

--- a/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServer
         "CS9163", // ErrorCode.ERR_SymbolDefinedInAssembly
         "CS9177", // ErrorCode.ERR_InterceptorArityNotCompatible
         "CS9178", // ErrorCode.ERR_InterceptorCannotBeGeneric
-        "CS9207" // ErrorCode.ERR_InterceptorCannotInterceptDelegateInvocation
+        "CS9207" // ErrorCode.ERR_InterceptableMethodMustBeOrdinary
         )]
     [Shared]
     internal sealed class CSharpLspBuildOnlyDiagnostics : ILspBuildOnlyDiagnostics


### PR DESCRIPTION
Closes #70061

[Spec](https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md#non-invocation-method-usages) says:

> Interception can only occur for calls to ordinary member methods--not constructors, delegates, properties, local functions, operators, etc. Support for more member kinds may be added in the future.

Looks like this wasn't thoroughly tested/the behaviors we expected in tests weren't in line with spec.

The interesting cases to test here are when we have an invocation in syntax but it's not invoking a member method, e.g. delegate, local function, and function pointer cases. I wasn't able to think of any others which are like that.

I tried to write a general purpose assertion for bound nodes which are associated with call syntax, to ensure we've always accounted for the possibility of the user trying to intercept the call in syntax. But the assertion I came up with ended up hitting too many cases for me to want to pursue adding it in this PR.