### PR TITLE
Add ReferenceOutputAssembly="false" to language server dlls we don't ship

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -57,10 +57,10 @@
     <ProjectReference Include="..\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
 
     <!-- Dlls we don't directly reference but need to include to build the MEF composition -->
-    <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
+    <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" ReferenceOutputAssembly="false" />
 
     <!-- Not directly referenced but needed for Razor source generators -->
-    <ProjectReference Include="..\..\..\Tools\ExternalAccess\RazorCompiler\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj" />
+    <ProjectReference Include="..\..\..\Tools\ExternalAccess\RazorCompiler\Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up PR per Sam's comment in https://github.com/dotnet/roslyn/pull/70176#discussion_r1341360613:
> This needs ReferenceOutputAssembly="false" added for compile-time enforcement of the "not directly referenced" condition