### PR TITLE
Update 'use collection expression' analyzer/fixer to support conversion when a capacity argument is passed.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -68,6 +68,9 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         // that as well.
         var individualElementCount = _objectCreationExpression.Initializer?.Expressions.Count ?? 0;
 
+        // Walk the matches, determining what individual elements are added as-is, as well as what values are going to
+        // be spread into the final collection.  We'll then ensure a correspondance between both and the expression the
+        // user is currently passing to the 'capacity' argument to make sure they're entirely congruent.
         using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var spreadElements);
         foreach (var match in matches)
         {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer;
 
@@ -28,14 +32,145 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
     protected override bool IsComplexElementInitializer(SyntaxNode expression)
         => expression.IsKind(SyntaxKind.ComplexElementInitializerExpression);
 
-    protected override bool HasExistingInvalidInitializerForCollection(BaseObjectCreationExpressionSyntax objectCreation)
+    protected override bool HasExistingInvalidInitializerForCollection()
     {
         // Can't convert to a collection expression if it already has an object-initializer.  Note, we do allow
         // conversion of empty `{ }` initializer.  So we only block if the expression count is more than zero.
-        return objectCreation.Initializer is InitializerExpressionSyntax
+        return _objectCreationExpression.Initializer is InitializerExpressionSyntax
         {
             RawKind: (int)SyntaxKind.ObjectInitializerExpression,
             Expressions.Count: > 0,
         };
+    }
+
+    protected override bool ValidateMatchesForCollectionExpression(
+        ArrayBuilder<Match<StatementSyntax>> matches, CancellationToken cancellationToken)
+    {
+        // Constructor wasn't called with any arguments.  Nothing to validate.
+        var argumentList = _objectCreationExpression.ArgumentList;
+        if (argumentList is null || argumentList.Arguments.Count == 0)
+            return true;
+
+        // Anything beyond just a single capacity argument isn't anything we can handle.
+        if (argumentList.Arguments.Count >= 2)
+            return false;
+
+        // must be a single `int capacity` constructor.
+        if (this.SemanticModel.GetSymbolInfo(_objectCreationExpression, cancellationToken).Symbol is not IMethodSymbol
+            {
+                MethodKind: MethodKind.Constructor,
+                Parameters: [{ Type.SpecialType: SpecialType.System_Int32, Name: "capacity" }],
+            } constructor)
+        {
+            return false;
+        }
+
+        var individualElementCount = 0;
+        var initializer = _objectCreationExpression.Initializer;
+        if (initializer != null)
+            individualElementCount += initializer.Expressions.Count;
+
+        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var spreadElements);
+
+        foreach (var match in matches)
+        {
+            switch (match.Statement)
+            {
+                case ExpressionStatementSyntax { Expression: InvocationExpressionSyntax invocation } expressionStatement:
+                    // x.AddRange(y).  Have to make sure we see y.Count in the capacity list.
+                    // x.Add(y, z).  Increment the total number of elements by the arg count.
+                    if (match.UseSpread)
+                        spreadElements.Add(invocation.ArgumentList.Arguments[0]);
+                    else
+                        individualElementCount += invocation.ArgumentList.Arguments.Count;
+
+                    continue;
+
+                case ForEachStatementSyntax foreachStatement:
+                    // foreach (var v in expr) x.Add(v).  Have to make sure we see expr.Count in the capacity list.
+
+                    spreadElements.Add(foreachStatement.Expression);
+                    continue;
+
+                default:
+                    // Something we don't support (yet).
+                    return false;
+            }
+        }
+
+        var expression = argumentList.Arguments[0].Expression;
+        using var _2 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionPieces);
+
+        // Break up an expression like `1 + x.Length + y.Count` into the parts separated by the +'s
+        while (true)
+        {
+            if (expression is BinaryExpressionSyntax binaryExpression)
+            {
+                if (binaryExpression.Kind() != SyntaxKind.AddExpression)
+                    return false;
+
+                expressionPieces.Add(binaryExpression.Right);
+                expression = binaryExpression.Left;
+            }
+            else
+            {
+                expressionPieces.Add(expression);
+                break;
+            }
+        }
+
+        // Determine the total constant value provided in the expression.  For each constant we see, remove that
+        // constant from the pieces list.
+        var totalConstantValue = 0;
+        for (var i = expressionPieces.Count - 1; i >= 0; i--)
+        {
+            var piece = expressionPieces[i];
+            var constant = this.SemanticModel.GetConstantValue(piece, cancellationToken);
+            if (constant.Value is int value)
+            {
+                totalConstantValue += value;
+                expressionPieces.RemoveAt(i);
+            }
+        }
+
+        // If the constant didn't match the number of individual elements to add, we can't update this code.
+        if (totalConstantValue != individualElementCount)
+            return false;
+
+        // After removing the constants, we should have an expression for each value we're going to spread.
+        if (expressionPieces.Count != spreadElements.Count)
+            return false;
+
+        foreach (var piece in expressionPieces)
+        {
+            // we support x.Length, x.Count, and x.Count()
+            var current = piece;
+            if (piece is InvocationExpressionSyntax invocationExpression)
+            {
+                if (invocationExpression.ArgumentList.Arguments.Count != 0)
+                    return false;
+
+                current = invocationExpression.Expression;
+            }
+
+            if (current is not MemberAccessExpressionSyntax(SyntaxKind.SimpleMemberAccessExpression) { Name.Identifier.ValueText: "Length" or "Count" } memberAccess)
+                return false;
+
+            current = memberAccess.Expression;
+
+            // Now see if we have an item we're spreading matching 'x'.
+            var matchIndex = spreadElements.FindIndex(SyntaxFacts.AreEquivalent, current);
+            if (matchIndex < 0)
+                return false;
+
+            spreadElements.RemoveAt(matchIndex);
+        }
+
+        // If we had any spread elements remaining we can't proceed.
+        if (spreadElements.Count > 0)
+            return false;
+
+        // We're all good.  The items we found matches up precisely to the capacity provided!
+        return true;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -85,7 +85,6 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
 
                 case ForEachStatementSyntax foreachStatement:
                     // foreach (var v in expr) x.Add(v).  Have to make sure we see expr.Count in the capacity list.
