### PR TITLE
Improve performance on SymbolCompletionProviderTests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -61,6 +61,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 displayTextPrefix, inlineDescription, isComplexTextEdit, matchingFilters, flags, options, skipSpeculation: skipSpeculation);
         }
 
+        private protected override Task BaseVerifyWorkerAsync(
+            string code, int position, bool usePreviousCharAsTrigger, bool? hasSuggestionItem, SourceCodeKind sourceCodeKind,
+            CompletionTestExpectedResult[] expectedResults,
+            List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
+        {
+            return base.VerifyWorkerAsync(
+                code, position, usePreviousCharAsTrigger, hasSuggestionItem, sourceCodeKind,
+                expectedResults, matchingFilters, flags, options, skipSpeculation);
+        }
+
         private protected override async Task VerifyWorkerAsync(
             string code, int position,
             string expectedItemOrNull, string expectedDescriptionOrNull,

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -256,77 +256,76 @@ class C {
         public async Task OpenStringLiteral()
         {
             var code = AddUsingDirectives("using System;", AddInsideMethod("string s = \"$$"));
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(code, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Absent("System")
-            );
-            await VerifyExpectedItemsAsync(code, result);
+            ]);
         }
 
         [Fact]
         public async Task OpenStringLiteralInDirective()
         {
             var code = "#r \"$$";
-            var result = ImmutableArray.Create(
-                CompletionTestExpectedResult.Absent("String"),
-                CompletionTestExpectedResult.Absent("System")
-            );
-            await VerifyExpectedItemsAsync(code, result, sourceCodeKind: SourceCodeKind.Script);
+            await VerifyExpectedItemsAsync(
+                code, [
+                    CompletionTestExpectedResult.Absent("String"),
+                    CompletionTestExpectedResult.Absent("System")
+                ],
+                sourceCodeKind: SourceCodeKind.Script);
         }
 
         [Fact]
         public async Task StringLiteral()
         {
             var code = AddUsingDirectives("using System;", AddInsideMethod("string s = \"$$\";"));
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(code, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Absent("System")
-            );
-            await VerifyExpectedItemsAsync(code, result);
+            ]);
         }
 
         [Fact]
         public async Task StringLiteralInDirective()
         {
             var code = "#r \"$$\"";
-            var result = ImmutableArray.Create(
-                CompletionTestExpectedResult.Absent("String"),
-                CompletionTestExpectedResult.Absent("System")
-            );
-            await VerifyExpectedItemsAsync(code, result, sourceCodeKind: SourceCodeKind.Script);
+            await VerifyExpectedItemsAsync(
+                code, [
+                    CompletionTestExpectedResult.Absent("String"),
+                    CompletionTestExpectedResult.Absent("System")
+                ],
+                sourceCodeKind: SourceCodeKind.Script);
         }
 
         [Fact]
         public async Task OpenCharLiteral()
         {
             var code = AddUsingDirectives("using System;", AddInsideMethod("char c = '$$"));
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(code, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Absent("System")
-            );
-            await VerifyExpectedItemsAsync(code, result);
+            ]);
         }
 
         [Fact]
         public async Task AssemblyAttribute1()
         {
             var code = @"[assembly: $$]";
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(code, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Exists("System")
-            );
-            await VerifyExpectedItemsAsync(code, result);
+            ]);
+
         }
 
         [Fact]
         public async Task AssemblyAttribute2()
         {
             var code = AddUsingDirectives("using System;", @"[assembly: $$]");
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(code, [
                 CompletionTestExpectedResult.Exists("System"),
                 CompletionTestExpectedResult.Exists("AttributeUsage")
-            );
-            await VerifyExpectedItemsAsync(code, result);
+            ]);
+
         }
 
         [Fact]
