### PR TITLE
File types need to account for pathmap

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // more than 50 items added before getting collected.
             _binderCache = new ConcurrentCache<BinderCacheKey, Binder>(50);
 
-            _buckStopsHereBinder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
+            _buckStopsHereBinder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree, compilation.Options.SourceReferenceResolver));
         }
 
         internal SyntaxTree SyntaxTree

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // more than 50 items added before getting collected.
             _binderCache = new ConcurrentCache<BinderCacheKey, Binder>(50);
 
-            _buckStopsHereBinder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree));
+            _buckStopsHereBinder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
         }
 
         internal SyntaxTree SyntaxTree

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // member symbol in hand, which makes things much easier.
             private static Binder MakeNameBinder(bool isParameter, bool isTypeParameterRef, Symbol memberSymbol, CSharpCompilation compilation, SyntaxTree syntaxTree)
             {
-                Binder binder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
+                Binder binder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree, compilation.Options.SourceReferenceResolver));
 
                 // All binders should have a containing symbol.
                 Symbol containingSymbol = memberSymbol.ContainingSymbol;

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // member symbol in hand, which makes things much easier.
             private static Binder MakeNameBinder(bool isParameter, bool isTypeParameterRef, Symbol memberSymbol, CSharpCompilation compilation, SyntaxTree syntaxTree)
             {
-                Binder binder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree));
+                Binder binder = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
 
                 // All binders should have a containing symbol.
                 Symbol containingSymbol = memberSymbol.ContainingSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -89,8 +89,11 @@ internal sealed class FileIdentifier
         }
     }
 
-    public static FileIdentifier Create(string filePath)
-        => new FileIdentifier(filePath);
+    public static FileIdentifier Create(SyntaxTree syntaxTree, SourceReferenceResolver? resolver)
+        => new FileIdentifier(syntaxTree.GetNormalizedPath(resolver));
+
+    public static FileIdentifier Create(string mappedFilePath)
+        => new FileIdentifier(mappedFilePath);
 
     public static FileIdentifier Create(ImmutableArray<byte> filePathChecksumOpt, string displayFilePath)
         => new FileIdentifier(filePathChecksumOpt, displayFilePath);

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -92,8 +92,8 @@ internal sealed class FileIdentifier
     public static FileIdentifier Create(SyntaxTree syntaxTree, SourceReferenceResolver? resolver)
         => new FileIdentifier(syntaxTree.GetNormalizedPath(resolver));
 
-    public static FileIdentifier Create(string mappedFilePath)
-        => new FileIdentifier(mappedFilePath);
+    public static FileIdentifier Create(string normalizedFilePath)
+        => new FileIdentifier(normalizedFilePath);
 
     public static FileIdentifier Create(ImmutableArray<byte> filePathChecksumOpt, string displayFilePath)
         => new FileIdentifier(filePathChecksumOpt, displayFilePath);

--- a/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FileIdentifier.cs
@@ -89,9 +89,6 @@ internal sealed class FileIdentifier
         }
     }
 
-    public static FileIdentifier Create(SyntaxTree tree)
-        => Create(tree.FilePath);
-
     public static FileIdentifier Create(string filePath)
         => new FileIdentifier(filePath);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -861,9 +861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return null;
                 }
 
-                // This is a path that is emitted and hence needs to go through mapping functions
-                var filePath = syntaxTree.GetNormalizedPath(DeclaringCompilation?.Options?.SourceReferenceResolver);
-                return FileIdentifier.Create(filePath);
+                return FileIdentifier.Create(syntaxTree, DeclaringCompilation?.Options?.SourceReferenceResolver);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -862,7 +862,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 // This is a path that is emitted and hence needs to go through mapping functions
-                var filePath = syntaxTree.GetDisplayPath(DeclaringCompilation?.Options?.SourceReferenceResolver);
+                var filePath = syntaxTree.GetNormalizedPath(DeclaringCompilation?.Options?.SourceReferenceResolver);
                 return FileIdentifier.Create(filePath);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -861,7 +861,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return null;
                 }
 
-                return FileIdentifier.Create(syntaxTree);
+                // This is a path that is emitted and hence needs to go through mapping functions
+                var filePath = syntaxTree.GetDisplayPath(DeclaringCompilation?.Options?.SourceReferenceResolver);
+                return FileIdentifier.Create(filePath);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpCompilation compilation = DeclaringCompilation;
 
             var syntaxNode = SyntaxNode;
