### PR TITLE
Reduce ImmutableDictionary allocations in CreateCompilationTrackerMap

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1552,7 +1552,7 @@ namespace Microsoft.CodeAnalysis
             if (_projectIdToTrackerMap.Count == 0)
                 return _projectIdToTrackerMap;
 
-            var newTrackerInfo = new List<KeyValuePair<ProjectId, ICompilationTracker>>();
+            var newTrackerInfo = ArrayBuilder<KeyValuePair<ProjectId, ICompilationTracker>>.GetInstance();
             var allReused = true;
             foreach (var (id, tracker) in _projectIdToTrackerMap)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1552,7 +1552,7 @@ namespace Microsoft.CodeAnalysis
             if (_projectIdToTrackerMap.Count == 0)
                 return _projectIdToTrackerMap;
 
-            var newTrackerInfo = ArrayBuilder<KeyValuePair<ProjectId, ICompilationTracker>>.GetInstance();
+            using var _ = ArrayBuilder<KeyValuePair<ProjectId, ICompilationTracker>>.GetInstance(_projectIdToTrackerMap.Count, out var newTrackerInfo);
             var allReused = true;
             foreach (var (id, tracker) in _projectIdToTrackerMap)
             {


### PR DESCRIPTION
1) No need to create a builder if _projectIdToTrackerMap is empty 
2) No need to create a new ImmutableDictionary if it would end up having the exact same contents as projectIdToTrackerMap