### PR TITLE
Fall back to using .NET Core MSBuild if no VS is installed

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BuildHostProcessManager.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BuildHostProcessManager.cs
@@ -33,22 +33,41 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
     {
         var neededBuildHostKind = GetKindForProject(projectFilePath);
 
-        _logger?.LogTrace($"Choosing a build host of type {neededBuildHostKind} for {projectFilePath}");
+        _logger?.LogTrace($"Choosing a build host of type {neededBuildHostKind} for {projectFilePath}.");
 
+        var buildHost = await GetBuildHostAsync(neededBuildHostKind, cancellationToken).ConfigureAwait(false);
+
+        // If this is a .NET Framework build host, we may not have have build tools installed and thus can't actually use it to build.
+        // Check if this is the case.
+        if (neededBuildHostKind == BuildHostProcessKind.NetFramework)
+        {
+            if (!await buildHost.IsProjectFileSupportedAsync(projectFilePath, cancellationToken))
+            {
+                // It's not usable, so we'll fall back to the .NET Core one.
+                _logger?.LogWarning($"An installation of Visual Studio or the Build Tools for Visual Studio could not be found; {projectFilePath} will be loaded with the .NET Core SDK and may encounter errors.");
+                return await GetBuildHostAsync(BuildHostProcessKind.NetCore, cancellationToken);
+            }
+        }
+
+        return buildHost;
+    }
+
+    private async Task<IBuildHost> GetBuildHostAsync(BuildHostProcessKind buildHostKind, CancellationToken cancellationToken)
+    {
         using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (!_processes.TryGetValue(neededBuildHostKind, out var buildHostProcess))
+            if (!_processes.TryGetValue(buildHostKind, out var buildHostProcess))
             {
-                var process = neededBuildHostKind switch
+                var process = buildHostKind switch
                 {
                     BuildHostProcessKind.NetCore => LaunchDotNetCoreBuildHost(),
                     BuildHostProcessKind.NetFramework => LaunchDotNetFrameworkBuildHost(),
-                    _ => throw ExceptionUtilities.UnexpectedValue(neededBuildHostKind)
+                    _ => throw ExceptionUtilities.UnexpectedValue(buildHostKind)
                 };
 
                 buildHostProcess = new BuildHostProcess(process, _loggerFactory);
                 buildHostProcess.Disconnected += BuildHostProcess_Disconnected;
-                _processes.Add(neededBuildHostKind, buildHostProcess);
+                _processes.Add(buildHostKind, buildHostProcess);
             }
 
             return buildHostProcess.BuildHost;

--- a/src/Workspaces/Core/MSBuild.BuildHost/IBuildHost.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/IBuildHost.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost;
 internal interface IBuildHost
 {
     /// <summary>
-    /// Returns whether this project's language is supported.
+    /// Returns whether this project's is supported by this host, considering both the project language and also MSBuild availability.
     /// </summary>
     Task<bool> IsProjectFileSupportedAsync(string projectFilePath, CancellationToken cancellationToken);
 


### PR DESCRIPTION
If we decide a project should be built with a .NET Framework MSBuild, we'd assume there was in fact a MSBuild install on the machine. If there isn't one, then we can try falling back to .NET Core after issuing a warning.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1884068
Fixes https://github.com/dotnet/vscode-csharp/issues/6436