### PR TITLE
Utilize ConstantValueOne while emitting conditionals

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -3763,26 +3763,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             static bool hasIntegralValueZeroOrOne(BoundExpression expr, out bool isOne)
             {
                 var constantValue = expr.ConstantValueOpt;
-                if (constantValue is not null &&
-                    (constantValue.IsIntegral ||
-                     constantValue.IsBoolean ||
-                     constantValue.IsChar))
+                switch (constantValue)
                 {
-                    if (constantValue.IsDefaultValue)
-                    {
+                    case { IsDefaultValue: true }:
                         isOne = false;
-                        return true;
-                    }
+                        break;
 
-                    if (constantValue.IsOne)
-                    {
+                    case { IsOne: true }:
                         isOne = true;
-                        return true;
-                    }
+                        break;
+
+                    default:
+                        isOne = default;
+                        return false;
                 }
 
-                isOne = default;
-                return false;
+                return 
+                    constantValue.IsIntegral ||
+                    constantValue.IsBoolean ||
+                    constantValue.IsChar;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -3682,8 +3682,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // Generate branchless IL for (b ? 1 : 0).
             if (used && _ilEmitStyle != ILEmitStyle.Debug &&
                 (IsNumeric(expr.Type) || expr.Type.PrimitiveTypeCode == Cci.PrimitiveTypeCode.Boolean) &&
-                hasIntegralValueZeroOrOne(expr.Consequence, out var isConsequenceOne) &&
-                hasIntegralValueZeroOrOne(expr.Alternative, out var isAlternativeOne) &&
+                expr.Consequence.ConstantValueOpt?.IsIntegralValueZeroOrOne(out bool isConsequenceOne) == true &&
+                expr.Alternative.ConstantValueOpt?.IsIntegralValueZeroOrOne(out bool isAlternativeOne) == true &&
                 isConsequenceOne != isAlternativeOne &&
                 TryEmitComparison(expr.Condition, sense: isConsequenceOne))
             {
@@ -3759,30 +3759,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             _builder.MarkLabel(doneLabel);
-
-            static bool hasIntegralValueZeroOrOne(BoundExpression expr, out bool isOne)
-            {
-                var constantValue = expr.ConstantValueOpt;
-                switch (constantValue)
-                {
-                    case { IsDefaultValue: true }:
-                        isOne = false;
-                        break;
-
-                    case { IsOne: true }:
-                        isOne = true;
-                        break;
-
-                    default:
-                        isOne = default;
-                        return false;
-                }
-
-                return
-                    constantValue.IsIntegral ||
-                    constantValue.IsBoolean ||
-                    constantValue.IsChar;
-            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -3778,7 +3778,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         return false;
                 }
 
-                return 
+                return
                     constantValue.IsIntegral ||
                     constantValue.IsBoolean ||
                     constantValue.IsChar;

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -3682,8 +3682,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // Generate branchless IL for (b ? 1 : 0).
             if (used && _ilEmitStyle != ILEmitStyle.Debug &&
                 (IsNumeric(expr.Type) || expr.Type.PrimitiveTypeCode == Cci.PrimitiveTypeCode.Boolean) &&
-                isIntegralValueZeroOrOne(expr.Consequence) is bool isConsequenceOne &&
-                isIntegralValueZeroOrOne(expr.Alternative) is bool isAlternativeOne &&
+                hasIntegralValueZeroOrOne(expr.Consequence, out var isConsequenceOne) &&
+                hasIntegralValueZeroOrOne(expr.Alternative, out var isAlternativeOne) &&
                 isConsequenceOne != isAlternativeOne &&
                 TryEmitComparison(expr.Condition, sense: isConsequenceOne))
             {
@@ -3760,7 +3760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             _builder.MarkLabel(doneLabel);
 
-            static bool? isIntegralValueZeroOrOne(BoundExpression expr)
+            static bool hasIntegralValueZeroOrOne(BoundExpression expr, out bool isOne)
             {
                 var constantValue = expr.ConstantValueOpt;
                 if (constantValue is not null &&
@@ -3770,16 +3770,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 {
                     if (constantValue.IsDefaultValue)
                     {
-                        return false;
+                        isOne = false;
+                        return true;
                     }
 
                     if (constantValue.IsOne)
                     {
+                        isOne = true;
                         return true;
                     }
                 }
 
-                return null;
+                isOne = default;
+                return false;
             }
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -96,7 +96,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var cv = ConstantValue.Create(1);
             Assert.Throws<InvalidOperationException>(() => { var c = cv.StringValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv.CharValue; });
             Assert.Throws<InvalidOperationException>(() => { var c = cv.DateTimeValue; });
 
             var cv1 = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -90,27 +90,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void ConstantValueOneTest01()
-        {
-            var cv1 = ConstantValue.Create(1);
-            Assert.True(cv1.IsOne);
-
-            Assert.Equal(1, cv1.ByteValue);
-            Assert.Equal(1, cv1.SByteValue);
-            Assert.Equal(true, cv1.BooleanValue);
-            Assert.Equal(1, cv1.DoubleValue);
-            Assert.Equal(1, cv1.SingleValue);
-            Assert.Equal(1, cv1.DecimalValue);
-            Assert.Equal(1, cv1.Int16Value);
-            Assert.Equal(1, cv1.UInt16Value);
-            Assert.Equal(1, cv1.Int32Value);
-            Assert.Equal(1U, cv1.UInt32Value);
-            Assert.Equal(1, cv1.Int64Value);
-            Assert.Equal(1U, cv1.UInt64Value);
-            Assert.Equal(1, cv1.CharValue);
-        }
-
-        [Fact]
         public void ConstantValueInvalidOperationTest01()
         {
             Assert.Throws<InvalidOperationException>(() => { ConstantValue.Create(null, ConstantValueTypeDiscriminator.Bad); });
@@ -131,6 +110,27 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<InvalidOperationException>(() => { var c = cvNull.SingleValue; });
             Assert.Throws<InvalidOperationException>(() => { var c = cvNull.SByteValue; });
             Assert.Throws<InvalidOperationException>(() => { var c = cvNull.ByteValue; });
+        }
+
+        [Fact]
+        public void ConstantValueOneTest01()
+        {
+            var cv1 = ConstantValue.Create(1);
+            Assert.True(cv1.IsOne);
+
+            Assert.Equal(1, cv1.ByteValue);
+            Assert.Equal(1, cv1.SByteValue);
+            Assert.Equal(true, cv1.BooleanValue);
+            Assert.Equal(1, cv1.DoubleValue);
+            Assert.Equal(1, cv1.SingleValue);
+            Assert.Equal(1, cv1.DecimalValue);
+            Assert.Equal(1, cv1.Int16Value);
+            Assert.Equal(1, cv1.UInt16Value);
+            Assert.Equal(1, cv1.Int32Value);
+            Assert.Equal(1U, cv1.UInt32Value);
+            Assert.Equal(1, cv1.Int64Value);
+            Assert.Equal(1U, cv1.UInt64Value);
+            Assert.Equal(1, cv1.CharValue);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Equal(1, cv1.ByteValue);
             Assert.Equal(1, cv1.SByteValue);
-            Assert.Equal(true, cv1.BooleanValue);
+            Assert.True(cv1.BooleanValue);
             Assert.Equal(1, cv1.DoubleValue);
             Assert.Equal(1, cv1.SingleValue);
             Assert.Equal(1, cv1.DecimalValue);

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -134,6 +134,24 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void ConstantValueOneTest02()
+        {
+            Assert.True(ConstantValue.Create((byte)1).IsOne);
+            Assert.True(ConstantValue.Create((sbyte)1).IsOne);
+            Assert.True(ConstantValue.Create(true).IsOne);
+            Assert.True(ConstantValue.Create((double)1).IsOne);
+            Assert.True(ConstantValue.Create((float)1).IsOne);
+            Assert.True(ConstantValue.Create((decimal)1).IsOne);
+            Assert.True(ConstantValue.Create((short)1).IsOne);
+            Assert.True(ConstantValue.Create((ushort)1).IsOne);
+            Assert.True(ConstantValue.Create((int)1).IsOne);
+            Assert.True(ConstantValue.Create((uint)1).IsOne);
+            Assert.True(ConstantValue.Create((long)1).IsOne);
+            Assert.True(ConstantValue.Create((ulong)1).IsOne);
+            Assert.True(ConstantValue.Create((char)1).IsOne);
+        }
+
+        [Fact]
         public void ConstantValuePropertiesTest01()
         {
             Assert.Equal(ConstantValue.Bad, ConstantValue.Default(ConstantValueTypeDiscriminator.Bad));

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -90,21 +90,47 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void ConstantValueOneTest01()
+        {
+            var cv1 = ConstantValue.Create(1);
+            Assert.True(cv1.IsOne);
+
+            Assert.Equal(1, cv1.ByteValue);
+            Assert.Equal(1, cv1.SByteValue);
+            Assert.Equal(true, cv1.BooleanValue);
+            Assert.Equal(1, cv1.DoubleValue);
+            Assert.Equal(1, cv1.SingleValue);
+            Assert.Equal(1, cv1.DecimalValue);
+            Assert.Equal(1, cv1.Int16Value);
+            Assert.Equal(1, cv1.UInt16Value);
+            Assert.Equal(1, cv1.Int32Value);
+            Assert.Equal(1U, cv1.UInt32Value);
+            Assert.Equal(1, cv1.Int64Value);
+            Assert.Equal(1U, cv1.UInt64Value);
+            Assert.Equal(1, cv1.CharValue);
+        }
+
+        [Fact]
         public void ConstantValueInvalidOperationTest01()
         {
             Assert.Throws<InvalidOperationException>(() => { ConstantValue.Create(null, ConstantValueTypeDiscriminator.Bad); });
 
-            var cv = ConstantValue.Create(1);
-            Assert.Throws<InvalidOperationException>(() => { var c = cv.StringValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv.DateTimeValue; });
+            var cv1 = ConstantValue.Create(1);
+            Assert.Throws<InvalidOperationException>(() => { var c = cv1.StringValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cv1.DateTimeValue; });
 
-            var cv1 = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.BooleanValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.DecimalValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.DoubleValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.SingleValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.SByteValue; });
-            Assert.Throws<InvalidOperationException>(() => { var c = cv1.ByteValue; });
+            var cv2 = ConstantValue.Create(2);
+            Assert.Throws<InvalidOperationException>(() => { var c = cv2.StringValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cv2.CharValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cv2.DateTimeValue; });
+
+            var cvNull = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.BooleanValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.DecimalValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.DoubleValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.SingleValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.SByteValue; });
+            Assert.Throws<InvalidOperationException>(() => { var c = cvNull.ByteValue; });
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis
 
         // returns true if value is in its default (zero-inited) form.
         public virtual bool IsDefaultValue { get { return false; } }
+        public virtual bool IsOne { get { return false; } }
 
         // NOTE: We do not have IsNumericZero. 
         //       The reason is that integral zeroes are same as default values
@@ -117,6 +118,10 @@ namespace Microsoft.CodeAnalysis
             if (value == default(char))
             {
                 return ConstantValueDefault.Char;
+            }
+            else if (value == (char)1)
+            {
+                return ConstantValueOne.Char;
             }
 
             return new ConstantValueI16(value);

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -840,6 +840,25 @@ namespace Microsoft.CodeAnalysis
             return this.Value?.ToString();
         }
 
+        internal bool IsIntegralValueZeroOrOne(out bool isOne)
+        {
+            if (IsDefaultValue)
+            {
+                isOne = false;
+            }
+            else if (IsOne)
+            {
+                isOne = true;
+            }
+            else
+            {
+                isOne = default;
+                return false;
+            }
+
+            return IsIntegral || IsBoolean || IsChar;
+        }
+
         // equal constants must have matching discriminators
         // derived types override this if equivalence is more than just discriminators match. 
         // singletons also override this since they only need a reference compare.

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -529,6 +529,7 @@ namespace Microsoft.CodeAnalysis
             public static readonly ConstantValueOne Double = new ConstantValueOne(ConstantValueTypeDiscriminator.Double);
             public static readonly ConstantValueOne Decimal = new ConstantValueDecimalOne();
             public static readonly ConstantValueOne Boolean = new ConstantValueOne(ConstantValueTypeDiscriminator.Boolean);
+            public static readonly ConstantValueOne Char = new ConstantValueOne(ConstantValueTypeDiscriminator.Char);
 
             protected ConstantValueOne(ConstantValueTypeDiscriminator discriminator)
                 : base(discriminator)
@@ -628,6 +629,22 @@ namespace Microsoft.CodeAnalysis
                 get
                 {
                     return 1;
+                }
+            }
+
+            public override char CharValue
+            {
+                get
+                {
+                    return (char)1;
+                }
+            }
+
+            public override bool IsOne
+            {
+                get
+                {
+                    return true;
                 }
             }
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1327,21 +1327,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private Function HasIntegralValueZeroOrOne(expr As BoundExpression, ByRef isOne As Boolean) As Boolean
             If expr.IsConstant Then
                 Dim constantValue = expr.ConstantValueOpt
-
-                If constantValue.IsIntegral AndAlso constantValue.UInt64Value <= 1 Then
-                    isOne = (constantValue.UInt64Value = 1)
-                    Return True
+                If constantValue.IsDefaultValue Then
+                    isOne = False
+                ElseIf constantValue.IsOne Then
+                    isOne = True
+                Else
+                    Return False
                 End If
 
-                If constantValue.IsBoolean Then
-                    isOne = constantValue.BooleanValue
-                    Return True
-                End If
-
-                If constantValue.IsChar AndAlso AscW(constantValue.CharValue) <= 1 Then
-                    isOne = (AscW(constantValue.CharValue) = 1)
-                    Return True
-                End If
+                Return constantValue.IsIntegral OrElse
+                       constantValue.IsBoolean OrElse
+                       constantValue.IsChar
             End If
 
             Return False

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1324,7 +1324,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             _builder.MarkLabel(doneLabel)
         End Sub
 
-        Private Function HasIntegralValueZeroOrOne(expr As BoundExpression, ByRef isOne As Boolean) As Boolean
+        Private Shared Function HasIntegralValueZeroOrOne(expr As BoundExpression, ByRef isOne As Boolean) As Boolean
             If expr.IsConstant Then
                 Dim constantValue = expr.ConstantValueOpt
                 If constantValue.IsDefaultValue Then

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1255,8 +1255,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Dim isOneWhenFalse = False
             If used AndAlso _ilEmitStyle <> ILEmitStyle.Debug AndAlso
                 (IsSimpleType(expr.Type.PrimitiveTypeCode) OrElse expr.Type.PrimitiveTypeCode = Cci.PrimitiveTypeCode.Char) AndAlso
-                HasIntegralValueZeroOrOne(expr.WhenTrue, isOneWhenTrue) AndAlso
-                HasIntegralValueZeroOrOne(expr.WhenFalse, isOneWhenFalse) AndAlso
+                expr.WhenTrue.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenTrue) AndAlso
+                expr.WhenFalse.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenFalse) AndAlso
                 isOneWhenTrue <> isOneWhenFalse AndAlso
                 TryEmitComparison(expr.Condition, sense:=isOneWhenTrue) Then
 