@@ -536,25 +535,26 @@ namespace A
                 namespace A.B.C3 { }
                 """;
 
-            var result = ImmutableArray.Create(
-                // Ideally, all the C* namespaces would be recommended but, because of how the parser
-                // recovers from the missing braces, they end up with the following qualified names...
-                //
-                //     C1 => A.B.?.C1
-                //     C2 => A.B.B.C2
-                //     C3 => A.A.B.C3
-                //
-                // ...none of which are found by the current algorithm.
-                CompletionTestExpectedResult.Absent("C1"),
-                CompletionTestExpectedResult.Absent("C2"),
-                CompletionTestExpectedResult.Absent("C3"),
-                CompletionTestExpectedResult.Absent("A"),
+            await VerifyExpectedItemsAsync(
+                source, [
+                    // Ideally, all the C* namespaces would be recommended but, because of how the parser
+                    // recovers from the missing braces, they end up with the following qualified names...
+                    //
+                    //     C1 => A.B.?.C1
+                    //     C2 => A.B.B.C2
+                    //     C3 => A.A.B.C3
+                    //
+                    // ...none of which are found by the current algorithm.
+                    CompletionTestExpectedResult.Absent("C1"),
+                    CompletionTestExpectedResult.Absent("C2"),
+                    CompletionTestExpectedResult.Absent("C3"),
+                    CompletionTestExpectedResult.Absent("A"),
 
-                // Because of the above, B does end up in the completion list
-                // since A.B.B appears to be a peer of the new declaration
-                CompletionTestExpectedResult.Exists("B")
-            );
-            await VerifyExpectedItemsAsync(source, result, SourceCodeKind.Regular);
+                    // Because of the above, B does end up in the completion list
+                    // since A.B.B appears to be a peer of the new declaration
+                    CompletionTestExpectedResult.Exists("B")
+                ],
+                SourceCodeKind.Regular);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/7213")]
@@ -681,25 +681,25 @@ namespace A
 
 namespace A.B.C.D3 { }";
 
-            var result = ImmutableArray.Create(
-                CompletionTestExpectedResult.Absent("A"),
-                CompletionTestExpectedResult.Absent("B"),
-                CompletionTestExpectedResult.Absent("C"),
+            await VerifyExpectedItemsAsync(
+                source, [
+                    CompletionTestExpectedResult.Absent("A"),
+                    CompletionTestExpectedResult.Absent("B"),
+                    CompletionTestExpectedResult.Absent("C"),
 
-                // Ideally, all the D* namespaces would be recommended but, because of how the parser
-                // recovers from the missing braces, they end up with the following qualified names...
-                //
-                //     D1 => A.B.C.C.?.D1
-                //     D2 => A.B.B.C.D2
-                //     D3 => A.A.B.C.D3
-                //
-                // ...none of which are found by the current algorithm.
-                CompletionTestExpectedResult.Absent("D1"),
-                CompletionTestExpectedResult.Absent("D2"),
-                CompletionTestExpectedResult.Absent("D3")
-
-            );
-            await VerifyExpectedItemsAsync(source, result, SourceCodeKind.Regular);
+                    // Ideally, all the D* namespaces would be recommended but, because of how the parser
+                    // recovers from the missing braces, they end up with the following qualified names...
+                    //
+                    //     D1 => A.B.C.C.?.D1
+                    //     D2 => A.B.B.C.D2
+                    //     D3 => A.A.B.C.D3
+                    //
+                    // ...none of which are found by the current algorithm.
+                    CompletionTestExpectedResult.Absent("D1"),
+                    CompletionTestExpectedResult.Absent("D2"),
+                    CompletionTestExpectedResult.Absent("D3")
+                ],
+                SourceCodeKind.Regular);
         }
 
         [Fact]
@@ -2376,10 +2376,13 @@ class C
     }
 }
 ";
-            await VerifyItemExistsAsync(markup, "ToString");
-            await VerifyItemIsAbsentAsync(markup, "GetType");
-            await VerifyItemIsAbsentAsync(markup, "Equals");
-            await VerifyItemIsAbsentAsync(markup, "GetHashCode");
+
+            await VerifyExpectedItemsAsync(markup, [
+                CompletionTestExpectedResult.Exists("ToString"),
+                CompletionTestExpectedResult.Absent("GetType"),
+                CompletionTestExpectedResult.Absent("Equals"),
+                CompletionTestExpectedResult.Absent("GetHashCode")
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/35178")]
@@ -2397,13 +2400,12 @@ class C
                 }
                 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("ToString"),
                 CompletionTestExpectedResult.Exists("GetType"),
                 CompletionTestExpectedResult.Exists("Equals"),
                 CompletionTestExpectedResult.Exists("GetHashCode")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/53585")]
@@ -2420,11 +2422,10 @@ class C
                 }
                 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("String"),
                 CompletionTestExpectedResult.Absent("parameter")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Theory]
@@ -2450,11 +2451,10 @@ class C
 }
 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("String"),
                 CompletionTestExpectedResult.Absent("parameter")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Theory]
@@ -2478,11 +2478,10 @@ class C
 }}
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Absent("parameter")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/60341")]
@@ -2498,8 +2497,11 @@ class C
     }
 }
 ";
-            await VerifyItemIsAbsentAsync(markup, "String");
-            await VerifyItemIsAbsentAsync(markup, "parameter");
+
+            await VerifyExpectedItemsAsync(markup, [
+                CompletionTestExpectedResult.Absent("String"),
+                CompletionTestExpectedResult.Absent("parameter")
+            ]);
         }
 
         [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/53585")]
@@ -2523,11 +2525,10 @@ class C
 }}
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Absent("String"),
                 CompletionTestExpectedResult.Absent("parameter")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25569")]
@@ -3081,12 +3082,11 @@ namespace Test
     class Program { }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("namespaceAttribute"),
                 CompletionTestExpectedResult.Absent("namespace"),
                 CompletionTestExpectedResult.Absent("@namespace")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545121")]
@@ -3100,12 +3100,11 @@ namespace Test
     class Program { }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("namespaceAttribute"),
                 CompletionTestExpectedResult.Absent("namespace"),
                 CompletionTestExpectedResult.Absent("@namespace")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545348")]
@@ -3123,7 +3122,7 @@ class C
     }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 // preprocessor keyword
                 CompletionTestExpectedResult.Exists("error"),
                 CompletionTestExpectedResult.Absent("@error"),
@@ -3135,8 +3134,7 @@ class C
                 // full keyword
                 CompletionTestExpectedResult.Exists("@int"),
                 CompletionTestExpectedResult.Absent("int")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545348")]
@@ -3152,11 +3150,10 @@ class C
     }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("@from"),
                 CompletionTestExpectedResult.Absent("from")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545348")]
@@ -3174,13 +3171,12 @@ class C
     }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("@from"),
                 CompletionTestExpectedResult.Absent("from"),
                 CompletionTestExpectedResult.Exists("@where"),
                 CompletionTestExpectedResult.Absent("where")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545348")]
@@ -3198,13 +3194,12 @@ class C
     }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("@from"),
                 CompletionTestExpectedResult.Absent("from"),
                 CompletionTestExpectedResult.Exists("@where"),
                 CompletionTestExpectedResult.Absent("where")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545121")]
@@ -3215,11 +3210,12 @@ class MyAttribute : System.Attribute { }
 [global::$$
 class Program { }";
 
-            var result = ImmutableArray.Create(
-                CompletionTestExpectedResult.Exists("My"),
-                CompletionTestExpectedResult.Absent("MyAttribute")
-            );
-            await VerifyExpectedItemsAsync(markup, result, SourceCodeKind.Regular);
+            await VerifyExpectedItemsAsync(
+                markup, [
+                    CompletionTestExpectedResult.Exists("My"),
+                    CompletionTestExpectedResult.Absent("MyAttribute")
+                ],
+                SourceCodeKind.Regular);
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545121")]
@@ -3230,12 +3226,13 @@ class namespaceAttribute : System.Attribute { }
 [global::$$
 class Program { }";
 
-            var result = ImmutableArray.Create(
-                CompletionTestExpectedResult.Exists("namespaceAttribute"),
-                CompletionTestExpectedResult.Absent("namespace"),
-                CompletionTestExpectedResult.Absent("@namespace")
-            );
-            await VerifyExpectedItemsAsync(markup, result, SourceCodeKind.Regular);
+            await VerifyExpectedItemsAsync(
+                markup, [
+                    CompletionTestExpectedResult.Exists("namespaceAttribute"),
+                    CompletionTestExpectedResult.Absent("namespace"),
+                    CompletionTestExpectedResult.Absent("@namespace")
+                ],
+                SourceCodeKind.Regular);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/25589")]
@@ -3312,13 +3309,12 @@ namespace Namespace1
 
 [$$]";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("Namespace1Alias"),
                 CompletionTestExpectedResult.Absent("Namespace2Alias"),
                 CompletionTestExpectedResult.Exists("Namespace3Alias"),
                 CompletionTestExpectedResult.Exists("Namespace4Alias")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact]
@@ -9926,7 +9922,7 @@ class C
     }
 }" + TestResources.NetFX.ValueTuple.tuplelib_cs;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("Alice"),
                 CompletionTestExpectedResult.Exists("Bob"),
                 CompletionTestExpectedResult.Exists("CompareTo"),
@@ -9946,8 +9942,7 @@ class C
                 CompletionTestExpectedResult.Absent("Item9"),
                 CompletionTestExpectedResult.Absent("Rest"),
                 CompletionTestExpectedResult.Absent("Item3")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/14546")]
@@ -10826,14 +10821,13 @@ class Builder
     public int Something { get; set; }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 CompletionTestExpectedResult.Exists("Something"),
                 CompletionTestExpectedResult.Absent("BeginInvoke"),
                 CompletionTestExpectedResult.Absent("Clone"),
                 CompletionTestExpectedResult.Absent("Method"),
                 CompletionTestExpectedResult.Absent("Target")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact]
@@ -10856,7 +10850,7 @@ class Program
     }
 }";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 // Guid
                 CompletionTestExpectedResult.Exists("ToByteArray"),
 
@@ -10870,8 +10864,7 @@ class Program
                 CompletionTestExpectedResult.Absent("Clone"),
                 CompletionTestExpectedResult.Absent("Method"),
                 CompletionTestExpectedResult.Absent("Target")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact]
@@ -10893,7 +10886,7 @@ class Program
         M(d => d.$$)
     }
 }";
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(markup, [
                 // Guid
                 CompletionTestExpectedResult.Exists("ToByteArray"),
 
@@ -10907,8 +10900,7 @@ class Program
                 CompletionTestExpectedResult.Absent("Clone"),
                 CompletionTestExpectedResult.Absent("Method"),
                 CompletionTestExpectedResult.Absent("Target")
-            );
-            await VerifyExpectedItemsAsync(markup, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/36029")]
@@ -11657,7 +11649,7 @@ class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Absent("M0"),
 
                 CompletionTestExpectedResult.Exists("M1"),
@@ -11665,8 +11657,7 @@ class Test
                 CompletionTestExpectedResult.Exists("M3"),
                 CompletionTestExpectedResult.Exists("P1"),
                 CompletionTestExpectedResult.Exists("E1")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
@@ -11689,13 +11680,12 @@ unsafe class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("X"),
                 CompletionTestExpectedResult.Exists("Y"),
                 CompletionTestExpectedResult.Exists("Method"),
                 CompletionTestExpectedResult.Exists("ToString")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
@@ -11718,13 +11708,12 @@ unsafe class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("X"),
                 CompletionTestExpectedResult.Exists("Y"),
                 CompletionTestExpectedResult.Exists("Method"),
                 CompletionTestExpectedResult.Exists("ToString")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
@@ -11749,19 +11738,17 @@ unsafe class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("X"),
                 CompletionTestExpectedResult.Exists("Y"),
                 CompletionTestExpectedResult.Exists("Method"),
                 CompletionTestExpectedResult.Exists("ToString")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
         public async Task CompletionOnOverloadedLambdaPointerParameter()
         {
-
             var source = @"
 struct TestStruct1
 {
@@ -11791,17 +11778,15 @@ unsafe class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("X"),
                 CompletionTestExpectedResult.Exists("Y")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
         public async Task CompletionOnOverloadedLambdaPointerParameterWithExplicitType()
         {
-
             var source = @"
 struct TestStruct1
 {
@@ -11831,11 +11816,10 @@ unsafe class Test
 }
 ";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("X"),
                 CompletionTestExpectedResult.Absent("Y")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/58081")]
@@ -12277,7 +12261,7 @@ public static class Extension
                 enum E : $$
                 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Exists("System"),
 
                 CompletionTestExpectedResult.Exists(underlyingType),
@@ -12286,8 +12270,7 @@ public static class Extension
                 CompletionTestExpectedResult.Absent("Console"),
                 CompletionTestExpectedResult.Absent("Action"),
                 CompletionTestExpectedResult.Absent("DateTime")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
@@ -12301,7 +12284,7 @@ public static class Extension
                 enum E : global::$$
                 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Absent("E"),
 
                 CompletionTestExpectedResult.Exists("System"),
@@ -12309,8 +12292,7 @@ public static class Extension
 
                 // Not accessible in the given context
                 CompletionTestExpectedResult.Absent(underlyingType)
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
@@ -12318,7 +12300,7 @@ public static class Extension
         {
             var source = "enum E : System.$$";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Absent("System"),
 
                 CompletionTestExpectedResult.Exists(underlyingType),
@@ -12327,8 +12309,7 @@ public static class Extension
                 CompletionTestExpectedResult.Absent("Console"),
                 CompletionTestExpectedResult.Absent("Action"),
                 CompletionTestExpectedResult.Absent("DateTime")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
@@ -12336,7 +12317,7 @@ public static class Extension
         {
             var source = "enum E : global::System.$$";
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Absent("System"),
 
                 CompletionTestExpectedResult.Exists(underlyingType),
@@ -12345,8 +12326,7 @@ public static class Extension
                 CompletionTestExpectedResult.Absent("Console"),
                 CompletionTestExpectedResult.Absent("Action"),
                 CompletionTestExpectedResult.Absent("DateTime")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact]
@@ -12413,7 +12393,7 @@ public static class Extension
                 enum E : MySystem.$$
                 """;
 
