### PR TITLE
Revert "[main] Update dependencies from dotnet/arcade"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,14 +27,14 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.23504.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23463.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>f1868a684ed9766d4247d672fd5f96bba4d4bb00</Sha>
+      <Sha>1d451c32dda2314c721adbf8829e1c0cd4e681ff</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23502.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23426.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
-      <Sha>0f36b29fb7374379609c3ee6a0b70caf457d8a0e</Sha>
+      <Sha>194f32828726c3f1f63f79f3dc09b9e99c157b11</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DiaSymReader" Version="2.0.0">
@@ -50,9 +50,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>5d10d428050c0d6afef30a072c4ae68776621877</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="9.0.0-beta.23504.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23463.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>f1868a684ed9766d4247d672fd5f96bba4d4bb00</Sha>
+      <Sha>1d451c32dda2314c721adbf8829e1c0cd4e681ff</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview.23468.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.7.2-1" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.6.0-2" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -379,13 +379,13 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   }
 
   # Minimum VS version to require.
-  $vsMinVersionReqdStr = '17.7'
+  $vsMinVersionReqdStr = '17.6'
   $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/RoslynTools.MSBuild/versions/17.7.2-1
-  $defaultXCopyMSBuildVersion = '17.7.2-1'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/RoslynTools.MSBuild/versions/17.6.0-2
+  $defaultXCopyMSBuildVersion = '17.6.0-2'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/global.json
+++ b/global.json
@@ -1,18 +1,18 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23455.8",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
     "rollForward": "latestPatch"
   },
   "tools": {
-    "dotnet": "8.0.100-rc.1.23455.8",
+    "dotnet": "8.0.100-preview.7.23376.3",
     "vs": {
       "version": "17.7.2"
     },
     "xcopy-msbuild": "17.7.2-1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23504.4",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.23504.4"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23463.1",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23463.1"
   }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListBuilderTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListBuilderTest.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             var builder = new ImmutableSegmentedList<int>.Builder(list);
 
             ref readonly var safeRef = ref builder.ItemRef(1);
-            ref var unsafeRef = ref Unsafe.AsRef(in safeRef);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
 
             Assert.Equal(2, builder.ItemRef(1));
 

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableSegmentedListTest.cs
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             var list = new[] { 1, 2, 3 }.ToImmutableSegmentedList();
 
             ref readonly var safeRef = ref list.ItemRef(1);
-            ref var unsafeRef = ref Unsafe.AsRef(in safeRef);
+            ref var unsafeRef = ref Unsafe.AsRef(safeRef);
 
             Assert.Equal(2, list.ItemRef(1));
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -130,9 +130,7 @@ namespace Microsoft.CodeAnalysis
             public void WriteTo(Span<byte> span)
             {
                 Contract.ThrowIfFalse(span.Length >= HashSize);
-#pragma warning disable CS9191 // The 'ref' modifier for an argument corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
                 Contract.ThrowIfFalse(MemoryMarshal.TryWrite(span, ref Unsafe.AsRef(in this)));
-#pragma warning restore CS9191
             }
 
             public static unsafe HashData FromPointer(HashData* hash)


### PR DESCRIPTION
Reverts dotnet/roslyn#70248

This is suspected as being the source of our official build breaks that caused OOM in the Signtool. 