### PR TITLE
Add `ExternalAccess.RazorCompiler.dll` reference to C# language server

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -132,13 +132,20 @@
     <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433; we pass
          BuildInParallel="false" to avoid multiple builds potentially building the same project at the same time, but since we
          expect the builds to have completed by this point they should be fast.  -->
-    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup" BuildInParallel="false" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
+    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)"
+         Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
+         BuildInParallel="false"
+         Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 
     <ItemGroup>
       <!-- We set Pack="false" because we only care about the RID-specific folders -->
-      <Content Include="%(NetFrameworkBuildHostAssets.Identity)" Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'" Pack="false" TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)" CopyToOutputDirectory="PreserveNewest" />
+      <Content Include="%(NetFrameworkBuildHostAssets.Identity)"
+         Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'"
+         Pack="false"
+         TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)"
+         CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -133,19 +133,19 @@
          BuildInParallel="false" to avoid multiple builds potentially building the same project at the same time, but since we
          expect the builds to have completed by this point they should be fast.  -->
     <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)"
-         Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
-         BuildInParallel="false"
-         Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
+             Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
+             BuildInParallel="false"
+             Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 
     <ItemGroup>
       <!-- We set Pack="false" because we only care about the RID-specific folders -->
       <Content Include="%(NetFrameworkBuildHostAssets.Identity)"
-         Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'"
-         Pack="false"
-         TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)"
-         CopyToOutputDirectory="PreserveNewest" />
+               Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'"
+               Pack="false"
+               TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)"
+               CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -58,6 +58,9 @@
 
     <!-- Dlls we don't directly reference but need to include to build the MEF composition -->
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
+
+    <!-- Not directly referenced but needed for Razor source generators -->
+    <ProjectReference Include="..\..\..\Tools\ExternalAccess\RazorCompiler\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,20 +132,13 @@
     <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433; we pass
          BuildInParallel="false" to avoid multiple builds potentially building the same project at the same time, but since we
          expect the builds to have completed by this point they should be fast.  -->
-    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)"
-             Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
-             BuildInParallel="false"
-             Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
+    <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)" Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup" BuildInParallel="false" Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 
     <ItemGroup>
       <!-- We set Pack="false" because we only care about the RID-specific folders -->
-      <Content Include="%(NetFrameworkBuildHostAssets.Identity)"
-               Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'"
-               Pack="false"
-               TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)"
-               CopyToOutputDirectory="PreserveNewest" />
+      <Content Include="%(NetFrameworkBuildHostAssets.Identity)" Condition="'%(NetFrameworkBuildHostAssets.TargetPath)' != '' and '%(NetFrameworkBuildHostAssets.Extension)' != '.xml'" Pack="false" TargetPath="BuildHost-net472\%(NetFrameworkBuildHostAssets.TargetPath)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Razor relies on Roslyn to ship this dll with the language server since they use it for source generators.