### PR TITLE
Include sqlite binaries to enable persistent storage in vscode

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,0 +1,8 @@
+content/LanguageServer/alpine-arm64/libe_sqlite3.so
+content/LanguageServer/alpine-x64/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-arm64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-arm/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/alpine-x64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-arm64/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-arm/native/libe_sqlite3.so
+content/LanguageServer/neutral/runtimes/linux-musl-x64/native/libe_sqlite3.so

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -263,6 +263,8 @@ function BuildSolution() {
   
   $isNpmAvailable = IsNpmAvailable
 
+  $symbolPublishingExcludeFile = Join-Path $RepoRoot "eng\SymbolPublishingExclusionsFile.txt"
+
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -286,6 +288,7 @@ function BuildSolution() {
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       /p:IsNpmPackable=$isNpmAvailable `
+      /p:SymbolPublishingExclusionsFile=$symbolPublishingExcludeFile `
       $suppressExtensionDeployment `
       $msbuildWarnAsError `
       $buildFromSource `

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -75,6 +75,13 @@
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+
+    <!--
+      Ensure we include the sqlite assemblies and their native dependencies in our package to enable persistent storage.
+    -->
+    <PackageReference Include="SQLitePCLRaw.core" Version="$(SQLitePCLRawbundle_greenVersion)" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawbundle_greenVersion)" />
+    <PackageReference Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="$(SQLitePCLRawbundle_greenVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,20 +136,13 @@
     <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433; we pass
          BuildInParallel="false" to avoid multiple builds potentially building the same project at the same time, but since we
          expect the builds to have completed by this point they should be fast.  -->
-    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)"
-             Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
-             BuildInParallel="false"
-             Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
+    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup" BuildInParallel="false" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 
     <ItemGroup>
       <!-- We set Pack="false" because we only care about the RID-specific folders -->
-      <Content Include="%(NetFrameworkBuildHostAssets.Identity)"
-               Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'"
-               Pack="false"
-               TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)"
-               CopyToOutputDirectory="PreserveNewest" />
+      <Content Include="%(NetFrameworkBuildHostAssets.Identity)" Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'" Pack="false" TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1894466 (internal)

Blocked on arcade.  
Certain platforms from sqlite seem to have invalid files for symbol publishing.  Arcade's mechanism of configuring exclusions (see https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md#can-we-exclude-symbols-from-publishing-to-symbols-server) does not work with the publish that happens with the build

The [Publish.proj](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj) that gets invoked via Build.proj does not read the exclusions.

But the PublishToSymbolServers.proj (not invoked in our build) [does read the exclusions](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Arcade.Sdk/tools/SdkTasks/PublishToSymbolServers.proj#L66C1-L67C1).

workarounds:
remove old publishing by always setting `DotnetPublishUsingPipelines` to true.  this requires moving the PR validation pipeline to v3 publishing (currently it relies on symbols being published in the build step)

manually generate the symbols package and manually exclude the sqlite binaries.