### PR TITLE
Avoid returning checksums unnecessarily during OOP calls.

### DIFF
--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,11 +15,12 @@ namespace Microsoft.CodeAnalysis.Remote
     internal interface ISolutionAssetProvider
     {
         /// <summary>
-        /// Streams serialized assets into the given stream.
+        /// Streams serialized assets into the given stream.  Assets will be serialized in the exact same order
+        /// corresponding to the checksum index in <paramref name="checksums"/>.
         /// </summary>
         /// <param name="pipeWriter">The writer to write the assets into.  Implementations of this method must call<see
         /// cref="PipeWriter.Complete"/> on it (in the event of failure or success).  Failing to do so will lead to
         /// hangs on the code that reads from the corresponding <see cref="PipeReader"/> side of this.</param>
-        ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken);
+        ValueTask WriteAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ISerializerService serializer,
             SolutionReplicationContext context,
             Checksum solutionChecksum,
-            Checksum[] checksums,
+            ImmutableArray<Checksum> checksums,
             CancellationToken cancellationToken)
         {
             using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
@@ -38,60 +38,57 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // special case
             if (checksums.Length == 0)
-            {
-                writer.WriteInt32(0);
                 return;
-            }
 
             if (singleAsset != null)
             {
-                writer.WriteInt32(1);
-                WriteAsset(writer, serializer, context, checksums[0], singleAsset, cancellationToken);
+                WriteAsset(writer, serializer, context, singleAsset, cancellationToken);
                 return;
             }
 
             Debug.Assert(assetMap != null);
-            writer.WriteInt32(assetMap.Count);
 
-            foreach (var (checksum, asset) in assetMap)
+            var count = 0;
+            foreach (var checksum in checksums)
             {
-                WriteAsset(writer, serializer, context, checksum, asset, cancellationToken);
+                var asset = assetMap[checksum];
 
-                // We flush after each item as that forms a reasonably sized chunk of data to want to then send over the
-                // pipe for the reader on the other side to read.  This allows the item-writing to remain entirely
-                // synchronous without any blocking on async flushing, while also ensuring that we're not buffering the
-                // entire stream of data into the pipe before it gets sent to the other side.
-                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                WriteAsset(writer, serializer, context, asset, cancellationToken);
+
+                // Flush every so often.  We don't want to flush on each write as that can be expensive.  But we also
+                // want to push reasonable chunks of data across the pipe so the host can start reading them.
+                // Note: our caller will flush teh remaining data at the end as well.
+                if (count % 512 == 0)
+                    await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                count++;
             }
 
             return;
 
-            static void WriteAsset(ObjectWriter writer, ISerializerService serializer, SolutionReplicationContext context, Checksum checksum, SolutionAsset asset, CancellationToken cancellationToken)
+            static void WriteAsset(ObjectWriter writer, ISerializerService serializer, SolutionReplicationContext context, SolutionAsset asset, CancellationToken cancellationToken)
             {
                 Debug.Assert(asset.Kind != WellKnownSynchronizationKind.Null, "We should not be sending null assets");
-                checksum.WriteTo(writer);
                 writer.WriteInt32((int)asset.Kind);
 
                 // null is already indicated by checksum and kind above:
                 if (asset.Value is not null)
-                {
                     serializer.Serialize(asset.Value, writer, context, cancellationToken);
-                }
             }
         }
 
