### PR TITLE
Set rollForward again

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   },
   "tools": {
     "dotnet": "8.0.100-preview.7.23376.3",


### PR DESCRIPTION
We had disabled this when internal builds were rolling forward to RC1 but that hadn't fully shipped; that's shipped so now this breaks things instead.