### PR TITLE
Change Blazor template group name for newer templates

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractWebApplicationTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractWebApplicationTest.cs
@@ -11,7 +11,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests
     {
         protected static class GroupIds
         {
-            public const string Server = "Microsoft.Web.Blazor.Server";
+            public const string Server = "Microsoft.Web.Blazor";
             public const string Wasm = "Microsoft.Web.Blazor.Wasm";
         }
 


### PR DESCRIPTION
Right now this is just to test against our official images, and not intended for merge. We'd probably want to add a condition for before/after.