-        public static async ValueTask<ImmutableArray<(Checksum, object)>> ReadDataAsync(
-            PipeReader pipeReader, Checksum solutionChecksum, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+        public static async ValueTask<ImmutableArray<object>> ReadDataAsync(
+            PipeReader pipeReader, Checksum solutionChecksum, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
             using var stream = await pipeReader.AsPrebufferedStreamAsync(cancellationToken).ConfigureAwait(false);
             return ReadData(stream, solutionChecksum, checksums, serializerService, cancellationToken);
         }
 
-        public static ImmutableArray<(Checksum, object)> ReadData(Stream stream, Checksum solutionChecksum, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+        public static ImmutableArray<object> ReadData(Stream stream, Checksum solutionChecksum, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
             Debug.Assert(!checksums.Contains(Checksum.Null));
 
-            using var _ = ArrayBuilder<(Checksum, object)>.GetInstance(out var results);
+            using var _ = ArrayBuilder<object>.GetInstance(checksums.Length, out var results);
 
             using var reader = ObjectReader.GetReader(stream, leaveOpen: true, cancellationToken);
 
@@ -100,14 +97,8 @@ namespace Microsoft.CodeAnalysis.Remote
             var responseSolutionChecksum = Checksum.ReadFrom(reader);
             Contract.ThrowIfFalse(solutionChecksum == responseSolutionChecksum);
 
-            var count = reader.ReadInt32();
-            Contract.ThrowIfFalse(count == checksums.Count);
-
-            for (var i = 0; i < count; i++)
+            for (int i = 0, n = checksums.Length; i < n; i++)
             {
-                var responseChecksum = Checksum.ReadFrom(reader);
-                Contract.ThrowIfFalse(checksums.Contains(responseChecksum));
-
                 var kind = (WellKnownSynchronizationKind)reader.ReadInt32();
 
                 // in service hub, cancellation means simply closed stream
@@ -115,10 +106,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 Debug.Assert(result != null, "We should not be requesting null assets");
 
-                results.Add((responseChecksum, result));
+                results.Add(result);
             }
 
-            return results.ToImmutable();
+            return results.ToImmutableAndClear();
         }
     }
 }

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -3,16 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
-using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -33,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Remote
             _services = services;
         }
 