-
                     spreadElements.Add(foreachStatement.Expression);
                     continue;
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -119,7 +119,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         }
 
         // Determine the total constant value provided in the expression.  For each constant we see, remove that
-        // constant from the pieces list.
+        // constant from the pieces list.  That way the pieces list only corresponds to the values to spread.
         var totalConstantValue = 0;
         for (var i = expressionPieces.Count - 1; i >= 0; i--)
         {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -64,13 +64,11 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             return false;
         }
 
-        var individualElementCount = 0;
-        var initializer = _objectCreationExpression.Initializer;
-        if (initializer != null)
-            individualElementCount += initializer.Expressions.Count;
+        // The original collection could have been passed elements explicitly in its initializer.  Ensure we account for
+        // that as well.
+        var individualElementCount = _objectCreationExpression.Initializer?.Expressions.Count ?? 0;
 
         using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var spreadElements);
-
         foreach (var match in matches)
         {
             switch (match.Statement)

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -70,7 +70,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
         if (initializer != null)
             individualElementCount += initializer.Expressions.Count;
 
-        using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var spreadElements);
+        using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var spreadElements);
 
         foreach (var match in matches)
         {
@@ -80,7 +80,7 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
                     // x.AddRange(y).  Have to make sure we see y.Count in the capacity list.
                     // x.Add(y, z).  Increment the total number of elements by the arg count.
                     if (match.UseSpread)
-                        spreadElements.Add(invocation.ArgumentList.Arguments[0]);
+                        spreadElements.Add(invocation.ArgumentList.Arguments[0].Expression);
                     else
                         individualElementCount += invocation.ArgumentList.Arguments.Count;
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionInitializer/CSharpUseCollectionInitializerAnalyzer.cs
@@ -97,23 +97,23 @@ internal sealed class CSharpUseCollectionInitializerAnalyzer : AbstractUseCollec
             }
         }
 
-        var expression = argumentList.Arguments[0].Expression;
+        // Now, break up an expression like `1 + x.Length + y.Count` into the parts separated by the +'s
+        var currentArgumentExpression = argumentList.Arguments[0].Expression;
         using var _2 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionPieces);
 