-            var result = ImmutableArray.Create(
+            await VerifyExpectedItemsAsync(source, [
                 CompletionTestExpectedResult.Absent("System"),
                 CompletionTestExpectedResult.Absent("MySystem"),
 
@@ -12423,8 +12403,7 @@ public static class Extension
                 CompletionTestExpectedResult.Absent("Console"),
                 CompletionTestExpectedResult.Absent("Action"),
                 CompletionTestExpectedResult.Absent("DateTime")
-            );
-            await VerifyExpectedItemsAsync(source, result);
+            ]);
         }
 
         [Fact]

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -14,17 +14,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
@@ -144,6 +140,30 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionItemFlags? flags,
             CompletionOptions options)
         {
+            var expectedResult = new CompletionTestExpectedResult(
+                Name: expectedItemOrNull,
+                IsAbsent: checkForAbsence,
+                ExpectedDescription: expectedDescriptionOrNull,
+                Glyph: glyph,
+                MatchPriority: matchPriority,
+                DisplayTextSuffix: displayTextSuffix,
+                DisplayTextPrefix: displayTextPrefix,
+                InlineDescription: inlineDescription,
+                IsComplexTextEdit: isComplexTextEdit);
+
+            var expectedResultArray = ImmutableArray.Create(expectedResult);
+            await CheckResultsAsync(document, position, usePreviousCharAsTrigger,
+                hasSuggestionModeItem, expectedResultArray, matchingFilters, flags, options);
+        }
+
+        private protected async Task CheckResultsAsync(
+            Document document, int position, bool usePreviousCharAsTrigger,
+            bool? hasSuggestionModeItem,
+            ImmutableArray<CompletionTestExpectedResult> expectedResults,
+            List<CompletionFilter> matchingFilters,
+            CompletionItemFlags? flags,
+            CompletionOptions options)
+        {
             options ??= GetCompletionOptions();
 
             var code = (await document.GetTextAsync()).ToString();
@@ -165,64 +185,105 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 Assert.Equal(hasSuggestionModeItem.Value, completionList.SuggestionModeItem != null);
             }
 
