### PR TITLE
Expose AnalysisContext.MinimumReportedSeverity

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -4227,5 +4227,29 @@ partial class B
                 }
             }
         }
+
+        [Theory]
+        // IDE scenario where no reported severities are filtered.
+        [InlineData(SeverityFilter.None, DiagnosticSeverity.Hidden)]
+        // Command line scenario where hidden and info severities are filtered.
+        [InlineData(SeverityFilter.Hidden | SeverityFilter.Info, DiagnosticSeverity.Warning)]
+        internal async Task TestMinimumReportedSeverity(SeverityFilter severityFilter, DiagnosticSeverity expectedMinimumReportedSeverity)
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"class C { }");
+            var compilation = CreateCompilation(new[] { tree });
+
+            var analyzer = new MinimumReportedSeverityAnalyzer();
+            var analyzersArray = ImmutableArray.Create<DiagnosticAnalyzer>(analyzer);
+            var analyzerManager = new AnalyzerManager(analyzersArray);
+            var driver = AnalyzerDriver.CreateAndAttachToCompilation(compilation, analyzersArray, AnalyzerOptions.Empty, analyzerManager, onAnalyzerException: null,
+                analyzerExceptionFilter: null, reportAnalyzer: false, severityFilter, trackSuppressedDiagnosticIds: false, out var newCompilation, CancellationToken.None);
+
+            // Force complete compilation event queue and analyzer execution.
+            _ = newCompilation.GetDiagnostics(CancellationToken.None);
+            _ = await driver.GetDiagnosticsAsync(newCompilation, CancellationToken.None);
+
+            Assert.True(analyzer.AnalyzerInvoked);
+            Assert.Equal(expectedMinimumReportedSeverity, analyzer.MinimumReportedSeverity);
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticLocalizationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticLocalizationTests.cs
@@ -309,7 +309,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 isCompilerAnalyzer: _ => false, analyzerManager, shouldSkipAnalysisOnGeneratedCode: _ => false,
                 shouldSuppressGeneratedCodeDiagnostic: (_, _, _, _) => false, isGeneratedCodeLocation: (_, _, _) => false,
                 isAnalyzerSuppressedForTree: (_, _, _, _) => false, getAnalyzerGate: _ => null,
-                getSemanticModel: tree => compilation.GetSemanticModel(tree, ignoreAccessibility: true));
+                getSemanticModel: tree => compilation.GetSemanticModel(tree, ignoreAccessibility: true),
+                SeverityFilter.None);
             var descriptors = analyzerManager.GetSupportedDiagnosticDescriptors(analyzer, analyzerExecutor, CancellationToken.None);
 
             Assert.Equal(1, descriptors.Length);

--- a/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SeverityFilter.cs
@@ -29,5 +29,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _ => false
             };
         }
+
+        internal static DiagnosticSeverity GetMinimumUnfilteredSeverity(this SeverityFilter severityFilter)
+        {
+            if (!severityFilter.Contains(ReportDiagnostic.Hidden))
+            {
+                return DiagnosticSeverity.Hidden;
+            }
+            else if (!severityFilter.Contains(ReportDiagnostic.Info))
+            {
+                return DiagnosticSeverity.Info;
+            }
+
+            return DiagnosticSeverity.Warning;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var analyzerExecutor = AnalyzerExecutor.Create(
                 compilation, analysisOptions.Options ?? AnalyzerOptions.Empty, addNotCategorizedDiagnostic, newOnAnalyzerException, analysisOptions.AnalyzerExceptionFilter,
                 IsCompilerAnalyzer, AnalyzerManager, ShouldSkipAnalysisOnGeneratedCode, ShouldSuppressGeneratedCodeDiagnostic, IsGeneratedOrHiddenCodeLocation, IsAnalyzerSuppressedForTree, GetAnalyzerGate,
-                getSemanticModel: GetOrCreateSemanticModel,
+                getSemanticModel: GetOrCreateSemanticModel, _severityFilter,
                 analysisOptions.LogAnalyzerExecutionTime, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic, s => _programmaticSuppressions!.Add(s));
 
             Initialize(analyzerExecutor, diagnosticQueue, compilationData, analysisScope, suppressedDiagnosticIds, cancellationToken);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -86,6 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// All analyzer callbacks for non-concurrent analyzers will be guarded with a lock on the gate.
         /// </param>
         /// <param name="getSemanticModel">Delegate to get a semantic model for the given syntax tree which can be shared across analyzers.</param>
+        /// <param name="severityFilter"><see cref="SeverityFilter"/> for analysis.</param>
         /// <param name="shouldSkipAnalysisOnGeneratedCode">Delegate to identify if analysis should be skipped on generated code.</param>
         /// <param name="shouldSuppressGeneratedCodeDiagnostic">Delegate to identify if diagnostic reported while analyzing generated code should be suppressed.</param>
         /// <param name="isGeneratedCodeLocation">Delegate to identify if the given location is in generated code.</param>
@@ -108,6 +109,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, CancellationToken, bool> isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?> getAnalyzerGate,
             Func<SyntaxTree, SemanticModel> getSemanticModel,
+            SeverityFilter severityFilter,
             bool logExecutionTime = false,
             Action<Diagnostic, DiagnosticAnalyzer, bool, CancellationToken>? addCategorizedLocalDiagnostic = null,
             Action<Diagnostic, DiagnosticAnalyzer, CancellationToken>? addCategorizedNonLocalDiagnostic = null,
@@ -121,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             return new AnalyzerExecutor(compilation, analyzerOptions, addNonCategorizedDiagnostic, onAnalyzerException, analyzerExceptionFilter,
                 isCompilerAnalyzer, analyzerManager, shouldSkipAnalysisOnGeneratedCode, shouldSuppressGeneratedCodeDiagnostic, isGeneratedCodeLocation,
-                isAnalyzerSuppressedForTree, getAnalyzerGate, getSemanticModel, analyzerExecutionTimeMap, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic,
+                isAnalyzerSuppressedForTree, getAnalyzerGate, getSemanticModel, severityFilter, analyzerExecutionTimeMap, addCategorizedLocalDiagnostic, addCategorizedNonLocalDiagnostic,
                 addSuppression);
         }
 