@@ -1323,25 +1323,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             _builder.MarkLabel(doneLabel)
         End Sub
-
-        Private Shared Function HasIntegralValueZeroOrOne(expr As BoundExpression, ByRef isOne As Boolean) As Boolean
-            If expr.IsConstant Then
-                Dim constantValue = expr.ConstantValueOpt
-                If constantValue.IsDefaultValue Then
-                    isOne = False
-                ElseIf constantValue.IsOne Then
-                    isOne = True
-                Else
-                    Return False
-                End If
-
-                Return constantValue.IsIntegral OrElse
-                       constantValue.IsBoolean OrElse
-                       constantValue.IsChar
-            End If
-
-            Return False
-        End Function
 
         ''' <summary>
         ''' Emit code for a null-coalescing operator.

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1255,8 +1255,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Dim isOneWhenFalse = False
             If used AndAlso _ilEmitStyle <> ILEmitStyle.Debug AndAlso
                 (IsSimpleType(expr.Type.PrimitiveTypeCode) OrElse expr.Type.PrimitiveTypeCode = Cci.PrimitiveTypeCode.Char) AndAlso
-                expr.WhenTrue.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenTrue) AndAlso
-                expr.WhenFalse.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenFalse) AndAlso
+                If(expr.WhenTrue.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenTrue), False) AndAlso
+                If(expr.WhenFalse.ConstantValueOpt?.IsIntegralValueZeroOrOne(isOneWhenFalse), False) AndAlso
                 isOneWhenTrue <> isOneWhenFalse AndAlso
                 TryEmitComparison(expr.Condition, sense:=isOneWhenTrue) Then
 


### PR DESCRIPTION
Since the value "one" now has semantic meaning, I think it makes sense to reflect this in ConstantValue to simplify emitting conditionals.