### PR TITLE
Revert "Add a struct enumerator for NodeStateTable<T>"

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -90,60 +90,17 @@ namespace Microsoft.CodeAnalysis
         public int GetTotalEntryItemCount()
             => _states.Sum(static e => e.Count);
 
-        public struct Enumerator
+        public IEnumerator<NodeStateEntry<T>> GetEnumerator()
         {
-            private readonly NodeStateTable<T> _stateTable;
-            private int _nextStatesIndex;
-            private int _nextInputEntryIndex;
-            private IncrementalGeneratorRunStep? _step;
-            private TableEntry _inputEntry;
-            private NodeStateEntry<T> _current;
-
-            public Enumerator(NodeStateTable<T> stateTable)
+            for (int i = 0; i < _states.Length; i++)
             {
-                _stateTable = stateTable;
-                _nextStatesIndex = 0;
-
-                UpdateAfterNextStatesIndexModification();
-            }
-
-            public NodeStateEntry<T> Current => _current;
-
-            public bool MoveNext()
-            {
-                while (_nextStatesIndex < _stateTable._states.Length)
+                TableEntry inputEntry = _states[i];
+                IncrementalGeneratorRunStep? step = HasTrackedSteps ? Steps[i] : null;
+                for (int j = 0; j < inputEntry.Count; j++)
                 {
-                    if (_nextInputEntryIndex < _inputEntry.Count)
-                    {
-                        _current = new NodeStateEntry<T>(_inputEntry.GetItem(_nextInputEntryIndex), _inputEntry.GetState(_nextInputEntryIndex), _nextInputEntryIndex, _step);
-                        _nextInputEntryIndex += 1;
-
-                        return true;
-                    }
-
-                    _nextStatesIndex += 1;
-
-                    UpdateAfterNextStatesIndexModification();
-                }
-
-                return false;
-            }
-
-            private void UpdateAfterNextStatesIndexModification()
-            {
-                _nextInputEntryIndex = 0;
-
-                if (_nextStatesIndex < _stateTable._states.Length)
-                {
-                    _step = _stateTable.HasTrackedSteps ? _stateTable.Steps[_nextStatesIndex] : null;
-                    _inputEntry = _stateTable._states[_nextStatesIndex];
+                    yield return new NodeStateEntry<T>(inputEntry.GetItem(j), inputEntry.GetState(j), j, step);
                 }
             }
-        }
-
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this);
         }
 
         public NodeStateTable<T> AsCached()


### PR DESCRIPTION
Reverts #70082

A series of accidents in how our ExternalAccess DLLs ship versus how the compiler ships means that this has caused a binary breaking change in the VS insertion. We might need to take this revert until we can work out how to dual insert this change with the .NET SDK.

cc @Cosifne @jaredpar