### PR TITLE
Add F1 help for `NameOf` keyword in Visual Basic

### DIFF
--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -2249,6 +2249,15 @@ Module Program
     End Sub
 End Module]]></a>.Value, "System.Int32.ToString")
         End Function
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/68003")>
+        Public Async Function TestNameOfExpression() As Task
+            Await TestAsync(<a><![CDATA[Module Program
+    Sub Main(args As String())
+        Dim x = NameOf[||](args)
+    End Sub
+End Module]]></a>.Value, "vb.NameOf")
+        End Function
     End Class
 End Namespace
 

--- a/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
@@ -417,6 +417,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
                 End If
             End Sub
 
+            Public Overrides Sub VisitNameOfExpression(node As NameOfExpressionSyntax)
+                result = Keyword(SyntaxKind.NameOfKeyword)
+            End Sub
+
             Public Overrides Sub VisitIdentifierName(node As IdentifierNameSyntax)
                 Select Case node.Identifier.Kind()
                     Case SyntaxKind.MyBaseKeyword


### PR DESCRIPTION
Fixes #68003.