### PR TITLE
Create and cache a singleton directive parser inside the lexer

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -6,22 +6,25 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
-    using Microsoft.CodeAnalysis.PooledObjects;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
-    internal class DirectiveParser : SyntaxParser
+    internal sealed class DirectiveParser : SyntaxParser
     {
         private const int MAX_DIRECTIVE_IDENTIFIER_WIDTH = 128;
 
-        private readonly DirectiveStack _context;
+        private DirectiveStack _context;
 
-        internal DirectiveParser(Lexer lexer, DirectiveStack context)
-            : base(lexer, LexerMode.Directive, null, null, false)
+        internal DirectiveParser(Lexer lexer)
+            : base(lexer, LexerMode.Directive, oldTree: null, changes: null, allowModeReset: false)
         {
+        }
+
+        public void ReInitialize(DirectiveStack context)
+        {
+            base.ReInitialize();
             _context = context;
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -37,10 +37,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private readonly SyntaxListPool _pool = new SyntaxListPool();
         private bool _isDelimited;
 
-        internal DocumentationCommentParser(Lexer lexer, LexerMode modeflags)
-            : base(lexer, LexerMode.XmlDocComment | LexerMode.XmlDocCommentLocationStart | modeflags, oldTree: null, changes: null, allowModeReset: true)
+        internal DocumentationCommentParser(Lexer lexer)
+            : base(lexer, LexerMode.None, oldTree: null, changes: null, allowModeReset: true)
         {
-            _isDelimited = (modeflags & LexerMode.XmlDocCommentStyleDelimited) != 0;
         }
 
         internal void ReInitialize(LexerMode modeflags)

--- a/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DocumentationCommentParser.cs
@@ -32,13 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     // trying to understand them, e.g. like comments or CDATA, so that they are available
     // to whoever processes these comments and do not produce an error. 
 
-    internal class DocumentationCommentParser : SyntaxParser
+    internal sealed class DocumentationCommentParser : SyntaxParser
     {
         private readonly SyntaxListPool _pool = new SyntaxListPool();
         private bool _isDelimited;
 
         internal DocumentationCommentParser(Lexer lexer, LexerMode modeflags)
-            : base(lexer, LexerMode.XmlDocComment | LexerMode.XmlDocCommentLocationStart | modeflags, null, null, true)
+            : base(lexer, LexerMode.XmlDocComment | LexerMode.XmlDocCommentLocationStart | modeflags, oldTree: null, changes: null, allowModeReset: true)
         {
             _isDelimited = (modeflags & LexerMode.XmlDocCommentStyleDelimited) != 0;
         }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
-    internal partial class LanguageParser : SyntaxParser
+    internal sealed partial class LanguageParser : SyntaxParser
     {
         // list pools - allocators for lists that are used to build sequences of nodes. The lists
         // can be reused (hence pooled) since the syntax factory methods don't keep references to

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2710,21 +2710,13 @@ top:
         private CSharpSyntaxNode LexXmlDocComment(XmlDocCommentStyle style)
         {
             var saveMode = _mode;
-            bool isTerminated;
 
-            var mode = style == XmlDocCommentStyle.SingleLine
-                    ? LexerMode.XmlDocCommentStyleSingleLine
-                    : LexerMode.XmlDocCommentStyleDelimited;
-            if (_xmlParser == null)
-            {
-                _xmlParser = new DocumentationCommentParser(this, mode);
-            }
-            else
-            {
-                _xmlParser.ReInitialize(mode);
-            }
+            _xmlParser ??= new DocumentationCommentParser(this);
+            _xmlParser.ReInitialize(style == XmlDocCommentStyle.SingleLine
+                ? LexerMode.XmlDocCommentStyleSingleLine
+                : LexerMode.XmlDocCommentStyleDelimited);
 
-            var docComment = _xmlParser.ParseDocumentationComment(out isTerminated);
+            var docComment = _xmlParser.ParseDocumentationComment(out var isTerminated);
 
             // We better have finished with the whole comment. There should be error
             // code in the implementation of ParseXmlDocComment that ensures this.

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _prevTokenTrailingTrivia = null;
             if (this.IsIncremental || _allowModeReset)
             {
-                _firstBlender = new Blender(this.lexer, null, null);
+                _firstBlender = new Blender(this.lexer, oldTree: null, changes: null);
             }
         }
 


### PR DESCRIPTION
Examination of traces in razor shows 6% of memory allocations is *just* the allocation for the DirectiveParser: 

![image](https://github.com/dotnet/roslyn/assets/4564579/e5e29be7-4cde-4371-9609-1509bcefe48d)

Taking a page from how we documentation comments, we can cache this as a single parser used by the lexer whenever it encounters a new directive.  We likely don't see this normally as most files don't have that many directives, whereas in razor it uses them *everywhere*.