### PR TITLE
Add extra validation for Compilations having the expected trees

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -17,7 +17,8 @@ internal static class WorkspaceConfigurationOptionsStorage
                                                globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
             DisableSharedSyntaxTrees: globalOptions.GetOption(DisableSharedSyntaxTrees),
             DeferCreatingRecoverableText: globalOptions.GetOption(DeferCreatingRecoverableText),
-            DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText));
+            DisableRecoverableText: globalOptions.GetOption(DisableRecoverableText),
+            ValidateCompilationTrackerStates: globalOptions.GetOption(ValidateCompilationTrackerStates));
 
     public static readonly Option2<StorageDatabase> Database = new(
         "dotnet_storage_database", WorkspaceConfigurationOptions.Default.CacheStorage, serializer: EditorConfigValueSerializer.CreateSerializerForEnum<StorageDatabase>());
@@ -33,6 +34,9 @@ internal static class WorkspaceConfigurationOptionsStorage
 
     public static readonly Option2<bool> DisableRecoverableText = new(
         "dotnet_disable_recoverable_text", WorkspaceConfigurationOptions.Default.DisableRecoverableText);
+
+    public static readonly Option2<bool> ValidateCompilationTrackerStates = new Option2<bool>(
+        "dotnet_validate_compilation_tracker_states", WorkspaceConfigurationOptions.Default.ValidateCompilationTrackerStates);
 
     /// <summary>
     /// This option allows the user to enable this. We are putting this behind a feature flag for now since we could have extensions

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -431,6 +431,7 @@ internal abstract class VisualStudioOptionStorage
         {"dotnet_disable_shared_syntax_trees", new FeatureFlagStorage(@"Roslyn.DisableSharedSyntaxTrees")},
         {"dotnet_defer_creating_recoverable_text", new FeatureFlagStorage(@"Roslyn.DeferCreatingRecoverableText")},
         {"dotnet_disable_recoverable_text", new FeatureFlagStorage(@"Roslyn.DisableRecoverableText")},
+        {"dotnet_validate_compilation_tracker_states", new FeatureFlagStorage(@"Roslyn.ValidateCompilationTrackerStates")},
         {"dotnet_enable_diagnostics_in_source_generated_files", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableDiagnosticsInSourceGeneratedFilesExperiment")},
         {"dotnet_enable_diagnostics_in_source_generated_files_feature_flag", new FeatureFlagStorage(@"Roslyn.EnableDiagnosticsInSourceGeneratedFiles")},
         {"dotnet_enable_opening_source_generated_files_in_workspace", new RoamingProfileStorage("TextEditor.Roslyn.Specific.EnableOpeningSourceGeneratedFilesInWorkspaceExperiment")},

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -42,7 +42,14 @@ namespace Microsoft.CodeAnalysis.Host
         [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
         [property: DataMember(Order = 2)] bool DisableSharedSyntaxTrees = false,
         [property: DataMember(Order = 3)] bool DeferCreatingRecoverableText = false,
-        [property: DataMember(Order = 4)] bool DisableRecoverableText = false)
+        [property: DataMember(Order = 4)] bool DisableRecoverableText = false,
+        [property: DataMember(Order = 5)] bool ValidateCompilationTrackerStates =
+#if DEBUG // We will default this on in DEBUG builds
+            true
+#else
+            false
+#endif
+        )
     {
         public WorkspaceConfigurationOptions()
             : this(CacheStorage: StorageDatabase.SQLite)
@@ -53,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Host
 
         /// <summary>
         /// These values are such that the correctness of remote services is not affected if these options are changed from defaults
-        /// to non-defauls while the services have already been executing.
+        /// to non-defaults while the services have already been executing.
         /// </summary>
         public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
             CacheStorage: StorageDatabase.None,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -1154,7 +1154,7 @@ namespace Microsoft.CodeAnalysis
 
             private static void ValidateCompilationTreesMatchesProjectState(Compilation compilation, ProjectState projectState, CompilationTrackerGeneratorInfo? generatorInfo)
             {
-                // We'll do this all in a try/catch so it makes validations easy to do with Contract.ThrowIfFalse().
+                // We'll do this all in a try/catch so it makes validations easy to do with ThrowExceptionIfFalse().
                 try
                 {
                     // Assert that all the trees we expect to see are in the Compilation...
@@ -1166,28 +1166,47 @@ namespace Microsoft.CodeAnalysis
 
                     foreach (var documentInProjectState in projectState.DocumentStates.States)
                     {
-                        Contract.ThrowIfFalse(documentInProjectState.Value.TryGetSyntaxTree(out var tree), "We should have a tree since we have a compilation that should contain it.");
+                        ThrowExceptionIfFalse(documentInProjectState.Value.TryGetSyntaxTree(out var tree), "We should have a tree since we have a compilation that should contain it.");
                         syntaxTreesInWorkspaceStates.Add(tree);
-                        Contract.ThrowIfFalse(compilation.ContainsSyntaxTree(tree), "The tree in the ProjectState should have been in the compilation.");
+                        ThrowExceptionIfFalse(compilation.ContainsSyntaxTree(tree), "The tree in the ProjectState should have been in the compilation.");
                     }
 
                     if (generatorInfo != null)
                     {
                         foreach (var generatedDocument in generatorInfo.Value.Documents.States)
                         {
-                            Contract.ThrowIfFalse(generatedDocument.Value.TryGetSyntaxTree(out var tree), "We should have a tree since we have a compilation that should contain it.");
+                            ThrowExceptionIfFalse(generatedDocument.Value.TryGetSyntaxTree(out var tree), "We should have a tree since we have a compilation that should contain it.");
                             syntaxTreesInWorkspaceStates.Add(tree);
-                            Contract.ThrowIfFalse(compilation.ContainsSyntaxTree(tree), "The tree for the generated document should have been in the compilation.");
+                            ThrowExceptionIfFalse(compilation.ContainsSyntaxTree(tree), "The tree for the generated document should have been in the compilation.");
                         }
                     }
 
                     // ...and that the reverse is true too.
                     foreach (var tree in compilation.SyntaxTrees)
-                        Contract.ThrowIfFalse(syntaxTreesInWorkspaceStates.Contains(tree), "The tree in the Compilation should have been from the workspace.");
+                        ThrowExceptionIfFalse(syntaxTreesInWorkspaceStates.Contains(tree), "The tree in the Compilation should have been from the workspace.");
                 }
                 catch (Exception e) when (FatalError.ReportWithDumpAndCatch(e, ErrorSeverity.Critical))
                 {
                 }
+            }
+
+            /// <summary>
+            /// This is just the same as <see cref="Contract.ThrowIfFalse(bool, string, int)"/> but throws a custom exception type to make this easier to find in telemetry since the exception type
+            /// is easily seen in telemetry.
+            /// </summary>
+            private static void ThrowExceptionIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string message)
+            {
+                if (!condition)
+                {
+                    throw new CompilationTrackerValidationException(message);
+                }
+            }
+
+            public class CompilationTrackerValidationException : Exception
+            {
+                public CompilationTrackerValidationException() { }
+                public CompilationTrackerValidationException(string message) : base(message) { }
+                public CompilationTrackerValidationException(string message, Exception inner) : base(message, inner) { }
             }
 
             #region Versions and Checksums


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/roslyn/pull/69747 to 17.7.

We're still getting reports where we are finding compilations that don't match the trees we expect to be in them. Unfortunately those reports are happening well after the corrupted stated happened. This will add validation when we're still producing those bad states.