-            if (checkForAbsence)
+            if (expectedResults.Length is 0)
             {
-                if (items == null)
-                {
-                    return;
-                }
+                Assert.Equal(items.Count, 0);
+            }
 
-                if (expectedItemOrNull == null)
+            foreach (var result in expectedResults)
+            {
+                if (result.SourceCodeKind is not null && result.SourceCodeKind != document.SourceCodeKind)
+                    continue;
+
+                if (result.IsAbsent)
                 {
-                    Assert.Empty(items);
+                    if (items == null)
+                    {
+                        return;
+                    }
+
+                    if (result.Name == null)
+                    {
+                        Assert.Empty(items);
+                    }
+                    else
+                    {
+                        AssertEx.None(
+                            items,
+                            c => CompareItems(c.DisplayText, result.Name)
+                                && CompareItems(c.DisplayTextSuffix, result.DisplayTextSuffix ?? "")
+                                && CompareItems(c.DisplayTextPrefix, result.DisplayTextPrefix ?? "")
+                                && CompareItems(c.InlineDescription, result.InlineDescription ?? "")
+                                && (result.ExpectedDescription != null ? completionService.GetDescriptionAsync(document, c, options, displayOptions).Result.Text == result.ExpectedDescription : true));
+                    }
                 }
                 else
                 {
-                    AssertEx.None(
-                        items,
-                        c => CompareItems(c.DisplayText, expectedItemOrNull)
-                                && CompareItems(c.DisplayTextSuffix, displayTextSuffix ?? "")
-                                && CompareItems(c.DisplayTextPrefix, displayTextPrefix ?? "")
-                                && CompareItems(c.InlineDescription, inlineDescription ?? "")
-                                && (expectedDescriptionOrNull != null ? completionService.GetDescriptionAsync(document, c, options, displayOptions).Result.Text == expectedDescriptionOrNull : true));
+                    if (result.Name == null)
+                    {
+                        Assert.NotEmpty(items);
+                    }
+                    else
+                    {
+                        AssertEx.Any(items, Predicate);
+                    }
+                }
+
+                bool Predicate(RoslynCompletion.CompletionItem c)
+                {
+                    if (!CompareItems(c.DisplayText, result.Name))
+                        return false;
+                    if (!CompareItems(c.DisplayTextSuffix, result.DisplayTextSuffix ?? ""))
+                        return false;
+                    if (!CompareItems(c.DisplayTextPrefix, result.DisplayTextPrefix ?? ""))
+                        return false;
+                    if (!CompareItems(c.InlineDescription, result.InlineDescription ?? ""))
+                        return false;
+                    if (result.ExpectedDescription != null && completionService.GetDescriptionAsync(document, c, options, displayOptions).Result.Text != result.ExpectedDescription)
+                        return false;
+                    if (result.Glyph.HasValue && !c.Tags.SequenceEqual(GlyphTags.GetTags((Glyph)result.Glyph.Value)))
+                        return false;
+                    if (result.MatchPriority.HasValue && c.Rules.MatchPriority != result.MatchPriority.Value)
+                        return false;
+                    if (matchingFilters != null && !FiltersMatch(matchingFilters, c))
+                        return false;
+                    if (flags != null && flags.Value != c.Flags)
+                        return false;
+                    if (result.IsComplexTextEdit is bool textEdit && textEdit != c.IsComplexTextEdit)
+                        return false;
+
+                    return true;
                 }
             }
