### PR TITLE
Fix GetDocumentationComment returns unresolved doc reference for inheritdoc typeparamref

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -7272,6 +7272,35 @@ public interface ICloneable<T>
         }
 
         [Fact]
+        public async Task TestInheritdocWithTypeParamRef1()
+        {
+            var markup =
+@"
+public interface ITest
+{
+    /// <summary>
+    /// A generic method <typeparamref name=""T""/>.
+    /// </summary>
+    /// <typeparam name=""T"">A generic type.</typeparam>
+    void Foo<T>();
+}
+
+public class Test : ITest
+{
+    /// <inheritdoc/>
+    public void $$Foo<T>() { }
+}";
+
+            await TestWithOptionsAsync(TestOptions.Regular8,
+                markup,
+                MainDescription($"void Test.Foo<T>()"),
+                Documentation("A generic method T."),
+                item => Assert.Equal(
+                    item.Sections.First(section => section.Kind == QuickInfoSectionKinds.DocumentationComments).TaggedParts.Select(p => p.Tag).ToArray(),
+                    new[] { "Text", "Space", "TypeParameter", "Text" }));
+        }
+
+        [Fact]
         public async Task TestInheritdocCycle1()
         {
             var markup =

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -440,9 +440,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                             if (index < typeArgs.Length)
                             {
                                 var docId = typeArgs[index].GetDocumentationCommentId();
-                                var replacement = new XElement(DocumentationCommentXmlNames.SeeElementName);
-                                replacement.SetAttributeValue(DocumentationCommentXmlNames.CrefAttributeName, docId);
-                                typeParameterRef.ReplaceWith(replacement);
+                                if (docId != null && !docId.StartsWith("!"))
+                                {
+                                    var replacement = new XElement(DocumentationCommentXmlNames.SeeElementName);
+                                    replacement.SetAttributeValue(DocumentationCommentXmlNames.CrefAttributeName, docId);
+                                    typeParameterRef.ReplaceWith(replacement);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The expansion of  `<typeparamref>` for `<inheritdoc/>` can produce unresolved `cref` references for uninstantiated generic type parameters, causing downstream tools unable to distinguish between an unresolved `typeparamref` vs a user error. This PR fixes that by only replace `<typeparamref>` for valid documentation ids.

Related: https://github.com/dotnet/roslyn/commit/984c295a322d50cb01e3c8ada4714cf667a3e6ed
Fixes https://github.com/dotnet/docfx/issues/8948