### PR TITLE
Do not restrict to type argument list context when a name could resolve to a generic and a non-generic symbol

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12391,6 +12391,33 @@ public static class Extension
             await VerifyItemExistsAsync(source, "C");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25572")]
+        public async Task PropertyAndGenericExtensionMethodCandidates()
+        {
+            var source = """
+                using System.Collections.Generic;
+                using System.Linq;
+
+                class C
+                {
+                    void M()
+                    {
+                        int foo;
+                        List<int> list;
+                        if (list.Count < $$)
+                        {
+                        }
+                    }
+                }
+                
+                """;
+
+            await VerifyItemExistsAsync(source, "foo");
+            await VerifyItemExistsAsync(source, "M");
+            await VerifyItemExistsAsync(source, "System");
+            await VerifyItemIsAbsentAsync(source, "Int32");
+        }
+
         private static string MakeMarkup(string source, string languageVersion = "Preview")
         {
             return $$"""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12409,7 +12409,6 @@ public static class Extension
                         }
                     }
                 }
-                
                 """;
 
             await VerifyItemExistsAsync(source, "foo");
@@ -12434,12 +12433,11 @@ public static class Extension
                     void A() { }
                     void A<T>() { }
                 }
-                
                 """;
 
-            await VerifyItemExistsAsync(source, "other");
             await VerifyItemExistsAsync(source, "System");
             await VerifyItemExistsAsync(source, "C");
+            await VerifyItemIsAbsentAsync(source, "other");
         }
 
         private static string MakeMarkup(string source, string languageVersion = "Preview")

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12418,6 +12418,30 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "Int32");
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25572")]
+        public async Task GenericWithNonGenericOverload()
+        {
+            var source = """
+                class C
+                {
+                    void M(C other)
+                    {
+                        if (other.A < $$)
+                        {
+                        }
+                    }
+
+                    void A() { }
+                    void A<T>() { }
+                }
+                
+                """;
+
+            await VerifyItemExistsAsync(source, "other");
+            await VerifyItemExistsAsync(source, "System");
+            await VerifyItemExistsAsync(source, "C");
+        }
+
         private static string MakeMarkup(string source, string languageVersion = "Preview")
         {
             return $$"""

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1017,7 +1017,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             var symbols = semanticModelOpt.LookupName(nameToken, cancellationToken);
-            return symbols.Any(static s =>
+            return symbols.All(static s =>
             {
                 return s switch
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //
             // goo.Baz<|
             //
-            // This could either be an incomlete generic type or method, or a binary less than operator
+            // This could either be an incomplete generic type or method, or a binary less than operator
             // To ensure that we are in the generic case, we need to match at least one generic method or type,
             // and all other candidates to be types or methods.
             var symbols = semanticModelOpt.LookupName(nameToken, cancellationToken);
@@ -1036,6 +1036,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     _ => false,
                 };
             });
+
             if (!anyGeneric)
                 return false;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1016,8 +1016,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
             }
 
+            // We have reached the expression:
+            //
+            // goo.Baz<|
+            //
+            // This could either be an incomlete generic type or method, or a binary less than operator
+            // To ensure that we are in the generic case, we need all symbols matching the name to be generic.
             var symbols = semanticModelOpt.LookupName(nameToken, cancellationToken);
-            return symbols.All(static s =>
+            return symbols.Length > 0 && symbols.All(static s =>
             {
                 return s switch
                 {


### PR DESCRIPTION
Fixes #25572

The new solution requires that all the symbols the name may resolve to are named types or methods and there exists at least one generic symbol of the aforementioned kinds in order to restrict the context into a generic type argument list. Otherwise, the context is not enforced as a generic type argument list.