### PR TITLE
Immunize System.Linq methods

### DIFF
--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         private const int P5MethodNameDefaultIndex = 5;
 
-        private static readonly ImmutableArray<string> UnblameableMethodPrefixes = ImmutableArray.Create("Roslyn.Utilities.Contract.");
+        private static readonly ImmutableArray<string> UnblameableMethodPrefixes = ImmutableArray.Create("Roslyn.Utilities.Contract.", "System.Linq.");
 
         /// <summary>
         /// Report Non-Fatal Watson for a given unhandled exception.


### PR DESCRIPTION
This way a call to System.Linq.Enumerable.First() blames the caller.

Closes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1592549