-        // Break up an expression like `1 + x.Length + y.Count` into the parts separated by the +'s
         while (true)
         {
-            if (expression is BinaryExpressionSyntax binaryExpression)
+            if (currentArgumentExpression is BinaryExpressionSyntax binaryExpression)
             {
                 if (binaryExpression.Kind() != SyntaxKind.AddExpression)
                     return false;
 
                 expressionPieces.Add(binaryExpression.Right);
-                expression = binaryExpression.Left;
+                currentArgumentExpression = binaryExpression.Left;
             }
             else
             {
-                expressionPieces.Add(expression);
+                expressionPieces.Add(currentArgumentExpression);
                 break;
             }
         }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -1354,10 +1354,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = new List<int>(1)
-                    {
-                        1
-                    };
+                    List<int> c = [1];
                 }
             }
             """);
@@ -4621,7 +4618,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact]
     public async Task TestCapacity15()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
             using System.Linq;
@@ -4630,8 +4627,26 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IEnumerable<int> y)
                 {
-                    List<int> c = new List<int>(1 + x.Length + y.Count());
-                    c.Add(0);
+                    List<int> c = [|new|] List<int>(1 + x.Length + y.Count());
+                    [|c.Add(|]0);
+                    c.AddRange(x);
+                    c.AddRange(y);
+                    c.Add(1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(1 + x.Length + y.Count())
+                    {
+                        0
+                    };
                     c.AddRange(x);
                     c.AddRange(y);
                     c.Add(1);
@@ -4643,7 +4658,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact]
     public async Task TestCapacity16()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -4651,8 +4666,23 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IEnumerable<int> y)
                 {
-                    List<int> c = new List<int>(1 - x.Length);
-                    c.Add(0);
+                    List<int> c = [|new|] List<int>(1 - x.Length);
+                    [|c.Add(|]0);
+                    c.AddRange(x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(1 - x.Length)
+                    {
+                        0
+                    };
                     c.AddRange(x);
                 }
             }
@@ -4662,7 +4692,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact]
     public async Task TestCapacity17()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -4670,8 +4700,23 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IEnumerable<int> y)
                 {
-                    List<int> c = new List<int>(1);
-                    c.Add(0);
+                    List<int> c = [|new|] List<int>(1);
+                    [|c.Add(|]0);
+                    c.AddRange(x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(1)
+                    {
+                        0
+                    };
                     c.AddRange(x);
                 }
             }
@@ -4681,7 +4726,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact]
     public async Task TestCapacity18()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -4689,8 +4734,23 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, int[] y)
                 {
-                    List<int> c = new List<int>(1 + x.Length + y.Length);
-                    c.Add(0);
+                    List<int> c = [|new|] List<int>(1 + x.Length + y.Length);
+                    [|c.Add(|]0);
+                    c.AddRange(x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = new List<int>(1 + x.Length + y.Length)
+                    {
+                        0
+                    };
                     c.AddRange(x);
                 }
             }
@@ -4700,7 +4760,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
     [Fact]
     public async Task TestCapacity19()
     {
-        await TestMissingInRegularAndScriptAsync(
+        await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
 
@@ -4708,8 +4768,23 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, int[] y)
                 {
-                    List<int> c = new List<int>(x);
-                    c.Add(0);
+                    List<int> c = [|new|] List<int>(x);
+                    [|c.Add(|]0);
+                    c.AddRange(y);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = new List<int>(x)
+                    {
+                        0
+                    };
                     c.AddRange(y);
                 }
             }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -4193,4 +4193,329 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestCapacity1()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>(0);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity2()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>(1);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity3()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>(1);
+                    c.Add(0);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [0];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity4()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = [|new|] List<int>(0);
+                    c.Add(1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M()
+                {
+                    List<int> c = new List<int>(0)
+                    {
+                        1,
+                    };
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity5()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> c = [|new|] List<int>(1 + x.Length);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> x = [0, .. x];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity6()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + 1);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> x = [0, .. x];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity7()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> c = [|new|] List<int>(2 + x.Length);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> x = [0, .. x, 1];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity8()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = [|new|] List<int>(2 + x.Length + y.Length);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> x = [0, .. x, .. y, 1];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity9()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + y.Length + 2);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> x = [0, .. x, .. y, 1];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity10()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IList<int> y)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + y.Count + 2);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IList<int> y)
+                {
+                    List<int> x = [0, .. x, .. y, 1];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity11()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + y.Count() + 2);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IList<int> y)
+                {
+                    List<int> x = [0, .. x, .. y, 1];
+                }
+            }
+            """);
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -4233,7 +4233,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M()
                 {
-                    List<int> c = [|new|] List<int>(1);
+                    List<int> c = new List<int>(1);
                 }
             }
             """);
@@ -4251,7 +4251,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c = [|new|] List<int>(1);
-                    c.Add(0);
+                    [|c.Add(|]0);
                 }
             }
             """,
