### PR TITLE
Update 'use collection expression' to support cases where an array was assigned to a span type.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/CSharpUseCollectionExpressionForArrayDiagnosticAnalyzer.cs
@@ -89,7 +89,7 @@ internal sealed partial class CSharpUseCollectionExpressionForArrayDiagnosticAna
             : initializer;
 
         if (!UseCollectionExpressionHelpers.CanReplaceWithCollectionExpression(
-                semanticModel, arrayCreationExpression, skipVerificationForReplacedNode: false, cancellationToken))
+                semanticModel, arrayCreationExpression, skipVerificationForReplacedNode: true, cancellationToken))
         {
             return;
         }

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -250,144 +250,163 @@ internal static class UseCollectionExpressionHelpers
         // We're going to potentially be seeing how a local symbol was used.  Ensure we don't get into any cycles
         // with locals.
         using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionsToProcess);
-        using var _2 = ArrayBuilder<(ILocalSymbol local, SyntaxNode declarator)>.GetInstance(out var localsToProcess);
-        using var _3 = PooledHashSet<ExpressionSyntax>.GetInstance(out var seenExpressions);
-        using var _4 = PooledHashSet<ILocalSymbol>.GetInstance(out var seenLocals);
+        using var _2 = PooledHashSet<ExpressionSyntax>.GetInstance(out var seenExpressions);
+        using var _3 = PooledHashSet<ILocalSymbol>.GetInstance(out var seenLocals);
 
-        expressionsToProcess.Push(expression);
+        AddExpressionToProcess(expression);
 
-        while (expressionsToProcess.Count > 0 || localsToProcess.Count > 0)
+        while (expressionsToProcess.Count > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (expressionsToProcess.Count > 0)
+            var currentExpression = expressionsToProcess.Pop();
+
+            var topMostExpression = currentExpression.WalkUpParentheses();
+
+            // Expression used on its own, without its result being used.  Safe to convet.
+            if (topMostExpression.Parent is ExpressionStatementSyntax)
+                continue;
+
+            // If the expression is returned out, then it definitely has non-local scope and we definitely cannot
+            // return it.
+            if (topMostExpression.Parent is ReturnStatementSyntax or ArrowExpressionClauseSyntax)
+                return false;
+
+            if (topMostExpression.Parent is ArgumentSyntax argument)
             {
-                var currentExpression = expressionsToProcess.Pop();
-
-                var topMostExpression = currentExpression.WalkUpParentheses();
-
-                // If the expression is returned out, then it definitely has non-local scope and we definitely cannot
-                // return it.
-                if (topMostExpression.Parent is ReturnStatementSyntax)
-                {
-                    return false;
-                }
-                else if (topMostExpression.Parent is ArgumentSyntax argument)
-                {
-                    // if it's passed into something, ensure that that is safe.  Note: this may discover more
-                    // expressions and variables to test out.
-                    if (!IsSafeUsageOfSpanAsArgument(argument))
-                        return false;
-
-                    continue;
-                }
-                else if (topMostExpression.Parent is MemberAccessExpressionSyntax memberAccess &&
-                    memberAccess.Expression == topMostExpression)
-                else if (topMostExpression.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })
-                {
-                    // if it's assigned to a new variable, check that variables for how it is used.
-                    if (semanticModel.GetDeclaredSymbol(declarator, cancellationToken) is not ILocalSymbol local)
-                        return false;
-
-                    if (seenLocals.Add(local))
-                        localsToProcess.Add((local, declarator));
-
-                    continue;
-                }
-                else if (topMostExpression.Parent is AssignmentExpressionSyntax assignment &&
-                    assignment.Right == topMostExpression)
-                {
-                    // If it's assigned to something, check that thing as well.
-                    if (seenExpressions.Add(assignment.Left))
-                        expressionsToProcess.Add(assignment.Left);
-
-                    continue;
-                }
-                else
-                {
-                    // Anything else is an expression we don't support (yet);
-                    return false;
-                }
-            }
-            else
-            {
-                var (currentLocal, declarator) = localsToProcess.Pop();
-
-                // if the local already has local-scope, then we know it's safe.
-                if (currentLocal.ScopedKind == ScopedKind.ScopedValue)
-                    continue;
-
-                var containingBlock = declarator.FirstAncestorOrSelf<BlockSyntax>();
-                if (containingBlock == null)
+                // if it's passed into something, ensure that that is safe.  Note: this may discover more
+                // expressions and variables to test out.
+                if (!IsSafeUsageOfSpanAsArgument(argument))
                     return false;
 
-                foreach (var identifier in containingBlock.DescendantNodes().OfType<IdentifierNameSyntax>())
-                {
-                    if (identifier.Identifier.ValueText != local.Name)
-                        continue;
-
-                    var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
-                    if (!local.Equals(symbol))
-                        continue;
-
-                    // Ok, found a reference to the local 
-                }
+                continue;
             }
 
