### PR TITLE
Fix build race

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -50,6 +50,14 @@
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != ''">true</PublishReadyToRun>
   </PropertyGroup>
 
+  <!-- When we are packing each RID, we set PackRuntimeIdentifier; by default this will also get passed to the builds of all ResolveProjectReferences
+       which causes a lot of duplicate building. This removes it. -->
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <GlobalPropertiesToRemove>PackRuntimeIdentifier</GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Workspaces\Core\MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\MSBuild.BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj" />
@@ -127,13 +135,11 @@
       </_NetFrameworkBuildHostProjectReference>
     </ItemGroup>
 
-    <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433; we pass
-         BuildInParallel="false" to avoid multiple builds potentially building the same project at the same time, but since we
-         expect the builds to have completed by this point they should be fast.  -->
+    <!-- We include Build as a target we invoke to work around https://github.com/dotnet/msbuild/issues/5433  -->
     <MSBuild Projects="@(_NetFrameworkBuildHostProjectReference)"
              Targets="Build;BuiltProjectOutputGroup;ReferenceCopyLocalPathsOutputGroup"
-             BuildInParallel="false"
-             Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework);RuntimeIdentifier=">
+             Properties="TargetFramework=%(_NetFrameworkBuildHostProjectReference.TargetFramework)"
+             RemoveProperties="PackRuntimeIdentifier">
       <Output TaskParameter="TargetOutputs" ItemName="NetFrameworkBuildHostAssets" />
     </MSBuild>
 

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/PackAllRids.targets
@@ -21,7 +21,7 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPack->'$(MSBuildProjectFullPath)')">
-          <AdditionalProperties>PackRuntimeIdentifier=%(RuntimeIdentifierForPack.Identity);BuildProjectReferences=false</AdditionalProperties>
+          <AdditionalProperties>PackRuntimeIdentifier=%(RuntimeIdentifierForPack.Identity)</AdditionalProperties>
       </ProjectToPublish>
     </ItemGroup>
 

--- a/src/Tools/BuildBoss/ProjectUtil.cs
+++ b/src/Tools/BuildBoss/ProjectUtil.cs
@@ -97,14 +97,9 @@ namespace BuildBoss
                 .Where(x => !string.IsNullOrEmpty(x));
         }
 
-        internal IEnumerable<XElement> GetItemGroup()
-        {
-            return Document.XPathSelectElements("//mb:ItemGroup", Manager);
-        }
-
         internal List<ProjectReferenceEntry> GetDeclaredProjectReferences()
         {
-            var references = Document.XPathSelectElements("//mb:ProjectReference", Manager);
+            var references = Document.XPathSelectElements("//mb:ItemGroup/mb:ProjectReference", Manager);
             var list = new List<ProjectReferenceEntry>();
             var directory = Path.GetDirectoryName(Key.FilePath);
             foreach (var r in references)
@@ -138,7 +133,7 @@ namespace BuildBoss
         internal List<PackageReference> GetPackageReferences()
         {
             var list = new List<PackageReference>();
-            foreach (var packageRef in Document.XPathSelectElements("//mb:PackageReference", Manager))
+            foreach (var packageRef in Document.XPathSelectElements("//mb:ItemGroup/mb:PackageReference", Manager))
             {
                 list.Add(GetPackageReference(packageRef));
             }


### PR DESCRIPTION
By setting RuntimeIdentifier= we were preventing MSBuild from only running that once, since the regular invocation of the build would set the TFM but not the RID. This doesn't seem necessary anymore, so we can just remove it.