### PR TITLE
Recommend `void` keyword in `using unsafe` directives

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/VoidKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VoidKeywordRecommenderTests.cs
@@ -931,5 +931,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                     public readonly $$
                 """);
         }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67986")]
+        public async Task TestInUsingUnsafeDirective()
+        {
+            await VerifyKeywordAsync("using unsafe T = $$");
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/67986")]
+        public async Task TestNotInRegularUsingDirective()
+        {
+            await VerifyAbsenceAsync("using T = $$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VoidKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VoidKeywordRecommender.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class VoidKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal sealed class VoidKeywordRecommender() : AbstractSyntacticSingleKeywordRecommender(SyntaxKind.VoidKeyword)
     {
         private static readonly ISet<SyntaxKind> s_validClassInterfaceRecordModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
         {
@@ -33,11 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             SyntaxKind.ReadOnlyKeyword,
         };
-
-        public VoidKeywordRecommender()
-            : base(SyntaxKind.VoidKeyword)
-        {
-        }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VoidKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VoidKeywordRecommender.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 IsUnsafeParameterTypeContext(context) ||
                 IsUnsafeCastTypeContext(context) ||
                 IsUnsafeDefaultExpressionContext(context) ||
+                IsUnsafeUsingDirectiveContext(context) ||
                 context.IsFixedVariableDeclarationContext ||
                 context.SyntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
                 context.SyntaxTree.IsLocalFunctionDeclarationContext(position, cancellationToken);
@@ -103,6 +104,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             }
 
             return false;
+        }
+
+        private static bool IsUnsafeUsingDirectiveContext(CSharpSyntaxContext context)
+        {
+            return
+                context.IsUsingAliasTypeContext &&
+                context.TargetToken.IsUnsafeContext();
         }
 
         private static bool IsMemberReturnTypeContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -504,7 +504,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return
                 targetToken.GetAncestors<StatementSyntax>().Any(s => s.IsKind(SyntaxKind.UnsafeStatement)) ||
                 targetToken.GetAncestors<MemberDeclarationSyntax>().Any(m => m.GetModifiers().Any(SyntaxKind.UnsafeKeyword) ||
-                targetToken.GetAncestors<LocalFunctionStatementSyntax>().Any(f => f.GetModifiers().Any(SyntaxKind.UnsafeKeyword)));
+                targetToken.GetAncestors<LocalFunctionStatementSyntax>().Any(f => f.GetModifiers().Any(SyntaxKind.UnsafeKeyword))) ||
+                targetToken.GetAncestors<UsingDirectiveSyntax>().Any(d => d.UnsafeKeyword.IsKind(SyntaxKind.UnsafeKeyword));
         }
 
         public static bool IsAfterYieldKeyword(this SyntaxToken targetToken)


### PR DESCRIPTION
Fixes #67986.