### PR TITLE
In most cases, remove the camel case matching for case sensitive matches

### DIFF
--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -446,20 +445,21 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                 //      i.e. CoFiPro would match CodeFixProvider, but CofiPro would not.  
                 if (patternChunk.PatternHumps.Count > 0)
                 {
-                    var camelCaseKind = TryUpperCaseCamelCaseMatch(candidate, candidateHumps, patternChunk, CompareOptions.None, out var matchedSpans);
-                    if (camelCaseKind.HasValue)
+                    // No need to do the case sensitive check unless the case insensitive check is successful
+                    var camelCaseKindIgnoreCase = TryUpperCaseCamelCaseMatch(candidate, candidateHumps, patternChunk, CompareOptions.IgnoreCase, out var matchedSpansIgnoreCase);
+                    if (camelCaseKindIgnoreCase.HasValue)
                     {
-                        return new PatternMatch(
-                            camelCaseKind.Value, punctuationStripped, isCaseSensitive: true,
-                            matchedSpans: matchedSpans);
-                    }
+                        var camelCaseKind = TryUpperCaseCamelCaseMatch(candidate, candidateHumps, patternChunk, CompareOptions.None, out var matchedSpans);
+                        if (camelCaseKind.HasValue)
+                        {
+                            return new PatternMatch(
+                                camelCaseKind.Value, punctuationStripped, isCaseSensitive: true,
+                                matchedSpans: matchedSpans);
+                        }
 
-                    camelCaseKind = TryUpperCaseCamelCaseMatch(candidate, candidateHumps, patternChunk, CompareOptions.IgnoreCase, out matchedSpans);
-                    if (camelCaseKind.HasValue)
-                    {
                         return new PatternMatch(
-                            camelCaseKind.Value, punctuationStripped, isCaseSensitive: false,
-                            matchedSpans: matchedSpans);
+                            camelCaseKindIgnoreCase.Value, punctuationStripped, isCaseSensitive: false,
+                            matchedSpans: matchedSpansIgnoreCase);
                     }
                 }
             }

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -445,7 +445,9 @@ namespace Microsoft.CodeAnalysis.PatternMatching
                 //      i.e. CoFiPro would match CodeFixProvider, but CofiPro would not.  
                 if (patternChunk.PatternHumps.Count > 0)
                 {
-                    // No need to do the case sensitive check unless the case insensitive check is successful
+                    // PERF: This can be called thousands of times per completion session with only a handful of matches found.
+                    // Checking for case insensitive initially reduces the TryUpperCaseCamelCaseMatch call count to 1 for the
+                    // non-matching candidates, but increases the call count to 2 for the much less frequent matching candidates.
                     var camelCaseKindIgnoreCase = TryUpperCaseCamelCaseMatch(candidate, candidateHumps, patternChunk, CompareOptions.IgnoreCase, out var matchedSpansIgnoreCase);
                     if (camelCaseKindIgnoreCase.HasValue)
                     {


### PR DESCRIPTION
There is no need to do this unless the pattern is successfully matched case insensitively. Prism has marked several PatternMatcher calls under TryCamelCaseMatch when looking at CPU stacks for the completion scenario.