@@ -139,6 +141,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Func<DiagnosticAnalyzer, SyntaxTree, SyntaxTreeOptionsProvider?, CancellationToken, bool> isAnalyzerSuppressedForTree,
             Func<DiagnosticAnalyzer, object?> getAnalyzerGate,
             Func<SyntaxTree, SemanticModel> getSemanticModel,
+            SeverityFilter severityFilter,
             ConcurrentDictionary<DiagnosticAnalyzer, StrongBox<long>>? analyzerExecutionTimeMap,
             Action<Diagnostic, DiagnosticAnalyzer, bool, CancellationToken>? addCategorizedLocalDiagnostic,
             Action<Diagnostic, DiagnosticAnalyzer, CancellationToken>? addCategorizedNonLocalDiagnostic,
@@ -157,6 +160,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _isAnalyzerSuppressedForTree = isAnalyzerSuppressedForTree;
             _getAnalyzerGate = getAnalyzerGate;
             _getSemanticModel = getSemanticModel;
+            SeverityFilter = severityFilter;
             _analyzerExecutionTimeMap = analyzerExecutionTimeMap;
             _addCategorizedLocalDiagnostic = addCategorizedLocalDiagnostic;
             _addCategorizedNonLocalDiagnostic = addCategorizedNonLocalDiagnostic;
@@ -169,7 +173,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal AnalyzerOptions AnalyzerOptions { get; }
 
+        internal SeverityFilter SeverityFilter { get; }
+
         internal Action<Exception, DiagnosticAnalyzer, Diagnostic, CancellationToken> OnAnalyzerException { get; }