@@ -4280,7 +4280,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M()
                 {
                     List<int> c = [|new|] List<int>(0);
-                    c.Add(1);
+                    [|c.Add(|]1);
                 }
             }
             """,
@@ -4293,7 +4293,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = new List<int>(0)
                     {
-                        1,
+                        1
                     };
                 }
             }
@@ -4313,7 +4313,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(1 + x.Length);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
+                    [|c.AddRange(|]x);
                 }
             }
             """,
@@ -4324,7 +4324,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x)
                 {
-                    List<int> x = [0, .. x];
+                    List<int> c = [0, .. x];
                 }
             }
             """);
@@ -4343,7 +4343,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(x.Length + 1);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
+                    [|c.AddRange(|]x);
                 }
             }
             """,
@@ -4354,7 +4354,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x)
                 {
-                    List<int> x = [0, .. x];
+                    List<int> c = [0, .. x];
                 }
             }
             """);
@@ -4373,7 +4373,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(2 + x.Length);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
+                    [|c.AddRange(|]x);
                     [|c.Add(|]1);
                 }
             }
@@ -4385,7 +4385,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x)
                 {
-                    List<int> x = [0, .. x, 1];
+                    List<int> c = [0, .. x, 1];
                 }
             }
             """);
@@ -4404,8 +4404,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(2 + x.Length + y.Length);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                     [|c.Add(|]1);
                 }
             }
@@ -4417,7 +4417,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, int[] y)
                 {
-                    List<int> x = [0, .. x, .. y, 1];
+                    List<int> c = [0, .. x, .. y, 1];
                 }
             }
             """);
@@ -4436,8 +4436,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(x.Length + y.Length + 2);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                     [|c.Add(|]1);
                 }
             }
@@ -4449,7 +4449,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, int[] y)
                 {
-                    List<int> x = [0, .. x, .. y, 1];
+                    List<int> c = [0, .. x, .. y, 1];
                 }
             }
             """);
@@ -4468,8 +4468,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(x.Length + y.Count + 2);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                     [|c.Add(|]1);
                 }
             }
@@ -4481,7 +4481,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IList<int> y)
                 {
-                    List<int> x = [0, .. x, .. y, 1];
+                    List<int> c = [0, .. x, .. y, 1];
                 }
             }
             """);
@@ -4500,8 +4500,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(x.Length + y.Count() + 2);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                     [|c.Add(|]1);
                 }
             }
@@ -4513,7 +4513,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IList<int> y)
                 {
-                    List<int> x = [0, .. x, .. y, 1];
+                    List<int> c = [0, .. x, .. y, 1];
                 }
             }
             """);
@@ -4531,8 +4531,8 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 void M(int[] x, IEnumerable<int> y)
                 {
                     List<int> c = [|new|] List<int>(x.Length + y.Count() + 2) { 0, 1 }
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                 }
             }
             """,
@@ -4543,7 +4543,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IList<int> y)
                 {
-                    List<int> x = [0, 1, .. x, .. y];
+                    List<int> c = [0, 1, .. x, .. y];
                 }
             }
             """);
@@ -4606,7 +4606,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             {
                 void M(int[] x, IList<int> y)
                 {
-                    List<int> x = [0, .. x, .. y, 1];
+                    List<int> c = [0, .. x, .. y, 1];
                 }
             }
             """);

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -4823,4 +4823,40 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             }
             """);
     }
+
+    [Fact]
+    public async Task TestCapacity21()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(1 + y.Count());
+                    [|c.Add(|]0);
+                    c.AddRange(x);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = new List<int>(1 + y.Count())
+                    {
+                        0
+                    };
+                    c.AddRange(x);
+                }
+            }
+            """);
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -4518,4 +4518,194 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             }
             """);
     }