-        public async ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken)
+        public async ValueTask WriteAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken)
         {
             // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
             // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
@@ -41,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Exception? exception = null;
             try
             {
-                await GetAssetsWorkerAsync(pipeWriter, solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);
+                await WriteAssetsWorkerAsync(pipeWriter, solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when ((exception = ex) == null)
             {
@@ -53,33 +52,41 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        private async ValueTask GetAssetsWorkerAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken)
+        private async ValueTask WriteAssetsWorkerAsync(PipeWriter pipeWriter, Checksum solutionChecksum, ImmutableArray<Checksum> checksums, CancellationToken cancellationToken)
         {
             var assetStorage = _services.GetRequiredService<ISolutionAssetStorageProvider>().AssetStorage;
             var serializer = _services.GetRequiredService<ISerializerService>();
             var scope = assetStorage.GetScope(solutionChecksum);
 
             SolutionAsset? singleAsset = null;
-            IReadOnlyDictionary<Checksum, SolutionAsset>? assetMap = null;
+            PooledDictionary<Checksum, SolutionAsset>? assetMap = null;
 
-            if (checksums.Length == 1)
+            try
             {
-                singleAsset = await scope.GetAssetAsync(checksums[0], cancellationToken).ConfigureAwait(false);
+
+                if (checksums.Length == 1)
+                {
+                    singleAsset = await scope.GetAssetAsync(checksums[0], cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    assetMap = await scope.GetAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var stream = new PipeWriterStream(pipeWriter);
+                await RemoteHostAssetSerialization.WriteDataAsync(
+                    stream, singleAsset, assetMap, serializer, scope.ReplicationContext,
+                    solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);
+
+                // Ensure any last data written into the stream makes it into the pipe.
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
-            else
+            finally
             {
-                assetMap = await scope.GetAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
+                assetMap?.Free();
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using var stream = new PipeWriterStream(pipeWriter);
-            await RemoteHostAssetSerialization.WriteDataAsync(
-                stream, singleAsset, assetMap, serializer, scope.ReplicationContext,
-                solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);
-
-            // Ensure any last data written into the stream makes it into the pipe.
-            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -93,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <remarks>
         /// Note: this stream does not have to <see cref="PipeWriter.Complete"/> the underlying <see cref="_writer"/> it
         /// is holding onto (including within <see cref="Flush"/>, <see cref="FlushAsync"/>, or <see cref="Dispose"/>).
-        /// Responsibility for that is solely in the hands of <see cref="GetAssetsAsync"/>.
+        /// Responsibility for that is solely in the hands of <see cref="WriteAssetsAsync"/>.
         /// </remarks>
         private class PipeWriterStream : Stream, IDisposableObservable
         {

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
@@ -65,15 +67,15 @@ internal partial class SolutionAssetStorage
         /// Retrieve assets of specified <paramref name="checksums"/> available within <see langword="this"/> from
         /// the storage.
         /// </summary>
-        public async ValueTask<IReadOnlyDictionary<Checksum, SolutionAsset>> GetAssetsAsync(
-            Checksum[] checksums, CancellationToken cancellationToken)
+        public async ValueTask<PooledDictionary<Checksum, SolutionAsset>> GetAssetsAsync(
+            ImmutableArray<Checksum> checksums, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             using var checksumsToFind = Creator.CreateChecksumSet(checksums);
 
             var numberOfChecksumsToSearch = checksumsToFind.Object.Count;
-            var result = new Dictionary<Checksum, SolutionAsset>(numberOfChecksumsToSearch);
+            var result = PooledDictionary<Checksum, SolutionAsset>.GetInstance();
 
             if (checksumsToFind.Object.Remove(Checksum.Null))
             {

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async ValueTask SynchronizeAssetsAsync(ISet<Checksum> checksums, CancellationToken cancellationToken)
         {
-            Debug.Assert(!checksums.Contains(Checksum.Null));
+            Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
             if (checksums.Count == 0)
                 return;
 

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return _assetCache.TryGetAsset<object>(checksum, out _);
         }
 
-        public async ValueTask SynchronizeAssetsAsync(ISet<Checksum> checksums, CancellationToken cancellationToken)
+        public async ValueTask SynchronizeAssetsAsync(HashSet<Checksum> checksums, CancellationToken cancellationToken)
         {
             Contract.ThrowIfTrue(checksums.Contains(Checksum.Null));
             if (checksums.Count == 0)

--- a/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/IAssetSource.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Serialization;
 
-namespace Microsoft.CodeAnalysis.Remote
+namespace Microsoft.CodeAnalysis.Remote;
+
+/// <summary>
+/// Provides assets given their checksums.
+/// </summary>
+internal interface IAssetSource
 {
-    /// <summary>
-    /// Provides assets given their checksums.
-    /// </summary>
-    internal interface IAssetSource
-    {
-        ValueTask<ImmutableArray<(Checksum, object)>> GetAssetsAsync(Checksum solutionChecksum, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
-    }
+    ValueTask<ImmutableArray<object>> GetAssetsAsync(Checksum solutionChecksum, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 SolutionAssetProvider.ServiceDescriptor,
                 (callback, cancellationToken) => callback.InvokeAsync(
                     (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, checksums, cancellationToken),
-                    (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums, serializerService, cancellationToken),
+                    (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums.Length, serializerService, cancellationToken),
                     cancellationToken),
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/SolutionAssetSource.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
             _client = client;
         }
 
-        public async ValueTask<ImmutableArray<(Checksum, object)>> GetAssetsAsync(Checksum solutionChecksum, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
+        public async ValueTask<ImmutableArray<object>> GetAssetsAsync(Checksum solutionChecksum, ImmutableArray<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken)
         {
             // Make sure we are on the thread pool to avoid UI thread dependencies if external code uses ConfigureAwait(true)
             await TaskScheduler.Default;
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 _client,
                 SolutionAssetProvider.ServiceDescriptor,
                 (callback, cancellationToken) => callback.InvokeAsync(
-                    (proxy, pipeWriter, cancellationToken) => proxy.GetAssetsAsync(pipeWriter, solutionChecksum, checksums.ToArray(), cancellationToken),
+                    (proxy, pipeWriter, cancellationToken) => proxy.WriteAssetsAsync(pipeWriter, solutionChecksum, checksums, cancellationToken),
                     (pipeReader, cancellationToken) => RemoteHostAssetSerialization.ReadDataAsync(pipeReader, solutionChecksum, checksums, serializerService, cancellationToken),
                     cancellationToken),
                 cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -11,6 +11,15 @@ namespace Roslyn.Utilities
 {
     internal static class ImmutableArrayExtensions
     {
+        public static ImmutableArray<T> ToImmutableArray<T>(this HashSet<T> set)
+        {
+            using var _ = ArrayBuilder<T>.GetInstance(set.Count, out var result);
+            foreach (var value in set)
+                result.Add(value);
+
+            return result.ToImmutableAndClear();
+        }
+
         public static bool Contains<T>(this ImmutableArray<T> items, T item, IEqualityComparer<T>? equalityComparer)
             => items.IndexOf(item, 0, equalityComparer) >= 0;
 


### PR DESCRIPTION
Our existing model is one where we send over a bunch of checksums, then send those checksums back with the objects they are attached to.  None of this is necessary as we know exactly what checksums we're sending over, and thus know exactly which ones the responses are associated with.  