### PR TITLE
Add refactoring to convert a primary-constructor-parameter to a normal constructor.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePrimaryConstructor/CSharpUsePrimaryConstructorDiagnosticAnalyzer.cs
@@ -204,8 +204,8 @@ internal sealed class CSharpUsePrimaryConstructorDiagnosticAnalyzer : AbstractBu
 
             for (var containingType = startSymbol.ContainingType; containingType != null; containingType = containingType.ContainingType)
             {
-                var containgTypeAnalyzer = TryGetOrCreateAnalyzer(containingType);
-                RegisterFieldOrPropertyAnalysisIfNecessary(containgTypeAnalyzer);
+                var containingTypeAnalyzer = TryGetOrCreateAnalyzer(containingType);
+                RegisterFieldOrPropertyAnalysisIfNecessary(containingTypeAnalyzer);
             }
 
             // Now try to make the analyzer for this type.

--- a/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePrimaryConstructor/CSharpUsePrimaryConstructorCodeFixProvider.cs
@@ -268,12 +268,12 @@ internal partial class CSharpUsePrimaryConstructorCodeFixProvider : CodeFixProvi
                     getElements(list),
                     (p, _) =>
                     {
-                        var parameterLeadingWhitespace = GetLeadingWhitespace(p);
-                        if (parameterLeadingWhitespace.EndsWith(indentation))
+                        var elementLeadingWhitespace = GetLeadingWhitespace(p);
+                        if (elementLeadingWhitespace.EndsWith(indentation))
                         {
                             var leadingTrivia = p.GetLeadingTrivia();
                             return p.WithLeadingTrivia(
-                                leadingTrivia.Take(leadingTrivia.Count - 1).Concat(Whitespace(parameterLeadingWhitespace[..^indentation.Length])));
+                                leadingTrivia.Take(leadingTrivia.Count - 1).Concat(Whitespace(elementLeadingWhitespace[..^indentation.Length])));
                         }
 
                         return p;

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -609,4 +609,7 @@
     <value>static int Main</value>
     <comment>{Locked}</comment>
   </data>
+  <data name="Convert_to_regular_constructor" xml:space="preserve">
+    <value>Convert to regular constructor</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -218,8 +218,8 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                     // We're skipping a param node.  Remove any blank xml lines preceding this.
                     if (IsDocCommentNewLine(content.LastOrDefault()))
                         content.RemoveLast();
-                    else if (content.Count == 1 && IsEmptyDocCommentStartText(content.LastOrDefault()))
-                        content.RemoveLast();
+                    //else if (content.Count == 1 && IsEmptyDocCommentStartText(content.LastOrDefault()))
+                    //    content.RemoveLast();
                 }
                 else
                 {
@@ -227,7 +227,8 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                 }
             }
 
-            if (content.Count == 0)
+            if (content.All(c => c is XmlTextSyntax xmlText && xmlText.TextTokens.All(
+                    t => t.Kind() == SyntaxKind.XmlTextLiteralNewLineToken || string.IsNullOrWhiteSpace(t.Text))))
             {
                 // Nothing but param nodes.  Just remove all the doc comments entirely.
                 var triviaIndex = triviaList.IndexOf(trivia);
@@ -279,7 +280,7 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                         if (referenceLocation.Location.FindNode(findInsideTrivia: true, getInnermostNodeForTie: true, cancellationToken) is not IdentifierNameSyntax identifierName)
                             continue;
 
-                        // Explicitly ignore references in the base-type-list.  Tehse don't need to be rewritten as
+                        // Explicitly ignore references in the base-type-list.  These don't need to be rewritten as
                         // they will still reference the parameter in the new constructor when we make the `:
                         // base(...)` initializer.
                         if (identifierName.GetAncestor<PrimaryConstructorBaseTypeSyntax>() != null)

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -90,6 +90,9 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
         var solutionEditor = new SolutionEditor(solution);
         var mainDocumentEditor = await solutionEditor.GetDocumentEditorAsync(document.Id, cancellationToken).ConfigureAwait(false);
 
+        var baseType = typeDeclaration.BaseList?.Types is [PrimaryConstructorBaseTypeSyntax type, ..] ? type : null;
+        var methodTargetingAttributes = typeDeclaration.AttributeLists.Where(list => list.Target?.Identifier.ValueText == "method");
+
         // Find the references to all the parameters.  This will help us determine how they're used and what change we
         // may need to make.
         var parameterReferences = await GetParameterReferencesAsync().ConfigureAwait(false);
@@ -110,7 +113,7 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
         AddNewFields();
         AddConstructorDeclaration();
         await RewritePrimaryConstructorParameterReferencesAsync().ConfigureAwait(false);
-        FixConstructoDeclarationFormatting();
+        FixConstructorDeclarationFormatting();
 
         return solutionEditor.GetChangedSolution();
 
@@ -247,7 +250,6 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
         void RemovePrimaryConstructorTargetingAttributes()
         {
             // Remove all the attributes from the type decl that we're moving to the constructor.
-            var methodTargetingAttributes = typeDeclaration.AttributeLists.Where(list => list.Target?.Identifier.ValueText == "method");
             foreach (var attributeList in methodTargetingAttributes)
                 mainDocumentEditor.RemoveNode(attributeList);
         }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -24,8 +24,14 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.FindSymbols;
 using System.Linq;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
+
+using static SyntaxFactory;
 
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertPrimaryToRegularConstructor), Shared]
 [method: ImportingConstructor]
@@ -52,12 +58,12 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
 
         context.RegisterRefactoring(CodeAction.Create(
             CSharpFeaturesResources.Convert_to_regular_constructor,
-            cancellationToken => ConvertAsync(document, typeDeclaration, typeDeclaration.ParameterList, cancellationToken),
+            cancellationToken => ConvertAsync(document, typeDeclaration, typeDeclaration.ParameterList, context.Options, cancellationToken),
             nameof(CSharpFeaturesResources.Convert_to_regular_constructor)));
     }
 
     private static async Task<Solution> ConvertAsync(
-        Document document, TypeDeclarationSyntax typeDeclaration, ParameterListSyntax parameterList, CancellationToken cancellationToken)
+        Document document, TypeDeclarationSyntax typeDeclaration, ParameterListSyntax parameterList, CodeActionOptionsProvider options, CancellationToken cancellationToken)
     {
         // 1. Create constructor
         // 2. Remove base arguments
@@ -72,10 +78,26 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
         var solution = document.Project.Solution;
         var solutionEditor = new SolutionEditor(solution);
 
+        var syntaxGenerator = CSharpSyntaxGenerator.Instance;
         var parameters = parameterList.Parameters.SelectAsArray(p => semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken));
 
         var parameterToNonDocCommentLocations = await GetParameterLocationsAsync(includeDocCommentLocations: false).ConfigureAwait(false);
-        var synthesizedFields = GetSynthesizedFields();
+        var parameterToSynthesizedFields = await GetSynthesizedFieldsAsync().ConfigureAwait(false);
+
+        var baseType = typeDeclaration.BaseList?.Types is [PrimaryConstructorBaseTypeSyntax type, ..] ? type : null;
+        var methodTargetingAttributes = typeDeclaration.AttributeLists.Where(list => list.Target?.Identifier.ValueText == "method");
+        var constructorDeclaration = CreateConstructorDeclaration();
+
+        // Now start editing the document
+        var mainDocumentEditor = await solutionEditor.GetDocumentEditorAsync(document.Id, cancellationToken).ConfigureAwait(false);
+
+        mainDocumentEditor.RemoveNode(parameterList);
+        if (baseType != null)
+            mainDocumentEditor.ReplaceNode(baseType, SimpleBaseType(baseType.Type).WithTriviaFrom(baseType));
+
+        foreach (var attributeList in methodTargetingAttributes)
+            mainDocumentEditor.RemoveNode(attributeList);
+
 
         return solutionEditor.GetChangedSolution();
 
@@ -142,26 +164,83 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
             }
         }
 
-        ImmutableDictionary<IParameterSymbol, IFieldSymbol> GetSynthesizedFields()
+        async Task<ImmutableDictionary<IParameterSymbol, IFieldSymbol>> GetSynthesizedFieldsAsync()
         {
             using var _ = PooledDictionary<IParameterSymbol, IFieldSymbol>.GetInstance(out var result);
 
             foreach (var parameter in parameters)
             {
-                var referencedLocations = parameterToNonDocCommentLocations[parameter];
-                if (referencedLocations.Count == 0)
+                var existingField = namedType.GetMembers().OfType<IFieldSymbol>().FirstOrDefault(
+                    f => f.IsImplicitlyDeclared && parameter.Locations.Contains(f.Locations.FirstOrDefault()!));
+                if (existingField == null)
                     continue;
 
-                // if the parameter is only referenced in a single location, and that location is initializing a
-                // field/property already, we don't need to create a field for it.
-                if (referencedLocations.Count == 1 && referencedLocations.Single().assignedFieldOrProperty != null)
-                    continue;
+                var synthesizedField = CodeGenerationSymbolFactory.CreateFieldSymbol(
+                    existingField,
+                    name: await MakeFieldNameAsync(parameter.Name).ConfigureAwait(false));
 
-                // it was referenced outside of a field/prop initializer.  Need to synthesize a field for it.
+                result.Add(parameter, synthesizedField);
+                //var referencedLocations = parameterToNonDocCommentLocations[parameter];
+                //if (referencedLocations.Count == 0)
+                //    continue;
+
+                //// if the parameter is only referenced in a single location, and that location is initializing a
+                //// field/property already, we don't need to create a field for it.
+                //if (referencedLocations.Count == 1 && referencedLocations.Single().assignedFieldOrProperty != null)
+                //    continue;
+
+                //// it was referenced outside of a field/prop initializer.  Need to synthesize a field for it.
+                //result.Add(
+                //    parameter,
+                //    CodeGenerationSymbolFactory.CreateFieldSymbol(
+                //        )
 
             }
 
             return result.ToImmutableDictionary();
+        }
+
+        async Task<string> MakeFieldNameAsync(string parameterName)
+        {
+            var rule = await document.GetApplicableNamingRuleAsync(
+                new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Field),
+                DeclarationModifiers.None,
+                Accessibility.Private,
+                options,
+                cancellationToken).ConfigureAwait(false);
+
+            var fieldName = rule.NamingStyle.MakeCompliant(parameterName).First();
+            return NameGenerator.GenerateUniqueName(fieldName, n => namedType.Name != n && !namedType.GetMembers(n).Any());
+        }
+
+        ConstructorDeclarationSyntax CreateConstructorDeclaration()
+        {
+            var attributes = List(methodTargetingAttributes);
+            var modifiers = typeDeclaration.Modifiers
+                .Where(m => SyntaxFacts.IsAccessibilityModifier(m.Kind()))
+                .Select(m => m.WithoutTrivia().WithAppendedTrailingTrivia(Space));
+
+            using var _ = ArrayBuilder<StatementSyntax>.GetInstance(out var assignmentStatements);
+            foreach (var parameter in parameters)
+            {
+                if (!parameterToSynthesizedFields.TryGetValue(parameter, out var field))
+                    continue;
+
+                var fieldName = field.Name.ToIdentifierName();
+                var left = parameter.Name == field.Name
+                    ? MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, ThisExpression(), fieldName)
+                    : (ExpressionSyntax)fieldName;
+                var assignment = AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, left, parameter.Name.ToIdentifierName());
+                assignmentStatements.Add(ExpressionStatement(assignment));
+            }
+
+            return ConstructorDeclaration(
+                attributes,
+                TokenList(modifiers),
+                typeDeclaration.Identifier.WithoutTrivia().WithAppendedTrailingTrivia(Space),
+                parameterList.WithoutTrivia(),
+                baseType?.ArgumentList is null ? null : ConstructorInitializer(SyntaxKind.BaseConstructorInitializer, baseType.ArgumentList),
+                Block(assignmentStatements));
         }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -204,7 +204,7 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                         if (referenceLocation.IsImplicit)
                             continue;
 
-                        if (referenceLocation.Location.FindNode(cancellationToken) is not IdentifierNameSyntax identifierName)
+                        if (referenceLocation.Location.FindNode(getInnermostNodeForTie: true, cancellationToken) is not IdentifierNameSyntax identifierName)
                             continue;
 
                         // Explicitly ignore references in the base-type-list.  Tehse don't need to be rewritten as

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -218,6 +218,8 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                     // We're skipping a param node.  Remove any blank xml lines preceding this.
                     if (IsDocCommentNewLine(content.LastOrDefault()))
                         content.RemoveLast();
+                    else if (content.Count == 1 && IsEmptyDocCommentStartText(content.LastOrDefault()))
+                        content.RemoveLast();
                 }
                 else
                 {
@@ -529,5 +531,9 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
 
     private static bool IsDocCommentNewLine([NotNullWhen(true)] XmlNodeSyntax? node)
         => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralNewLineToken), (kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
+           string.IsNullOrWhiteSpace(precedingText.Text);
+
+    private static bool IsEmptyDocCommentStartText([NotNullWhen(true)] XmlNodeSyntax? node)
+        => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
            string.IsNullOrWhiteSpace(precedingText.Text);
 }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -404,23 +404,29 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                     var node = docComment.Content[i];
                     if (IsXmlElement(node, "param", out var paramElement))
                     {
-                        content.Add(node);
+                        content.Add(node);//.WithAdditionalAnnotations(Formatter.Annotation));
 
                         // if the param tag is followed with a newline, then preserve that when transferring over.
                         if (i + 1 < docComment.Content.Count && IsDocCommentNewLine(docComment.Content[i + 1]))
-                            content.Add(docComment.Content[i + 1]);
+                            content.Add(docComment.Content[i + 1]);//.WithAdditionalAnnotations(Formatter.Annotation));
                     }
                 }
 
                 if (content.Count > 0)
                 {
-                    if (!content[0].GetLeadingTrivia().Any(SyntaxKind.DocumentationCommentExteriorTrivia))
+                    if (content[0].GetLeadingTrivia().Any(SyntaxKind.DocumentationCommentExteriorTrivia))
+                    {
+                        content[0] = content[0].WithPrependedLeadingTrivia(ElasticMarker);
+                    }
+                    else
+                    {
                         content[0] = content[0].WithLeadingTrivia(DocumentationCommentExterior("/// "));
+                    }
 
                     content[^1] = content[^1].WithTrailingTrivia(EndOfLine(""));
 
                     var finalTrivia = DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, List(content));
