### PR TITLE
Fix incorrect isInsideDelimiters assumption in MoveCaretToSemicolonPosition

### DIFF
--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -141,20 +141,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
             //    `obj.ToString$()` where `token` references `(` but the caret isn't actually inside the argument list.
             //    `obj.ToString()$` or `obj.method()$ .method()` where `token` references `)` but the caret isn't inside the argument list.
             //    `defa$$ult(object)` where `token` references `default` but the caret isn't inside the parentheses.
-            var delimiters = startingNode.GetParentheses();
-            if (delimiters == default)
-            {
-                delimiters = startingNode.GetBrackets();
-            }
-
-            if (delimiters == default)
-            {
-                delimiters = startingNode.GetBraces();
-            }
-
-            var (openingDelimiter, closingDelimiter) = delimiters;
-            if (!openingDelimiter.IsKind(SyntaxKind.None) && openingDelimiter.Span.Start >= caretPosition
-                || !closingDelimiter.IsKind(SyntaxKind.None) && closingDelimiter.Span.End <= caretPosition)
+            if (HasDelimitersButCaretIsOutside(startingNode, caretPosition))
             {
                 startingNode = startingNode.GetRequiredParent();
             }
@@ -208,12 +195,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                     return false;
                 }
 
+                // We know the current node has delimiters due to the Kind() check above, so isInsideDelimiters is
+                // simply the inverse of being outside the delimiters.
+                isInsideDelimiters = !HasDelimitersButCaretIsOutside(currentNode, caret.Position);
+
                 var newCaret = args.SubjectBuffer.CurrentSnapshot.GetPoint(newCaretPosition);
                 if (!TryGetStartingNode(root, newCaret, out currentNode, cancellationToken))
                     return false;
 
                 return MoveCaretToSemicolonPosition(
-                    speculative, args, document, root, originalCaret, newCaret, syntaxFacts, currentNode, isInsideDelimiters: true, cancellationToken);
+                    speculative, args, document, root, originalCaret, newCaret, syntaxFacts, currentNode, isInsideDelimiters, cancellationToken);
             }
             else if (currentNode.IsKind(SyntaxKind.DoStatement))
             {
@@ -462,6 +453,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
             return currentNode.GetBrackets().closeBracket.IsMissing ||
                 currentNode.GetParentheses().closeParen.IsMissing ||
                 currentNode.GetBraces().closeBrace.IsMissing;
+        }
+
+        private static bool HasDelimitersButCaretIsOutside(SyntaxNode currentNode, int caretPosition)
+        {
+            if (currentNode.GetParentheses() is ((not SyntaxKind.None) openParenthesis, (not SyntaxKind.None) closeParenthesis))
+            {
+                return openParenthesis.SpanStart >= caretPosition || closeParenthesis.Span.End <= caretPosition;
+            }
+            else if (currentNode.GetBrackets() is ((not SyntaxKind.None) openBracket, (not SyntaxKind.None) closeBracket))
+            {
+                return openBracket.SpanStart >= caretPosition || closeBracket.Span.End <= caretPosition;
+            }
+            else if (currentNode.GetBraces() is ((not SyntaxKind.None) openBrace, (not SyntaxKind.None) closeBrace))
+            {
+                return openBrace.SpanStart >= caretPosition || closeBrace.Span.End <= caretPosition;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4306,6 +4306,27 @@ public class Bar
             VerifyNoSpecialSemicolonHandling(code);
         }
 
+        [WpfFact]
+        [WorkItem("https://github.com/dotnet/roslyn/issues/70224")]
+        public void TestNotBeforeKeywordInSwitchExpression()
+        {
+            var code = @"
+public class Bar
+{
+    public void Test(string myString)
+    {
+        var a = myString$$ switch
+        {
+            ""Hello"" => 1,
+            ""World"" => 2,
+            _ => 3
+        }
+    }
+}";
+
+            VerifyNoSpecialSemicolonHandling(code);
+        }
+
         protected override TestWorkspace CreateTestWorkspace(string code)
             => TestWorkspace.CreateCSharp(code);
     }

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
@@ -4246,7 +4244,7 @@ public class ClassC
             var expected = code.Replace("$$", ";$$");
 
             Verify(code, expected, ExecuteTest,
-                setOptionsOpt: workspace =>
+                setOptions: workspace =>
                 {
                     var globalOptions = workspace.GetService<IGlobalOptionService>();
                     globalOptions.SetGlobalOption(CompleteStatementOptionsStorage.AutomaticallyCompleteStatementOnSemicolon, false);

--- a/src/EditorFeatures/TestUtilities/CompleteStatement/AbstractCompleteStatementTests.cs
+++ b/src/EditorFeatures/TestUtilities/CompleteStatement/AbstractCompleteStatementTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
@@ -21,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
     [UseExportProvider]
     public abstract class AbstractCompleteStatementTests
     {
-        internal static char semicolon = ';';
+        internal const char Semicolon = ';';
 
         internal abstract ICommandHandler GetCommandHandler(TestWorkspace workspace);
 
@@ -59,8 +57,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
         {
             var commandHandler = GetCommandHandler(workspace);
 
-            var commandArgs = new TypeCharCommandArgs(view, view.TextBuffer, semicolon);
-            var nextHandler = CreateInsertTextHandler(view, semicolon.ToString());
+            var commandArgs = new TypeCharCommandArgs(view, view.TextBuffer, Semicolon);
+            var nextHandler = CreateInsertTextHandler(view, Semicolon.ToString());
 
             commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
         }
@@ -77,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
 
         protected void Verify(string initialMarkup, string expectedMarkup,
             Action<IWpfTextView, TestWorkspace> execute,
-            Action<TestWorkspace> setOptionsOpt = null)
+            Action<TestWorkspace>? setOptions = null)
         {
             using (var workspace = CreateTestWorkspace(initialMarkup))
             {
@@ -99,12 +97,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
 
                 view.Caret.MoveTo(new SnapshotPoint(view.TextSnapshot, startCaretPosition));
 
-                setOptionsOpt?.Invoke(workspace);
+                setOptions?.Invoke(workspace);
 
                 execute(view, workspace);
                 MarkupTestFile.GetPosition(expectedMarkup, out var expectedCode, out int expectedPosition);
 
-                Assert.Equal(expectedCode, view.TextSnapshot.GetText());
+                AssertEx.EqualOrDiff(expectedCode, view.TextSnapshot.GetText());
 
                 var endCaretPosition = view.Caret.Position.BufferPosition.Position;
                 Assert.True(expectedPosition == endCaretPosition,


### PR DESCRIPTION
Review commit-by-commit recommended. The fix for #70224 is the first commit, and the second commit is minor code cleanup.

Fixes #70224