### PR TITLE
Load solutions out-of-proc

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BuildHostProcessManager.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/BuildHostProcessManager.cs
@@ -41,7 +41,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         // Check if this is the case.
         if (neededBuildHostKind == BuildHostProcessKind.NetFramework)
         {
-            if (!await buildHost.IsProjectFileSupportedAsync(projectFilePath, cancellationToken))
+            if (!await buildHost.HasUsableMSBuildAsync(projectFilePath, cancellationToken))
             {
                 // It's not usable, so we'll fall back to the .NET Core one.
                 _logger?.LogWarning($"An installation of Visual Studio or the Build Tools for Visual Studio could not be found; {projectFilePath} will be loaded with the .NET Core SDK and may encounter errors.");
@@ -52,7 +52,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         return buildHost;
     }
 
-    private async Task<IBuildHost> GetBuildHostAsync(BuildHostProcessKind buildHostKind, CancellationToken cancellationToken)
+    public async Task<IBuildHost> GetBuildHostAsync(BuildHostProcessKind buildHostKind, CancellationToken cancellationToken)
     {
         using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -211,7 +211,7 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         return BuildHostProcessKind.NetFramework;
     }
 
-    private enum BuildHostProcessKind
+    public enum BuildHostProcessKind
     {
         NetCore,
         NetFramework

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -64,8 +64,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" ExcludeAssets="Runtime" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />

--- a/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/LanguageServerProjectSystemOptionsStorage.cs
@@ -14,11 +14,5 @@ namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace
         /// A folder to log binlogs to when running design-time builds.
         /// </summary>
         public static readonly Option2<string?> BinaryLogPath = new Option2<string?>("dotnet_binary_log_path", defaultValue: null, s_optionGroup);
-
-        /// <summary>
-        /// Whether we are doing design-time builds in-process; this is only to offer a fallback if the OOP builds are broken, and should be removed once
-        /// we don't have folks using this.
-        /// </summary>
-        public static readonly Option2<bool> LoadInProcess = new("dotnet_load_in_process", defaultValue: false, s_optionGroup);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -61,7 +61,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
             LspOptionsStorage.LspEnableReferencesCodeLens,
             LspOptionsStorage.LspEnableTestsCodeLens,
             // Project system
-            LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
-            LanguageServerProjectSystemOptionsStorage.LoadInProcess);
+            LanguageServerProjectSystemOptionsStorage.BinaryLogPath);
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -145,7 +145,6 @@ public class A { }";
                 "code_lens.dotnet_enable_references_code_lens",
                 "code_lens.dotnet_enable_tests_code_lens",
                 "projects.dotnet_binary_log_path",
-                "projects.dotnet_load_in_process",
             }.OrderBy(name => name);
 
             Assert.Equal(expectedNames, actualNames);

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -226,7 +226,6 @@ public class VisualStudioOptionStorageTests
             "dotnet_style_operator_placement_when_wrapping",                                // Doesn't have VS UI. TODO: https://github.com/dotnet/roslyn/issues/66062
             "dotnet_style_prefer_foreach_explicit_cast_in_source",                          // For a small customer segment, doesn't warrant VS UI.
             "dotnet_binary_log_path",                                                       // VSCode only option for the VS Code project system; does not apply to VS
-            "dotnet_load_in_process",                                                       // VSCode only option for the VS Code project system; does not apply to VS
             "dotnet_lsp_using_devkit",                                                      // VSCode internal only option.  Does not need any UI.
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.

--- a/src/Workspaces/Core/MSBuild.BuildHost/IBuildHost.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/IBuildHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +14,14 @@ namespace Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost;
 internal interface IBuildHost
 {
     /// <summary>
-    /// Returns whether this project's is supported by this host, considering both the project language and also MSBuild availability.
+    /// Returns true if this build host was able to discover a usable MSBuild instance. This should be called before calling other methods.
+    /// </summary>
+    Task<bool> HasUsableMSBuildAsync(string projectOrSolutionFilePath, CancellationToken cancellationToken);
+
+    Task<ImmutableArray<(string ProjectPath, string ProjectGuid)>> GetProjectsInSolutionAsync(string solutionFilePath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns whether this project's is supported by this host.
     /// </summary>
     Task<bool> IsProjectFileSupportedAsync(string projectFilePath, CancellationToken cancellationToken);
 


### PR DESCRIPTION
This brings a few benefits:

1. It's possible that the user might have an 8.0 SDK but only a 7.0 runtime installed; in that case, our language server will run with the 7.0 runtime, but will fail to find an MSBuild since the only one on the machine might be the 8.0 version which is not runnable. This enures we can still function in that scenario. We'll also fall back to using a .NET Framework MSBuild if somehow that's all you have.
2. When we loaded an MSBuild, that sets environment variables, which might not be the same variables set if we're registering a different version in our child processes. But the environment variables might get inherited, which could result in surprises.

In this PR I'm also removing the fallback flag to enable in-proc builds; we never needed it and no bugs got filed, so just removing it for good.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1886993