-            else
+        }
+
+        private protected record CompletionTestExpectedResult(
+            string Name,
+            bool IsAbsent,
+            string ExpectedDescription = null,
+            int? Glyph = null,
+            int? MatchPriority = null,
+            string DisplayTextSuffix = null,
+            string DisplayTextPrefix = null,
+            string InlineDescription = null,
+            bool? IsComplexTextEdit = null,
+            SourceCodeKind? SourceCodeKind = null)
+        {
+            public static ImmutableArray<CompletionTestExpectedResult> None = CreateGeneralMatchingArray(true);
+            public static ImmutableArray<CompletionTestExpectedResult> Any = CreateGeneralMatchingArray(false);
+
+            private static ImmutableArray<CompletionTestExpectedResult> CreateGeneralMatchingArray(bool absent)
             {
-                if (expectedItemOrNull == null)
-                {
-                    Assert.NotEmpty(items);
-                }
-                else
-                {
-                    AssertEx.Any(items, Predicate);
-                }
+                return ImmutableArray.Create(new CompletionTestExpectedResult(Name: null, IsAbsent: absent));
             }
 
-            bool Predicate(RoslynCompletion.CompletionItem c)
+            public static CompletionTestExpectedResult Exists(string name)
             {
-                if (!CompareItems(c.DisplayText, expectedItemOrNull))
-                    return false;
-                if (!CompareItems(c.DisplayTextSuffix, displayTextSuffix ?? ""))
-                    return false;
-                if (!CompareItems(c.DisplayTextPrefix, displayTextPrefix ?? ""))
-                    return false;
-                if (!CompareItems(c.InlineDescription, inlineDescription ?? ""))
-                    return false;
-                if (expectedDescriptionOrNull != null && completionService.GetDescriptionAsync(document, c, options, displayOptions).Result.Text != expectedDescriptionOrNull)
-                    return false;
-                if (glyph.HasValue && !c.Tags.SequenceEqual(GlyphTags.GetTags((Glyph)glyph.Value)))
-                    return false;
-                if (matchPriority.HasValue && c.Rules.MatchPriority != matchPriority.Value)
-                    return false;
-                if (matchingFilters != null && !FiltersMatch(matchingFilters, c))
-                    return false;
-                if (flags != null && flags.Value != c.Flags)
-                    return false;
-                if (isComplexTextEdit is bool textEdit && textEdit != c.IsComplexTextEdit)
-                    return false;
-
-                return true;
+                return new CompletionTestExpectedResult(name, false);
+            }
+            public static CompletionTestExpectedResult Absent(string name)
+            {
+                return new CompletionTestExpectedResult(name, true);
             }
         }
 
