### PR TITLE
Check for particular collection expr attribute by name, as it can be provided internally in packages

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForCreateDiagnosticAnalyzer.cs
@@ -27,9 +27,6 @@ internal sealed partial class CSharpUseCollectionExpressionForCreateDiagnosticAn
     {
     }
 
-    protected override bool IsSupported(Compilation compilation)
-        => compilation.CollectionBuilderAttribute() is not null;
-
     protected override void InitializeWorker(CodeBlockStartAnalysisContext<SyntaxKind> context)
         => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -132,8 +132,7 @@ internal static class UseCollectionExpressionHelpers
                     return true;
 
                 // If it has a [CollectionBuilder] attribute on it, it is a valid collection expression type.
-                var collectionBuilderType = compilation.CollectionBuilderAttribute();
-                if (namedType.GetAttributes().Any(a => a.AttributeClass?.Equals(collectionBuilderType) is true))
+                if (namedType.GetAttributes().Any(a => a.AttributeClass.IsCollectionBuilderAttribute()))
                     return true;
 
                 // At this point, all that is left are collection-initializer types.  These need to derive from
@@ -513,12 +512,10 @@ internal static class UseCollectionExpressionHelpers
         }
 
         memberAccess = memberAccessExpression;
-        var createMethod = semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol as IMethodSymbol;
-        if (createMethod is not { IsStatic: true })
+        if (semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol is not IMethodSymbol  { IsStatic: true } createMethod)
             return false;
 
-        var factoryType = semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol as INamedTypeSymbol;
-        if (factoryType is null)
+        if (semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol is not INamedTypeSymbol factoryType)
             return false;
 
         var compilation = semanticModel.Compilation;
@@ -526,10 +523,9 @@ internal static class UseCollectionExpressionHelpers
         // The pattern is a type like `ImmutableArray` (non-generic), returning an instance of `ImmutableArray<T>`.  The
         // actual collection type (`ImmutableArray<T>`) has to have a `[CollectionBuilder(...)]` attribute on it that
         // then points at the factory type.
-        var collectionBuilderAttribute = compilation.CollectionBuilderAttribute()!;
         var collectionBuilderAttributeData = createMethod.ReturnType.OriginalDefinition
             .GetAttributes()
-            .FirstOrDefault(a => collectionBuilderAttribute.Equals(a.AttributeClass));
+            .FirstOrDefault(a => a.AttributeClass.IsCollectionBuilderAttribute());
         if (collectionBuilderAttributeData?.ConstructorArguments is not [{ Value: ITypeSymbol collectionBuilderType }, { Value: CreateName }])
             return false;
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -512,7 +512,7 @@ internal static class UseCollectionExpressionHelpers
         }
 
         memberAccess = memberAccessExpression;
-        if (semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol is not IMethodSymbol  { IsStatic: true } createMethod)
+        if (semanticModel.GetSymbolInfo(memberAccessExpression, cancellationToken).Symbol is not IMethodSymbol { IsStatic: true } createMethod)
             return false;
 
         if (semanticModel.GetSymbolInfo(memberAccessExpression.Expression, cancellationToken).Symbol is not INamedTypeSymbol factoryType)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ICompilationExtensions.cs
@@ -195,9 +195,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static INamedTypeSymbol? OnSerializedAttribute(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(OnSerializedAttribute).FullName!);
 
-        public static INamedTypeSymbol? CollectionBuilderAttribute(this Compilation compilation)
-            => compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.CollectionBuilderAttribute");
-
         public static INamedTypeSymbol? ComRegisterFunctionAttribute(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(ComRegisterFunctionAttribute).FullName!);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -619,5 +619,24 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static INamedTypeSymbol TryConstruct(this INamedTypeSymbol type, ITypeSymbol[] typeArguments)
             => typeArguments.Length > 0 ? type.Construct(typeArguments) : type;
+
+        public static bool IsCollectionBuilderAttribute([NotNullWhen(true)] this INamedTypeSymbol? type)
+            => type is
+            {
+                Name: "CollectionBuilderAttribute",
+                ContainingNamespace:
+                {
+                    Name: nameof(System.Runtime.CompilerServices),
+                    ContainingNamespace:
+                    {
+                        Name: nameof(System.Runtime),
+                        ContainingNamespace:
+                        {
+                            Name: nameof(System),
+                            ContainingNamespace.IsGlobalNamespace: true,
+                        }
+                    }
+                }
+            };
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/70178

Core issue here is that this attribute could jsut be internal, and included with a nuget package (like System.Collections.Immutable) to mark their types as supporting collection exprs.  We should not assume there is a single well known attribute class that everyone will use.