-            bool IsSafeUsageOfSpanAsArgument(ArgumentSyntax argument)
+            if (topMostExpression.Parent is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Expression == topMostExpression)
             {
-                var parameter = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
-                if (parameter is null)
-                    return false;
-
-                // Goo([i]) is always safe if the argument is 'scoped' as this can't escape.
-                if (parameter.ScopedKind != ScopedKind.ScopedValue)
+                // something like s.Slice(...).  We're safe if the result of this invocation is safe.
+                if (memberAccess.Parent is InvocationExpressionSyntax invocationExpression)
                 {
-                    // Ok.  Was passed to something non-scoped.  Check the rest of the signature.
-                    if (parameter.ContainingSymbol is not IMethodSymbol method)
-                        return false;
-
-                    // method returns something by-ref.  Have to make sure the entire method call is safe.
-                    if (argument.Parent is not BaseArgumentListSyntax { Parent: ExpressionSyntax parentInvocation } argumentList)
-                        return false;
-
-                    if (method.ReturnType.IsRefLikeType)
-                    {
-                        if (seenExpressions.Add(parentInvocation))
-                            expressionsToProcess.Add(parentInvocation);
-                    }
-
-                    // Now check the rest of the arguments.  If there are any out-parameters that are ref-structs,
-                    // then make sure those are safe as well.
-                    foreach (var siblingArgument in argumentList.Arguments)
-                    {
-                        if (siblingArgument != argument)
-                        {
-                            var siblingParameter = siblingArgument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
-                            if (siblingParameter is null)
-                                return false;
-
-                            if (siblingParameter.Type.IsRefLikeType &&
-                                siblingArgument.RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword &&
-                                siblingArgument.Expression is DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax designation })
-                            {
-                                // if it's assigned to a new variable, check that variables for how it is used.
-                                if (semanticModel.GetDeclaredSymbol(designation, cancellationToken) is not ILocalSymbol local)
-                                    return false;
-
-                                if (seenLocals.Add(local))
-                                    localsToProcess.Add((local, designation));
-                            }
-                        }
-                    }
+                    AddExpressionToProcess(invocationExpression);
                 }
 
-                // This should be safe to convert.
-                return true;
+                // Something like s[...].  We're safe if the result of the element access it safe.
+                if (memberAccess.Parent is ElementAccessExpressionSyntax elementAccess)
+                {
+                    AddExpressionToProcess(elementAccess);
+                }
+
+                // just a property access.  Like 's.Length'.  This is safe to convert keep going.
+                continue;
             }
+
+            if (topMostExpression.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })
+            {
+                // if it's assigned to a new variable, check that variables for how it is used.
+                if (!AddLocalToProcess(declarator))
+                    return false;
+
+                continue;
+            }
+
+            if (topMostExpression.Parent is AssignmentExpressionSyntax assignment &&
+                assignment.Right == topMostExpression)
+            {
+                // If it's assigned to something, check that thing as well.
+                AddExpressionToProcess(assignment.Left);
+                continue;
+            }
+
+            // Anything else is an expression we don't support (yet);
+            return false;
         }
 
         // Something unsupported.  Can always add new cases here in the future if it can be determined.
         return false;
