### PR TITLE
EnC: Replace debug-only assertion with release check to fail fast

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -1319,8 +1319,10 @@ namespace Microsoft.CodeAnalysis.Emit
 
                 // Fails if we are attempting to make a change that should have been reported as rude,
                 // e.g. the corresponding definitions type don't match, etc.
-                Debug.Assert(containsItem);
-                Debug.Assert(rowId > 0);
+                if (!containsItem || rowId == 0)
+                {
+                    throw ExceptionUtilities.UnexpectedValue(item);
+                }
 
                 return rowId;
             }


### PR DESCRIPTION
If this condition fails in release we won't have the right stack in telemetry because the execution just continues, the callers use invalid value and something will fail later on.