### PR TITLE
Ensure bulk included diagnostic IDs for Code cleanup only fix Warning/Error diagnostics

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -883,6 +883,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         /// <param name="code">The input code to be processed and tested.</param>
         /// <param name="systemUsingsFirst">Indicates whether <c><see cref="System"/>.*</c> '<c>using</c>' directives should preceed others. Default is <c>true</c>.</param>
         /// <param name="separateUsingGroups">Indicates whether '<c>using</c>' directives should be organized into separated groups. Default is <c>true</c>.</param>
+        /// <param name="enabledFixIdsFilter">Optional filter to determine if a specific fix ID is explicitly enabled for cleanup.</param>
+        /// <param name="diagnosticIdsWithSeverity">Optional list of diagnostic IDs with effective severities to be configured in editorconfig.</param>
         /// <returns>The <see cref="Task"/> to test code cleanup.</returns>
         private protected static Task AssertCodeCleanupResult(string expected, string code, bool systemUsingsFirst = true, bool separateUsingGroups = false, Func<string, bool> enabledFixIdsFilter = null, (string, DiagnosticSeverity)[] diagnosticIdsWithSeverity = null)
             => AssertCodeCleanupResult(expected, code, new(AddImportPlacement.OutsideNamespace, NotificationOption2.Silent), systemUsingsFirst, separateUsingGroups, enabledFixIdsFilter, diagnosticIdsWithSeverity);
@@ -895,6 +897,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         /// <param name="preferredImportPlacement">Indicates the code style option for the preferred 'using' directives placement.</param>
         /// <param name="systemUsingsFirst">Indicates whether <c><see cref="System"/>.*</c> '<c>using</c>' directives should preceed others. Default is <c>true</c>.</param>
         /// <param name="separateUsingGroups">Indicates whether '<c>using</c>' directives should be organized into separated groups. Default is <c>true</c>.</param>
+        /// <param name="enabledFixIdsFilter">Optional filter to determine if a specific fix ID is explicitly enabled for cleanup.</param>
+        /// <param name="diagnosticIdsWithSeverity">Optional list of diagnostic IDs with effective severities to be configured in editorconfig.</param>
         /// <returns>The <see cref="Task"/> to test code cleanup.</returns>
         private protected static async Task AssertCodeCleanupResult(string expected, string code, CodeStyleOption2<AddImportPlacement> preferredImportPlacement, bool systemUsingsFirst = true, bool separateUsingGroups = false, Func<string, bool> enabledFixIdsFilter = null, (string, DiagnosticSeverity)[] diagnosticIdsWithSeverity = null)
         {

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -573,6 +573,69 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             return AssertCodeCleanupResult(expected, code, OutsidePreferPreservationOption);
         }
 