+
+        void AddExpressionToProcess(ExpressionSyntax expression)
+        {
+            if (seenExpressions.Add(expression))
+                expressionsToProcess.Push(expression);
+        }
+
+        bool AddLocalToProcess(SyntaxNode declarator)
+        {
+            if (semanticModel.GetDeclaredSymbol(declarator, cancellationToken) is not ILocalSymbol local)
+                return false;
+
+            // Only process a local once.
+            if (!seenLocals.Add(local))
+                return true;
+
+            var containingBlock = declarator.FirstAncestorOrSelf<BlockSyntax>();
+            if (containingBlock == null)
+                return false;
+
+            foreach (var identifier in containingBlock.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifier.Identifier.ValueText != local.Name)
+                    continue;
+
+                var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
+                if (!local.Equals(symbol))
+                    continue;
+
+                // Ok, found a reference to the local, add this to the list to process.
+                AddExpressionToProcess(identifier);
+            }
+
+            return true;
+        }
+
+        bool IsSafeUsageOfSpanAsArgument(ArgumentSyntax argument)
+        {
+            var parameter = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
+            if (parameter is null)
+                return false;
+
+            // Goo([i]) is always safe if the argument is 'scoped' as this can't escape.
+            if (parameter.ScopedKind != ScopedKind.ScopedValue)
+            {
+                // Ok.  Was passed to something non-scoped.  Check the rest of the signature.
+                if (parameter.ContainingSymbol is not IMethodSymbol method)
+                    return false;
+
+                // method returns something by-ref.  Have to make sure the entire method call is safe.
+                if (argument.Parent is not BaseArgumentListSyntax { Parent: ExpressionSyntax parentInvocation } argumentList)
+                    return false;
+
+                if (method.ReturnType.IsRefLikeType)
+                {
+                    if (seenExpressions.Add(parentInvocation))
+                        expressionsToProcess.Add(parentInvocation);
+                }
+
+                // Now check the rest of the arguments.  If there are any out-parameters that are ref-structs,
+                // then make sure those are safe as well.
+                foreach (var siblingArgument in argumentList.Arguments)
+                {
+                    if (siblingArgument != argument)
+                    {
+                        var siblingParameter = siblingArgument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
+                        if (siblingParameter is null)
+                            return false;
+
+                        if (siblingParameter.Type.IsRefLikeType &&
+                            siblingArgument.RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword &&
+                            siblingArgument.Expression is DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax designation })
+                        {
+                            // if it's assigned to a new variable, check that variables for how it is used.
+                            if (!AddLocalToProcess(designation))
+                                return false;
+                        }
+                    }
+                }
+            }
+
+            // This should be safe to convert.
+            return true;
+        }
 
         bool IsPrimitiveConstant(ExpressionSyntax expression)
             => semanticModel.GetConstantValue(expression, cancellationToken).HasValue &&

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -262,8 +262,9 @@ internal static class UseCollectionExpressionHelpers
         //  1. the argument must either be 'scoped', or
         //  2. the thing being called must not have a ref-struct return value, or non-scoped ref-struct out parameter.
 
-        // We're going to potentially be seeing how a local symbol was used.  Ensure we don't get into any cycles
-        // with locals.
+        // We do our analysis in an iterative fashion.  Starting with the original expression and seeing how its scope
+        // flows outward (including to other locals).  Because we're analyzing the code in multiple passes (until we
+        // reach a fixed point), we have to ensure we only examine locals and expressions once.
         using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionsToProcess);
         using var _2 = PooledHashSet<ExpressionSyntax>.GetInstance(out var seenExpressions);
         using var _3 = PooledHashSet<ILocalSymbol>.GetInstance(out var seenLocals);

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -251,16 +251,13 @@ internal static class UseCollectionExpressionHelpers
             return false;
         }
 
-        // Ok, we have non primitive/constant values.  Moving to a collection expression will make this span have
-        // local scope.  Have to make sure that's ok.  We take a conservative position.  We will not allow the
-        // value to be returned.  And, if it is passed as an argument to anything:
+        // Ok, we have non primitive/constant values.  Moving to a collection expression will make this span have local
+        // scope.  Have to make sure that's ok.  We do our analysis in an iterative fashion.  Starting with the original
+        // expression and seeing how its scope flows outward (including to other locals).  We will then require that any
+        // ref-type values we encounter (including the initial one) cannot flow out of the method we're in.
         //
