### PR TITLE
Improve checksum perf

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis
         // Explicitly implement this method as default jit for records on netfx doesn't properly devirtualize the
         // standard calls to EqualityComparer<HashData>.Default.Equals
         public bool Equals(Checksum other)
-            => Hash.Equals(other.Hash);
+            => other != null && Hash.Equals(other.Hash);
 
         // Directly call into Hash to avoid any overhead that records add when hashing things like the EqualityContract
         public override int GetHashCode()

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -102,6 +102,15 @@ namespace Microsoft.CodeAnalysis
         public static Func<IEnumerable<Checksum>, string> GetChecksumsLogInfo { get; }
             = checksums => string.Join("|", checksums.Select(c => c.ToString()));
 
+        // Explicitly implement this method as default jit for records on netfx doesn't properly devirtualize the
+        // standard calls to EqualityComparer<HashData>.Default.Equals
+        public bool Equals(Checksum other)
+            => Hash.Equals(other.Hash);
+
+        // Directly call into Hash to avoid any overhead that records add when hashing things like the EqualityContract
+        public override int GetHashCode()
+            => Hash.GetHashCode();
+
         /// <summary>
         /// This structure stores the 20-byte hash as an inline value rather than requiring the use of
         /// <c>byte[]</c>.
@@ -136,6 +145,11 @@ namespace Microsoft.CodeAnalysis
                 // The checksum is already a hash. Just read a 4-byte value to get a well-distributed hash code.
                 return (int)Data1;
             }
+
+            // Explicitly implement this method as default jit for records on netfx doesn't properly devirtualize the
+            // standard calls to EqualityComparer<long>.Default.Equals
+            public bool Equals(HashData other)
+                => this.Data1 == other.Data1 && this.Data2 == other.Data2 && this.Data3 == other.Data3;
         }
     }
 }


### PR DESCRIPTION
Noticed in traces i was looking at.  Unfortunately, the stock code the compiler produces for records does not exhibit good performance on netfx.  Use of things like `EqualityComparer<T>.Default....` ends up not devirtualizing or inlining.  So you end up with assembly like:

```
    L0000: push rdi
    L0001: push rsi
    L0002: sub rsp, 0x28
    L0006: mov esi, edx
    L0008: mov edi, r8d
    L000b: mov ecx, 0x1
    L0010: mov edx, 0x8f
    L0015: call 0x7ffc25dd1750
    L001a: mov rcx, 0x1ccb5fdbb78
    L0024: mov rcx, [rcx]
    L0027: mov edx, esi
    L0029: mov r8d, edi
    L002c: mov rax, [rcx]
    L002f: mov rax, [rax+0x40]
    L0033: call qword [rax+0x20]
    L0036: movzx eax, al
    L0039: add rsp, 0x28
    L003d: pop rsi
    L003e: pop rdi
    L003f: ret
```

For a simple int comparison instead of:

```
    L0000: xor eax, eax
    L0002: cmp ecx, edx
    L0004: sete al
    L0007: ret
```

As checksum computation/matching is a super hot spot for us, writing these out by hand helps a fair bit.