@@ -259,6 +320,27 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                     matchPriority, hasSuggestionModeItem, displayTextSuffix, displayTextPrefix,
                     inlineDescription, isComplexTextEdit, matchingFilters, flags,
                     options, skipSpeculation: skipSpeculation).ConfigureAwait(false);
+            }
+        }
+
+        private async Task VerifyAsync(
+            string markup, SourceCodeKind? sourceCodeKind, bool usePreviousCharAsTrigger,
+            ImmutableArray<CompletionTestExpectedResult> results, bool? hasSuggestionModeItem,
+            List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
+        {
+            foreach (var sourceKind in sourceCodeKind.HasValue ? new[] { sourceCodeKind.Value } : new[] { SourceCodeKind.Regular, SourceCodeKind.Script })
+            {
+                using var workspaceFixture = GetOrCreateWorkspaceFixture();
+
+                var workspace = workspaceFixture.Target.GetWorkspace(markup, GetComposition());
+                var code = workspaceFixture.Target.Code;
+                var position = workspaceFixture.Target.Position;
+
+                // Set options that are not CompletionOptions
+                NonCompletionOptions?.SetGlobalOptions(workspace.GlobalOptions);
+
+                await VerifyWorkerAsync(code, position, usePreviousCharAsTrigger, hasSuggestionModeItem,
+                    sourceKind, results, matchingFilters, flags, options, skipSpeculation);
             }
         }
 
@@ -363,29 +445,32 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private protected async Task VerifyAnyItemExistsAsync(
             string markup, SourceCodeKind? sourceCodeKind = null, bool usePreviousCharAsTrigger = false,
-            bool? hasSuggestionModeItem = null, string displayTextSuffix = null, string displayTextPrefix = null,
-            string inlineDescription = null, CompletionOptions options = null)
+            bool? hasSuggestionModeItem = null, CompletionOptions options = null)
         {
-            await VerifyAsync(markup, expectedItemOrNull: null, expectedDescriptionOrNull: null,
-                sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
-                checkForAbsence: false, glyph: null, matchPriority: null,
-                hasSuggestionModeItem: hasSuggestionModeItem, displayTextSuffix: displayTextSuffix,
-                displayTextPrefix: displayTextPrefix, inlineDescription: inlineDescription,
-                isComplexTextEdit: null, matchingFilters: null, flags: null, options);
+            await VerifyExpectedItemsAsync(
+                markup, results: CompletionTestExpectedResult.Any, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
+                hasSuggestionModeItem: hasSuggestionModeItem, options: options);
         }
 
         private protected async Task VerifyNoItemsExistAsync(
             string markup, SourceCodeKind? sourceCodeKind = null,
             bool usePreviousCharAsTrigger = false, bool? hasSuggestionModeItem = null,
-            string displayTextSuffix = null, string inlineDescription = null, CompletionOptions options = null)
+            CompletionOptions options = null)
         {
-            await VerifyAsync(
-                markup, expectedItemOrNull: null, expectedDescriptionOrNull: null,
-                sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
-                checkForAbsence: true, glyph: null, matchPriority: null,
-                hasSuggestionModeItem: hasSuggestionModeItem, displayTextSuffix: displayTextSuffix,
-                displayTextPrefix: null, inlineDescription: inlineDescription,
-                isComplexTextEdit: null, matchingFilters: null, flags: null, options);
+            await VerifyExpectedItemsAsync(
+                markup, results: CompletionTestExpectedResult.None, sourceCodeKind, usePreviousCharAsTrigger: usePreviousCharAsTrigger,
+                hasSuggestionModeItem: hasSuggestionModeItem, options: options);
+        }
+
+        private protected async Task VerifyExpectedItemsAsync(
+            string markup, ImmutableArray<CompletionTestExpectedResult> results,
+            SourceCodeKind? sourceCodeKind = null, bool usePreviousCharAsTrigger = false,
+            bool? hasSuggestionModeItem = null, CompletionOptions options = null)
+        {
+            await VerifyAsync(markup,
+                sourceCodeKind, usePreviousCharAsTrigger, results: results,
+                hasSuggestionModeItem: hasSuggestionModeItem, matchingFilters: null,
+                flags: null, options);
         }
 
         internal abstract Type GetCompletionProviderType();