-        //  1. the argument must either be 'scoped', or
-        //  2. the thing being called must not have a ref-struct return value, or non-scoped ref-struct out parameter.
-
-        // We do our analysis in an iterative fashion.  Starting with the original expression and seeing how its scope
-        // flows outward (including to other locals).  Because we're analyzing the code in multiple passes (until we
-        // reach a fixed point), we have to ensure we only examine locals and expressions once.
+        // Because we're analyzing the code in multiple passes (until we reach a fixed point), we have to ensure we only
+        // examine locals and expressions once.
         using var _1 = ArrayBuilder<ExpressionSyntax>.GetInstance(out var expressionsToProcess);
         using var _2 = PooledHashSet<ExpressionSyntax>.GetInstance(out var seenExpressions);
         using var _3 = PooledHashSet<ILocalSymbol>.GetInstance(out var seenLocals);

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -306,12 +306,6 @@ internal static class UseCollectionExpressionHelpers
                     AddExpressionToProcess(invocationExpression);
                     AddRefLikeOutParameters(invocationExpression.ArgumentList, argumentToSkip: null);
                 }
-                else if (memberAccess.Parent is ElementAccessExpressionSyntax elementAccess)
-                {
-                    // Something like s[...].  We're safe if the result of the element access it safe.
-                    AddExpressionToProcess(elementAccess);
-                    AddRefLikeOutParameters(elementAccess.ArgumentList, argumentToSkip: null);
-                }
                 else
                 {
                     // just a property access.  Like 's.Length'.  This is safe to convert keep going.
@@ -321,6 +315,13 @@ internal static class UseCollectionExpressionHelpers
                 }
 
                 continue;
+            }
+
+            if (topMostExpression.Parent is ElementAccessExpressionSyntax elementAccess)
+            {
+                // Something like s[...].  We're safe if the result of the element access it safe.
+                AddExpressionToProcess(elementAccess);
+                AddRefLikeOutParameters(elementAccess.ArgumentList, argumentToSkip: null);
             }
 
             if (topMostExpression.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -333,6 +333,7 @@ internal static class UseCollectionExpressionHelpers
                     AddExpressionToProcess(elementAccess);
 
                 AddRefLikeOutParameters(elementAccess.ArgumentList, argumentToSkip: null);
+                continue;
             }
 
             if (topMostExpression.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -251,6 +251,9 @@ internal static class UseCollectionExpressionHelpers
             {
                 return true;
             }
+
+            // Don't support anything else without an initializer (for now).
+            return false;
         }
 
         // Ok, we have non primitive/constant values.  Moving to a collection expression will make this span have
@@ -345,7 +348,7 @@ internal static class UseCollectionExpressionHelpers
         }
 
         // Everything we processed was good.  Can safely convert this global-scoped array to a local scoped span.
-        return false;
+        return true;
 
         void AddExpressionToProcess(ExpressionSyntax expression)
         {

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -458,6 +458,7 @@ internal static class UseCollectionExpressionHelpers
             BinaryExpressionSyntax binaryExpression => IsInTargetTypedBinaryExpression(binaryExpression, topExpression),
             ArgumentSyntax or AttributeArgumentSyntax => true,
             ReturnStatementSyntax => true,
+            ArrowExpressionClauseSyntax => true,
             _ => false,
         };
 

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -915,13 +915,13 @@ internal static class UseCollectionExpressionHelpers
                 if (arguments.Count == 1 &&
                     compilation.SupportsRuntimeCapability(RuntimeCapability.InlineArrayTypes) &&
                     originalCreateMethod.Parameters is [
+                    {
+                        Type: INamedTypeSymbol
                         {
-                            Type: INamedTypeSymbol
-                            {
-                                Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
-                                TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
-                            } spanType
-                        }])
+                            Name: nameof(Span<int>) or nameof(ReadOnlySpan<int>),
+                            TypeArguments: [ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method }]
+                        } spanType
+                    }])
                 {
                     if (spanType.OriginalDefinition.Equals(compilation.SpanOfTType()) ||
                         spanType.OriginalDefinition.Equals(compilation.ReadOnlySpanOfTType()))

--- a/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCollectionExpression/UseCollectionExpressionHelpers.cs
@@ -211,11 +211,7 @@ internal static class UseCollectionExpressionHelpers
                 return IsSafeConversionOfArrayToSpanType(semanticModel, expression, cancellationToken);
             }
 