+
         internal ImmutableDictionary<DiagnosticAnalyzer, TimeSpan> AnalyzerExecutionTimes
         {
             get
@@ -184,15 +191,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <param name="analyzer">Analyzer to get session wide analyzer actions.</param>
         /// <param name="sessionScope">Session scope to store register session wide analyzer actions.</param>
+        /// <param name="severityFilter">Severity filter for analysis.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>
         /// Note that this API doesn't execute any <see cref="CompilationStartAnalyzerAction"/> registered by the Initialize invocation.
         /// Use <see cref="ExecuteCompilationStartActions(ImmutableArray{CompilationStartAnalyzerAction}, HostCompilationStartAnalysisScope, CancellationToken)"/> API
         /// to get execute these actions to get the per-compilation analyzer actions.
         /// </remarks>
-        public void ExecuteInitializeMethod(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope sessionScope, CancellationToken cancellationToken)
+        public void ExecuteInitializeMethod(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope sessionScope, SeverityFilter severityFilter, CancellationToken cancellationToken)
         {
-            var context = new AnalyzerAnalysisContext(analyzer, sessionScope);
+            var context = new AnalyzerAnalysisContext(analyzer, sessionScope, severityFilter);
 
             // The Initialize method should be run asynchronously in case it is not well behaved, e.g. does not terminate.
             ExecuteAndCatchIfThrows(

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         return Task.Run(() =>
                         {
                             var sessionScope = new HostSessionStartAnalysisScope();
-                            executor.ExecuteInitializeMethod(context._analyzer, sessionScope, cancellationToken);
+                            executor.ExecuteInitializeMethod(context._analyzer, sessionScope, executor.SeverityFilter, cancellationToken);
                             return sessionScope;
                         }, cancellationToken);
                     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -223,6 +223,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
+        /// Indicates the minimum reported diagnostic severity for this analysis context.
+        /// Analyzer diagnostics with severity lesser than this severity are not reported.
+        /// </summary>
+        public virtual DiagnosticSeverity MinimumReportedSeverity => throw new NotImplementedException();
+
+        /// <summary>
         /// Attempts to compute or get the cached value provided by the given <paramref name="valueProvider"/> for the given <paramref name="text"/>.
         /// Note that the pair {<paramref name="valueProvider"/>, <paramref name="text"/>} acts as the key.
         /// Reusing the same <paramref name="valueProvider"/> instance across analyzer actions and/or analyzer instances can improve the overall analyzer performance by avoiding recomputation of the values.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Indicates the minimum reported diagnostic severity for this analysis context.
         /// Analyzer diagnostics with severity lesser than this severity are not reported.
         /// </summary>
-        public virtual DiagnosticSeverity MinimumReportedSeverity => throw new NotImplementedException();
+        public virtual DiagnosticSeverity MinimumReportedSeverity => DiagnosticSeverity.Hidden;
 
         /// <summary>
         /// Attempts to compute or get the cached value provided by the given <paramref name="valueProvider"/> for the given <paramref name="text"/>.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -22,10 +22,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly DiagnosticAnalyzer _analyzer;
         private readonly HostSessionStartAnalysisScope _scope;
 
-        public AnalyzerAnalysisContext(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope scope)
+        public AnalyzerAnalysisContext(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope scope, SeverityFilter severityFilter)
         {
             _analyzer = analyzer;
             _scope = scope;
+            MinimumReportedSeverity = severityFilter.GetMinimumUnfilteredSeverity();
         }
 
         public override void RegisterCompilationStartAction(Action<CompilationStartAnalysisContext> action)
@@ -115,6 +116,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             _scope.ConfigureGeneratedCodeAnalysis(_analyzer, mode);
         }
+
+        public override DiagnosticSeverity MinimumReportedSeverity { get; }
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,5 +9,6 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalyzerDiagnosti
 static Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzerExtensions.WithAnalyzers(this Microsoft.CodeAnalysis.Compilation! compilation, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer!> analyzers, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions? options = null) -> Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers!
 static Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzerExtensions.WithAnalyzers(this Microsoft.CodeAnalysis.Compilation! compilation, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer!> analyzers, Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions? options, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers!
 Microsoft.CodeAnalysis.RefKind.RefReadOnlyParameter = 4 -> Microsoft.CodeAnalysis.RefKind
+virtual Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.MinimumReportedSeverity.get -> Microsoft.CodeAnalysis.DiagnosticSeverity
 virtual Microsoft.CodeAnalysis.SyntaxContextReceiverCreator.Invoke() -> Microsoft.CodeAnalysis.ISyntaxContextReceiver?
 virtual Microsoft.CodeAnalysis.SyntaxReceiverCreator.Invoke() -> Microsoft.CodeAnalysis.ISyntaxReceiver!

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -3125,5 +3125,27 @@ namespace Microsoft.CodeAnalysis
                 }
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class MinimumReportedSeverityAnalyzer : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor _descriptor = new DiagnosticDescriptor(
+                "ID1",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public DiagnosticSeverity MinimumReportedSeverity { get; private set; }
+            public bool AnalyzerInvoked { get; private set; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                MinimumReportedSeverity = context.MinimumReportedSeverity;
+                AnalyzerInvoked = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Work towards #52991

Implements the compiler/analyzer driver performance change from https://github.com/dotnet/roslyn/issues/52991#issuecomment-1709912198 This flag indicates the minimum reported diagnostic severity for analyzer execution context. For command line builds, this will be warning, while for the IDE case this will be hidden. Analyzer diagnostics with severity lesser than this severity are not reported by the driver.

This flag will allow the IDE code style analyzers to turn on/off in command line builds based on `option_name = option_value:severity` entries in editorconfig.