-                    return constructorDeclaration.WithLeadingTrivia(Trivia(finalTrivia).WithAdditionalAnnotations(Formatter.Annotation));
+                    return constructorDeclaration.WithLeadingTrivia(Trivia(finalTrivia)); //.WithAdditionalAnnotations(Formatter.Annotation));
                 }
             }
 

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -249,7 +249,6 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
 
         void RemovePrimaryConstructorBaseTypeArgumentList()
         {
-            var baseType = typeDeclaration.BaseList?.Types is [PrimaryConstructorBaseTypeSyntax type, ..] ? type : null;
             if (baseType != null)
                 mainDocumentEditor.ReplaceNode(baseType, (current, _) => SimpleBaseType(((PrimaryConstructorBaseTypeSyntax)current).Type).WithTriviaFrom(baseType));
         }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -288,17 +288,17 @@ internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringP
         void AddNewFields()
         {
             mainDocumentEditor.ReplaceNode(
-            typeDeclaration,
-            (current, _) =>
-            {
-                var currentTypeDeclaration = (TypeDeclarationSyntax)current;
-                var fieldsInOrder = parameters
-                    .Select(p => parameterToSynthesizedFields.TryGetValue(p, out var field) ? field : null)
-                    .WhereNotNull();
-                var codeGenService = document.GetRequiredLanguageService<ICodeGenerationService>();
-                return codeGenService.AddMembers(
-                    currentTypeDeclaration, fieldsInOrder, contextInfo, cancellationToken);
-            });
+                typeDeclaration,
+                (current, _) =>
+                {
+                    var currentTypeDeclaration = (TypeDeclarationSyntax)current;
+                    var fieldsInOrder = parameters
+                        .Select(p => parameterToSynthesizedFields.TryGetValue(p, out var field) ? field : null)
+                        .WhereNotNull();
+                    var codeGenService = document.GetRequiredLanguageService<ICodeGenerationService>();
+                    return codeGenService.AddMembers(
+                        currentTypeDeclaration, fieldsInOrder, contextInfo, cancellationToken);
+                });
         }
 
         void AddConstructorDeclaration()

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.LanguageService;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.FindSymbols;
+using System.Linq;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
+
+[ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertPrimaryToRegularConstructor), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider()
+    : CodeRefactoringProvider
+{
+    public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+    {
+        var (document, span, cancellationToken) = context;
+        var typeDeclaration = await context.TryGetRelevantNodeAsync<TypeDeclarationSyntax>().ConfigureAwait(false);
+        if (typeDeclaration?.ParameterList is null)
+            return;
+
+        // Converting a record to a non-primary-constructor form is a lot more work (for example, having to synthesize a
+        // Deconstruct method, and figure out how to specify properties, etc.).  We can consider adding support for that
+        // scenario later if desired.
+        if (typeDeclaration is RecordDeclarationSyntax)
+            return;
+
+        var triggerSpan = TextSpan.FromBounds(typeDeclaration.SpanStart, typeDeclaration.ParameterList.FullSpan.End);
+        if (!triggerSpan.Contains(span))
+            return;
+
+        context.RegisterRefactoring(CodeAction.Create(
+            CSharpFeaturesResources.Convert_to_regular_constructor,
+            cancellationToken => ConvertAsync(document, typeDeclaration, typeDeclaration.ParameterList, cancellationToken),
+            nameof(CSharpFeaturesResources.Convert_to_regular_constructor)));
+    }
+
+    private static async Task<Solution> ConvertAsync(
+        Document document, TypeDeclarationSyntax typeDeclaration, ParameterListSyntax parameterList, CancellationToken cancellationToken)
+    {
+        // 1. Create constructor
+        // 2. Remove base arguments
+        // 3. Add fields if necessary
+        // 4. Update references to parameters to be references to fields
+        // 5. Format as appropriate
+
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var namedType = semanticModel.GetRequiredDeclaredSymbol(typeDeclaration, cancellationToken);
+
+        // We may have to update multiple files (in the case of a partial type).  Use a solution-editor to make that simple.
+        var solution = document.Project.Solution;
+        var solutionEditor = new SolutionEditor(solution);
+
+        var parameters = parameterList.Parameters.SelectAsArray(p => semanticModel.GetRequiredDeclaredSymbol(p, cancellationToken));
+
+        var parameterToNonDocCommentLocations = await GetParameterLocationsAsync(includeDocCommentLocations: false).ConfigureAwait(false);
+        var synthesizedFields = GetSynthesizedFields();
+
+        return solutionEditor.GetChangedSolution();
+
+        async Task<MultiDictionary<IParameterSymbol, (IdentifierNameSyntax referencedLocation, ISymbol? assignedFieldOrProperty)>> GetParameterLocationsAsync(bool includeDocCommentLocations)
+        {
+            var result = new MultiDictionary<IParameterSymbol, (IdentifierNameSyntax referencedLocation, ISymbol? assignedFieldOrProperty)>();
+
+            foreach (var parameter in parameters)
+            {
+                var references = await SymbolFinder.FindReferencesAsync(parameter, solution, cancellationToken).ConfigureAwait(false);
+                foreach (var reference in references)
+                {
+                    // We may hit a location multiple times due to how we do FAR for linked symbols, but each linked symbol
+                    // is allowed to report the entire set of references it think it is compatible with.  So ensure we're 
+                    // hitting each location only once.
+                    // 
+                    // Note Use DistinctBy (.Net6) once available.
+                    foreach (var referenceLocation in reference.Locations.Distinct(LinkedFileReferenceLocationEqualityComparer.Instance))
+                    {
+                        if (referenceLocation.IsImplicit)
+                            continue;
+
+                        if (referenceLocation.Location.FindNode(cancellationToken) is not IdentifierNameSyntax identifierName)
+                            continue;
+
+                        // Explicitly ignore references to the base-constructor.  We don't need to generate fields for these.
+                        if (identifierName.GetAncestor<PrimaryConstructorBaseTypeSyntax>() != null)
+                            continue;
+
+                        if (!includeDocCommentLocations && identifierName.GetAncestor<DocumentationCommentTriviaSyntax>() != null)
+                            continue;
+
+                        var expr = identifierName.WalkUpParentheses();
+                        var assignedFieldOrProperty = GetAssignedFieldOrProperty(identifierName);
+                        result.Add(parameter, (identifierName, assignedFieldOrProperty));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        // See if this is a reference to the parameter that is just initializing an existing field or property.
+        ISymbol? GetAssignedFieldOrProperty(IdentifierNameSyntax identifierName)
+        {
+            var expr = identifierName.WalkUpParentheses();
+            if (expr.Parent is EqualsValueClauseSyntax equalsValue)
+            {
+                return equalsValue.Parent is PropertyDeclarationSyntax or VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax } }
+                    ? semanticModel.GetRequiredDeclaredSymbol(equalsValue.Parent, cancellationToken)
+                    : null;
+            }
+            else if (expr.Parent is ArrowExpressionClauseSyntax arrowExpression)
+            {
+                return arrowExpression.Parent is PropertyDeclarationSyntax
+                    ? semanticModel.GetRequiredDeclaredSymbol(arrowExpression.Parent, cancellationToken)
+                    : arrowExpression.Parent is AccessorDeclarationSyntax { Parent: PropertyDeclarationSyntax }
+                        ? semanticModel.GetRequiredDeclaredSymbol(arrowExpression.Parent.Parent, cancellationToken)
+                        : null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        ImmutableDictionary<IParameterSymbol, IFieldSymbol> GetSynthesizedFields()
+        {
+            using var _ = PooledDictionary<IParameterSymbol, IFieldSymbol>.GetInstance(out var result);
+
+            foreach (var parameter in parameters)
+            {
+                var referencedLocations = parameterToNonDocCommentLocations[parameter];
+                if (referencedLocations.Count == 0)
+                    continue;
+
+                // if the parameter is only referenced in a single location, and that location is initializing a
+                // field/property already, we don't need to create a field for it.
+                if (referencedLocations.Count == 1 && referencedLocations.Single().assignedFieldOrProperty != null)
+                    continue;
+
+                // it was referenced outside of a field/prop initializer.  Need to synthesize a field for it.
+
+            }
+
+            return result.ToImmutableDictionary();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -179,7 +179,7 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                 if (lastFieldOrProperty >= 0)
                 {
                     constructorDeclaration = constructorDeclaration
-                        .WithPrependedLeadingTrivia(ElasticCarriageReturnLineFeed, ElasticCarriageReturnLineFeed);
+                        .WithPrependedLeadingTrivia(ElasticCarriageReturnLineFeed);
 
                     return currentTypeDeclaration.WithMembers(
                         currentTypeDeclaration.Members.Insert(lastFieldOrProperty + 1, constructorDeclaration));

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -112,7 +112,21 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
 
         // Remove all the initializers from existing fields/props the params are assigned to.
         foreach (var (parameter, (fieldOrProperty, initializer)) in parameterToExistingFieldOrProperty)
-            mainDocumentEditor.RemoveNode(initializer);
+        {
+            if (initializer.Parent is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                mainDocumentEditor.ReplaceNode(
+                    propertyDeclaration,
+                    propertyDeclaration
+                        .WithInitializer(null)
+                        .WithSemicolonToken(default)
+                        .WithTrailingTrivia(propertyDeclaration.GetTrailingTrivia()));
+            }
+            else
+            {
+                mainDocumentEditor.RemoveNode(initializer);
+            }
+        }
 
         // Now add all the fields.
         mainDocumentEditor.ReplaceNode(

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -201,54 +201,6 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
             return semanticModel;
         }
 
-        TypeDeclarationSyntax RemoveParamXmlElements(TypeDeclarationSyntax typeDeclaration)
-        {
-            var triviaList = typeDeclaration.GetLeadingTrivia();
-            var trivia = GetDocComment(triviaList);
-            var docComment = GetDocCommentStructure(trivia);
-            if (docComment == null)
-                return typeDeclaration;
-
-            using var _ = ArrayBuilder<XmlNodeSyntax>.GetInstance(out var content);
-
-            foreach (var node in docComment.Content)
-            {
-                if (IsXmlElement(node, "param", out var paramElement))
-                {
-                    // We're skipping a param node.  Remove any blank xml lines preceding this.
-                    if (IsDocCommentNewLine(content.LastOrDefault()))
-                        content.RemoveLast();
-                    //else if (content.Count == 1 && IsEmptyDocCommentStartText(content.LastOrDefault()))
-                    //    content.RemoveLast();
-                }
-                else
-                {
-                    content.Add(node);
-                }
-            }
-
-            if (content.All(c => c is XmlTextSyntax xmlText && xmlText.TextTokens.All(
-                    t => t.Kind() == SyntaxKind.XmlTextLiteralNewLineToken || string.IsNullOrWhiteSpace(t.Text))))
-            {
-                // Nothing but param nodes.  Just remove all the doc comments entirely.
-                var triviaIndex = triviaList.IndexOf(trivia);
-
-                // remove the doc comment itself
-                var updatedTriviaList = triviaList.RemoveAt(triviaIndex);
-
-                // If the comment was on a line that started with whitespace, remove that whitespce too.
-                if (triviaIndex > 0 && triviaList[triviaIndex - 1].IsWhitespace())
-                    updatedTriviaList = updatedTriviaList.RemoveAt(triviaIndex - 1);
-
-                return typeDeclaration.WithLeadingTrivia(updatedTriviaList);
-            }
-            else
-            {
-                var updatedTrivia = Trivia(docComment.WithContent(List(content)));
-                return typeDeclaration.WithLeadingTrivia(triviaList.Replace(trivia, updatedTrivia));
-            }
-        }
-
         async Task<MultiDictionary<IParameterSymbol, IdentifierNameSyntax>> GetParameterReferencesAsync()
         {
             var result = new MultiDictionary<IParameterSymbol, IdentifierNameSyntax>();
@@ -452,19 +404,24 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                     var node = docComment.Content[i];
                     if (IsXmlElement(node, "param", out var paramElement))
                     {
-                        // if the param tag was on a newline, the preserve that when transferring over.
-                        if (content.Count > 0 && IsDocCommentNewLine(docComment.Content[i - 1]))
-                            content.Add(docComment.Content[i - 1]);
-
                         content.Add(node);
+
+                        // if the param tag is followed with a newline, then preserve that when transferring over.
+                        if (i + 1 < docComment.Content.Count && IsDocCommentNewLine(docComment.Content[i + 1]))
+                            content.Add(docComment.Content[i + 1]);
                     }
                 }
 
                 if (content.Count > 0)
-                    content.Add(XmlText(XmlTextNewLine("\r\n", continueXmlDocumentationComment: false)));
+                {
+                    if (!content[0].GetLeadingTrivia().Any(SyntaxKind.DocumentationCommentExteriorTrivia))
+                        content[0] = content[0].WithLeadingTrivia(DocumentationCommentExterior("/// "));
 
-                if (content.Count > 0)
-                    return constructorDeclaration.WithLeadingTrivia(Trivia(DocumentationComment(content.ToArray())).WithAdditionalAnnotations(Formatter.Annotation));
+                    content[^1] = content[^1].WithTrailingTrivia(EndOfLine(""));
+
+                    var finalTrivia = DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, List(content));
+                    return constructorDeclaration.WithLeadingTrivia(Trivia(finalTrivia).WithAdditionalAnnotations(Formatter.Annotation));
+                }
             }
 
             return constructorDeclaration;
@@ -530,11 +487,112 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
         return element != null;
     }
 
-    private static bool IsDocCommentNewLine([NotNullWhen(true)] XmlNodeSyntax? node)
-        => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralNewLineToken), (kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
-           string.IsNullOrWhiteSpace(precedingText.Text);
+    //private static bool IsDocCommentNewLine([NotNullWhen(true)] XmlNodeSyntax? node)
+    //{
+    //    if (node is not XmlTextSyntax xmlText)
+    //        return false;
 
-    private static bool IsEmptyDocCommentStartText([NotNullWhen(true)] XmlNodeSyntax? node)
-        => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
-           string.IsNullOrWhiteSpace(precedingText.Text);
+    //    var textTokens = xmlText.TextTokens;
+    //    if (textTokens )
+    //    : [(kind: SyntaxKind.XmlTextLiteralNewLineToken), (kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
+    //       string.IsNullOrWhiteSpace(precedingText.Text);
+
+    //private static bool IsEmptyDocCommentStartText([NotNullWhen(true)] XmlNodeSyntax? node)
+    //    => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
+    //       string.IsNullOrWhiteSpace(precedingText.Text);
+
+    private static TypeDeclarationSyntax RemoveParamXmlElements(TypeDeclarationSyntax typeDeclaration)
+    {
+        var triviaList = typeDeclaration.GetLeadingTrivia();
+        var trivia = GetDocComment(triviaList);
+        var docComment = GetDocCommentStructure(trivia);
+        if (docComment == null)
+            return typeDeclaration;
+
+        using var _ = ArrayBuilder<XmlNodeSyntax>.GetInstance(out var content);
+
+        foreach (var node in docComment.Content)
+        {
+            if (IsXmlElement(node, "param", out var paramElement))
+            {
+                // We're skipping a param node.  Fixup any preceding text node we may have before it.
+                FixupLastTextNode();
+            }
+            else
+            {
+                content.Add(node);
+            }
+        }
+
+        if (content.All(c => c is XmlTextSyntax xmlText && xmlText.TextTokens.All(
+                t => t.Kind() == SyntaxKind.XmlTextLiteralNewLineToken || string.IsNullOrWhiteSpace(t.Text))))
+        {
+            // Nothing but param nodes.  Just remove all the doc comments entirely.
+            var triviaIndex = triviaList.IndexOf(trivia);
+
+            // remove the doc comment itself
+            var updatedTriviaList = triviaList.RemoveAt(triviaIndex);
+
+            // If the comment was on a line that started with whitespace, remove that whitespce too.
+            if (triviaIndex > 0 && triviaList[triviaIndex - 1].IsWhitespace())
+                updatedTriviaList = updatedTriviaList.RemoveAt(triviaIndex - 1);
+
+            return typeDeclaration.WithLeadingTrivia(updatedTriviaList);
+        }
+        else
+        {
+            var updatedTrivia = Trivia(docComment.WithContent(List(content)));
+            return typeDeclaration.WithLeadingTrivia(triviaList.Replace(trivia, updatedTrivia));
+        }
+
+        void FixupLastTextNode()
+        {
+            var node = content.LastOrDefault();
+            if (node is not XmlTextSyntax xmlText)
+                return;
+
+            var tokens = xmlText.TextTokens;
+            var lastIndex = tokens.Count;
+            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(tokens[lastIndex - 1].Text))
+                lastIndex--;
+
+            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
+                lastIndex--;
+
+            if (lastIndex == tokens.Count)
+            {
+                // no change necessary.
+                return;
+            }
+            else if (lastIndex == 0)
+            {
+                // Removed all tokens from the text node.  So remove the text node entirely.
+                content.RemoveLast();
+            }
+            else
+            {
+                // Otherwise, replace with newlines stripped.
+                content[^1] = xmlText.WithTextTokens(TokenList(tokens.Take(lastIndex)));
+            }
+        }
+    }
+
+    private static bool IsDocCommentNewLine(XmlNodeSyntax node)
+    {
+        if (node is not XmlTextSyntax xmlText)
+            return false;
+
+        foreach (var textToken in xmlText.TextTokens)
+        {
+            if (textToken.Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
+                continue;
+
+            if (textToken.Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(textToken.Text))
+                continue;
+
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -404,29 +402,23 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
                     var node = docComment.Content[i];
                     if (IsXmlElement(node, "param", out var paramElement))
                     {
-                        content.Add(node);//.WithAdditionalAnnotations(Formatter.Annotation));
+                        content.Add(node);
 
                         // if the param tag is followed with a newline, then preserve that when transferring over.
                         if (i + 1 < docComment.Content.Count && IsDocCommentNewLine(docComment.Content[i + 1]))
-                            content.Add(docComment.Content[i + 1]);//.WithAdditionalAnnotations(Formatter.Annotation));
+                            content.Add(docComment.Content[i + 1]);
                     }
                 }
 
                 if (content.Count > 0)
                 {
-                    if (content[0].GetLeadingTrivia().Any(SyntaxKind.DocumentationCommentExteriorTrivia))
-                    {
-                        content[0] = content[0].WithPrependedLeadingTrivia(ElasticMarker);
-                    }
-                    else
-                    {
+                    if (!content[0].GetLeadingTrivia().Any(SyntaxKind.DocumentationCommentExteriorTrivia))
                         content[0] = content[0].WithLeadingTrivia(DocumentationCommentExterior("/// "));
-                    }
 
                     content[^1] = content[^1].WithTrailingTrivia(EndOfLine(""));
 
                     var finalTrivia = DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, List(content));
-                    return constructorDeclaration.WithLeadingTrivia(Trivia(finalTrivia)); //.WithAdditionalAnnotations(Formatter.Annotation));
+                    return constructorDeclaration.WithLeadingTrivia(Trivia(finalTrivia));
                 }
             }
 

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,7 +33,7 @@ using static SyntaxFactory;
 [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertPrimaryToRegularConstructor), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider()
+internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringProvider()
     : CodeRefactoringProvider
 {
     public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
@@ -460,137 +459,5 @@ internal sealed class ConvertPrimaryToRegularConstructorCodeRefactoringProvider(
 
             return null;
         }
-    }
-
-    private static SyntaxTrivia GetDocComment(SyntaxNode node)
-        => GetDocComment(node.GetLeadingTrivia());
-
-    private static SyntaxTrivia GetDocComment(SyntaxTriviaList trivia)
-        => trivia.LastOrDefault(t => t.IsSingleLineDocComment());
-
-    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxNode node)
-        => GetDocCommentStructure(node.GetLeadingTrivia());
-
-    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTriviaList trivia)
-        => GetDocCommentStructure(GetDocComment(trivia));
-
-    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTrivia trivia)
-        => (DocumentationCommentTriviaSyntax?)trivia.GetStructure();
-
-    private static bool IsXmlElement(XmlNodeSyntax node, string name, [NotNullWhen(true)] out XmlElementSyntax? element)
-    {
-        element = node is XmlElementSyntax { StartTag.Name.LocalName.ValueText: var elementName } xmlElement && elementName == name
-            ? xmlElement
-            : null;
-        return element != null;
-    }
-
-    //private static bool IsDocCommentNewLine([NotNullWhen(true)] XmlNodeSyntax? node)
-    //{
-    //    if (node is not XmlTextSyntax xmlText)
-    //        return false;
-
-    //    var textTokens = xmlText.TextTokens;
-    //    if (textTokens )
-    //    : [(kind: SyntaxKind.XmlTextLiteralNewLineToken), (kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
-    //       string.IsNullOrWhiteSpace(precedingText.Text);
-
-    //private static bool IsEmptyDocCommentStartText([NotNullWhen(true)] XmlNodeSyntax? node)
-    //    => node is XmlTextSyntax { TextTokens: [(kind: SyntaxKind.XmlTextLiteralToken) precedingText] } &&
-    //       string.IsNullOrWhiteSpace(precedingText.Text);
-
-    private static TypeDeclarationSyntax RemoveParamXmlElements(TypeDeclarationSyntax typeDeclaration)
-    {
-        var triviaList = typeDeclaration.GetLeadingTrivia();
-        var trivia = GetDocComment(triviaList);
-        var docComment = GetDocCommentStructure(trivia);
-        if (docComment == null)
-            return typeDeclaration;
-
-        using var _ = ArrayBuilder<XmlNodeSyntax>.GetInstance(out var content);
-
-        foreach (var node in docComment.Content)
-        {
-            if (IsXmlElement(node, "param", out var paramElement))
-            {
-                // We're skipping a param node.  Fixup any preceding text node we may have before it.
-                FixupLastTextNode();
-            }
-            else
-            {
-                content.Add(node);
-            }
-        }
-
-        if (content.All(c => c is XmlTextSyntax xmlText && xmlText.TextTokens.All(
-                t => t.Kind() == SyntaxKind.XmlTextLiteralNewLineToken || string.IsNullOrWhiteSpace(t.Text))))
-        {
-            // Nothing but param nodes.  Just remove all the doc comments entirely.
-            var triviaIndex = triviaList.IndexOf(trivia);
-
-            // remove the doc comment itself
-            var updatedTriviaList = triviaList.RemoveAt(triviaIndex);
-
-            // If the comment was on a line that started with whitespace, remove that whitespce too.
-            if (triviaIndex > 0 && triviaList[triviaIndex - 1].IsWhitespace())
-                updatedTriviaList = updatedTriviaList.RemoveAt(triviaIndex - 1);
-
-            return typeDeclaration.WithLeadingTrivia(updatedTriviaList);
-        }
-        else
-        {
-            var updatedTrivia = Trivia(docComment.WithContent(List(content)));
-            return typeDeclaration.WithLeadingTrivia(triviaList.Replace(trivia, updatedTrivia));
-        }
-
-        void FixupLastTextNode()
-        {
-            var node = content.LastOrDefault();
-            if (node is not XmlTextSyntax xmlText)
-                return;
-
-            var tokens = xmlText.TextTokens;
-            var lastIndex = tokens.Count;
-            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(tokens[lastIndex - 1].Text))
-                lastIndex--;
-
-            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
-                lastIndex--;
-
-            if (lastIndex == tokens.Count)
-            {
-                // no change necessary.
-                return;
-            }
-            else if (lastIndex == 0)
-            {
-                // Removed all tokens from the text node.  So remove the text node entirely.
-                content.RemoveLast();
-            }
-            else
-            {
-                // Otherwise, replace with newlines stripped.
-                content[^1] = xmlText.WithTextTokens(TokenList(tokens.Take(lastIndex)));
-            }
-        }
-    }
-
-    private static bool IsDocCommentNewLine(XmlNodeSyntax node)
-    {
-        if (node is not XmlTextSyntax xmlText)
-            return false;
-
-        foreach (var textToken in xmlText.TextTokens)
-        {
-            if (textToken.Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
-                continue;
-
-            if (textToken.Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(textToken.Text))
-                continue;
-
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider_DocumentationComments.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider_DocumentationComments.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
+
+using static SyntaxFactory;
+
+internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringProvider
+{
+    private static SyntaxTrivia GetDocComment(SyntaxNode node)
+        => GetDocComment(node.GetLeadingTrivia());
+
+    private static SyntaxTrivia GetDocComment(SyntaxTriviaList trivia)
+        => trivia.LastOrDefault(t => t.IsSingleLineDocComment());
+
+    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxNode node)
+        => GetDocCommentStructure(node.GetLeadingTrivia());
+
+    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTriviaList trivia)
+        => GetDocCommentStructure(GetDocComment(trivia));
+
+    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTrivia trivia)
+        => (DocumentationCommentTriviaSyntax?)trivia.GetStructure();
+
+    private static bool IsXmlElement(XmlNodeSyntax node, string name, [NotNullWhen(true)] out XmlElementSyntax? element)
+    {
+        element = node is XmlElementSyntax { StartTag.Name.LocalName.ValueText: var elementName } xmlElement && elementName == name
+            ? xmlElement
+            : null;
+        return element != null;
+    }
+
+    private static TypeDeclarationSyntax RemoveParamXmlElements(TypeDeclarationSyntax typeDeclaration)
+    {
+        var triviaList = typeDeclaration.GetLeadingTrivia();
+        var trivia = GetDocComment(triviaList);
+        var docComment = GetDocCommentStructure(trivia);
+        if (docComment == null)
+            return typeDeclaration;
+
+        using var _ = ArrayBuilder<XmlNodeSyntax>.GetInstance(out var content);
+
+        foreach (var node in docComment.Content)
+        {
+            if (IsXmlElement(node, "param", out var paramElement))
+            {
+                // We're skipping a param node.  Fixup any preceding text node we may have before it.
+                FixupLastTextNode();
+            }
+            else
+            {
+                content.Add(node);
+            }
+        }
+
+        if (content.All(c => c is XmlTextSyntax xmlText && xmlText.TextTokens.All(
+                t => t.Kind() == SyntaxKind.XmlTextLiteralNewLineToken || string.IsNullOrWhiteSpace(t.Text))))
+        {
+            // Nothing but param nodes.  Just remove all the doc comments entirely.
+            var triviaIndex = triviaList.IndexOf(trivia);
+
+            // remove the doc comment itself
+            var updatedTriviaList = triviaList.RemoveAt(triviaIndex);
+
+            // If the comment was on a line that started with whitespace, remove that whitespce too.
+            if (triviaIndex > 0 && triviaList[triviaIndex - 1].IsWhitespace())
+                updatedTriviaList = updatedTriviaList.RemoveAt(triviaIndex - 1);
+
+            return typeDeclaration.WithLeadingTrivia(updatedTriviaList);
+        }
+        else
+        {
+            var updatedTrivia = Trivia(docComment.WithContent(List(content)));
+            return typeDeclaration.WithLeadingTrivia(triviaList.Replace(trivia, updatedTrivia));
+        }
+
+        void FixupLastTextNode()
+        {
+            var node = content.LastOrDefault();
+            if (node is not XmlTextSyntax xmlText)
+                return;
+
+            var tokens = xmlText.TextTokens;
+            var lastIndex = tokens.Count;
+            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(tokens[lastIndex - 1].Text))
+                lastIndex--;
+
+            if (lastIndex - 1 >= 0 && tokens[lastIndex - 1].Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
+                lastIndex--;
+
+            if (lastIndex == tokens.Count)
+            {
+                // no change necessary.
+                return;
+            }
+            else if (lastIndex == 0)
+            {
+                // Removed all tokens from the text node.  So remove the text node entirely.
+                content.RemoveLast();
+            }
+            else
+            {
+                // Otherwise, replace with newlines stripped.
+                content[^1] = xmlText.WithTextTokens(TokenList(tokens.Take(lastIndex)));
+            }
+        }
+    }
+
+    private static bool IsDocCommentNewLine(XmlNodeSyntax node)
+    {
+        if (node is not XmlTextSyntax xmlText)
+            return false;
+
+        foreach (var textToken in xmlText.TextTokens)
+        {
+            if (textToken.Kind() == SyntaxKind.XmlTextLiteralNewLineToken)
+                continue;
+
+            if (textToken.Kind() == SyntaxKind.XmlTextLiteralToken && string.IsNullOrWhiteSpace(textToken.Text))
+                continue;
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider_DocumentationComments.cs
+++ b/src/Features/CSharp/Portable/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorCodeRefactoringProvider_DocumentationComments.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -17,17 +16,8 @@ using static SyntaxFactory;
 
 internal sealed partial class ConvertPrimaryToRegularConstructorCodeRefactoringProvider
 {
-    private static SyntaxTrivia GetDocComment(SyntaxNode node)
-        => GetDocComment(node.GetLeadingTrivia());
-
     private static SyntaxTrivia GetDocComment(SyntaxTriviaList trivia)
         => trivia.LastOrDefault(t => t.IsSingleLineDocComment());
-
-    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxNode node)
-        => GetDocCommentStructure(node.GetLeadingTrivia());
-
-    private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTriviaList trivia)
-        => GetDocCommentStructure(GetDocComment(trivia));
 
     private static DocumentationCommentTriviaSyntax? GetDocCommentStructure(SyntaxTrivia trivia)
         => (DocumentationCommentTriviaSyntax?)trivia.GetStructure();

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Převést na nezpracovaný řetězec</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Převést na běžný řetězec</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">In Rohzeichenfolge konvertieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">In reguläre Zeichenfolge konvertieren</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Convertir en cadena sin formato</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Convertir en cadena regular</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Convertir en chaîne brute</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Convertir en chaîne classique</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Converti in stringa non elaborata</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Converti in stringa normale</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">生文字列に変換する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">正規文字列に変換する</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">원시 문자열로 변환</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">일반 문자열로 변환</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Konwertuj na nieprzetworzony ciąg</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Konwertuj na zwykły ciąg</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Converter em cadeia de caracteres bruta</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Converter para cadeia de caracteres regular</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Преобразовать в необработанную строку</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Преобразовать в обычную строку</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Ham dizeye dönüştür</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">Normal dizeye dönüştür</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">转换为原始字符串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">转换为正则字符串</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">轉換成原始字串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Convert_to_regular_constructor">
+        <source>Convert to regular constructor</source>
+        <target state="new">Convert to regular constructor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Convert_to_regular_string">
         <source>Convert to regular string</source>
         <target state="translated">轉換為一般字串</target>

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -406,6 +406,32 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
+    public async Task TestWithComplexRightSide2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int i)|]
+                {
+                    private int i = i * i;
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private int i;
+
+                    public C(int i)
+                    {
+                        this.i = i * i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestBlockWithMultipleAssignments1()
     {
         await new VerifyCS.Test

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -477,7 +477,6 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -505,7 +504,6 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -534,7 +532,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     private long J { get; } = j;
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -589,7 +586,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -628,7 +624,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -667,7 +662,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -706,7 +700,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -747,7 +740,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -790,7 +782,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -833,7 +824,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -950,24 +940,24 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                /// <summary>Doc comment on single line</summary>
+                /// <param name="i">Doc about i single line</param>
+                class [|C(int i)|]
+                {
+                    private int i = i;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int i;
 
                     /// <summary>Doc comment on single line</summary>
                     /// <param name="i">Doc about i single line</param>
-                    public [|C|](int i)
+                    public C(int i)
                     {
                         this.i = i;
                     }
-                }
-                """,
-            FixedCode = """
-                /// <summary>Doc comment on single line</summary>
-                /// <param name="i">Doc about i single line</param>
-                class C(int i)
-                {
-                    private int i = i;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -982,6 +972,23 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines
+                    /// </summary>
+                    /// <param name="i">
+                    /// Doc about i
+                    /// on multiple lines
+                    /// </param>
+                    class [|C(int i)|]
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
                     class C
                     {
                         private int i;
@@ -994,27 +1001,10 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// Doc about i
                         /// on multiple lines
                         /// </param>
-                        public [|C|](int i)
+                        public C(int i)
                         {
                             this.i = i;
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>
-                    /// Doc comment
-                    /// On multiple lines
-                    /// </summary>
-                    /// <param name="i">
-                    /// Doc about i
-                    /// on multiple lines
-                    /// </param>
-                    class C(int i)
-                    {
-                        private int i = i;
                     }
                 }
                 """,
@@ -1030,6 +1020,21 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines</summary>
+                    /// <param name="i">
+                    /// Doc about i
+                    /// on multiple lines</param>
+                    class [|C(int i)|]
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
                     class C
                     {
                         private int i;
@@ -1040,25 +1045,10 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// <param name="i">
                         /// Doc about i
                         /// on multiple lines</param>
-                        public [|C|](int i)
+                        public C(int i)
                         {
                             this.i = i;
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>
-                    /// Doc comment
-                    /// On multiple lines</summary>
-                    /// <param name="i">
-                    /// Doc about i
-                    /// on multiple lines</param>
-                    class C(int i)
-                    {
-                        private int i = i;
                     }
                 }
                 """,
@@ -1074,6 +1064,19 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
+                    /// <summary>Doc comment
+                    /// On multiple lines</summary>
+                    /// <param name="i">Doc about i
+                    /// on multiple lines</param>
+                    class [|C(int i)|]
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
                     class C
                     {
                         private int i;
@@ -1082,23 +1085,10 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// On multiple lines</summary>
                         /// <param name="i">Doc about i
                         /// on multiple lines</param>
-                        public [|C|](int i)
+                        public C(int i)
                         {
                             this.i = i;
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>Doc comment
-                    /// On multiple lines</summary>
-                    /// <param name="i">Doc about i
-                    /// on multiple lines</param>
-                    class C(int i)
-                    {
-                        private int i = i;
                     }
                 }
                 """,
@@ -1117,20 +1107,14 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// Existing doc comment
                     /// </summary>
-                    class C
+                    /// <remarks>Constructor comment
+                    /// On multiple lines</remarks>
+                    /// <param name="i">Doc about i</param>
+                    /// <param name="i">Doc about j</param>
+                    class [|C(int i, int j)|]
                     {
-                        private int i;
-                        private int j;
-
-                        /// <summary>Constructor comment
-                        /// On multiple lines</summary>
-                        /// <param name="i">Doc about i</param>
-                        /// <param name="i">Doc about j</param>
-                        public [|C|](int i, int j)
-                        {
-                            this.i = i;
-                            this.j = j;
-                        }
+                        private int i = i;
+                        private int j = j;
                     }
                 }
                 """,
@@ -1140,14 +1124,20 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// Existing doc comment
                     /// </summary>
-                    /// <remarks>Constructor comment
-                    /// On multiple lines</remarks>
-                    /// <param name="i">Doc about i</param>
-                    /// <param name="i">Doc about j</param>
-                    class C(int i, int j)
+                    class C
                     {
-                        private int i = i;
-                        private int j = j;
+                        private int i;
+                        private int j;
+
+                        /// <summary>Constructor comment
+                        /// On multiple lines</summary>
+                        /// <param name="i">Doc about i</param>
+                        /// <param name="i">Doc about j</param>
+                        public C(int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
                     }
                 }
                 """,
@@ -1164,6 +1154,22 @@ public class ConvertPrimaryToRegularConstructorTests
                 namespace N
                 {
                     /// <summary>Existing doc comment</summary>
+                    /// <remarks>Constructor comment</remarks>
+                    /// <param name="i">Doc about
+                    /// i</param>
+                    /// <param name="i">Doc about
+                    /// j</param>
+                    class [|C(int i, int j)|]
+                    {
+                        private int i = i;
+                        private int j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>Existing doc comment</summary>
                     class C
                     {
                         private int i;
@@ -1174,27 +1180,11 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// i</param>
                         /// <param name="i">Doc about
                         /// j</param>
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.i = i;
                             this.j = j;
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>Existing doc comment</summary>
-                    /// <remarks>Constructor comment</remarks>
-                    /// <param name="i">Doc about
-                    /// i</param>
-                    /// <param name="i">Doc about
-                    /// j</param>
-                    class C(int i, int j)
-                    {
-                        private int i = i;
-                        private int j = j;
                     }
                 }
                 """,
@@ -1210,6 +1200,18 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
+                    /// <param name="i">Docs for i.</param>
+                    /// <param name="j">
+                    /// Docs for j.
+                    /// </param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
                     class C
                     {
                         /// <summary>Docs for i.</summary>
@@ -1219,7 +1221,7 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// </summary>
                         private int j;
 
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.i = i;
                             this.j = j;
@@ -1227,19 +1229,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <param name="i">Docs for i.</param>
-                    /// <param name="j">
-                    /// Docs for j.
-                    /// </param>
-                    class C(int i, int j)
-                    {
-                    }
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1252,6 +1241,18 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
+                    /// <param name="i">Docs for x.</param>
+                    /// <param name="j">
+                    /// Docs for y.
+                    /// </param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
                     class C
                     {
                         /// <summary>Docs for x.</summary>
@@ -1261,7 +1262,7 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// </summary>
                         private int y;
 
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.x = i;
                             this.y = j;
@@ -1269,19 +1270,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <param name="i">Docs for x.</param>
-                    /// <param name="j">
-                    /// Docs for y.
-                    /// </param>
-                    class C(int i, int j)
-                    {
-                    }
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1297,20 +1285,12 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// C docs
                     /// </summary>
-                    class C
+                    /// <param name="i">Docs for i.</param>
+                    /// <param name="j">
+                    /// Docs for j.
+                    /// </param>
+                    class [|C(int i, int j)|]
                     {
-                        /// <summary>Docs for i.</summary>
-                        private int i;
-                        /// <summary>
-                        /// Docs for j.
-                        /// </summary>
-                        private int j;
-
-                        public [|C|](int i, int j)
-                        {
-                            this.i = i;
-                            this.j = j;
-                        }
                     }
                 }
                 """,
@@ -1320,16 +1300,23 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// C docs
                     /// </summary>
-                    /// <param name="i">Docs for i.</param>
-                    /// <param name="j">
-                    /// Docs for j.
-                    /// </param>
-                    class C(int i, int j)
+                    class C
                     {
+                        /// <summary>Docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Docs for j.
+                        /// </summary>
+                        private int j;
+
+                        public C(int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
                     }
                 }
                 """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1345,6 +1332,19 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// C docs
                     /// </summary>
+                    /// <param name="i">Param docs for i</param>
+                    /// <param name="j">Param docs for j</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
                     class C
                     {
                         /// <summary>Field docs for i.</summary>
@@ -1356,7 +1356,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                         /// <param name="i">Param docs for i</param>
                         /// <param name="j">Param docs for j</param>
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.i = i;
                             this.j = j;
@@ -1364,20 +1364,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>
-                    /// C docs
-                    /// </summary>
-                    /// <param name="i">Param docs for i</param>
-                    /// <param name="j">Param docs for j</param>
-                    class C(int i, int j)
-                    {
-                    }
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1393,6 +1379,19 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// C docs
                     /// </summary>
+                    /// <param name="j">Param docs for j</param>
+                    /// <param name="i">Field docs for i.</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
                     class C
                     {
                         /// <summary>Field docs for i.</summary>
@@ -1403,7 +1402,7 @@ public class ConvertPrimaryToRegularConstructorTests
                         private int j;
 
                         /// <param name="j">Param docs for j</param>
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.i = i;
                             this.j = j;
@@ -1411,20 +1410,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>
-                    /// C docs
-                    /// </summary>
-                    /// <param name="j">Param docs for j</param>
-                    /// <param name="i">Field docs for i.</param>
-                    class C(int i, int j)
-                    {
-                    }
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1440,6 +1425,21 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// C docs
                     /// </summary>
+                    /// <param name="i">Param docs for i</param>
+                    /// <param name="j">
+                    /// Field docs for j.
+                    /// </param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
                     class C
                     {
                         /// <summary>Field docs for i.</summary>
@@ -1450,7 +1450,7 @@ public class ConvertPrimaryToRegularConstructorTests
                         private int j;
 
                         /// <param name="i">Param docs for i</param>
-                        public [|C|](int i, int j)
+                        public C(int i, int j)
                         {
                             this.i = i;
                             this.j = j;
@@ -1458,192 +1458,9 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                namespace N
-                {
-                    /// <summary>
-                    /// C docs
-                    /// </summary>
-                    /// <param name="i">Param docs for i</param>
-                    /// <param name="j">
-                    /// Field docs for j.
-                    /// </param>
-                    class C(int i, int j)
-                    {
-                    }
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
-
-    [Fact]
-    public async Task TestFixAll1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    public [|C|](int i)
-                    {
-                    }
-                }
-
-                class D
-                {
-                    public [|D|](int j)
-                    {
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                }
-
-                class D(int j)
-                {
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestFixAll2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    public [|C|](int i)
-                    {
-                    }
-                
-                    class D
-                    {
-                        public [|D|](int j)
-                        {
-                        }
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                    class D(int j)
-                    {
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestFixAll3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int i;
-
-                    public [|C|](int i)
-                    {
-                        this.i = i;
-                    }
-                
-                    class D
-                    {
-                        private int J { get; }
-
-                        public [|D|](int j)
-                        {
-                            this.J = j;
-                        }
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                    private int i = i;
-
-                    class D(int j)
-                    {
-                        private int J { get; } = j;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    //[Fact]
-    //public async Task TestFixAll4()
-    //{
-    //    await new VerifyCS.Test
-    //    {
-    //        TestCode = """
-    //            using System;
-    //            class C
-    //            {
-    //                private int i;
-
-    //                public [|C|](int i)
-    //                {
-    //                    this.i = i;
-    //                }
-
-    //                void M()
-    //                {
-    //                    Console.WriteLine(i);
-    //                }
-                
-    //                class D
-    //                {
-    //                    private int J { get; }
-
-    //                    public [|D|](int j)
-    //                    {
-    //                        this.J = j;
-    //                    }
-                
-    //                    void N()
-    //                    {
-    //                        Console.WriteLine(J);
-    //                    }
-    //                }
-    //            }
-    //            """,
-    //        FixedCode = """
-    //            using System;
-    //            class C(int i)
-    //            {
-    //                void M()
-    //                {
-    //                    Console.WriteLine(i);
-    //                }
-
-    //                class D(int j)
-    //                {
-    //                    void N()
-    //                    {
-    //                        Console.WriteLine(j);
-    //                    }
-    //                }
-    //            }
-    //            """,
-    //        LanguageVersion = LanguageVersion.CSharp12,
-    //        CodeActionIndex = 1,
-    //        NumberOfFixAllIterations = 1,
-    //    }.RunAsync();
-    //}
 
     [Fact]
     public async Task TestMoveConstructorAttributes1()
@@ -1652,19 +1469,19 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                using System;
+               [method: Obsolete("", error: true)]
+               class [|C(int i)|]
+               {
+               }
+               """,
+            FixedCode = """
+               using System;
                class C
                {
                    [Obsolete("", error: true)]
                    public [|C|](int i)
                    {
                    }
-               }
-               """,
-            FixedCode = """
-               using System;
-               [method: Obsolete("", error: true)]
-               class C(int i)
-               {
                }
                """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -1679,20 +1496,20 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                using System;
                [Obsolete("", error: true)]
-               class C
+               [method: Obsolete("", error: true)]
+               class [|C(int i)|]
                {
-                   [Obsolete("", error: true)]
-                   public [|C|](int i)
-                   {
-                   }
                }
                """,
             FixedCode = """
                using System;
                [Obsolete("", error: true)]
-               [method: Obsolete("", error: true)]
-               class C(int i)
+               class C
                {
+                   [Obsolete("", error: true)]
+                   public C(int i)
+                   {
+                   }
                }
                """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -1706,26 +1523,26 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+
+                namespace N
+                {
+                    [method: Obsolete("", error: true)]
+                    class [|C(int i)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
      
                 namespace N
                 {
                     class C
                     {
                         [Obsolete("", error: true)]
-                        public [|C|](int i)
+                        public C(int i)
                         {
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace N
-                {
-                    [method: Obsolete("", error: true)]
-                    class C(int i)
-                    {
                     }
                 }
                 """,
@@ -1740,6 +1557,18 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    [method: Obsolete("", error: true)]
+                    class [|C(int i)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
      
                 namespace N
                 {
@@ -1747,21 +1576,9 @@ public class ConvertPrimaryToRegularConstructorTests
                     class C
                     {
                         [Obsolete("", error: true)]
-                        public [|C|](int i)
+                        public C(int i)
                         {
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace N
-                {
-                    [Obsolete("", error: true)]
-                    [method: Obsolete("", error: true)]
-                    class C(int i)
-                    {
                     }
                 }
                 """,
@@ -1776,6 +1593,18 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+
+                namespace N
+                {
+                    [method: Obsolete("", error: true)]
+                    class [|C(int i)|]
+                    {
+                        int x;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
      
                 namespace N
                 {
@@ -1784,21 +1613,9 @@ public class ConvertPrimaryToRegularConstructorTests
                         int x;
 
                         [Obsolete("", error: true)]
-                        public [|C|](int i)
+                        public C(int i)
                         {
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace N
-                {
-                    [method: Obsolete("", error: true)]
-                    class C(int i)
-                    {
-                        int x;
                     }
                 }
                 """,
@@ -1813,6 +1630,19 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    [method: Obsolete("", error: true)]
+                    class [|C(int i)|]
+                    {
+                        int x;
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
      
                 namespace N
                 {
@@ -1822,22 +1652,9 @@ public class ConvertPrimaryToRegularConstructorTests
                         int x;
 
                         [Obsolete("", error: true)]
-                        public [|C|](int i)
+                        public C(int i)
                         {
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace N
-                {
-                    [Obsolete("", error: true)]
-                    [method: Obsolete("", error: true)]
-                    class C(int i)
-                    {
-                        int x;
                     }
                 }
                 """,
@@ -1854,23 +1671,23 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
 
                 [Serializable]
-                class C
+                [method: CLSCompliant(false)]
+                [method: Obsolete("", error: true)]
+                class [|C(int i)|]
                 {
-                    [CLSCompliant(false)]
-                    [Obsolete("", error: true)]
-                    public [|C|](int i)
-                    {
-                    }
                 }
                 """,
             FixedCode = """
                 using System;
 
                 [Serializable]
-                [method: CLSCompliant(false)]
-                [method: Obsolete("", error: true)]
-                class C(int i)
+                class C
                 {
+                    [CLSCompliant(false)]
+                    [Obsolete("", error: true)]
+                    public C(int i)
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -1886,6 +1703,17 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
 
                 [Serializable]
+                [method: CLSCompliant(false)]
+                [method: Obsolete("", error: true)]
+                class [|C(int i)|]
+                {
+                    int x;
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                [Serializable]
                 class C
                 {
                     int x;
@@ -1895,17 +1723,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     public [|C|](int i)
                     {
                     }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                [Serializable]
-                [method: CLSCompliant(false)]
-                [method: Obsolete("", error: true)]
-                class C(int i)
-                {
-                    int x;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -1920,20 +1737,20 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System;
 
+                class [|C(int i,
+                    int j)|]
+                {
+                }
+                """,
+            FixedCode = """
+                using System;
+
                 class C
                 {
                     public [|C|](int i,
                         int j)
                     {
                     }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                class C(int i,
-                    int j)
-                {
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -1950,12 +1767,9 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C
+                    class [|C(int i,
+                        int j)|]
                     {
-                        public [|C|](int i,
-                            int j)
-                        {
-                        }
                     }
                 }
                 """,
@@ -1964,9 +1778,12 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C(int i,
-                        int j)
+                    class C
                     {
+                        public [|C|](int i,
+                            int j)
+                        {
+                        }
                     }
                 }
                 """,
@@ -1982,22 +1799,22 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System;
 
-                class C
+                class [|C(
+                    int i,
+                    int j)|]
                 {
-                    public [|C|](
-                        int i,
-                        int j)
-                    {
-                    }
                 }
                 """,
             FixedCode = """
                 using System;
 
-                class C(
-                    int i,
-                    int j)
+                class C
                 {
+                    public C(
+                        int i,
+                        int j)
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2014,13 +1831,10 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C
+                    class [|C(
+                        int i,
+                        int j)|]
                     {
-                        public [|C|](
-                            int i,
-                            int j)
-                        {
-                        }
                     }
                 }
                 """,
@@ -2029,10 +1843,13 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C(
-                        int i,
-                        int j)
+                    class C
                     {
+                        public C(
+                            int i,
+                            int j)
+                        {
+                        }
                     }
                 }
                 """,
@@ -2048,20 +1865,20 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System;
 
-                class C
+                class [|C(
+                    int i, int j)|]
                 {
-                    public [|C|](
-                        int i, int j)
-                    {
-                    }
                 }
                 """,
             FixedCode = """
                 using System;
 
-                class C(
-                    int i, int j)
+                class C
                 {
+                    public C(
+                        int i, int j)
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2078,12 +1895,9 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C
+                    class [|C(
+                        int i, int j)|]
                     {
-                        public [|C|](
-                            int i, int j)
-                        {
-                        }
                     }
                 }
                 """,
@@ -2092,9 +1906,12 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C(
-                        int i, int j)
+                    class C
                     {
+                        public C(
+                            int i, int j)
+                        {
+                        }
                     }
                 }
                 """,
@@ -2110,22 +1927,22 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System;
 
-                class C
-                {
-                    public [|C|](
+                class [|C(
                 int i,
-                int j)
-                    {
-                    }
+                int j)|]
+                {
                 }
                 """,
             FixedCode = """
                 using System;
 
-                class C(
+                class C
+                {
+                    public C(
                 int i,
                 int j)
-                {
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2142,13 +1959,10 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C
-                    {
-                        public [|C|](
+                    class [|C(
                 int i,
-                int j)
-                        {
-                        }
+                int j)|]
+                    {
                     }
                 }
                 """,
@@ -2157,10 +1971,13 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 namespace N
                 {
-                    class C(
+                    class C
+                    {
+                        public C(
                 int i,
                 int j)
-                    {
+                        {
+                        }
                     }
                 }
                 """,
@@ -2174,21 +1991,21 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(C.D d)|]
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     public class D
                     {
                     }
 
-                    public [|C|](D d)
-                    {
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(C.D d)
-                {
-                    public class D
+                    public C(D d)
                     {
                     }
                 }
@@ -2205,13 +2022,9 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System.Collections.Generic;
 
-                class C<T>
+                class [|C<T>(List<C<T>.D> d)|]
                 {
                     public class D
-                    {
-                    }
-
-                    public [|C|](List<D> d)
                     {
                     }
                 }
@@ -2219,9 +2032,13 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 using System.Collections.Generic;
 
-                class C<T>(List<C<T>.D> d)
+                class C<T>
                 {
                     public class D
+                    {
+                    }
+
+                    public C(List<D> d)
                     {
                     }
                 }
@@ -2236,21 +2053,21 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(C.D d)|]
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     public class D
                     {
                     }
 
-                    public [|C|](C.D d)
-                    {
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(C.D d)
-                {
-                    public class D
+                    public C(C.D d)
                     {
                     }
                 }
@@ -2267,13 +2084,9 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 using System.Collections.Generic;
 
-                class C<T>
+                class [|C<T>(List<C<T>.D> d)|]
                 {
                     public class D
-                    {
-                    }
-
-                    public [|C|](List<C<T>.D> d)
                     {
                     }
                 }
@@ -2281,31 +2094,14 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 using System.Collections.Generic;
 
-                class C<T>(List<C<T>.D> d)
+                class C<T>
                 {
                     public class D
                     {
                     }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
 
-    [Fact]
-    public async Task TestNotWithNonAutoProperty()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    // Can't assign a primary constructor parameter to a non-auto property.
-                    private int I { get { return 0; } set { } }
-
-                    public C(int i)
+                    public C(List<C<T>.D> d)
                     {
-                        this.I = i;
                     }
                 }
                 """,
@@ -2319,20 +2115,20 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(in int i)|]
+                {
+                    private int i = i;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int i;
 
-                    public [|C|](in int i)
+                    public C(in int i)
                     {
                         this.i = i;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(in int i)
-                {
-                    private int i = i;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2345,211 +2141,18 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i)|]
+                {
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int i;
 
-                    public [|C|](in int i)
+                    public C(in int i)
                     {
                         this.i = i;
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                }
-                """,
-            CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    public C(int i)
-                    {
-                #if NET6
-                        Console.WriteLine();
-                #endif
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    public C(int i)
-                    {
-                #if false
-                        Console.WriteLine();
-                #endif
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                #if NET6
-                        => _i = i;
-                #else
-                        => this._i = i;
-                #endif
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion4()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                #if true
-                        => _i = i;
-                #else
-                        => this._i = i;
-                #endif
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion5()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                #if false
-                        => _i = i;
-                #else
-                        => this._i = i;
-                #endif
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion6()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                    {
-                #if true
-                        _i = i;
-                #endif
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion7()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                    {
-                #if true
-                        _i = i;
-                #else
-                        this._i = i;
-                #endif
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithPreprocessorRegion8()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                class C
-                {
-                    private int _i;
-
-                    public C(int i)
-                    {
-                #if false
-                        _i = i;
-                #else
-                        this._i = i;
-                #endif
                     }
                 }
                 """,
@@ -2563,6 +2166,16 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i)|]
+                {
+                
+                    #region constructors
+
+                    #endregion
+
+                }
+                """,
+            FixedCode = """
                 class C
                 {
 
@@ -2571,16 +2184,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     public [|C|](int i)
                     {
                     }
-
-                    #endregion
-
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                
-                    #region constructors
 
                     #endregion
 
@@ -2596,14 +2199,10 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
+                class [|C(int i)|]
                 {
 
                     #region constructors
-
-                    public [|C|](int i)
-                    {
-                    }
 
                     public C(string s) : this(s.Length)
                     {
@@ -2614,10 +2213,14 @@ public class ConvertPrimaryToRegularConstructorTests
                 }
                 """,
             FixedCode = """
-                class C(int i)
+                class C
                 {
 
                     #region constructors
+
+                    public C(int i)
+                    {
+                    }
 
                     public C(string s) : this(s.Length)
                     {
@@ -2640,23 +2243,23 @@ public class ConvertPrimaryToRegularConstructorTests
                 /// <summary>
                 /// Provides strongly typed wrapper around <see cref="_i"/>.
                 /// </summary>
-                class C
+                class [|C(int i)|]
                 {
-                    private int _i;
-
-                    public [|C|](int i)
-                    {
-                        _i = i;
-                    }
+                    private int _i = i;
                 }
                 """,
             FixedCode = """
                 /// <summary>
                 /// Provides strongly typed wrapper around <see cref="_i"/>.
                 /// </summary>
-                class C(int i)
+                class C
                 {
-                    private int _i = i;
+                    private int _i;
+
+                    public C(int i)
+                    {
+                        _i = i;
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2670,6 +2273,14 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 /// <summary>
+                /// Provides strongly typed wrapper around <paramref name="i"/>.
+                /// </summary>
+                class [|C(int i)|]
+                {
+                }
+                """,
+            FixedCode = """
+                /// <summary>
                 /// Provides strongly typed wrapper around <see cref="_i"/>.
                 /// </summary>
                 class C
@@ -2682,15 +2293,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                /// <summary>
-                /// Provides strongly typed wrapper around <paramref name="i"/>.
-                /// </summary>
-                class C(int i)
-                {
-                }
-                """,
-            CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -2701,22 +2303,22 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i = C.Default)|]
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private const int Default = 0;
                     private int _i;
 
-                    public [|C|](int i = Default)
+                    public C(int i = Default)
                     {
                         _i = i;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(int i = C.Default)
-                {
-                    private const int Default = 0;
-                    private int _i = i;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2729,22 +2331,22 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i = C.Default)|]
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private const int Default = 0;
                     private int _i;
 
-                    public [|C|](int i = C.Default)
+                    public C(int i = C.Default)
                     {
                         _i = i;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(int i = C.Default)
-                {
-                    private const int Default = 0;
-                    private int _i = i;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2757,22 +2359,22 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C<T>(int i = C<T>.Default)|]
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            FixedCode = """
                 class C<T>
                 {
                     private const int Default = 0;
                     private int _i;
 
-                    public [|C|](int i = Default)
+                    public C(int i = Default)
                     {
                         _i = i;
                     }
-                }
-                """,
-            FixedCode = """
-                class C<T>(int i = C<T>.Default)
-                {
-                    private const int Default = 0;
-                    private int _i = i;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2785,6 +2387,37 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                using System;
+
+                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
+                {
+                    /// <summary>
+                    /// Active instruction identifier.
+                    /// It has the information necessary to track an active instruction within the debug session.
+                    /// </summary>
+                    /// <remarks>
+                    /// Creates an ActiveInstructionId.
+                    /// </remarks>
+                    /// <param name="method">Method which the instruction is scoped to.</param>
+                    /// <param name="ilOffset">IL offset for the instruction.</param>
+                    [CLSCompliant(false)]
+                    internal readonly struct [|ManagedInstructionId(
+                        string method,
+                        int ilOffset)|]
+                    {
+                        /// <summary>
+                        /// Method which the instruction is scoped to.
+                        /// </summary>
+                        public string Method { get; } = method;
+
+                        /// <summary>
+                        /// The IL offset for the instruction.
+                        /// </summary>
+                        public int ILOffset { get; } = ilOffset;
+                    }
+                }
+                """,
+            FixedCode = """
                 using System;
 
                 namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
@@ -2811,44 +2444,13 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// </summary>
                         /// <param name="method">Method which the instruction is scoped to.</param>
                         /// <param name="ilOffset">IL offset for the instruction.</param>
-                        public [|ManagedInstructionId|](
+                        public ManagedInstructionId(
                             string method,
                             int ilOffset)
                         {
                             Method = method;
                             ILOffset = ilOffset;
                         }
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
-                {
-                    /// <summary>
-                    /// Active instruction identifier.
-                    /// It has the information necessary to track an active instruction within the debug session.
-                    /// </summary>
-                    /// <remarks>
-                    /// Creates an ActiveInstructionId.
-                    /// </remarks>
-                    /// <param name="method">Method which the instruction is scoped to.</param>
-                    /// <param name="ilOffset">IL offset for the instruction.</param>
-                    [CLSCompliant(false)]
-                    internal readonly struct ManagedInstructionId(
-                        string method,
-                        int ilOffset)
-                    {
-                        /// <summary>
-                        /// Method which the instruction is scoped to.
-                        /// </summary>
-                        public string Method { get; } = method;
-
-                        /// <summary>
-                        /// The IL offset for the instruction.
-                        /// </summary>
-                        public int ILOffset { get; } = ilOffset;
                     }
                 }
                 """,

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -951,11 +951,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 namespace N
                 {
+                    /// <summary>Doc comment on single line</summary>
                     class C
                     {
                         private int i;
 
-                        /// <summary>Doc comment on single line</summary>
                         /// <param name="i">Doc about i single line</param>
                         public C(int i)
                         {
@@ -990,11 +990,11 @@ public class ConvertPrimaryToRegularConstructorTests
                 namespace N
                 {
                 #if true
+                    /// <summary>Doc comment on single line</summary>
                     class C
                     {
                         private int i;
 
-                        /// <summary>Doc comment on single line</summary>
                         /// <param name="i">Doc about i single line</param>
                         public C(int i)
                         {
@@ -1022,11 +1022,11 @@ public class ConvertPrimaryToRegularConstructorTests
                 }
                 """,
             FixedCode = """
+                /// <summary>Doc comment on single line</summary>
                 class C
                 {
                     private int i;
 
-                    /// <summary>Doc comment on single line</summary>
                     /// <param name="i">Doc about i single line</param>
                     public C(int i)
                     {
@@ -1052,7 +1052,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 }
                 """,
             FixedCode = """
-                /// <summary>Doc comment on single line</summary>
+                ///<summary>Doc comment on single line</summary>
                 class C
                 {
                     private int i;
@@ -1139,13 +1139,13 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 namespace N
                 {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines</summary>
                     class C
                     {
                         private int i;
 
-                        /// <summary>
-                        /// Doc comment
-                        /// On multiple lines</summary>
                         /// <param name="i">
                         /// Doc about i
                         /// on multiple lines</param>
@@ -1181,12 +1181,12 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 namespace N
                 {
+                    /// <summary>Doc comment
+                    /// On multiple lines</summary>
                     class C
                     {
                         private int i;
 
-                        /// <summary>Doc comment
-                        /// On multiple lines</summary>
                         /// <param name="i">Doc about i
                         /// on multiple lines</param>
                         public C(int i)
@@ -1276,13 +1276,13 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// <summary>
                     /// Existing doc comment
                     /// </summary>
+                    /// <remarks>Constructor comment
+                    /// On multiple lines</remarks>
                     class C
                     {
                         private int i;
                         private int j;
 
-                        /// <summary>Constructor comment
-                        /// On multiple lines</summary>
                         /// <param name="i">Doc about i</param>
                         /// <param name="i">Doc about j</param>
                         public C(int i, int j)
@@ -1322,12 +1322,12 @@ public class ConvertPrimaryToRegularConstructorTests
                 namespace N
                 {
                     /// <summary>Existing doc comment</summary>
+                    /// <remarks>Constructor comment</remarks>
                     class C
                     {
                         private int i;
                         private int j;
 
-                        /// <summary>Constructor comment</summary>
                         /// <param name="i">Doc about
                         /// i</param>
                         /// <param name="i">Doc about

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -345,7 +345,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                     public C(int i)
                     {
-                        this.I = i;
+                        I = i;
                     }
                 }
                 """,
@@ -462,11 +462,20 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembers1()
+    public async Task TestRemoveMembers1_Used()
     {
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i, int j)|]
+                {
+                    int M()
+                    {
+                        return i + j;
+                    }
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int i;
@@ -477,11 +486,33 @@ public class ConvertPrimaryToRegularConstructorTests
                         this.i = i;
                         this.j = j;
                     }
+
+                    int M()
+                    {
+                        return i + j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembers1_Unused()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int i, int j)|]
+                {
                 }
                 """,
             FixedCode = """
-                class C(int i, int j)
+                class C
                 {
+                    public C(int i, int j)
+                    {
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -2181,12 +2212,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-
-                    #region constructors
-
-                    public [|C|](int i)
+                    public C(int i)
                     {
                     }
+
+                    #region constructors
 
                     #endregion
 
@@ -2218,12 +2248,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-
-                    #region constructors
-
                     public C(int i)
                     {
                     }
+
+                    #region constructors
 
                     public C(string s) : this(s.Length)
                     {

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -1,0 +1,3080 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertPrimaryToRegularConstructor;
+
+using VerifyCS = CSharpCodeRefactoringVerifier<ConvertPrimaryToRegularConstructorCodeRefactoringProvider>;
+
+public class ConvertPrimaryToRegularConstructorTests
+{
+    [Fact]
+    public async Task TestInCSharp12()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int i)|]
+                {
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    public C(int i)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithNonPublicConstructor()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private C(int i)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestStruct()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                struct C
+                {
+                    public [|C|](int i)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                struct C(int i)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithUnchainedConstructor()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public C(int i)
+                    {
+                    }
+
+                    public C()
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithThisChainedConstructor()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public [|C|](int i)
+                    {
+                    }
+
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBaseChainedConstructor1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B(int i)
+                {
+                }
+
+                class C : B
+                {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class B(int i)
+                {
+                }
+
+                class C(int i) : B(i)
+                {
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBaseChainedConstructor2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B(int i)
+                {
+                }
+
+                class C : B
+                {
+                    public [|C|](int i) : base(i * i)
+                    {
+                    }
+
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class B(int i)
+                {
+                }
+
+                class C(int i) : B(i * i)
+                {
+                    public C() : this(0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBaseChainedConstructor3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C : B
+                {
+                    public [|C|](int i, int j) : base(i,
+                        j)
+                    {
+                    }
+
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C(int i, int j) : B(i,
+                    j)
+                {
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBaseChainedConstructor4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C : B
+                {
+                    public [|C|](int i, int j) : base(
+                        i, j)
+                    {
+                    }
+
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C(int i, int j) : B(
+                    i, j)
+                {
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBaseChainedConstructor5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C : B
+                {
+                    public [|C|](int i, int j) : base(
+                        i,
+                        j)
+                    {
+                    }
+
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class B(int i, int j)
+                {
+                }
+
+                class C(int i, int j) : B(
+                    i,
+                    j)
+                {
+                    public C() : this(0, 0)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithBadExpressionBody()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public C(int i)
+                        => System.Console.WriteLine(i);
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithBadBlockBody()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public C(int i)
+                    {
+                        System.Console.WriteLine(i);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExpressionBodyAssignmentToField1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](int i)
+                        => this.i = i;
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    private int i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExpressionBodyAssignmentToProperty1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int I { get; }
+
+                    public [|C|](int i)
+                        => this.I = i;
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    private int I { get; } = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExpressionBodyAssignmentToField2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](int j)
+                        => this.i = j;
+                }
+                """,
+            FixedCode = """
+                class C(int j)
+                {
+                    private int i = j;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithExpressionBodyAssignmentToField3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](int j)
+                        => i = j;
+                }
+                """,
+            FixedCode = """
+                class C(int j)
+                {
+                    private int i = j;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithAssignmentToBaseField1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B
+                {
+                    public int i;
+                }
+
+                class C : B
+                {
+                    public C(int i)
+                        => this.i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithAssignmentToBaseField2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class B
+                {
+                    public int i;
+                }
+
+                class C : B
+                {
+                    public C(int i)
+                        => base.i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithCompoundAssignmentToField()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int i;
+
+                    public C(int i)
+                        => this.i += i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithTwoWritesToTheSameMember()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int i;
+
+                    public C(int i, int j)
+                    {
+                        this.i = i;
+                        this.i = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithComplexRightSide1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](int i)
+                        => this.i = i * 2;
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    private int i = i * 2;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestBlockWithMultipleAssignments1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int i;
+                    public int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    public int i = i;
+                    public int j = j;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestBlockWithMultipleAssignments2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int i, j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    public int i = i, j = j;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembers1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+                    private int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembers2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int I { get; }
+                    private int J { get; }
+
+                    public [|C|](int i, int j)
+                    {
+                        this.I = i;
+                        this.J = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersOnlyWithMatchingType()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int I { get; }
+                    private long J { get; }
+
+                    public [|C|](int i, int j)
+                    {
+                        this.I = i;
+                        this.J = j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i, int j)
+                {
+                    private long J { get; } = j;
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestDoNotRemovePublicMembers1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public int i;
+                    public int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task DoNotRemoveMembersUsedInNestedTypes()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class OuterType
+                {
+                    private int _i;
+                    private int _j;
+
+                    public [|OuterType|](int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    public struct Enumerator
+                    {
+                        private int _i;
+
+                        public Enumerator(OuterType c)
+                        {
+                            _i = c._i;
+                            Console.WriteLine(c);
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class OuterType(int i, int j)
+                {
+                    private int _i = i;
+
+                    public struct Enumerator
+                    {
+                        private int _i;
+                
+                        public Enumerator(OuterType c)
+                        {
+                            _i = c._i;
+                            Console.WriteLine(c);
+                        }
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersUpdateReferences1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class C
+                {
+                    private int i;
+                    private int j;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+
+                    void M()
+                    {
+                        Console.WriteLine(this.i + this.j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C(int i, int j)
+                {
+                    void M()
+                    {
+                        Console.WriteLine(i + j);
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersUpdateReferences2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class C
+                {
+                    private int i;
+                    private int j;
+
+                    public [|C|](int @this, int @delegate)
+                    {
+                        this.i = @this;
+                        this.j = @delegate;
+                    }
+
+                    void M()
+                    {
+                        Console.WriteLine(this.i + this.j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C(int @this, int @delegate)
+                {
+                    void M()
+                    {
+                        Console.WriteLine(@this + @delegate);
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersUpdateReferencesWithRename1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class C
+                {
+                    private int _i;
+                    private int _j;
+
+                    public [|C|](int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    void M()
+                    {
+                        Console.WriteLine(_i + _j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C(int i, int j)
+                {
+                    void M()
+                    {
+                        Console.WriteLine(i + j);
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersOnlyPrivateMembers()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class C
+                {
+                    private int _i;
+                    public int _j;
+
+                    public [|C|](int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    void M()
+                    {
+                        Console.WriteLine(_i + _j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C(int i, int j)
+                {
+                    public int _j = j;
+
+                    void M()
+                    {
+                        Console.WriteLine(i + _j);
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersOnlyMembersWithoutAttributes()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+            using System;
+            class C
+            {
+                private int _i;
+                [CLSCompliant(true)]
+                private int _j;
+
+                public [|C|](int i, int j)
+                {
+                    _i = i;
+                    _j = j;
+                }
+
+                void M()
+                {
+                    Console.WriteLine(_i + _j);
+                }
+            }
+            """,
+            FixedCode = """
+            using System;
+            class C(int i, int j)
+            {
+                [CLSCompliant(true)]
+                private int _j = j;
+
+                void M()
+                {
+                    Console.WriteLine(i + _j);
+                }
+            }
+            """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersAccessedOffThis()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class C
+                {
+                    private int _i;
+                    private int _j;
+
+                    public [|C|](int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    void M(C c)
+                    {
+                        Console.WriteLine(_i);
+                        Console.WriteLine(_j == c._j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C(int i, int j)
+                {
+                    private int _j = j;
+
+                    void M(C c)
+                    {
+                        Console.WriteLine(i);
+                        Console.WriteLine(_j == c._j);
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWhenRightSideReferencesThis1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int x;
+
+                    public C(int i)
+                    {
+                        x = M(i);
+                    }
+
+                    int M(int y) => y;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWhenRightSideReferencesThis2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int x;
+
+                    public C(int i)
+                    {
+                        x = this.M(i);
+                    }
+
+                    int M(int y) => y;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWhenRightSideDoesNotReferenceThis()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int x;
+
+                    public [|C|](int i)
+                    {
+                        x = M(i);
+                    }
+
+                    static int M(int y) => y;
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    private int x = M(i);
+
+                    static int M(int y) => y;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        private int i;
+
+                        /// <summary>Doc comment on single line</summary>
+                        /// <param name="i">Doc about i single line</param>
+                        public [|C|](int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>Doc comment on single line</summary>
+                    /// <param name="i">Doc about i single line</param>
+                    class C(int i)
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_IfDef1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                #if true
+                    class C
+                    {
+                        private int i;
+
+                        /// <summary>Doc comment on single line</summary>
+                        /// <param name="i">Doc about i single line</param>
+                        public [|C|](int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                #endif
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                #if true
+                    /// <summary>Doc comment on single line</summary>
+                    /// <param name="i">Doc about i single line</param>
+                    class C(int i)
+                    {
+                        private int i = i;
+                    }
+                #endif
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    /// <summary>Doc comment on single line</summary>
+                    /// <param name="i">Doc about i single line</param>
+                    public [|C|](int i)
+                    {
+                        this.i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary>Doc comment on single line</summary>
+                /// <param name="i">Doc about i single line</param>
+                class C(int i)
+                {
+                    private int i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        private int i;
+
+                        /// <summary>
+                        /// Doc comment
+                        /// On multiple lines
+                        /// </summary>
+                        /// <param name="i">
+                        /// Doc about i
+                        /// on multiple lines
+                        /// </param>
+                        public [|C|](int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines
+                    /// </summary>
+                    /// <param name="i">
+                    /// Doc about i
+                    /// on multiple lines
+                    /// </param>
+                    class C(int i)
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        private int i;
+
+                        /// <summary>
+                        /// Doc comment
+                        /// On multiple lines</summary>
+                        /// <param name="i">
+                        /// Doc about i
+                        /// on multiple lines</param>
+                        public [|C|](int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines</summary>
+                    /// <param name="i">
+                    /// Doc about i
+                    /// on multiple lines</param>
+                    class C(int i)
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        private int i;
+
+                        /// <summary>Doc comment
+                        /// On multiple lines</summary>
+                        /// <param name="i">Doc about i
+                        /// on multiple lines</param>
+                        public [|C|](int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>Doc comment
+                    /// On multiple lines</summary>
+                    /// <param name="i">Doc about i
+                    /// on multiple lines</param>
+                    class C(int i)
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorParamDocCommentsIntoTypeDocComments1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// Existing doc comment
+                    /// </summary>
+                    class C
+                    {
+                        private int i;
+                        private int j;
+
+                        /// <summary>Constructor comment
+                        /// On multiple lines</summary>
+                        /// <param name="i">Doc about i</param>
+                        /// <param name="i">Doc about j</param>
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// Existing doc comment
+                    /// </summary>
+                    /// <remarks>Constructor comment
+                    /// On multiple lines</remarks>
+                    /// <param name="i">Doc about i</param>
+                    /// <param name="i">Doc about j</param>
+                    class C(int i, int j)
+                    {
+                        private int i = i;
+                        private int j = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorParamDocCommentsIntoTypeDocComments2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>Existing doc comment</summary>
+                    class C
+                    {
+                        private int i;
+                        private int j;
+
+                        /// <summary>Constructor comment</summary>
+                        /// <param name="i">Doc about
+                        /// i</param>
+                        /// <param name="i">Doc about
+                        /// j</param>
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>Existing doc comment</summary>
+                    /// <remarks>Constructor comment</remarks>
+                    /// <param name="i">Doc about
+                    /// i</param>
+                    /// <param name="i">Doc about
+                    /// j</param>
+                    class C(int i, int j)
+                    {
+                        private int i = i;
+                        private int j = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        /// <summary>Docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Docs for j.
+                        /// </summary>
+                        private int j;
+
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <param name="i">Docs for i.</param>
+                    /// <param name="j">
+                    /// Docs for j.
+                    /// </param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments_MembersWithDifferentNames1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        /// <summary>Docs for x.</summary>
+                        private int x;
+                        /// <summary>
+                        /// Docs for y.
+                        /// </summary>
+                        private int y;
+
+                        public [|C|](int i, int j)
+                        {
+                            this.x = i;
+                            this.y = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <param name="i">Docs for x.</param>
+                    /// <param name="j">
+                    /// Docs for y.
+                    /// </param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenTypeDocComments1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    class C
+                    {
+                        /// <summary>Docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Docs for j.
+                        /// </summary>
+                        private int j;
+
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    /// <param name="i">Docs for i.</param>
+                    /// <param name="j">
+                    /// Docs for j.
+                    /// </param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersKeepConstructorDocs1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    class C
+                    {
+                        /// <summary>Field docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Field docs for j.
+                        /// </summary>
+                        private int j;
+
+                        /// <param name="i">Param docs for i</param>
+                        /// <param name="j">Param docs for j</param>
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    /// <param name="i">Param docs for i</param>
+                    /// <param name="j">Param docs for j</param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersKeepConstructorDocs2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    class C
+                    {
+                        /// <summary>Field docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Field docs for j.
+                        /// </summary>
+                        private int j;
+
+                        /// <param name="j">Param docs for j</param>
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    /// <param name="j">Param docs for j</param>
+                    /// <param name="i">Field docs for i.</param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersKeepConstructorDocs3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    class C
+                    {
+                        /// <summary>Field docs for i.</summary>
+                        private int i;
+                        /// <summary>
+                        /// Field docs for j.
+                        /// </summary>
+                        private int j;
+
+                        /// <param name="i">Param docs for i</param>
+                        public [|C|](int i, int j)
+                        {
+                            this.i = i;
+                            this.j = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    /// <summary>
+                    /// C docs
+                    /// </summary>
+                    /// <param name="i">Param docs for i</param>
+                    /// <param name="j">
+                    /// Field docs for j.
+                    /// </param>
+                    class C(int i, int j)
+                    {
+                    }
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestFixAll1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public [|C|](int i)
+                    {
+                    }
+                }
+
+                class D
+                {
+                    public [|D|](int j)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                }
+
+                class D(int j)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestFixAll2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public [|C|](int i)
+                    {
+                    }
+                
+                    class D
+                    {
+                        public [|D|](int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    class D(int j)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestFixAll3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](int i)
+                    {
+                        this.i = i;
+                    }
+                
+                    class D
+                    {
+                        private int J { get; }
+
+                        public [|D|](int j)
+                        {
+                            this.J = j;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                    private int i = i;
+
+                    class D(int j)
+                    {
+                        private int J { get; } = j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    //[Fact]
+    //public async Task TestFixAll4()
+    //{
+    //    await new VerifyCS.Test
+    //    {
+    //        TestCode = """
+    //            using System;
+    //            class C
+    //            {
+    //                private int i;
+
+    //                public [|C|](int i)
+    //                {
+    //                    this.i = i;
+    //                }
+
+    //                void M()
+    //                {
+    //                    Console.WriteLine(i);
+    //                }
+                
+    //                class D
+    //                {
+    //                    private int J { get; }
+
+    //                    public [|D|](int j)
+    //                    {
+    //                        this.J = j;
+    //                    }
+                
+    //                    void N()
+    //                    {
+    //                        Console.WriteLine(J);
+    //                    }
+    //                }
+    //            }
+    //            """,
+    //        FixedCode = """
+    //            using System;
+    //            class C(int i)
+    //            {
+    //                void M()
+    //                {
+    //                    Console.WriteLine(i);
+    //                }
+
+    //                class D(int j)
+    //                {
+    //                    void N()
+    //                    {
+    //                        Console.WriteLine(j);
+    //                    }
+    //                }
+    //            }
+    //            """,
+    //        LanguageVersion = LanguageVersion.CSharp12,
+    //        CodeActionIndex = 1,
+    //        NumberOfFixAllIterations = 1,
+    //    }.RunAsync();
+    //}
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+               using System;
+               class C
+               {
+                   [Obsolete("", error: true)]
+                   public [|C|](int i)
+                   {
+                   }
+               }
+               """,
+            FixedCode = """
+               using System;
+               [method: Obsolete("", error: true)]
+               class C(int i)
+               {
+               }
+               """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes1A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+               using System;
+               [Obsolete("", error: true)]
+               class C
+               {
+                   [Obsolete("", error: true)]
+                   public [|C|](int i)
+                   {
+                   }
+               }
+               """,
+            FixedCode = """
+               using System;
+               [Obsolete("", error: true)]
+               [method: Obsolete("", error: true)]
+               class C(int i)
+               {
+               }
+               """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+     
+                namespace N
+                {
+                    class C
+                    {
+                        [Obsolete("", error: true)]
+                        public [|C|](int i)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    [method: Obsolete("", error: true)]
+                    class C(int i)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes2A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+     
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    class C
+                    {
+                        [Obsolete("", error: true)]
+                        public [|C|](int i)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    [method: Obsolete("", error: true)]
+                    class C(int i)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+     
+                namespace N
+                {
+                    class C
+                    {
+                        int x;
+
+                        [Obsolete("", error: true)]
+                        public [|C|](int i)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    [method: Obsolete("", error: true)]
+                    class C(int i)
+                    {
+                        int x;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes3A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+     
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    class C
+                    {
+                        int x;
+
+                        [Obsolete("", error: true)]
+                        public [|C|](int i)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    [Obsolete("", error: true)]
+                    [method: Obsolete("", error: true)]
+                    class C(int i)
+                    {
+                        int x;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                [Serializable]
+                class C
+                {
+                    [CLSCompliant(false)]
+                    [Obsolete("", error: true)]
+                    public [|C|](int i)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                [Serializable]
+                [method: CLSCompliant(false)]
+                [method: Obsolete("", error: true)]
+                class C(int i)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorAttributes4A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                [Serializable]
+                class C
+                {
+                    int x;
+                
+                    [CLSCompliant(false)]
+                    [Obsolete("", error: true)]
+                    public [|C|](int i)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                [Serializable]
+                [method: CLSCompliant(false)]
+                [method: Obsolete("", error: true)]
+                class C(int i)
+                {
+                    int x;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public [|C|](int i,
+                        int j)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C(int i,
+                    int j)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove1A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                namespace N
+                {
+                    class C
+                    {
+                        public [|C|](int i,
+                            int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    class C(int i,
+                        int j)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public [|C|](
+                        int i,
+                        int j)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C(
+                    int i,
+                    int j)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove2A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                namespace N
+                {
+                    class C
+                    {
+                        public [|C|](
+                            int i,
+                            int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    class C(
+                        int i,
+                        int j)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public [|C|](
+                        int i, int j)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C(
+                    int i, int j)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove3A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                namespace N
+                {
+                    class C
+                    {
+                        public [|C|](
+                            int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    class C(
+                        int i, int j)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public [|C|](
+                int i,
+                int j)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                class C(
+                int i,
+                int j)
+                {
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMultipleParametersMove4A()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                namespace N
+                {
+                    class C
+                    {
+                        public [|C|](
+                int i,
+                int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace N
+                {
+                    class C(
+                int i,
+                int j)
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToNestedType1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public class D
+                    {
+                    }
+
+                    public [|C|](D d)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(C.D d)
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToNestedType2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C<T>
+                {
+                    public class D
+                    {
+                    }
+
+                    public [|C|](List<D> d)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                class C<T>(List<C<T>.D> d)
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToNestedType3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    public class D
+                    {
+                    }
+
+                    public [|C|](C.D d)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(C.D d)
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToNestedType4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System.Collections.Generic;
+
+                class C<T>
+                {
+                    public class D
+                    {
+                    }
+
+                    public [|C|](List<C<T>.D> d)
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                using System.Collections.Generic;
+
+                class C<T>(List<C<T>.D> d)
+                {
+                    public class D
+                    {
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithNonAutoProperty()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    // Can't assign a primary constructor parameter to a non-auto property.
+                    private int I { get { return 0; } set { } }
+
+                    public C(int i)
+                    {
+                        this.I = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInParameter1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](in int i)
+                    {
+                        this.i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(in int i)
+                {
+                    private int i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestInParameter2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private int i;
+
+                    public [|C|](in int i)
+                    {
+                        this.i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public C(int i)
+                    {
+                #if NET6
+                        Console.WriteLine();
+                #endif
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    public C(int i)
+                    {
+                #if false
+                        Console.WriteLine();
+                #endif
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                #if NET6
+                        => _i = i;
+                #else
+                        => this._i = i;
+                #endif
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                #if true
+                        => _i = i;
+                #else
+                        => this._i = i;
+                #endif
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                #if false
+                        => _i = i;
+                #else
+                        => this._i = i;
+                #endif
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                    {
+                #if true
+                        _i = i;
+                #endif
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion7()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                    {
+                #if true
+                        _i = i;
+                #else
+                        this._i = i;
+                #endif
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestNotWithPreprocessorRegion8()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                class C
+                {
+                    private int _i;
+
+                    public C(int i)
+                    {
+                #if false
+                        _i = i;
+                #else
+                        this._i = i;
+                #endif
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithRegionDirective1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+
+                    #region constructors
+
+                    public [|C|](int i)
+                    {
+                    }
+
+                    #endregion
+
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+                
+                    #region constructors
+
+                    #endregion
+
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithRegionDirective2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+
+                    #region constructors
+
+                    public [|C|](int i)
+                    {
+                    }
+
+                    public C(string s) : this(s.Length)
+                    {
+                    }
+
+                    #endregion
+
+                }
+                """,
+            FixedCode = """
+                class C(int i)
+                {
+
+                    #region constructors
+
+                    public C(string s) : this(s.Length)
+                    {
+                    }
+
+                    #endregion
+
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSeeTag1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C
+                {
+                    private int _i;
+
+                    public [|C|](int i)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C(int i)
+                {
+                    private int _i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestSeeTag2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <see cref="_i"/>.
+                /// </summary>
+                class C
+                {
+                    private int _i;
+
+                    public [|C|](int i)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                /// <summary>
+                /// Provides strongly typed wrapper around <paramref name="i"/>.
+                /// </summary>
+                class C(int i)
+                {
+                }
+                """,
+            CodeActionIndex = 1,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToConstantInParameterInitializer1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private const int Default = 0;
+                    private int _i;
+
+                    public [|C|](int i = Default)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i = C.Default)
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToConstantInParameterInitializer2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C
+                {
+                    private const int Default = 0;
+                    private int _i;
+
+                    public [|C|](int i = C.Default)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C(int i = C.Default)
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestReferenceToConstantInParameterInitializer3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class C<T>
+                {
+                    private const int Default = 0;
+                    private int _i;
+
+                    public [|C|](int i = Default)
+                    {
+                        _i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C<T>(int i = C<T>.Default)
+                {
+                    private const int Default = 0;
+                    private int _i = i;
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMergeConstructorSummaryIntoTypeDocComment()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+
+                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
+                {
+                    /// <summary>
+                    /// Active instruction identifier.
+                    /// It has the information necessary to track an active instruction within the debug session.
+                    /// </summary>
+                    [CLSCompliant(false)]
+                    internal readonly struct ManagedInstructionId
+                    {
+                        /// <summary>
+                        /// Method which the instruction is scoped to.
+                        /// </summary>
+                        public string Method { get; }
+                
+                        /// <summary>
+                        /// The IL offset for the instruction.
+                        /// </summary>
+                        public int ILOffset { get; }
+
+                        /// <summary>
+                        /// Creates an ActiveInstructionId.
+                        /// </summary>
+                        /// <param name="method">Method which the instruction is scoped to.</param>
+                        /// <param name="ilOffset">IL offset for the instruction.</param>
+                        public [|ManagedInstructionId|](
+                            string method,
+                            int ilOffset)
+                        {
+                            Method = method;
+                            ILOffset = ilOffset;
+                        }
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+
+                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
+                {
+                    /// <summary>
+                    /// Active instruction identifier.
+                    /// It has the information necessary to track an active instruction within the debug session.
+                    /// </summary>
+                    /// <remarks>
+                    /// Creates an ActiveInstructionId.
+                    /// </remarks>
+                    /// <param name="method">Method which the instruction is scoped to.</param>
+                    /// <param name="ilOffset">IL offset for the instruction.</param>
+                    [CLSCompliant(false)]
+                    internal readonly struct ManagedInstructionId(
+                        string method,
+                        int ilOffset)
+                    {
+                        /// <summary>
+                        /// Method which the instruction is scoped to.
+                        /// </summary>
+                        public string Method { get; } = method;
+
+                        /// <summary>
+                        /// The IL offset for the instruction.
+                        /// </summary>
+                        public int ILOffset { get; } = ilOffset;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+}

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -1381,6 +1381,102 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <param name="i">Docs for i.</param> 
+                    /// <param name="j">Docs for j.</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        /// <param name="i">Docs for i.</param> 
+                        /// <param name="j">Docs for j.</param>
+                        public C(int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments5()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <param name="i">Docs for i.</param> 
+                    /// <param name="j">Docs for j.</param> 
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        /// <param name="i">Docs for i.</param> 
+                        /// <param name="j">Docs for j.</param> 
+                        public C(int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments6()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    /// <param name="i">Docs for i.</param> 
+                    ///<param name="j">Docs for j.</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        /// <param name="i">Docs for i.</param> 
+                        ///<param name="j">Docs for j.</param>
+                        public C(int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments2()
     {
         await new VerifyCS.Test
@@ -1402,7 +1498,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        /// <param name="i">Docs for i.</param>
+                        ///<param name="i">Docs for i.</param>
                         ///<param name="j">
                         ///Docs for j.
                         ///</param>
@@ -1436,7 +1532,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        /// <param name="i">Docs for i.</param>
+                        ///<param name="i">Docs for i.</param>
                         ///<param name="j">Docs for j.</param>
                         public C(int i, int j)
                         {
@@ -2654,6 +2750,9 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// Active instruction identifier.
                     /// It has the information necessary to track an active instruction within the debug session.
                     /// </summary>
+                    /// <remarks>
+                    /// Creates an ActiveInstructionId.
+                    /// </remarks>
                     [CLSCompliant(false)]
                     internal readonly struct ManagedInstructionId
                     {
@@ -2667,9 +2766,6 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// </summary>
                         public int ILOffset { get; }
 
-                        /// <summary>
-                        /// Creates an ActiveInstructionId.
-                        /// </summary>
                         /// <param name="method">Method which the instruction is scoped to.</param>
                         /// <param name="ilOffset">IL offset for the instruction.</param>
                         public ManagedInstructionId(

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -557,54 +557,27 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembers2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int I { get; }
-                    private int J { get; }
-
-                    public [|C|](int i, int j)
-                    {
-                        this.I = i;
-                        this.J = j;
-                    }
-                }
-                """,
-            FixedCode = """
-                class C(int i, int j)
-                {
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
     public async Task TestRemoveMembersOnlyWithMatchingType()
     {
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i, int j)|]
+                {
+                    private long J { get; } = j;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int I { get; }
                     private long J { get; }
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         this.I = i;
                         this.J = j;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(int i, int j)
-                {
-                    private long J { get; } = j;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -881,8 +854,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int _i;
                     private int _j;
+                    private int _i;
 
                     public C(int i, int j)
                     {
@@ -898,6 +871,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+            EditorConfig = FieldNamesCamelCaseWithFieldUnderscorePrefixEditorConfig,
         }.RunAsync();
     }
 
@@ -1420,19 +1394,10 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// </summary>
                     class C
                     {
-                        /// <summary>Field docs for i.</summary>
-                        private int i;
-                        /// <summary>
-                        /// Field docs for j.
-                        /// </summary>
-                        private int j;
-
                         /// <param name="i">Param docs for i</param>
                         /// <param name="j">Param docs for j</param>
                         public C(int i, int j)
                         {
-                            this.i = i;
-                            this.j = j;
                         }
                     }
                 }

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -47,6 +47,11 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
                 """,
+            FixedCode = """
+                record class C(int i)
+                {
+                }
+                """,
             LanguageVersion = LanguageVersion.CSharp12,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
@@ -2002,11 +2007,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-                    public class D
+                    public C(D d)
                     {
                     }
 
-                    public C(D d)
+                    public class D
                     {
                     }
                 }
@@ -2035,11 +2040,11 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 class C<T>
                 {
-                    public class D
+                    public C(List<D> d)
                     {
                     }
 
-                    public C(List<D> d)
+                    public class D
                     {
                     }
                 }
@@ -2064,11 +2069,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-                    public class D
+                    public C(D d)
                     {
                     }
 
-                    public C(C.D d)
+                    public class D
                     {
                     }
                 }
@@ -2097,11 +2102,11 @@ public class ConvertPrimaryToRegularConstructorTests
 
                 class C<T>
                 {
-                    public class D
+                    public C(List<D> d)
                     {
                     }
 
-                    public C(List<C<T>.D> d)
+                    public class D
                     {
                     }
                 }
@@ -2341,7 +2346,7 @@ public class ConvertPrimaryToRegularConstructorTests
                     private const int Default = 0;
                     private int _i;
 
-                    public C(int i = C.Default)
+                    public C(int i = Default)
                     {
                         _i = i;
                     }

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -313,7 +313,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithBlockBodyAssignmentToField1()
+    public async Task TestWithReferenceOnlyInExistingSameNamedField()
     {
         await new VerifyCS.Test
         {
@@ -339,7 +339,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithBlockBodyAssignmentToProperty1()
+    public async Task TestWithReferenceOnlyInPropertyInitializer1()
     {
         await new VerifyCS.Test
         {
@@ -365,7 +365,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithBlockBodyAssignmentToField2()
+    public async Task TestWithReferenceInDifferentNamedField()
     {
         await new VerifyCS.Test
         {
@@ -391,7 +391,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithComplexRightSide1()
+    public async Task TestWithComplexFieldInitializer1()
     {
         await new VerifyCS.Test
         {
@@ -417,7 +417,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithComplexRightSide2()
+    public async Task TestWithComplexFieldInitializer2()
     {
         await new VerifyCS.Test
         {
@@ -443,7 +443,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithComplexRightSide3()
+    public async Task TestWithComplexFieldInitializer3()
     {
         await new VerifyCS.Test
         {
@@ -472,7 +472,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestBlockWithMultipleAssignments1()
+    public async Task TestMultipleParametersWithFieldInitializers1()
     {
         await new VerifyCS.Test
         {
@@ -501,7 +501,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestBlockWithMultipleAssignments2()
+    public async Task TestMultipleParametersWithFieldInitializers2()
     {
         await new VerifyCS.Test
         {
@@ -528,7 +528,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembers1_Used()
+    public async Task TestWithParametersReferencedOutsideOfConstructor()
     {
         await new VerifyCS.Test
         {
@@ -564,7 +564,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembers1_Used_Written1()
+    public async Task TestWithParametersReferencedOutsideOfConstructor_Mutation1()
     {
         await new VerifyCS.Test
         {
@@ -600,7 +600,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembers1_Unused()
+    public async Task TestWithoutParametersReferencedOutsideOfConstructor()
     {
         await new VerifyCS.Test
         {
@@ -622,7 +622,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersOnlyWithMatchingType()
+    public async Task TestAssignmentToPropertyOfDifferentType()
     {
         await new VerifyCS.Test
         {
@@ -648,7 +648,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestNestedTypes()
+    public async Task TestAssignedToFieldUsedInNestedType()
     {
         await new VerifyCS.Test
         {
@@ -700,7 +700,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersUpdateReferences1()
+    public async Task TestWithNotMutatedReferencesOutsideOfConstructor1()
     {
         await new VerifyCS.Test
         {
@@ -738,7 +738,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersUpdateReferences2()
+    public async Task TestEscapedParameterNames()
     {
         await new VerifyCS.Test
         {
@@ -776,45 +776,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersUpdateReferencesWithRename1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-                class [|C(int i, int j)|]
-                {
-                    void M()
-                    {
-                        Console.WriteLine(i + j);
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-                class C
-                {
-                    private readonly int i;
-                    private readonly int j;
-
-                    public C(int i, int j)
-                    {
-                        this.i = i;
-                        this.j = j;
-                    }
-
-                    void M()
-                    {
-                        Console.WriteLine(i + j);
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestRemoveMembersOnlyPrivateMembers()
+    public async Task TestWithNotMutatedReferencesOutsideOfConstructor2()
     {
         await new VerifyCS.Test
         {
@@ -854,7 +816,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersOnlyMembersWithoutAttributes()
+    public async Task TestWithNotMutatedReferencesOutsideOfConstructor3()
     {
         await new VerifyCS.Test
         {
@@ -896,7 +858,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersAccessedOffThis1()
+    public async Task TestGenerateUnderscoreName1()
     {
         await new VerifyCS.Test
         {
@@ -939,7 +901,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersAccessedOffThis2()
+    public async Task TestGenerateUnderscoreName2()
     {
         await new VerifyCS.Test
         {
@@ -982,7 +944,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWhenRightSideDoesNotReferenceThis()
+    public async Task TestComplexFieldInitializer()
     {
         await new VerifyCS.Test
         {
@@ -1012,7 +974,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_1()
+    public async Task TestMoveParamDocs1()
     {
         await new VerifyCS.Test
         {
@@ -1048,7 +1010,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_IfDef1()
+    public async Task TestMoveParamDocs2()
     {
         await new VerifyCS.Test
         {
@@ -1088,37 +1050,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                /// <summary>Doc comment on single line</summary>
-                /// <param name="i">Doc about i single line</param>
-                class [|C(int i)|]
-                {
-                    private int i = i;
-                }
-                """,
-            FixedCode = """
-                /// <summary>Doc comment on single line</summary>
-                class C
-                {
-                    private int i;
-
-                    /// <param name="i">Doc about i single line</param>
-                    public C(int i)
-                    {
-                        this.i = i;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_3()
+    public async Task TestMoveParamDocs3()
     {
         await new VerifyCS.Test
         {
@@ -1148,7 +1080,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_1()
+    public async Task TestMoveParamDocs4()
     {
         await new VerifyCS.Test
         {
@@ -1196,7 +1128,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_2()
+    public async Task TestMoveParamDocs5()
     {
         await new VerifyCS.Test
         {
@@ -1240,7 +1172,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_3()
+    public async Task TestMoveParamDocs6()
     {
         await new VerifyCS.Test
         {
@@ -1280,7 +1212,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_4()
+    public async Task TestMoveParamDocs7()
     {
         await new VerifyCS.Test
         {
@@ -1328,7 +1260,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorParamDocCommentsIntoTypeDocComments1()
+    public async Task TestMoveParamDocs9()
     {
         await new VerifyCS.Test
         {
@@ -1377,7 +1309,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestMoveConstructorParamDocCommentsIntoTypeDocComments2()
+    public async Task TestMoveParamDocs10()
     {
         await new VerifyCS.Test
         {
@@ -1424,7 +1356,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments1()
+    public async Task TestMoveParamDocs11()
     {
         await new VerifyCS.Test
         {
@@ -1460,7 +1392,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments4()
+    public async Task TestMoveParamDocs13()
     {
         await new VerifyCS.Test
         {
@@ -1492,7 +1424,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments5()
+    public async Task TestMoveParamDocs14()
     {
         await new VerifyCS.Test
         {
@@ -1524,7 +1456,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments6()
+    public async Task TestMoveParamDocs15()
     {
         await new VerifyCS.Test
         {
@@ -1556,7 +1488,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments2()
+    public async Task TestMoveParamDocs16()
     {
         await new VerifyCS.Test
         {
@@ -1592,7 +1524,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments3()
+    public async Task TestMoveParamDocs17()
     {
         await new VerifyCS.Test
         {
@@ -1624,7 +1556,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments_MembersWithDifferentNames1()
+    public async Task TestMoveParamDocs18()
     {
         await new VerifyCS.Test
         {
@@ -1660,7 +1592,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersMoveDocComments_WhenTypeDocComments1()
+    public async Task TestMoveParamDocs19()
     {
         await new VerifyCS.Test
         {
@@ -1702,7 +1634,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersKeepConstructorDocs1()
+    public async Task TestMoveParamDocs20()
     {
         await new VerifyCS.Test
         {
@@ -1740,7 +1672,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersKeepConstructorDocs2()
+    public async Task TestMoveParamDocs21()
     {
         await new VerifyCS.Test
         {
@@ -1778,7 +1710,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersKeepConstructorDocs3()
+    public async Task TestMoveParamDocs22()
     {
         await new VerifyCS.Test
         {
@@ -2777,83 +2709,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     public C(int i = Default)
                     {
                         _i = i;
-                    }
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestMergeConstructorSummaryIntoTypeDocComment()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                using System;
-
-                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
-                {
-                    /// <summary>
-                    /// Active instruction identifier.
-                    /// It has the information necessary to track an active instruction within the debug session.
-                    /// </summary>
-                    /// <remarks>
-                    /// Creates an ActiveInstructionId.
-                    /// </remarks>
-                    /// <param name="method">Method which the instruction is scoped to.</param>
-                    /// <param name="ilOffset">IL offset for the instruction.</param>
-                    [CLSCompliant(false)]
-                    internal readonly struct [|ManagedInstructionId(
-                        string method,
-                        int ilOffset)|]
-                    {
-                        /// <summary>
-                        /// Method which the instruction is scoped to.
-                        /// </summary>
-                        public string Method { get; } = method;
-
-                        /// <summary>
-                        /// The IL offset for the instruction.
-                        /// </summary>
-                        public int ILOffset { get; } = ilOffset;
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-
-                namespace Microsoft.CodeAnalysis.Contracts.EditAndContinue
-                {
-                    /// <summary>
-                    /// Active instruction identifier.
-                    /// It has the information necessary to track an active instruction within the debug session.
-                    /// </summary>
-                    /// <remarks>
-                    /// Creates an ActiveInstructionId.
-                    /// </remarks>
-                    [CLSCompliant(false)]
-                    internal readonly struct ManagedInstructionId
-                    {
-                        /// <summary>
-                        /// Method which the instruction is scoped to.
-                        /// </summary>
-                        public string Method { get; }
-                
-                        /// <summary>
-                        /// The IL offset for the instruction.
-                        /// </summary>
-                        public int ILOffset { get; }
-
-                        /// <param name="method">Method which the instruction is scoped to.</param>
-                        /// <param name="ilOffset">IL offset for the instruction.</param>
-                        public ManagedInstructionId(
-                            string method,
-                            int ilOffset)
-                        {
-                            Method = method;
-                            ILOffset = ilOffset;
-                        }
                     }
                 }
                 """,

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -443,6 +443,35 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
+    public async Task TestWithComplexRightSide3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int i)|]
+                {
+                    private int i = i * i;
+                    private int j = i + i;
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private int i;
+                    private int j;
+
+                    public C(int i)
+                    {
+                        this.i = i * i;
+                        this.j = i + i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestBlockWithMultipleAssignments1()
     {
         await new VerifyCS.Test

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -1233,7 +1233,7 @@ public class ConvertPrimaryToRegularConstructorTests
                     {
                         private int i;
 
-                        ///<param name="i">
+                            ///<param name="i">
                         ///Doc about i
                         ///on multiple lines
                         ///</param>

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -845,7 +845,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                     public [|C|](int i, int j)
                     {
-                       this. i = i;
+                        this. i = i;
                         _j = j;
                     }
 
@@ -1039,6 +1039,36 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_SingleLine_3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                ///<summary>Doc comment on single line</summary>
+                ///<param name="i">Doc about i single line</param>
+                class [|C(int i)|]
+                {
+                    private int i = i;
+                }
+                """,
+            FixedCode = """
+                /// <summary>Doc comment on single line</summary>
+                class C
+                {
+                    private int i;
+
+                    ///<param name="i">Doc about i single line</param>
+                    public C(int i)
+                    {
+                        this.i = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
     public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_1()
     {
         await new VerifyCS.Test
@@ -1063,14 +1093,14 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 namespace N
                 {
+                    /// <summary>
+                    /// Doc comment
+                    /// On multiple lines
+                    /// </summary>
                     class C
                     {
                         private int i;
 
-                        /// <summary>
-                        /// Doc comment
-                        /// On multiple lines
-                        /// </summary>
                         /// <param name="i">
                         /// Doc about i
                         /// on multiple lines
@@ -1159,6 +1189,54 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// On multiple lines</summary>
                         /// <param name="i">Doc about i
                         /// on multiple lines</param>
+                        public C(int i)
+                        {
+                            this.i = i;
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestMoveConstructorDocCommentWhenNothingOnType_MultiLine_4()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    ///<summary>
+                    ///Doc comment
+                    ///On multiple lines
+                    ///</summary>
+                    ///<param name="i">
+                    ///Doc about i
+                    ///on multiple lines
+                    ///</param>
+                    class [|C(int i)|]
+                    {
+                        private int i = i;
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    ///<summary>
+                    ///Doc comment
+                    ///On multiple lines
+                    ///</summary>
+                    class C
+                    {
+                        private int i;
+
+                        ///<param name="i">
+                        ///Doc about i
+                        ///on multiple lines
+                        ///</param>
                         public C(int i)
                         {
                             this.i = i;
@@ -1292,6 +1370,74 @@ public class ConvertPrimaryToRegularConstructorTests
                         /// <param name="j">
                         /// Docs for j.
                         /// </param>
+                        public C(int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    ///<param name="i">Docs for i.</param>
+                    ///<param name="j">
+                    ///Docs for j.
+                    ///</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        ///<param name="i">Docs for i.</param>
+                        ///<param name="j">
+                        ///Docs for j.
+                        ///</param>
+                        public C(int i, int j)
+                        {
+                        }
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersMoveDocComments_WhenNoTypeDocComments3()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                namespace N
+                {
+                    ///<param name="i">Docs for i.</param>
+                    ///<param name="j">Docs for j.</param>
+                    class [|C(int i, int j)|]
+                    {
+                    }
+                }
+                """,
+            FixedCode = """
+                namespace N
+                {
+                    class C
+                    {
+                        ///<param name="i">Docs for i.</param>
+                        ///<param name="j">Docs for j.</param>
                         public C(int i, int j)
                         {
                         }

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -463,7 +463,7 @@ public class ConvertPrimaryToRegularConstructorTests
                     public C(int i)
                     {
                         this.i = i * i;
-                        this.j = i + i;
+                        j = i + i;
                     }
                 }
                 """,

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.ConvertPrimaryToRegularConstructor;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertPrimaryToRegularConstructor;
@@ -47,6 +48,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
         }.RunAsync();
     }
 
@@ -566,12 +568,10 @@ public class ConvertPrimaryToRegularConstructorTests
                 class OuterType
                 {
                     private int _i;
-                    private int _j;
 
                     public [|OuterType|](int i, int j)
                     {
                         _i = i;
-                        _j = j;
                     }
 
                     public struct Enumerator
@@ -1476,6 +1476,7 @@ public class ConvertPrimaryToRegularConstructorTests
                """,
             FixedCode = """
                using System;
+
                class C
                {
                    [Obsolete("", error: true)]
@@ -2136,23 +2137,20 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestInParameter2()
+    public async Task TestInParameter2_Unused()
     {
         await new VerifyCS.Test
         {
             TestCode = """
-                class [|C(int i)|]
+                class [|C(in int i)|]
                 {
                 }
                 """,
             FixedCode = """
                 class C
                 {
-                    private int i;
-
                     public C(in int i)
                     {
-                        this.i = i;
                     }
                 }
                 """,

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -544,8 +544,8 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-                    private int i;
-                    private int j;
+                    private readonly int i;
+                    private readonly int j;
 
                     public [|C|](int i, int j)
                     {
@@ -556,6 +556,42 @@ public class ConvertPrimaryToRegularConstructorTests
                     int M()
                     {
                         return i + j;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembers1_Used_Written1()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int i, int j)|]
+                {
+                    int M()
+                    {
+                        return i++ + j;
+                    }
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private readonly int j;
+                    private int i;
+
+                    public [|C|](int i, int j)
+                    {
+                        this.i = i;
+                        this.j = j;
+                    }
+
+                    int M()
+                    {
+                        return i++ + j;
                     }
                 }
                 """,
@@ -682,8 +718,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int i;
-                    private int j;
+                    private readonly int i;
+                    private readonly int j;
 
                     public C(int i, int j)
                     {
@@ -720,8 +756,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int @this;
-                    private int @delegate;
+                    private readonly int @this;
+                    private readonly int @delegate;
 
                     public C(int @this, int @delegate)
                     {
@@ -758,8 +794,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int i;
-                    private int j;
+                    private readonly int i;
+                    private readonly int j;
 
                     public C(int i, int j)
                     {
@@ -798,8 +834,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
+                    private readonly int i;
                     public int _j;
-                    private int i;
 
                     public C(int i, int j)
                     {
@@ -839,9 +875,9 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
+                    private readonly int i;
                     [CLSCompliant(true)]
                     private int _j;
-                    private int i;
 
                     public [|C|](int i, int j)
                     {
@@ -860,7 +896,7 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestRemoveMembersAccessedOffThis()
+    public async Task TestRemoveMembersAccessedOffThis1()
     {
         await new VerifyCS.Test
         {
@@ -881,6 +917,49 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
+                    private readonly int _i;
+                    private int _j;
+
+                    public C(int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    void M(C c)
+                    {
+                        Console.WriteLine(_i);
+                        Console.WriteLine(_j == c._j);
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+            EditorConfig = FieldNamesCamelCaseWithFieldUnderscorePrefixEditorConfig,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestRemoveMembersAccessedOffThis2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                using System;
+                class [|C(int i, int j)|]
+                {
+                    private int _j = j;
+
+                    void M(C c)
+                    {
+                        Console.WriteLine(i++);
+                        Console.WriteLine(_j == c._j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
+                class C
+                {
                     private int _j;
                     private int _i;
 
@@ -892,7 +971,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                     void M(C c)
                     {
-                        Console.WriteLine(_i);
+                        Console.WriteLine(_i++);
                         Console.WriteLine(_j == c._j);
                     }
                 }
@@ -2563,7 +2642,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 /// </summary>
                 class C
                 {
-                    private int i;
+                    private readonly int i;
 
                     public C(int i)
                     {
@@ -2603,7 +2682,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 /// </summary>
                 class C
                 {
-                    private int _i;
+                    private readonly int _i;
 
                     public C(int i)
                     {

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -599,13 +599,11 @@ public class ConvertPrimaryToRegularConstructorTests
             FixedCode = """
                 class C
                 {
-                    private int I { get; }
                     private long J { get; }
 
                     public C(int i, int j)
                     {
-                        this.I = i;
-                        this.J = j;
+                        J = j;
                     }
                 }
                 """,
@@ -695,7 +693,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                     void M()
                     {
-                        Console.WriteLine(this.i + this.j);
+                        Console.WriteLine(i + j);
                     }
                 }
                 """,
@@ -722,18 +720,18 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int i;
-                    private int j;
+                    private int @this;
+                    private int @delegate;
 
                     public C(int @this, int @delegate)
                     {
-                        this.i = @this;
-                        this.j = @delegate;
+                        this.@this = @this;
+                        this.@delegate = @delegate;
                     }
 
                     void M()
                     {
-                        Console.WriteLine(this.i + this.j);
+                        Console.WriteLine(@this + @delegate);
                     }
                 }
                 """,
@@ -760,18 +758,18 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int _i;
-                    private int _j;
+                    private int i;
+                    private int j;
 
                     public C(int i, int j)
                     {
-                        _i = i;
-                        _j = j;
+                        this.i = i;
+                        this.j = j;
                     }
 
                     void M()
                     {
-                        Console.WriteLine(_i + _j);
+                        Console.WriteLine(i + j);
                     }
                 }
                 """,
@@ -800,18 +798,18 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int _i;
                     public int _j;
+                    private int i;
 
                     public C(int i, int j)
                     {
-                        _i = i;
+                        this.i = i;
                         _j = j;
                     }
 
                     void M()
                     {
-                        Console.WriteLine(_i + _j);
+                        Console.WriteLine(i + _j);
                     }
                 }
                 """,
@@ -841,19 +839,19 @@ public class ConvertPrimaryToRegularConstructorTests
                 using System;
                 class C
                 {
-                    private int _i;
                     [CLSCompliant(true)]
                     private int _j;
+                    private int i;
 
                     public [|C|](int i, int j)
                     {
-                        _i = i;
+                       this. i = i;
                         _j = j;
                     }
 
                     void M()
                     {
-                        Console.WriteLine(_i + _j);
+                        Console.WriteLine(i + _j);
                     }
                 }
                 """,
@@ -1290,17 +1288,12 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        /// <summary>Docs for i.</summary>
-                        private int i;
-                        /// <summary>
+                        /// <param name="i">Docs for i.</param>
+                        /// <param name="j">
                         /// Docs for j.
-                        /// </summary>
-                        private int j;
-
+                        /// </param>
                         public C(int i, int j)
                         {
-                            this.i = i;
-                            this.j = j;
                         }
                     }
                 }
@@ -1331,17 +1324,12 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        /// <summary>Docs for x.</summary>
-                        private int x;
-                        /// <summary>
+                        /// <param name="i">Docs for x.</param>
+                        /// <param name="j">
                         /// Docs for y.
-                        /// </summary>
-                        private int y;
-
+                        /// </param>
                         public C(int i, int j)
                         {
-                            this.x = i;
-                            this.y = j;
                         }
                     }
                 }
@@ -1378,17 +1366,12 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// </summary>
                     class C
                     {
-                        /// <summary>Docs for i.</summary>
-                        private int i;
-                        /// <summary>
+                        /// <param name="i">Docs for i.</param>
+                        /// <param name="j">
                         /// Docs for j.
-                        /// </summary>
-                        private int j;
-
+                        /// </param>
                         public C(int i, int j)
                         {
-                            this.i = i;
-                            this.j = j;
                         }
                     }
                 }
@@ -1461,18 +1444,10 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// </summary>
                     class C
                     {
-                        /// <summary>Field docs for i.</summary>
-                        private int i;
-                        /// <summary>
-                        /// Field docs for j.
-                        /// </summary>
-                        private int j;
-
                         /// <param name="j">Param docs for j</param>
+                        /// <param name="i">Field docs for i.</param>
                         public C(int i, int j)
                         {
-                            this.i = i;
-                            this.j = j;
                         }
                     }
                 }
@@ -1509,18 +1484,12 @@ public class ConvertPrimaryToRegularConstructorTests
                     /// </summary>
                     class C
                     {
-                        /// <summary>Field docs for i.</summary>
-                        private int i;
-                        /// <summary>
-                        /// Field docs for j.
-                        /// </summary>
-                        private int j;
-
                         /// <param name="i">Param docs for i</param>
+                        /// <param name="j">
+                        /// Field docs for j.
+                        /// </param>
                         public C(int i, int j)
                         {
-                            this.i = i;
-                            this.j = j;
                         }
                     }
                 }

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -845,7 +845,7 @@ public class ConvertPrimaryToRegularConstructorTests
 
                     public [|C|](int i, int j)
                     {
-                        this. i = i;
+                        this.i = i;
                         _j = j;
                     }
 
@@ -1402,7 +1402,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        ///<param name="i">Docs for i.</param>
+                        /// <param name="i">Docs for i.</param>
                         ///<param name="j">
                         ///Docs for j.
                         ///</param>
@@ -1436,7 +1436,7 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                     class C
                     {
-                        ///<param name="i">Docs for i.</param>
+                        /// <param name="i">Docs for i.</param>
                         ///<param name="j">Docs for j.</param>
                         public C(int i, int j)
                         {

--- a/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
+++ b/src/Features/CSharpTest/ConvertPrimaryToRegularConstructor/ConvertPrimaryToRegularConstructorTests.cs
@@ -37,16 +37,13 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestNotWithNonPublicConstructor()
+    public async Task TestNotWithRecord()
     {
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
+                record class [|C(int i)|]
                 {
-                    private C(int i)
-                    {
-                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -59,35 +56,14 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-                struct C
+                struct [|C(int i)|]
                 {
-                    public [|C|](int i)
-                    {
-                    }
                 }
                 """,
             FixedCode = """
-                struct C(int i)
-                {
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithUnchainedConstructor()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
+                struct C
                 {
                     public C(int i)
-                    {
-                    }
-
-                    public C()
                     {
                     }
                 }
@@ -102,20 +78,20 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
+                class [|C(int i)|]
                 {
-                    public [|C|](int i)
-                    {
-                    }
-
                     public C() : this(0)
                     {
                     }
                 }
                 """,
             FixedCode = """
-                class C(int i)
+                class C
                 {
+                    public C(int i)
+                    {
+                    }
+
                     public C() : this(0)
                     {
                     }
@@ -135,12 +111,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C : B
+                class [|C(int i)|] : B(i)
                 {
-                    public [|C|](int i) : base(i)
-                    {
-                    }
-
                     public C() : this(0)
                     {
                     }
@@ -151,8 +123,12 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C(int i) : B(i)
+                class C : B
                 {
+                    public [|C|](int i) : base(i)
+                    {
+                    }
+
                     public C() : this(0)
                     {
                     }
@@ -172,12 +148,8 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C : B
+                class [|C(int i)|] : B(i * i)
                 {
-                    public [|C|](int i) : base(i * i)
-                    {
-                    }
-
                     public C() : this(0)
                     {
                     }
@@ -188,8 +160,12 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C(int i) : B(i * i)
+                class C : B
                 {
+                    public [|C|](int i) : base(i * i)
+                    {
+                    }
+
                     public C() : this(0)
                     {
                     }
@@ -209,13 +185,9 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C : B
+                class [|C(int i, int j)|] : B(i,
+                    j)
                 {
-                    public [|C|](int i, int j) : base(i,
-                        j)
-                    {
-                    }
-
                     public C() : this(0, 0)
                     {
                     }
@@ -226,9 +198,13 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C(int i, int j) : B(i,
-                    j)
+                class C : B
                 {
+                    public C(int i, int j) : base(i,
+                        j)
+                    {
+                    }
+
                     public C() : this(0, 0)
                     {
                     }
@@ -248,13 +224,9 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C : B
+                class [|C(int i, int j)|] : B(
+                    i, j)
                 {
-                    public [|C|](int i, int j) : base(
-                        i, j)
-                    {
-                    }
-
                     public C() : this(0, 0)
                     {
                     }
@@ -265,9 +237,13 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C(int i, int j) : B(
-                    i, j)
+                class C : B
                 {
+                    public [|C|](int i, int j) : base(
+                        i, j)
+                    {
+                    }
+
                     public C() : this(0, 0)
                     {
                     }
@@ -287,14 +263,10 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C : B
+                class [|C(int i, int j)|] : B(
+                    i,
+                    j)
                 {
-                    public [|C|](int i, int j) : base(
-                        i,
-                        j)
-                    {
-                    }
-
                     public C() : this(0, 0)
                     {
                     }
@@ -305,10 +277,14 @@ public class ConvertPrimaryToRegularConstructorTests
                 {
                 }
 
-                class C(int i, int j) : B(
-                    i,
-                    j)
+                class C : B
                 {
+                    public C(int i, int j) : base(
+                        i,
+                        j)
+                    {
+                    }
+
                     public C() : this(0, 0)
                     {
                     }
@@ -319,32 +295,24 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestNotWithBadExpressionBody()
+    public async Task TestWithBlockBodyAssignmentToField1()
     {
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
+                class [|C(int i)|]
                 {
-                    public C(int i)
-                        => System.Console.WriteLine(i);
+                    private int i = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithBadBlockBody()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
+            FixedCode = """
                 class C
                 {
+                    private int i;
+
                     public C(int i)
                     {
-                        System.Console.WriteLine(i);
+                        this.i = i;
                     }
                 }
                 """,
@@ -353,175 +321,50 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestWithExpressionBodyAssignmentToField1()
+    public async Task TestWithBlockBodyAssignmentToProperty1()
     {
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
-                {
-                    private int i;
-
-                    public [|C|](int i)
-                        => this.i = i;
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                    private int i = i;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestWithExpressionBodyAssignmentToProperty1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int I { get; }
-
-                    public [|C|](int i)
-                        => this.I = i;
-                }
-                """,
-            FixedCode = """
-                class C(int i)
+                class [|C(int i)|]
                 {
                     private int I { get; } = i;
                 }
                 """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestWithExpressionBodyAssignmentToField2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int i;
-
-                    public [|C|](int j)
-                        => this.i = j;
-                }
-                """,
             FixedCode = """
-                class C(int j)
-                {
-                    private int i = j;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestWithExpressionBodyAssignmentToField3()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
                 class C
                 {
-                    private int i;
-
-                    public [|C|](int j)
-                        => i = j;
-                }
-                """,
-            FixedCode = """
-                class C(int j)
-                {
-                    private int i = j;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithAssignmentToBaseField1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class B
-                {
-                    public int i;
-                }
-
-                class C : B
-                {
-                    public C(int i)
-                        => this.i = i;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithAssignmentToBaseField2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class B
-                {
-                    public int i;
-                }
-
-                class C : B
-                {
-                    public C(int i)
-                        => base.i = i;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithCompoundAssignmentToField()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    public int i;
+                    private int I { get; }
 
                     public C(int i)
-                        => this.i += i;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWithTwoWritesToTheSameMember()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    public int i;
-
-                    public C(int i, int j)
                     {
-                        this.i = i;
-                        this.i = j;
+                        this.I = i;
+                    }
+                }
+                """,
+            LanguageVersion = LanguageVersion.CSharp12,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestWithBlockBodyAssignmentToField2()
+    {
+        await new VerifyCS.Test
+        {
+            TestCode = """
+                class [|C(int j)|]
+                {
+                    private int i = j;
+                }
+                """,
+            FixedCode = """
+                class C
+                {
+                    private int i;
+
+                    public C(int j)
+                    {
+                        i = j;
                     }
                 }
                 """,
@@ -535,18 +378,20 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i)|]
+                {
+                    private int i = i * 2;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     private int i;
 
-                    public [|C|](int i)
-                        => this.i = i * 2;
-                }
-                """,
-            FixedCode = """
-                class C(int i)
-                {
-                    private int i = i * 2;
+                    public C(int i)
+                    {
+                        this.i = i * 2;
+                    }
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -559,23 +404,23 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i, int j)|]
+                {
+                    public int i = i;
+                    public int j = j;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     public int i;
                     public int j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         this.i = i;
                         this.j = j;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(int i, int j)
-                {
-                    public int i = i;
-                    public int j = j;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -588,21 +433,21 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
+                class [|C(int i, int j)|]
+                {
+                    public int i = i, j = j;
+                }
+                """,
+            FixedCode = """
                 class C
                 {
                     public int i, j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         this.i = i;
                         this.j = j;
                     }
-                }
-                """,
-            FixedCode = """
-                class C(int i, int j)
-                {
-                    public int i = i, j = j;
                 }
                 """,
             LanguageVersion = LanguageVersion.CSharp12,
@@ -695,34 +540,30 @@ public class ConvertPrimaryToRegularConstructorTests
     }
 
     [Fact]
-    public async Task TestDoNotRemovePublicMembers1()
+    public async Task TestNestedTypes()
     {
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
-                {
-                    public int i;
-                    public int j;
+                using System;
 
-                    public [|C|](int i, int j)
+                class [|OuterType(int i, int j)|]
+                {
+                    private int _i = i;
+
+                    public struct Enumerator
                     {
-                        this.i = i;
-                        this.j = j;
+                        private int _i;
+                
+                        public Enumerator(OuterType c)
+                        {
+                            _i = c._i;
+                            Console.WriteLine(c);
+                        }
                     }
                 }
                 """,
-            CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task DoNotRemoveMembersUsedInNestedTypes()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
+            FixedCode = """
                 using System;
 
                 class OuterType
@@ -748,25 +589,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                using System;
-
-                class OuterType(int i, int j)
-                {
-                    private int _i = i;
-
-                    public struct Enumerator
-                    {
-                        private int _i;
-                
-                        public Enumerator(OuterType c)
-                        {
-                            _i = c._i;
-                            Console.WriteLine(c);
-                        }
-                    }
-                }
-                """,
             CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
@@ -779,12 +601,22 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+                class [|C(int i, int j)|]
+                {
+                    void M()
+                    {
+                        Console.WriteLine(i + j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
                 class C
                 {
                     private int i;
                     private int j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         this.i = i;
                         this.j = j;
@@ -793,16 +625,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     void M()
                     {
                         Console.WriteLine(this.i + this.j);
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-                class C(int i, int j)
-                {
-                    void M()
-                    {
-                        Console.WriteLine(i + j);
                     }
                 }
                 """,
@@ -818,12 +640,22 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+                class [|C(int @this, int @delegate)|]
+                {
+                    void M()
+                    {
+                        Console.WriteLine(@this + @delegate);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
                 class C
                 {
                     private int i;
                     private int j;
 
-                    public [|C|](int @this, int @delegate)
+                    public C(int @this, int @delegate)
                     {
                         this.i = @this;
                         this.j = @delegate;
@@ -832,16 +664,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     void M()
                     {
                         Console.WriteLine(this.i + this.j);
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-                class C(int @this, int @delegate)
-                {
-                    void M()
-                    {
-                        Console.WriteLine(@this + @delegate);
                     }
                 }
                 """,
@@ -857,12 +679,22 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+                class [|C(int i, int j)|]
+                {
+                    void M()
+                    {
+                        Console.WriteLine(i + j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
                 class C
                 {
                     private int _i;
                     private int _j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         _i = i;
                         _j = j;
@@ -871,16 +703,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     void M()
                     {
                         Console.WriteLine(_i + _j);
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-                class C(int i, int j)
-                {
-                    void M()
-                    {
-                        Console.WriteLine(i + j);
                     }
                 }
                 """,
@@ -896,12 +718,24 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+                class [|C(int i, int j)|]
+                {
+                    public int _j = j;
+
+                    void M()
+                    {
+                        Console.WriteLine(i + _j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
                 class C
                 {
                     private int _i;
                     public int _j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         _i = i;
                         _j = j;
@@ -910,18 +744,6 @@ public class ConvertPrimaryToRegularConstructorTests
                     void M()
                     {
                         Console.WriteLine(_i + _j);
-                    }
-                }
-                """,
-            FixedCode = """
-                using System;
-                class C(int i, int j)
-                {
-                    public int _j = j;
-
-                    void M()
-                    {
-                        Console.WriteLine(i + _j);
                     }
                 }
                 """,
@@ -936,38 +758,38 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-            using System;
-            class C
-            {
-                private int _i;
-                [CLSCompliant(true)]
-                private int _j;
-
-                public [|C|](int i, int j)
+                using System;
+                class [|C(int i, int j)|]
                 {
-                    _i = i;
-                    _j = j;
-                }
+                    [CLSCompliant(true)]
+                    private int _j = j;
 
-                void M()
-                {
-                    Console.WriteLine(_i + _j);
+                    void M()
+                    {
+                        Console.WriteLine(i + _j);
+                    }
                 }
-            }
-            """,
+                """,
             FixedCode = """
-            using System;
-            class C(int i, int j)
-            {
-                [CLSCompliant(true)]
-                private int _j = j;
-
-                void M()
+                using System;
+                class C
                 {
-                    Console.WriteLine(i + _j);
+                    private int _i;
+                    [CLSCompliant(true)]
+                    private int _j;
+
+                    public [|C|](int i, int j)
+                    {
+                        _i = i;
+                        _j = j;
+                    }
+
+                    void M()
+                    {
+                        Console.WriteLine(_i + _j);
+                    }
                 }
-            }
-            """,
+                """,
             CodeActionIndex = 1,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
@@ -980,12 +802,25 @@ public class ConvertPrimaryToRegularConstructorTests
         {
             TestCode = """
                 using System;
+                class [|C(int i, int j)|]
+                {
+                    private int _j = j;
+
+                    void M(C c)
+                    {
+                        Console.WriteLine(i);
+                        Console.WriteLine(_j == c._j);
+                    }
+                }
+                """,
+            FixedCode = """
+                using System;
                 class C
                 {
                     private int _i;
                     private int _j;
 
-                    public [|C|](int i, int j)
+                    public C(int i, int j)
                     {
                         _i = i;
                         _j = j;
@@ -998,64 +833,7 @@ public class ConvertPrimaryToRegularConstructorTests
                     }
                 }
                 """,
-            FixedCode = """
-                using System;
-                class C(int i, int j)
-                {
-                    private int _j = j;
-
-                    void M(C c)
-                    {
-                        Console.WriteLine(i);
-                        Console.WriteLine(_j == c._j);
-                    }
-                }
-                """,
             CodeActionIndex = 1,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWhenRightSideReferencesThis1()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int x;
-
-                    public C(int i)
-                    {
-                        x = M(i);
-                    }
-
-                    int M(int y) => y;
-                }
-                """,
-            LanguageVersion = LanguageVersion.CSharp12,
-        }.RunAsync();
-    }
-
-    [Fact]
-    public async Task TestNotWhenRightSideReferencesThis2()
-    {
-        await new VerifyCS.Test
-        {
-            TestCode = """
-                class C
-                {
-                    private int x;
-
-                    public C(int i)
-                    {
-                        x = this.M(i);
-                    }
-
-                    int M(int y) => y;
-                }
-                """,
             LanguageVersion = LanguageVersion.CSharp12,
         }.RunAsync();
     }
@@ -1066,22 +844,22 @@ public class ConvertPrimaryToRegularConstructorTests
         await new VerifyCS.Test
         {
             TestCode = """
-                class C
+                class [|C(int i)|]
                 {
-                    private int x;
-
-                    public [|C|](int i)
-                    {
-                        x = M(i);
-                    }
+                    private int x = M(i);
 
                     static int M(int y) => y;
                 }
                 """,
             FixedCode = """
-                class C(int i)
+                class C
                 {
-                    private int x = M(i);
+                    private int x;
+
+                    public C(int i)
+                    {
+                        x = M(i);
+                    }
 
                     static int M(int y) => y;
                 }
@@ -1098,27 +876,27 @@ public class ConvertPrimaryToRegularConstructorTests
             TestCode = """
                 namespace N
                 {
-                    class C
+                    /// <summary>Doc comment on single line</summary>
+                    /// <param name="i">Doc about i single line</param>
+                    class [|C(int i)|]
                     {
-                        private int i;
-
-                        /// <summary>Doc comment on single line</summary>
-                        /// <param name="i">Doc about i single line</param>
-                        public [|C|](int i)
-                        {
-                            this.i = i;
-                        }
+                        private int i = i;
                     }
                 }
                 """,
             FixedCode = """
                 namespace N
                 {
-                    /// <summary>Doc comment on single line</summary>
-                    /// <param name="i">Doc about i single line</param>
-                    class C(int i)
+                    class C
                     {
-                        private int i = i;
+                        private int i;
+
+                        /// <summary>Doc comment on single line</summary>
+                        /// <param name="i">Doc about i single line</param>
+                        public C(int i)
+                        {
+                            this.i = i;
+                        }
                     }
                 }
                 """,
@@ -1135,16 +913,11 @@ public class ConvertPrimaryToRegularConstructorTests
                 namespace N
                 {
                 #if true
-                    class C
+                    /// <summary>Doc comment on single line</summary>
+                    /// <param name="i">Doc about i single line</param>
+                    class [|C(int i)|]
                     {
-                        private int i;
-
-                        /// <summary>Doc comment on single line</summary>
-                        /// <param name="i">Doc about i single line</param>
-                        public [|C|](int i)
-                        {
-                            this.i = i;
-                        }
+                        private int i = i;
                     }
                 #endif
                 }
@@ -1153,11 +926,16 @@ public class ConvertPrimaryToRegularConstructorTests
                 namespace N
                 {
                 #if true
-                    /// <summary>Doc comment on single line</summary>
-                    /// <param name="i">Doc about i single line</param>
-                    class C(int i)
+                    class C
                     {
-                        private int i = i;
+                        private int i;
+
+                        /// <summary>Doc comment on single line</summary>
+                        /// <param name="i">Doc about i single line</param>
+                        public C(int i)
+                        {
+                            this.i = i;
+                        }
                     }
                 #endif
                 }

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public const string ConvertNamespace = "Convert Namespace";
         public const string ConvertNumericLiteral = nameof(ConvertNumericLiteral);
         public const string ConvertPlaceholderToInterpolatedString = nameof(ConvertPlaceholderToInterpolatedString);
+        public const string ConvertPrimaryToRegularConstructor = nameof(ConvertPrimaryToRegularConstructor);
         public const string ConvertToInterpolatedString = "Convert To Interpolated String Code Action Provider";
         public const string ConvertToProgramMain = "Convert To Program.Main";
         public const string ConvertToRawString = nameof(ConvertToRawString);

--- a/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -78,7 +78,6 @@ namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
             CodeActionOptionsProvider fallbackOptions,
             CancellationToken cancellationToken)
         {
-
             Contract.ThrowIfNull(document.DocumentState.ParseOptions);
 
             var editor = new SyntaxEditor(root, document.Project.Solution.Services);


### PR DESCRIPTION
We already have an feature to do the reverse.  This now lets you switch back easily.

Note: we do want this as primary constructors have limitations (for example, being able to add argument checks).  So if a person starts with a primary constructor and wants to easily move off of it to make such changes, we don't want that to be an arduous process.