### PR TITLE
Ensure GetRelatedDocumentIds() only returns IDs for source documents

### DIFF
--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -4402,5 +4402,25 @@ class C
             var projectOptions = document.Project.GetAnalyzerConfigOptions();
             Assert.Equal(appliedToEntireProject, projectOptions?.AnalyzerOptions.TryGetValue("indent_style", out value) == true && value == "tab");
         }
+
+        [Fact]
+        public void GetRelatedDocumentsDoesNotReturnOtherTypesOfDocuments()
+        {
+            using var workspace = CreateWorkspace();
+
+            const string FilePath = "File.cs";
+
+            var solution = workspace.CurrentSolution
+                .AddProject("TestProject", "TestProject", LanguageNames.CSharp)
+                .AddDocument("File.cs", "", filePath: FilePath).Project
+                .AddAdditionalDocument("File.cs", text: "", filePath: FilePath).Project.Solution;
+
+            // GetDocumentIdsWithFilePath should return two, since it'll count all types of documents
+            Assert.Equal(2, solution.GetDocumentIdsWithFilePath(FilePath).Length);
+
+            var regularDocumentId = solution.Projects.Single().DocumentIds.Single();
+
+            Assert.Single(solution.GetRelatedDocumentIds(regularDocumentId));
+        }
     }
 }


### PR DESCRIPTION
Prior to 308dd649dc569041a9661d8d3663bd772a5a753e GetRelatedDocumentIDs would only return IDs for regular documents; we accidentally introduced a bug where it return IDs for other types of documents if somebody accidentally created an additional file with the same path as a regular document, or other similar problems. This change restores the behavior back.

While writing this up, I did look at whether we should change GetDocumentIdsWithFilePath to only return regular document IDs, but concluded there is enough code already there that expects it to work for other types of documents that it should be left as-is.

Fixes https://github.com/dotnet/roslyn/issues/70134
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1880580
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1853903
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1851897