@@ -410,26 +495,57 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             CompletionOptions options,
             bool skipSpeculation = false)
         {
+            var expectedResult = new CompletionTestExpectedResult(
+                Name: expectedItemOrNull,
+                IsAbsent: checkForAbsence,
+                ExpectedDescription: expectedDescriptionOrNull,
+                Glyph: glyph,
+                MatchPriority: matchPriority,
+                DisplayTextSuffix: displayTextSuffix,
+                DisplayTextPrefix: displayTextPrefix,
+                InlineDescription: inlineDescription,
+                IsComplexTextEdit: isComplexTextEdit);
+
+            var expectedResultArray = ImmutableArray.Create(expectedResult);
+
+            await VerifyWorkerAsync(
+                code, position, usePreviousCharAsTrigger,
+                hasSuggestionModeItem, sourceCodeKind, expectedResultArray,
+                matchingFilters, flags, options, skipSpeculation);
+        }
+
+        /// <summary>
+        /// Override this to change parameters or return without verifying anything, e.g. for script sources. Or to test in other code contexts.
+        /// </summary>
+        /// <param name="code">The source code (not markup).</param>
+        /// <param name="expectedResults">The expected results. If this is empty, verifies that item shows up for this CompletionProvider (or no items show up if checkForAbsence is true).</param>
+        /// <param name="usePreviousCharAsTrigger">Whether or not the previous character in markup should be used to trigger IntelliSense for this provider. If false, invokes it through the invoke IntelliSense command.</param>
+        private protected virtual async Task VerifyWorkerAsync(
+            string code, int position, bool usePreviousCharAsTrigger,
+            bool? hasSuggestionModeItem, SourceCodeKind sourceCodeKind,
+            ImmutableArray<CompletionTestExpectedResult> expectedResults,
+            List<CompletionFilter> matchingFilters,
+            CompletionItemFlags? flags,
+            CompletionOptions options,
+            bool skipSpeculation = false)
+        {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
             workspaceFixture.Target.GetWorkspace(GetComposition());
             var document1 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind);
 
             await CheckResultsAsync(
-                document1, position, expectedItemOrNull,
-                expectedDescriptionOrNull, usePreviousCharAsTrigger,
-                checkForAbsence, glyph, matchPriority,
-                hasSuggestionModeItem, displayTextSuffix, displayTextPrefix,
-                inlineDescription, isComplexTextEdit, matchingFilters, flags, options);
+                document1, position, usePreviousCharAsTrigger,
+                hasSuggestionModeItem, expectedResults,
+                matchingFilters, flags, options);
 
             if (!skipSpeculation && await CanUseSpeculativeSemanticModelAsync(document1, position))
             {
                 var document2 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind, cleanBeforeUpdate: false);
                 await CheckResultsAsync(
-                    document2, position, expectedItemOrNull, expectedDescriptionOrNull,
-                    usePreviousCharAsTrigger, checkForAbsence, glyph, matchPriority,
-                    hasSuggestionModeItem, displayTextSuffix, displayTextPrefix,
-                    inlineDescription, isComplexTextEdit, matchingFilters, flags, options);
+                    document2, position, usePreviousCharAsTrigger,
+                    hasSuggestionModeItem, expectedResults,
+                    matchingFilters, flags, options);
             }
         }
 

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 InlineDescription: inlineDescription,
                 IsComplexTextEdit: isComplexTextEdit);
 
-            var expectedResultArray = ImmutableArray.Create(expectedResult);
+            var expectedResultArray = new[] { expectedResult };
             await CheckResultsAsync(document, position, usePreviousCharAsTrigger,
                 hasSuggestionModeItem, expectedResultArray, matchingFilters, flags, options);
         }
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private protected async Task CheckResultsAsync(
             Document document, int position, bool usePreviousCharAsTrigger,
             bool? hasSuggestionModeItem,
-            ImmutableArray<CompletionTestExpectedResult> expectedResults,
+            CompletionTestExpectedResult[] expectedResults,
             List<CompletionFilter> matchingFilters,
             CompletionItemFlags? flags,
             CompletionOptions options)
