### PR TITLE
Short-circuit tagger usage of interval tree when tagging complete snapshot

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -398,13 +398,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             private IEnumerable<ITagSpan<TTag>> GetNonIntersectingTagSpans(IEnumerable<SnapshotSpan> spansToInvalidate, TagSpanIntervalTree<TTag> oldTagTree)
             {
                 var firstSpanToInvalidate = spansToInvalidate.First();
+                var snapshot = firstSpanToInvalidate.Snapshot;
 
                 // Performance: No need to fully realize spansToInvalidate or do any of the calculations below if the
                 //   full snapshot is being invalidated.
-                if (firstSpanToInvalidate.Length == firstSpanToInvalidate.Snapshot.Length)
+                if (firstSpanToInvalidate.Length == snapshot.Length)
                     return Array.Empty<ITagSpan<TTag>>();
-
-                var snapshot = firstSpanToInvalidate.Snapshot;
 
                 return oldTagTree.GetSpans(snapshot).Except(
                     spansToInvalidate.SelectMany(oldTagTree.GetIntersectingSpans),

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -397,7 +397,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
             private IEnumerable<ITagSpan<TTag>> GetNonIntersectingTagSpans(IEnumerable<SnapshotSpan> spansToInvalidate, TagSpanIntervalTree<TTag> oldTagTree)
             {
-                var snapshot = spansToInvalidate.First().Snapshot;
+                var firstSpanToInvalidate = spansToInvalidate.First();
+
+                // Performance: No need to fully realize spansToInvalidate or do any of the calculations below if the
+                //   full snapshot is being invalidated.
+                if (firstSpanToInvalidate.Length == firstSpanToInvalidate.Snapshot.Length)
+                    return Array.Empty<ITagSpan<TTag>>();
+
+                var snapshot = firstSpanToInvalidate.Snapshot;
 
                 return oldTagTree.GetSpans(snapshot).Except(
                     spansToInvalidate.SelectMany(oldTagTree.GetIntersectingSpans),


### PR DESCRIPTION
Noticed when looking at CPU usage on prism for completion scenario. It looks like the primary culprit that I saw when debugging locally was outlining (TTag was IStructureTag2). I was seeing requests spanning the full snapshot with ~2000 entries in spansToInvalidate when editing in the languageparser.cs file in the Roslyn sln. The Except call would end up creating a 2000 entry set, and proceed to remove all 2000 entries from it.

Fixes [AB#1897704](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1897704)