+        [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70187")]
+        [InlineData(true, true, DiagnosticSeverity.Warning)]
+        [InlineData(true, false, DiagnosticSeverity.Warning)]
+        [InlineData(false, true, DiagnosticSeverity.Warning)]
+        [InlineData(false, false, DiagnosticSeverity.Warning)]
+        [InlineData(true, true, DiagnosticSeverity.Info)]
+        [InlineData(true, false, DiagnosticSeverity.Info)]
+        [InlineData(false, true, DiagnosticSeverity.Info)]
+        [InlineData(false, false, DiagnosticSeverity.Info)]
+        public Task FixAllWarningsAndErrorsWithCustomFixIdsExplicitlyEnabled(bool applyAllAnalyzerFixersId, bool explicitlyIncludeCompilerId, DiagnosticSeverity severity)
+        {
+            var code = """
+                namespace A
+                {
+                    internal class Program
+                    {
+                        private void Method()
+                        {
+                            int a = 42; // CS0219: The variable 'a' is assigned but its value is never used.
+                        }
+                    }
+                }
+                """;
+
+            var expectedCleanup = false;
+            if (explicitlyIncludeCompilerId)
+            {
+                expectedCleanup = true;
+            }
+            else if (applyAllAnalyzerFixersId)
+            {
+                expectedCleanup = severity >= DiagnosticSeverity.Warning;
+            }
+
+            var expected = code;
+            if (expectedCleanup)
+            {
+                expected = """
+                namespace A
+                {
+                    internal class Program
+                    {
+                        private void Method()
+                        {
+                        }
+                    }
+                }
+                """;
+            }
+
+            Func<string, bool> enabledFixIdsFilter = id =>
+                id switch
+                {
+                    "CS0219" => explicitlyIncludeCompilerId,
+                    "ApplyAllAnalyzerFixersId" => applyAllAnalyzerFixersId,
+                    _ => false
+                };
+
+            var diagnosticIdsWithSeverity = new[] { ("CS0219", severity) };
+
+            return AssertCodeCleanupResult(expected, code, enabledFixIdsFilter: enabledFixIdsFilter, diagnosticIdsWithSeverity: diagnosticIdsWithSeverity);
+        }
+
         [Theory]
         [InlineData(LanguageNames.CSharp)]
         [InlineData(LanguageNames.VisualBasic)]
@@ -825,8 +888,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         /// <param name="systemUsingsFirst">Indicates whether <c><see cref="System"/>.*</c> '<c>using</c>' directives should preceed others. Default is <c>true</c>.</param>
         /// <param name="separateUsingGroups">Indicates whether '<c>using</c>' directives should be organized into separated groups. Default is <c>true</c>.</param>
         /// <returns>The <see cref="Task"/> to test code cleanup.</returns>
-        private protected static Task AssertCodeCleanupResult(string expected, string code, bool systemUsingsFirst = true, bool separateUsingGroups = false)
-            => AssertCodeCleanupResult(expected, code, new(AddImportPlacement.OutsideNamespace, NotificationOption2.Silent), systemUsingsFirst, separateUsingGroups);
+        private protected static Task AssertCodeCleanupResult(string expected, string code, bool systemUsingsFirst = true, bool separateUsingGroups = false, Func<string, bool> enabledFixIdsFilter = null, (string, DiagnosticSeverity)[] diagnosticIdsWithSeverity = null)
+            => AssertCodeCleanupResult(expected, code, new(AddImportPlacement.OutsideNamespace, NotificationOption2.Silent), systemUsingsFirst, separateUsingGroups, enabledFixIdsFilter, diagnosticIdsWithSeverity);
 
         /// <summary>
         /// Assert the expected code value equals the actual processed input <paramref name="code"/>.
@@ -837,7 +900,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         /// <param name="systemUsingsFirst">Indicates whether <c><see cref="System"/>.*</c> '<c>using</c>' directives should preceed others. Default is <c>true</c>.</param>
         /// <param name="separateUsingGroups">Indicates whether '<c>using</c>' directives should be organized into separated groups. Default is <c>true</c>.</param>
         /// <returns>The <see cref="Task"/> to test code cleanup.</returns>
-        private protected static async Task AssertCodeCleanupResult(string expected, string code, CodeStyleOption2<AddImportPlacement> preferredImportPlacement, bool systemUsingsFirst = true, bool separateUsingGroups = false)
+        private protected static async Task AssertCodeCleanupResult(string expected, string code, CodeStyleOption2<AddImportPlacement> preferredImportPlacement, bool systemUsingsFirst = true, bool separateUsingGroups = false, Func<string, bool> enabledFixIdsFilter = null, (string, DiagnosticSeverity)[] diagnosticIdsWithSeverity = null)
         {
             using var workspace = TestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
 
@@ -853,6 +916,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                 new AnalyzerFileReference(typeof(UseExpressionBodyDiagnosticAnalyzer).Assembly.Location, TestAnalyzerAssemblyLoader.LoadFromFile)
             });
 
+            if (diagnosticIdsWithSeverity != null)
+            {
+                var editorconfigText = "is_global = true";
+                foreach (var (diagnosticId, severity) in diagnosticIdsWithSeverity)
+                {
+                    editorconfigText += $"\ndotnet_diagnostic.{diagnosticId}.severity = {severity.ToEditorConfigString()}";
+                }
+
+                var project = solution.Projects.Single();
+                project = project.AddAnalyzerConfigDocument(".editorconfig", SourceText.From(editorconfigText), filePath: @"z:\\.editorconfig").Project;
+                solution = project.Solution;
+            }
+
             workspace.TryApplyChanges(solution);
 
             // register this workspace to solution crawler so that analyzer service associate itself with given workspace
@@ -865,6 +941,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
 
             var enabledDiagnostics = codeCleanupService.GetAllDiagnostics();
