### PR TITLE
Fix 'fix all' support for code actions being broken

### DIFF
--- a/src/Features/Core/Portable/CodeFixesAndRefactorings/AbstractFixAllGetFixesService.cs
+++ b/src/Features/Core/Portable/CodeFixesAndRefactorings/AbstractFixAllGetFixesService.cs
@@ -16,6 +16,14 @@ namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
 
 internal abstract class AbstractFixAllGetFixesService : IFixAllGetFixesService
 {
+    protected abstract Solution? GetChangedSolution(
+        Workspace workspace,
+        Solution currentSolution,
+        Solution newSolution,
+        string fixAllPreviewChangesTitle,
+        string fixAllTopLevelHeader,
+        Glyph glyph);
+
     public async Task<Solution?> GetFixAllChangedSolutionAsync(IFixAllContext fixAllContext)
     {
         var codeAction = await GetFixAllCodeActionAsync(fixAllContext).ConfigureAwait(false);
@@ -96,7 +104,7 @@ internal abstract class AbstractFixAllGetFixesService : IFixAllGetFixesService
     public Solution? PreviewChanges(
         Workspace workspace,
         Solution currentSolution,
-        Solution? newSolution,
+        Solution newSolution,
         FixAllKind fixAllKind,
         string previewChangesTitle,
         string topLevelHeader,
@@ -145,17 +153,6 @@ internal abstract class AbstractFixAllGetFixesService : IFixAllGetFixesService
             FixAllLogger.LogPreviewChangesResult(fixAllKind, correlationId, applied: true, allChangesApplied: changedSolution == newSolution);
             return changedSolution;
         }
-    }
-
-    protected virtual Solution? GetChangedSolution(
-        Workspace workspace,
-        Solution currentSolution,
-        Solution? newSolution,
-        string fixAllPreviewChangesTitle,
-        string fixAllTopLevelHeader,
-        Glyph glyph)
-    {
-        return currentSolution;
     }
 
     private static async Task<CodeAction?> GetFixAllCodeActionAsync(IFixAllContext fixAllContext)

--- a/src/Features/Core/Portable/CodeFixesAndRefactorings/FeaturesFixAllGetFixesService.cs
+++ b/src/Features/Core/Portable/CodeFixesAndRefactorings/FeaturesFixAllGetFixesService.cs
@@ -5,20 +5,17 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixesAndRefactorings;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 
-[ExportWorkspaceServiceFactory(typeof(IFixAllGetFixesService), ServiceLayer.Host), Shared]
-internal sealed class FeaturesFixAllGetFixesService : AbstractFixAllGetFixesService, IWorkspaceServiceFactory
+[ExportWorkspaceService(typeof(IFixAllGetFixesService), ServiceLayer.Default), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class FeaturesFixAllGetFixesService() : AbstractFixAllGetFixesService
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public FeaturesFixAllGetFixesService()
+    protected override Solution? GetChangedSolution(Workspace workspace, Solution currentSolution, Solution newSolution, string fixAllPreviewChangesTitle, string fixAllTopLevelHeader, Glyph glyph)
     {
+        return newSolution;
     }
-
-    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        => this;
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1900225

Test hole here tracked with https://github.com/dotnet/roslyn/issues/27806.  Now that we have regressed this, it is a requirement to fix the test hole immediately.