### PR TITLE
Add async operation listener to allow integration tests to wait for server side operations

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandlerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandlerFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
 {
@@ -13,20 +14,23 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Configuration
     internal class DidChangeConfigurationNotificationHandlerFactory : ILspServiceFactory
     {
         private readonly IGlobalOptionService _globalOptionService;
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public DidChangeConfigurationNotificationHandlerFactory(
-            IGlobalOptionService globalOptionService)
+            IGlobalOptionService globalOptionService,
+            IAsynchronousOperationListenerProvider listenerProvider)
         {
             _globalOptionService = globalOptionService;
+            _listenerProvider = listenerProvider;
         }
 
         public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
         {
             var clientManager = lspServices.GetRequiredService<IClientLanguageServerManager>();
             var lspLogger = lspServices.GetRequiredService<ILspServiceLogger>();
-            return new DidChangeConfigurationNotificationHandler(lspLogger, _globalOptionService, clientManager);
+            return new DidChangeConfigurationNotificationHandler(lspLogger, _globalOptionService, clientManager, _listenerProvider);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/TestHooks/WaitForAsyncOperationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/TestHooks/WaitForAsyncOperationsHandler.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.TestHooks;
+
+/// <summary>
+/// Implements an LSP request handler to allow the integration tests on the client side to wait for certain server side operations to complete.
+/// This is useful in a few cases where the client makes requests to the server but does not wait for the processing to complete, for example
+///     1.  Loading projects
+///     2.  Reacting to LSP notifications (which are fire and forget)
+///     
+/// This should generally only be used as a last resort when it is impossible for the client to wait specifically for a result it asked for.
+/// </summary>
+[ExportCSharpVisualBasicStatelessLspService(typeof(WaitForAsyncOperationsHandler)), Shared]
+[Method(MethodName)]
+internal class WaitForAsyncOperationsHandler : ILspServiceRequestHandler<WaitForAsyncOperationsParams, WaitForAsyncOperationsResponse>
+{
+    internal const string MethodName = "workspace/waitForAsyncOperations";
+
+    private readonly AsynchronousOperationListenerProvider _provider;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public WaitForAsyncOperationsHandler(AsynchronousOperationListenerProvider listenerProvider)
+    {
+        _provider = listenerProvider;
+    }
+
+    public bool MutatesSolutionState => false;
+
+    public bool RequiresLSPSolution => true;
+
+    public async Task<WaitForAsyncOperationsResponse> HandleRequestAsync(WaitForAsyncOperationsParams request, RequestContext context, CancellationToken _)
+    {
+        context.TraceInformation($"Waiting for {string.Join(", ", request.Operations)} to complete");
+        await _provider.WaitAllAsync(context.Solution!.Workspace, request.Operations).ConfigureAwait(false);
+        return new WaitForAsyncOperationsResponse(true);
+    }
+}
+
+[DataContract]
+internal record WaitForAsyncOperationsParams([property: DataMember(Name = "operations")] string[] Operations);
+
+[DataContract]
+internal record WaitForAsyncOperationsResponse([property: DataMember(Name = "result")] bool Result);


### PR DESCRIPTION
In most cases for vscode integration tests the async operation listener is not necessary.  Generally the vscode integration tests work on a client request model, where we ask the server a question and wait for the response.  

However there are certain operations where the client does not (or cannot) request and wait for a response.  Some examples
1.  LSP notifications sent from the client - these never wait for a response from the server (e.g. option changes).
2.  Project system operations - we don't want to wait and block on the client side for the entire project to load.

This adds an LSP request to hook into the async operation listener on the server side.  After the test side loads a project or restores assets on disk or changes options, etc, the test can call this API to wait for the pending operations to complete before continuing.

This is generally a last resort - everything else should make requests and wait for responses.