@@ -269,12 +269,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             bool? IsComplexTextEdit = null,
             SourceCodeKind? SourceCodeKind = null)
         {
-            public static ImmutableArray<CompletionTestExpectedResult> None = CreateGeneralMatchingArray(true);
-            public static ImmutableArray<CompletionTestExpectedResult> Any = CreateGeneralMatchingArray(false);
+            public static CompletionTestExpectedResult[] None = CreateGeneralMatchingArray(true);
+            public static CompletionTestExpectedResult[] Any = CreateGeneralMatchingArray(false);
 
-            private static ImmutableArray<CompletionTestExpectedResult> CreateGeneralMatchingArray(bool absent)
+            private static CompletionTestExpectedResult[] CreateGeneralMatchingArray(bool absent)
             {
-                return ImmutableArray.Create(new CompletionTestExpectedResult(Name: null, IsAbsent: absent));
+                return new[] { new CompletionTestExpectedResult(Name: null, IsAbsent: absent) };
             }
 
             public static CompletionTestExpectedResult Exists(string name)
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         private async Task VerifyAsync(
             string markup, SourceCodeKind? sourceCodeKind, bool usePreviousCharAsTrigger,
-            ImmutableArray<CompletionTestExpectedResult> results, bool? hasSuggestionModeItem,
+            CompletionTestExpectedResult[] results, bool? hasSuggestionModeItem,
             List<CompletionFilter> matchingFilters, CompletionItemFlags? flags, CompletionOptions options, bool skipSpeculation = false)
         {
             foreach (var sourceKind in sourceCodeKind.HasValue ? new[] { sourceCodeKind.Value } : new[] { SourceCodeKind.Regular, SourceCodeKind.Script })
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         }
 
         private protected async Task VerifyExpectedItemsAsync(
-            string markup, ImmutableArray<CompletionTestExpectedResult> results,
+            string markup, CompletionTestExpectedResult[] results,
             SourceCodeKind? sourceCodeKind = null, bool usePreviousCharAsTrigger = false,
             bool? hasSuggestionModeItem = null, CompletionOptions options = null)
         {
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 InlineDescription: inlineDescription,
                 IsComplexTextEdit: isComplexTextEdit);
 
-            var expectedResultArray = ImmutableArray.Create(expectedResult);
+            var expectedResultArray = new[] { expectedResult };
 
             await VerifyWorkerAsync(
                 code, position, usePreviousCharAsTrigger,
@@ -523,7 +523,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private protected virtual async Task VerifyWorkerAsync(
             string code, int position, bool usePreviousCharAsTrigger,
             bool? hasSuggestionModeItem, SourceCodeKind sourceCodeKind,
-            ImmutableArray<CompletionTestExpectedResult> expectedResults,
+            CompletionTestExpectedResult[] expectedResults,
             List<CompletionFilter> matchingFilters,
             CompletionItemFlags? flags,
             CompletionOptions options,

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -106,16 +106,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
             ' Items cannot be partially written if we're checking for their absence,
             ' or if we're verifying that the list will show up (without specifying an actual item)
-            Dim firstItemName = expectedResults(0).Name
-            If Not expectedResults(0).IsAbsent AndAlso firstItemName IsNot Nothing Then
-                Await VerifyAtPosition_ItemPartiallyWrittenAsync(
-                    code, position, usePreviousCharAsTrigger, hasSuggestionModeItem, sourceCodeKind,
-                    expectedResults, firstItemName, matchingFilters, flags:=Nothing, options, skipSpeculation)
+            For Each item In expectedResults
+                If Not item.IsAbsent AndAlso item.Name IsNot Nothing Then
+                    Await VerifyAtPosition_ItemPartiallyWrittenAsync(
+                        code, position, usePreviousCharAsTrigger, hasSuggestionModeItem, sourceCodeKind,
+                        expectedResults, item.Name, matchingFilters, flags:=Nothing, options, skipSpeculation)
 
-                Await VerifyAtEndOfFile_ItemPartiallyWrittenAsync(
-                    code, position, usePreviousCharAsTrigger, hasSuggestionModeItem, sourceCodeKind,
-                    expectedResults, firstItemName, matchingFilters, flags:=Nothing, options)
-            End If
+                    Await VerifyAtEndOfFile_ItemPartiallyWrittenAsync(
+                        code, position, usePreviousCharAsTrigger, hasSuggestionModeItem, sourceCodeKind,
+                        expectedResults, item.Name, matchingFilters, flags:=Nothing, options)
+                End If
+            Next
+
         End Function
 
         Protected Overrides Async Function VerifyCustomCommitProviderWorkerAsync(codeBeforeCommit As String, position As Integer, itemToCommit As String, expectedCodeAfterCommit As String, sourceCodeKind As SourceCodeKind, Optional commitChar As Char? = Nothing) As Task


### PR DESCRIPTION
With approval from @CyrusNajmabadi, many tests in `SymbolCompletionProviderTests` were adjusted with new methods that allow checking for multiple items in the suggestions with a single run, hence improving performance.

This PR contains those adjustments for many tests that were the biggest hits, with either many verifications in the same method on the same source, or in test theories that have many distinct combinations.

Additionally, the new API makes it cheaper to test the available and displayed items more extensively.

## Benchmarks

Running all the tests in SymbolCompletionProviderTests (about 830), takes:
- Before: ~2.4 min
- After: ~1.5 min

The performance aligns with the theory of each individual `await Verify...` doing unnecessary work to parse, etc. up until the completion is triggered, in order to a.

## Notes

The new version removes seemingly unnecessary arguments and bathces each individual argument about a specific item in a record. These may be freely updated depending on the requirements for each test.

Test methods that only verify exactly one item are not meant to be updated.