### PR TITLE
Add Global prefix to VBCSCompiler mutex to make it visible on nix systems

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 }
             }
 #endif
-            
+
             [Fact]
             [WorkItem(70166, "https://github.com/dotnet/roslyn/issues/70166")]
             public void TestIfMutexIsGlobal()

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -122,6 +122,19 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 }
             }
 #endif
+            
+            [Fact]
+            [WorkItem(70166, "https://github.com/dotnet/roslyn/issues/70166")]
+            public void TestIfMutexIsGlobal()
+            {
+                const string GlobalPrefix = "Global\\";
+
+                var clientMutexName = BuildServerConnection.GetClientMutexName(_pipeName);
+                Assert.True(clientMutexName.StartsWith(GlobalPrefix));
+
+                var serverMutexName = BuildServerConnection.GetServerMutexName(_pipeName);
+                Assert.True(serverMutexName.StartsWith(GlobalPrefix));
+            }
 
             [Fact]
             public async Task ConnectToPipe()

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         // Spend up to 20s connecting to a new process, to allow time for it to start.
         internal const int TimeOutMsNewProcess = 20000;
-        
+
         // To share a mutex between processes the name should have the Global prefix
         private const string GlobalMutexPrefix = "Global\\";
 

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -25,6 +25,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         // Spend up to 20s connecting to a new process, to allow time for it to start.
         internal const int TimeOutMsNewProcess = 20000;
+        
+        // To share a mutex between processes the name should have the Global prefix
+        private const string GlobalMutexPrefix = "Global\\";
 
         /// <summary>
         /// Determines if the compiler server is supported in this environment.
@@ -581,12 +584,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static string GetServerMutexName(string pipeName)
         {
-            return $"{pipeName}.server";
+            return $"{GlobalMutexPrefix}{pipeName}.server";
         }
 
         internal static string GetClientMutexName(string pipeName)
         {
-            return $"{pipeName}.client";
+            return $"{GlobalMutexPrefix}{pipeName}.client";
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #70166

Add the 'Global\' prefix to the VBCSComiler mutex used for uniqueness check. 

At this moment `dotnet build-server shutdown` doesn't work on *nix systems because VBCSCompiler checks named mutex, but this mutex is not visible out of process. To fix this issue ['Global' prefix should be used](https://learn.microsoft.com/en-us/dotnet/api/system.threading.mutex?view=net-7.0).