### PR TITLE
Update VS version used for signed builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.100-rc.1.23455.8",
     "vs": {
-      "version": "17.6.0"
+      "version": "17.7.2"
     },
-    "xcopy-msbuild": "17.6.0-2"
+    "xcopy-msbuild": "17.7.2-1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23504.4",


### PR DESCRIPTION
Fixes signed builds: https://dev.azure.com/dnceng/internal/_build?definitionId=327&_a=summary

Similar to:
- https://github.com/dotnet/roslyn/pull/68647
- https://github.com/dotnet/roslyn/pull/68651

@RikkiGibson @dibarbet