+
+            if (enabledFixIdsFilter != null)
+                enabledDiagnostics = VisualStudio.LanguageServices.Implementation.CodeCleanup.AbstractCodeCleanUpFixer.AdjustDiagnosticOptions(enabledDiagnostics, enabledFixIdsFilter);
 
             var newDoc = await codeCleanupService.CleanupAsync(
                 document, enabledDiagnostics, CodeAnalysisProgress.None, globalOptions.CreateProvider(), CancellationToken.None);

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -574,15 +574,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         }
 
         [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/70187")]
-        [InlineData(true, true, DiagnosticSeverity.Warning)]
-        [InlineData(true, false, DiagnosticSeverity.Warning)]
-        [InlineData(false, true, DiagnosticSeverity.Warning)]
-        [InlineData(false, false, DiagnosticSeverity.Warning)]
-        [InlineData(true, true, DiagnosticSeverity.Info)]
-        [InlineData(true, false, DiagnosticSeverity.Info)]
-        [InlineData(false, true, DiagnosticSeverity.Info)]
-        [InlineData(false, false, DiagnosticSeverity.Info)]
-        public Task FixAllWarningsAndErrorsWithCustomFixIdsExplicitlyEnabled(bool applyAllAnalyzerFixersId, bool explicitlyIncludeCompilerId, DiagnosticSeverity severity)
+        [CombinatorialData]
+        public Task FixAllWarningsAndErrorsWithCustomFixIdsExplicitlyEnabled(
+            bool applyAllAnalyzerFixersId,
+            bool explicitlyIncludeCompilerId,
+            [CombinatorialValues(DiagnosticSeverity.Warning, DiagnosticSeverity.Info)] DiagnosticSeverity severity)
         {
             var code = """
                 namespace A

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="..\..\Features\CSharpTest\CodeActions\AbstractCSharpCodeActionTest.cs" Link="CodeActions\AbstractCSharpCodeActionTest.cs" />
     <Compile Include="..\..\Features\CSharpTest\CodeActions\Preview\ErrorCases\ExceptionInCodeAction.cs" Link="CodeActions\ExceptionInCodeAction.cs" />
     <Compile Include="..\..\Features\CSharpTest\Utilities\CodeSnippets.cs" Link="Utilities\CodeSnippets.cs" />
+    <Compile Include="..\..\VisualStudio\Core\Def\CodeCleanup\AbstractCodeCleanUpFixer_Helper.cs" Link="Formatting\AbstractCodeCleanUpFixer_Helper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Interactive\CodeActions\" />

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/DiagnosticSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/DiagnosticSet.cs
@@ -15,10 +15,31 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         public string Description { get; }
         public ImmutableArray<string> DiagnosticIds { get; }
 
-        public DiagnosticSet(string description, params string[] diagnosticIds)
+        /// <summary>
+        /// Diagnostic set is enabled for all severities if it has been explicitly selected as part of the cleanup profile.
+        /// If the diagnostic set has not been explicitly selected, but gets bulk included by selecting
+        /// "Fix all warnings and errors set in EditorConfig", then we only include diagnostics with Warning Or Error severity.
+        /// </summary>
+        public bool IsAnyDiagnosticIdExplicitlyEnabled { get; }
+
+        private DiagnosticSet(string description, ImmutableArray<string> diagnosticIds, bool isAnyDiagnosticIdExplicitlyEnabled)
         {
             Description = description;
-            DiagnosticIds = ImmutableArray.Create(diagnosticIds);
+            DiagnosticIds = diagnosticIds;
+            IsAnyDiagnosticIdExplicitlyEnabled = isAnyDiagnosticIdExplicitlyEnabled;
+        }
+
+        public DiagnosticSet(string description, params string[] diagnosticIds)
+            : this(description, ImmutableArray.Create(diagnosticIds), isAnyDiagnosticIdExplicitlyEnabled: true)
+        {
+        }
+
+        public DiagnosticSet With(bool isAnyDiagnosticIdExplicitlyEnabled)
+        {
+            if (this.IsAnyDiagnosticIdExplicitlyEnabled == isAnyDiagnosticIdExplicitlyEnabled)
+                return this;
+
+            return new(Description, DiagnosticIds, isAnyDiagnosticIdExplicitlyEnabled);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
@@ -42,9 +42,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, TextDocument document, TextSpan textSpan, ICodeActionRequestPriorityProvider priorityProvider, CodeActionOptionsProvider fallbackOptions, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
             => service.StreamFixesAsync(document, textSpan, priorityProvider, fallbackOptions, addOperationScope, cancellationToken).ToImmutableArrayAsync(cancellationToken);
 
-        public static Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(this ICodeFixService service, TextDocument document, TextSpan range, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
-            => service.GetDocumentFixAllForIdInSpanAsync(document, range, diagnosticId, DiagnosticSeverity.Hidden, fallbackOptions, cancellationToken);
-
         public static Task<TDocument> ApplyCodeFixesForSpecificDiagnosticIdAsync<TDocument>(this ICodeFixService service, TDocument document, string diagnosticId, IProgress<CodeAnalysisProgress> progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken) where TDocument : TextDocument
             => service.ApplyCodeFixesForSpecificDiagnosticIdAsync(document, diagnosticId, DiagnosticSeverity.Hidden, progressTracker, fallbackOptions, cancellationToken);
     }

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -37,14 +37,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
     /// be implementing the <see cref="ICodeCleanUpFixer"/> interface, this abstract base class allows Roslyn to operate
     /// on MEF instances of fixers known to be relevant in the context of Roslyn languages.
     /// </summary>
-    internal abstract class AbstractCodeCleanUpFixer : ICodeCleanUpFixer
+    internal abstract partial class AbstractCodeCleanUpFixer : ICodeCleanUpFixer
     {
-        protected internal const string FormatDocumentFixId = nameof(FormatDocumentFixId);
-        protected internal const string RemoveUnusedImportsFixId = nameof(RemoveUnusedImportsFixId);
-        protected internal const string SortImportsFixId = nameof(SortImportsFixId);
-        protected internal const string ApplyThirdPartyFixersId = nameof(ApplyThirdPartyFixersId);
-        protected internal const string ApplyAllAnalyzerFixersId = nameof(ApplyAllAnalyzerFixersId);
-
         private readonly IThreadingContext _threadingContext;
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly IVsHierarchyItemManager _vsHierarchyItemManager;
@@ -324,57 +318,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             var codeCleanupService = document.GetRequiredLanguageService<ICodeCleanupService>();
 
             var enabledDiagnostics = codeCleanupService.GetAllDiagnostics();
-            if (!enabledFixIds.IsFixIdEnabled(ApplyAllAnalyzerFixersId))
-            {
-                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
-
-                foreach (var diagnostic in enabledDiagnostics.Diagnostics)
-                {
-                    foreach (var diagnosticId in diagnostic.DiagnosticIds)
-                    {
-                        if (enabledFixIds.IsFixIdEnabled(diagnosticId))
-                        {
-                            enabledDiagnosticSets.Add(diagnostic);
-                            break;
-                        }
-                    }
-                }
-
-                var isFormatDocumentEnabled = enabledFixIds.IsFixIdEnabled(FormatDocumentFixId);
-                var isRemoveUnusedUsingsEnabled = enabledFixIds.IsFixIdEnabled(RemoveUnusedImportsFixId);
-                var isSortUsingsEnabled = enabledFixIds.IsFixIdEnabled(SortImportsFixId);
-                var isApplyThirdPartyFixersEnabled = enabledFixIds.IsFixIdEnabled(ApplyThirdPartyFixersId);
-                enabledDiagnostics = new EnabledDiagnosticOptions(
-                    isFormatDocumentEnabled,
-                    isApplyThirdPartyFixersEnabled,
-                    enabledDiagnosticSets.ToImmutableArray(),
-                    new OrganizeUsingsSet(isRemoveUnusedUsingsEnabled, isSortUsingsEnabled));
-            }
-            else
-            {
-                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
-
-                foreach (var diagnostic in enabledDiagnostics.Diagnostics)
-                {
-                    var isAnyDiagnosticIdExplicitlyEnabled = false;
-                    foreach (var diagnosticId in diagnostic.DiagnosticIds)
-                    {
-                        if (enabledFixIds.IsFixIdEnabled(diagnosticId))
-                        {
-                            isAnyDiagnosticIdExplicitlyEnabled = true;
-                            break;
-                        }
-                    }
-
-                    enabledDiagnosticSets.Add(diagnostic.With(isAnyDiagnosticIdExplicitlyEnabled));
-                }
-
-                enabledDiagnostics = new EnabledDiagnosticOptions(
-                    enabledDiagnostics.FormatDocument,
-                    enabledDiagnostics.RunThirdPartyFixers,
-                    enabledDiagnosticSets.ToImmutableArray(),
-                    enabledDiagnostics.OrganizeUsings);
-            }
+            enabledDiagnostics = AdjustDiagnosticOptions(enabledDiagnostics, enabledFixIds.IsFixIdEnabled);
 
             return await codeCleanupService.CleanupAsync(
                 document, enabledDiagnostics, progressTracker, ideOptions.CreateProvider(), cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -350,6 +350,31 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                     enabledDiagnosticSets.ToImmutableArray(),
                     new OrganizeUsingsSet(isRemoveUnusedUsingsEnabled, isSortUsingsEnabled));
             }
+            else
+            {
+                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
+
+                foreach (var diagnostic in enabledDiagnostics.Diagnostics)
+                {
+                    var isAnyDiagnosticIdExplicitlyEnabled = false;
+                    foreach (var diagnosticId in diagnostic.DiagnosticIds)
+                    {
+                        if (enabledFixIds.IsFixIdEnabled(diagnosticId))
+                        {
+                            isAnyDiagnosticIdExplicitlyEnabled = true;
+                            break;
+                        }
+                    }
+
+                    enabledDiagnosticSets.Add(diagnostic.With(isAnyDiagnosticIdExplicitlyEnabled));
+                }
+
+                enabledDiagnostics = new EnabledDiagnosticOptions(
+                    enabledDiagnostics.FormatDocument,
+                    enabledDiagnostics.RunThirdPartyFixers,
+                    enabledDiagnosticSets.ToImmutableArray(),
+                    enabledDiagnostics.OrganizeUsings);
+            }
 
             return await codeCleanupService.CleanupAsync(
                 document, enabledDiagnostics, progressTracker, ideOptions.CreateProvider(), cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer_Helper.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer_Helper.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeCleanup;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
+{
+    internal abstract partial class AbstractCodeCleanUpFixer
+    {
+        protected internal const string FormatDocumentFixId = nameof(FormatDocumentFixId);
+        protected internal const string RemoveUnusedImportsFixId = nameof(RemoveUnusedImportsFixId);
+        protected internal const string SortImportsFixId = nameof(SortImportsFixId);
+        protected internal const string ApplyThirdPartyFixersId = nameof(ApplyThirdPartyFixersId);
+        protected internal const string ApplyAllAnalyzerFixersId = nameof(ApplyAllAnalyzerFixersId);
+
+        internal static EnabledDiagnosticOptions AdjustDiagnosticOptions(EnabledDiagnosticOptions enabledDiagnostics, Func<string, bool> isFixIdEnabled)
+        {
+            if (!isFixIdEnabled(ApplyAllAnalyzerFixersId))
+            {
+                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
+
+                foreach (var diagnostic in enabledDiagnostics.Diagnostics)
+                {
+                    foreach (var diagnosticId in diagnostic.DiagnosticIds)
+                    {
+                        if (isFixIdEnabled(diagnosticId))
+                        {
+                            enabledDiagnosticSets.Add(diagnostic);
+                            break;
+                        }
+                    }
+                }
+
+                var isFormatDocumentEnabled = isFixIdEnabled(FormatDocumentFixId);
+                var isRemoveUnusedUsingsEnabled = isFixIdEnabled(RemoveUnusedImportsFixId);
+                var isSortUsingsEnabled = isFixIdEnabled(SortImportsFixId);
+                var isApplyThirdPartyFixersEnabled = isFixIdEnabled(ApplyThirdPartyFixersId);
+                return new EnabledDiagnosticOptions(
+                    isFormatDocumentEnabled,
+                    isApplyThirdPartyFixersEnabled,
+                    enabledDiagnosticSets.ToImmutableArray(),
+                    new OrganizeUsingsSet(isRemoveUnusedUsingsEnabled, isSortUsingsEnabled));
+            }
+            else
+            {
+                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
+
+                foreach (var diagnostic in enabledDiagnostics.Diagnostics)
+                {
+                    var isAnyDiagnosticIdExplicitlyEnabled = false;
+                    foreach (var diagnosticId in diagnostic.DiagnosticIds)
+                    {
+                        if (isFixIdEnabled(diagnosticId))
+                        {
+                            isAnyDiagnosticIdExplicitlyEnabled = true;
+                            break;
+                        }
+                    }
+
+                    enabledDiagnosticSets.Add(diagnostic.With(isAnyDiagnosticIdExplicitlyEnabled));
+                }
+
+                return new EnabledDiagnosticOptions(
+                    enabledDiagnostics.FormatDocument,
+                    enabledDiagnostics.RunThirdPartyFixers,
+                    enabledDiagnosticSets.ToImmutableArray(),
+                    enabledDiagnostics.OrganizeUsings);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Strongly recommended to review commit-by-commit - first commit has the core fix**

Fixes #70187

Code cleanup profile allows users to explicitly select individual first-party fixes or bulk include either all third-party fixes for warnings/errors OR all fixes for warnings/errors.

For explicitly selected first-party fixes, we apply fixes for any severity diagnostics. For bulk enabled ones, we want to only apply fixes for diagnostics with Warning or Error severity. This was correctly implemented for third-party fixes, but not for all fixes selection. This PR adds that support by tracking if a specific DiagnosticSet was explicitly included or bulk included.

Verified that this change fixes the repro in the fixed issue.

~~**TODO:** Add regression test if the fix looks good.~~ Added regression test with https://github.com/dotnet/roslyn/pull/70353/commits/aa2359d585a1eb16dbd42078570b479285012f94