-            Binder result = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxNode.SyntaxTree));
+            Binder result = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxNode.SyntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
             var globalNamespace = compilation.GlobalNamespace;
             var declaringSymbol = (SourceNamespaceSymbol)compilation.SourceModule.GlobalNamespace;
             result = WithExternAndUsingAliasesBinder.Create(declaringSymbol, syntaxNode, WithUsingNamespacesAndTypesBinder.Create(declaringSymbol, syntaxNode, result));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpCompilation compilation = DeclaringCompilation;
 
             var syntaxNode = SyntaxNode;
-            Binder result = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxNode.SyntaxTree.GetDisplayPath(compilation.Options.SourceReferenceResolver)));
+            Binder result = new BuckStopsHereBinder(compilation, FileIdentifier.Create(syntaxNode.SyntaxTree, compilation.Options.SourceReferenceResolver));
             var globalNamespace = compilation.GlobalNamespace;
             var declaringSymbol = (SourceNamespaceSymbol)compilation.SourceModule.GlobalNamespace;
             result = WithExternAndUsingAliasesBinder.Create(declaringSymbol, syntaxNode, WithUsingNamespacesAndTypesBinder.Create(declaringSymbol, syntaxNode, result));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -818,14 +818,6 @@ public partial class C
         }
     }
 
-    private void DeterminismCore(
-        string fileTypeName,
-        CSharpCompilation comp1,
-        CSharpCompilation comp2,
-        CSharpCompilation comp3)
-    {
-    }
-
     [Theory]
     [InlineData("""
             file class Outer1 { }

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// <summary>
     /// Used when the client cannot connect to the server.
     /// </summary>
-    file class CannotConnectResponse : BuildResponse
+    internal sealed class CannotConnectResponse : BuildResponse
     {
         public override ResponseType Type => ResponseType.CannotConnect;
 

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -446,7 +446,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
     }
 
-    internal sealed class MismatchedVersionBuildResponse : BuildResponse
+    file sealed class MismatchedVersionBuildResponse : BuildResponse
     {
         public override ResponseType Type => ResponseType.MismatchedVersion;
 
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// <summary>
     /// Used when the client cannot connect to the server.
     /// </summary>
-    internal sealed class CannotConnectResponse : BuildResponse
+    file class CannotConnectResponse : BuildResponse
     {
         public override ResponseType Type => ResponseType.CannotConnect;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -293,9 +293,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns the path used for emit purposes.
+        /// Returns the path used for emit purposes. This takes into account /pathmap arguments passed into
+        /// the compiler.
         /// </summary>
-        internal string GetDisplayPath(SourceReferenceResolver? resolver)
+        internal string GetNormalizedPath(SourceReferenceResolver? resolver)
         {
             if (resolver is null)
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTree.cs
@@ -284,12 +284,25 @@ namespace Microsoft.CodeAnalysis
         internal string GetDisplayPath(TextSpan span, SourceReferenceResolver? resolver)
         {
             var mappedSpan = GetMappedLineSpan(span);
-            if (resolver == null || mappedSpan.Path.IsEmpty())
+            if (resolver is null || mappedSpan.Path.IsEmpty())
             {
                 return mappedSpan.Path;
             }
 
             return resolver.NormalizePath(mappedSpan.Path, baseFilePath: mappedSpan.HasMappedPath ? FilePath : null) ?? mappedSpan.Path;
+        }
+
+        /// <summary>
+        /// Returns the path used for emit purposes.
+        /// </summary>
+        internal string GetDisplayPath(SourceReferenceResolver? resolver)
+        {
+            if (resolver is null)
+            {
+                return FilePath;
+            }
+
+            return resolver.NormalizePath(FilePath, baseFilePath: null) ?? FilePath;
         }
 
         /// <summary>

--- a/src/Tools/BuildValidator/DemoLogger.cs
+++ b/src/Tools/BuildValidator/DemoLogger.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace BuildValidator
 {
-    internal sealed class DemoLogger : ILogger
+    file class DemoLogger : ILogger
     {
         private const int IndentIncrement = 2;
 

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -85,7 +85,7 @@ if ((output = await sr.ReadLineAsync().ConfigureAwait(false)) is not null)
 
 return ExitFailure;
 
-internal sealed class Sink : IMessageSink
+file class Sink : IMessageSink
 {
     public bool AnyWriteFailures { get; private set; }
 


### PR DESCRIPTION
The emitted name for a `file` type is a generated name and one of the inputs is the path of the containing source file. This process is deterministic today but not repeatable because it doesn't take into account `/pathmap` options. That means the same code built on two different directory paths will produce different results. This change updates the generated name code to take into account `/pathmap`.

This also updates several types in our code base to be `file` local types. This means our determinism integration test will now properly validate `file` local types. Had we ever tried to check in a `file` local type before this to roslyn that test would have caught this bug.

closes #70284