-            // ReadOnlySpan<X> x = new X[] ...
-            //
-            // This will be an X[] converted to a ReadOnlySpan<X>.  This is always safe as ReadOnlySpan is more
-            // restrictive than Span<X>.  However, in the case of a local, we have to make 
-
+            // Add more cases to support here.
             return false;
         }
     }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -3893,7 +3893,7 @@ public class UseCollectionExpressionForArrayTests
                 {
                     ReadOnlySpan<int> M(int i)
                     {
-                        ReadOnlySpan<int> span = new[] { i };
+                        ReadOnlySpan<int> span = [|[|new|][]|] { i };
                         X(span, out var v);
                         return v;
                     }
@@ -3935,9 +3935,9 @@ public class UseCollectionExpressionForArrayTests
                 
                 class C
                 {
-                    ReadOnlySpan<int> M(int i)
+                    void M(int i)
                     {
-                        ReadOnlySpan<int> span = new[] { i };
+                        ReadOnlySpan<int> span = [|[|new|][]|] { i };
                         X(span, out var v);
                     }
 
@@ -3951,7 +3951,7 @@ public class UseCollectionExpressionForArrayTests
                 
                 class C
                 {
-                    ReadOnlySpan<int> M(int i)
+                    void M(int i)
                     {
                         ReadOnlySpan<int> span = [i];
                         X(span, out var v);
@@ -3979,9 +3979,9 @@ public class UseCollectionExpressionForArrayTests
                 {
                     ReadOnlySpan<int> M(int i)
                     {
-                        ReadOnlySpan<int> span = new[] { i };
+                        ReadOnlySpan<int> span = [|[|new|][]|] { i };
                         X(span, out var v);
-                        return v;
+                        return v.Slice(0, 1);
                     }
 
                     void X(scoped ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
@@ -4007,12 +4007,5 @@ public class UseCollectionExpressionForArrayTests
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
-    }
-
-    private void M()
-    {
-        ReadOnlySpan<int> r = default;
-        r.ToString();
-        var v = r[0..1];
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.UseCollectionExpression;
@@ -3019,5 +3020,1001 @@ public class UseCollectionExpressionForArrayTests
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        ReadOnlySpan<int> t;
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        ReadOnlySpan<int> t;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int[] globalArray;
+
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        ReadOnlySpan<int> t = globalArray;
+                        return t;
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int[] globalArray;
+
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        ReadOnlySpan<int> t = globalArray;
+                        return t;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        ReadOnlySpan<int> t = s;
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        ReadOnlySpan<int> t = s;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        X(s);
+                    }
+
+                    void X(ReadOnlySpan<int> span) { }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        X(s);
+                    }
+                
+                    void X(ReadOnlySpan<int> span) { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int[] globalArray;
+
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return X(s);
+                    }
+
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return X(s);
+                    }
+                
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        s.Slice(0, 1);
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        s.Slice(0, 1);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan7_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    string M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return s.ToString();
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    string M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return s.ToString();
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return X(s.Slice(0, 1));
+                    }
+                
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return X(s.Slice(0, 1));
+                    }
+                
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan9()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return X(s[0..1]);
+                    }
+                
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return X(s[0..1]);
+                    }
+                
+                    ReadOnlySpan<int> X(scoped ReadOnlySpan<int> span) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan9_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return s[0];
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return s[0];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan10()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return s.Length;
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return s.Length;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan11()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [|[|new|][]|] { i };
+                        return nameof(s).Length;
+                    }
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    int M(int i)
+                    {
+                        ReadOnlySpan<int> s = [i];
+                        return nameof(s).Length;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> s = new[] { i };
+                        return s;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan13()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        return new[] { i };
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan13_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                        => new[] { i };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan14()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        return X(new[] { i });
+                    }
+
+                    ReadOnlySpan<int> X(ReadOnlySpan<int> y) => y;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan14_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                        => X(new[] { i });
+
+                    ReadOnlySpan<int> X(ReadOnlySpan<int> y) => y;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan15()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        return X(new[] { i });
+                    }
+
+                    ReadOnlySpan<int> X(ReadOnlySpan<int> y) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan15_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                        => X(new[] { i });
+
+                    ReadOnlySpan<int> X(ReadOnlySpan<int> y) => default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan16()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        return span.Slice(0, 1);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan17()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        return span[0..1];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan18()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        ReadOnlySpan<int> t = span;
+                        return t;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan19()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        ReadOnlySpan<int> t = span;
+                        return t.Slice(0, 1);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan20()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                        return v;
+                    }
+
+                    void X(ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = s;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan21()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                        return v;
+                    }
+
+                    void X(ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan21_A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                        return v.Slice(0, 1);
+                    }
+
+                    void X(ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan22()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                        return v;
+                    }
+
+                    void X(scoped ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = [i];
+                        X(span, out var v);
+                        return v;
+                    }
+
+                    void X(scoped ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan23()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                    }
+
+                    void X(ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = [i];
+                        X(span, out var v);
+                    }
+
+                    void X(ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestLocalSpan24()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = new[] { i };
+                        X(span, out var v);
+                        return v;
+                    }
+
+                    void X(scoped ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            FixedCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    ReadOnlySpan<int> M(int i)
+                    {
+                        ReadOnlySpan<int> span = [i];
+                        X(span, out var v);
+                        return v.Slice(0, 1);
+                    }
+
+                    void X(scoped ReadOnlySpan<int> s, out ReadOnlySpan<int> t) => t = default;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    private void M()
+    {
+        ReadOnlySpan<int> r = default;
+        r.ToString();
+        var v = r[0..1];
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -3232,8 +3232,6 @@ public class UseCollectionExpressionForArrayTests
                 
                 class C
                 {
-                    int[] globalArray;
-
                     ReadOnlySpan<int> M(int i)
                     {
                         ReadOnlySpan<int> s = [|[|new|][]|] { i };

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForArrayTests.cs
@@ -2826,6 +2826,29 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
+    [Fact]
+    public async Task TestForSpanField2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                ref struct C
+                {
+                    private static readonly int i = 0;
+                    private ReadOnlySpan<int> span = new int[] { i };
+
+                    public C() { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
     [Theory, MemberData(nameof(EmptyOrConstantsOnly))]
     public async Task TestForSpanProperty1(string expression, string expected)
     {
@@ -2916,6 +2939,27 @@ public class UseCollectionExpressionForArrayTests
         }.RunAsync();
     }
 
+    [Fact]
+    public async Task TestForSpanProperty4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private static readonly int i = 1;
+                    private ReadOnlySpan<int> Span => new int[] { i };
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
     [Theory, MemberData(nameof(EmptyOrConstantsOnly))]
     public async Task TestForMethodReturn(string expression, string expected)
     {
@@ -2939,6 +2983,27 @@ public class UseCollectionExpressionForArrayTests
                 class C
                 {
                     private ReadOnlySpan<int> Span() => {{expected}};
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForSpanMethodReturn2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = $$"""
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private static readonly int i = 1;
+                    private ReadOnlySpan<int> Span() => new int[] { i };
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,

--- a/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionExpression/UseCollectionExpressionForEmptyTests.cs
@@ -1249,4 +1249,234 @@ public class UseCollectionExpressionForEmptyTests
             },
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task TestForSpanField()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                ref struct C
+                {
+                    private ReadOnlySpan<int> span = Array.[|Empty|]<int>();
+
+                    public C() { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                ref struct C
+                {
+                    private ReadOnlySpan<int> span = [];
+                
+                    public C() { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForSpanProperty1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span => Array.[|Empty|]<int>();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span => [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForSpanProperty2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span { get => Array.[|Empty|]<int>(); }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span { get => []; }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForSpanProperty3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span { get { return Array.[|Empty|]<int>(); } }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span { get { return []; } }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForMethodReturn()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span() => Array.[|Empty|]<int>();
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    private ReadOnlySpan<int> Span() => [];
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForMethodLocal1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M()
+                    {
+                        ReadOnlySpan<int> span = Array.[|Empty|]<int>();
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M()
+                    {
+                        ReadOnlySpan<int> span = [];
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestForArgument()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M()
+                    {
+                        X(Array.[|Empty|]<int>());
+                    }
+
+                    void X(ReadOnlySpan<int> span) { }
+                }
+                """,
+            FixedCode = """
+                using System;
+                using System.Linq;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    void M()
+                    {
+                        X([]);
+                    }
+                
+                    void X(ReadOnlySpan<int> span) { }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
for example:

```c#
public static readonly ReadOnlySpan<int> X => new [] { 1, 2, 3 }; // to
public static readonly ReadOnlySpan<int> X => [1, 2, 3];
```

This also works in the locals case, doing the work to ensure that the code remains legal, even if a previously 'global scoped' span now becomes locally scoped.