+
+    [Fact]
+    public async Task TestCapacity12()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + y.Count() + 2) { 0, 1 }
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IList<int> y)
+                {
+                    List<int> x = [0, 1, .. x, .. y];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity13()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> c = [|new|] List<int>(1 + x.Length);
+                    [|c.Add(|]1);
+                    [|foreach (var v in |]x)
+                        c.Add(v);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x)
+                {
+                    List<int> c = [1, .. x];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity14()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(1 + x.Length + y.Count() + 1);
+                    [|c.Add(|]0);
+                    [|c.AddRange|](x);
+                    [|c.AddRange|](y);
+                    [|c.Add(|]1);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IList<int> y)
+                {
+                    List<int> x = [0, .. x, .. y, 1];
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity15()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = new List<int>(1 + x.Length + y.Count());
+                    c.Add(0);
+                    c.AddRange(x);
+                    c.AddRange(y);
+                    c.Add(1);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity16()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = new List<int>(1 - x.Length);
+                    c.Add(0);
+                    c.AddRange(x);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity17()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = new List<int>(1);
+                    c.Add(0);
+                    c.AddRange(x);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity18()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = new List<int>(1 + x.Length + y.Length);
+                    c.Add(0);
+                    c.AddRange(x);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity19()
+    {
+        await TestMissingInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+
+            class C
+            {
+                void M(int[] x, int[] y)
+                {
+                    List<int> c = new List<int>(x);
+                    c.Add(0);
+                    c.AddRange(y);
+                }
+            }
+            """);
+    }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests_CollectionExpression.cs
@@ -4493,6 +4493,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
         await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
@@ -4508,10 +4509,11 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             """,
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
-                void M(int[] x, IList<int> y)
+                void M(int[] x, IEnumerable<int> y)
                 {
                     List<int> c = [0, .. x, .. y, 1];
                 }
@@ -4525,12 +4527,13 @@ public partial class UseCollectionInitializerTests_CollectionExpression
         await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
                 void M(int[] x, IEnumerable<int> y)
                 {
-                    List<int> c = [|new|] List<int>(x.Length + y.Count() + 2) { 0, 1 }
+                    List<int> c = [|new|] List<int>(x.Length + y.Count() + 2) { 0, 1 };
                     [|c.AddRange(|]x);
                     [|c.AddRange(|]y);
                 }
@@ -4538,10 +4541,11 @@ public partial class UseCollectionInitializerTests_CollectionExpression
             """,
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
-                void M(int[] x, IList<int> y)
+                void M(int[] x, IEnumerable<int> y)
                 {
                     List<int> c = [0, 1, .. x, .. y];
                 }
@@ -4586,6 +4590,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
         await TestInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
@@ -4593,18 +4598,19 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                 {
                     List<int> c = [|new|] List<int>(1 + x.Length + y.Count() + 1);
                     [|c.Add(|]0);
-                    [|c.AddRange|](x);
-                    [|c.AddRange|](y);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
                     [|c.Add(|]1);
                 }
             }
             """,
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
-                void M(int[] x, IList<int> y)
+                void M(int[] x, IEnumerable<int> y)
                 {
                     List<int> c = [0, .. x, .. y, 1];
                 }
@@ -4618,6 +4624,7 @@ public partial class UseCollectionInitializerTests_CollectionExpression
         await TestMissingInRegularAndScriptAsync(
             """
             using System.Collections.Generic;
+            using System.Linq;
 
             class C
             {
@@ -4704,6 +4711,39 @@ public partial class UseCollectionInitializerTests_CollectionExpression
                     List<int> c = new List<int>(x);
                     c.Add(0);
                     c.AddRange(y);
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task TestCapacity20()
+    {
+        await TestInRegularAndScriptAsync(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [|new|] List<int>(x.Length + y.Count() + 2) { 0 };
+                    [|c.Add(|]1);
+                    [|c.AddRange(|]x);
+                    [|c.AddRange(|]y);
+                }
+            }
+            """,
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(int[] x, IEnumerable<int> y)
+                {
+                    List<int> c = [0, 1, .. x, .. y];
                 }
             }
             """);

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -48,7 +49,8 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
         TAnalyzer>, new()
 {
     protected abstract bool IsComplexElementInitializer(SyntaxNode expression);
-    protected abstract bool HasExistingInvalidInitializerForCollection(TObjectCreationExpressionSyntax objectCreation);
+    protected abstract bool HasExistingInvalidInitializerForCollection();
+    protected abstract bool ValidateMatchesForCollectionExpression(ArrayBuilder<Match<TStatementSyntax>> matches, CancellationToken cancellationToken);
 
     protected abstract IUpdateExpressionSyntaxHelper<TExpressionSyntax, TStatementSyntax> SyntaxHelper { get; }
 
@@ -124,6 +126,9 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
             }
         }
 
+        if (_analyzeForCollectionExpression)
+            return ValidateMatchesForCollectionExpression(matches, cancellationToken);
+
         return true;
     }
 
@@ -176,20 +181,9 @@ internal abstract class AbstractUseCollectionInitializerAnalyzer<
 
     protected sealed override bool ShouldAnalyze(CancellationToken cancellationToken)
     {
-        if (this.HasExistingInvalidInitializerForCollection(_objectCreationExpression))
+        if (this.HasExistingInvalidInitializerForCollection())
             return false;
 
-        // Can't use a collection expression if the original object creation has arguments.
-        if (_analyzeForCollectionExpression)
-        {
-            var argumentList = this.SyntaxFacts.GetArgumentListOfBaseObjectCreationExpression(_objectCreationExpression);
-            if (argumentList != null)
-            {
-                var arguments = this.SyntaxFacts.GetArgumentsOfArgumentList(argumentList);
-                if (arguments.Count > 0)
-                    return false;
-            }
-        }
         var type = this.SemanticModel.GetTypeInfo(_objectCreationExpression, cancellationToken).Type;
         if (type == null)
             return false;

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -10,7 +10,9 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.UseCollectionInitializer;
 
@@ -211,11 +213,6 @@ internal abstract partial class AbstractUseCollectionInitializerDiagnosticAnalyz
 
             // Don't bother analyzing for the collection expression case if the lang/version doesn't even support it.
             if (!this.AreCollectionExpressionsSupported(context.Compilation))
-                return null;
-
-            // TODO: support updating if there is a single 'int capacity' argument provided.
-            var arguments = syntaxFacts.GetArgumentsOfObjectCreationExpression(objectCreationExpression);
-            if (arguments.Count != 0)
                 return null;
 
             var matches = analyzer.Analyze(semanticModel, syntaxFacts, objectCreationExpression, analyzeForCollectionExpression: true, cancellationToken);

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -10,9 +10,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.UseCollectionInitializer;
 

--- a/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseCollectionInitializer/VisualBasicCollectionInitializerAnalyzer.vb
@@ -2,6 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.UseCollectionInitializer
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -30,9 +32,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             Throw ExceptionUtilities.Unreachable()
         End Function
 
-        Protected Overrides Function HasExistingInvalidInitializerForCollection(objectCreation As ObjectCreationExpressionSyntax) As Boolean
+        Protected Overrides Function HasExistingInvalidInitializerForCollection() As Boolean
             ' In VB we cannot add a `From { }` initializer to an object if it already has a `With { }` initializer.
-            Return TypeOf objectCreation.Initializer Is ObjectMemberInitializerSyntax
+            Return TypeOf _objectCreationExpression.Initializer Is ObjectMemberInitializerSyntax
+        End Function
+
+        Protected Overrides Function ValidateMatchesForCollectionExpression(matches As ArrayBuilder(Of Match(Of StatementSyntax)), cancellationToken As CancellationToken) As Boolean
+            ' Only called for collection expressions, which VB does not support
+            Throw ExceptionUtilities.Unreachable()
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
This now means that we will detect and properly suggest the fix in cases like:

```c#
List<int> list = new List<int>(1 + x.Count);
list.Add(0);
list.AddRange(x);

// suggest converting to:
List<int> list = [0, .. x];
```

The capacity expression is checked to make sure it matches up with the data being added.  If so, the fix is offered, since we know the compiler will do the same analysis and information passing when constructing the collection.
