### PR TITLE
Clear 'run code analysis' results when a build completes

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
@@ -55,7 +55,12 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
                 case WorkspaceChangeKind.SolutionCleared:
                 case WorkspaceChangeKind.SolutionReloaded:
                 case WorkspaceChangeKind.SolutionRemoved:
+
                     _analyzedProjectIds.Clear();
+                    _clearedProjectIds.Clear();
+
+                    // Let LSP know so that it requests up to date info, and will see our cached info disappear.
+                    _diagnosticsRefresher.RequestWorkspaceRefresh();
                     break;
             }
         }
@@ -102,6 +107,8 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
             // Add the given project to the analyzed projects list **after** analysis has completed.
             // We need this ordering to ensure that 'HasProjectBeenAnalyzed' call above functions correctly.
             _analyzedProjectIds.Add(project.Id);
+
+            // Remove from the cleared list now that we've run a more recent "run code analysis" on this project.
             _clearedProjectIds.Remove(project.Id);
 
             // Now raise the callback into our caller to indicate this project has been analyzed.

--- a/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
@@ -32,7 +32,21 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
         private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
         private readonly IDiagnosticsRefresher _diagnosticsRefresher;
         private readonly Workspace _workspace;
+
+        /// <summary>
+        /// List of projects that we've finished running "run code analysis" on.  Cached results can now be returned for
+        /// these through <see cref="GetLastComputedDocumentDiagnosticsAsync"/> and <see
+        /// cref="GetLastComputedProjectDiagnosticsAsync"/>.
+        /// </summary>
         private readonly ConcurrentSet<ProjectId> _analyzedProjectIds = new();
+
+        /// <summary>
+        /// Previously analyzed projects that we no longer want to report results for.  This happens when an explicit
+        /// build is kicked off.  At that point, we want the build results to win out for a particular project.  We mark
+        /// this project (as opposed to removing from <see cref="_analyzedProjectIds"/>) as we want our LSP handler to
+        /// still think it should process it, as that will the cause the diagnostics to be removed when they now
+        /// transition to an empty list returned from this type.
+        /// </summary>
         private readonly ConcurrentSet<ProjectId> _clearedProjectIds = new();
 
         public CodeAnalysisDiagnosticAnalyzerService(

--- a/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/CodeAnalysisDiagnosticAnalyzerService.cs
@@ -128,7 +128,7 @@ internal sealed class CodeAnalysisDiagnosticAnalyzerServiceFactory() : IWorkspac
         /// </summary>
         public Task<ImmutableArray<DiagnosticData>> GetLastComputedProjectDiagnosticsAsync(ProjectId projectId, CancellationToken cancellationToken)
             => !_analyzedProjectIds.Contains(projectId)
-                ? SpecializedTasks.EmptyImmutableArray<DiagnosticData> ()
+                ? SpecializedTasks.EmptyImmutableArray<DiagnosticData>()
                 : _diagnosticAnalyzerService.GetCachedDiagnosticsAsync(_workspace, projectId, documentId: null,
                     includeSuppressedDiagnostics: false, includeLocalDocumentDiagnostics: false,
                     includeNonLocalDocumentDiagnostics: false, cancellationToken);

--- a/src/Features/Core/Portable/Diagnostics/ICodeAnalysisDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/ICodeAnalysisDiagnosticAnalyzerService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 /// </summary>
 internal interface ICodeAnalysisDiagnosticAnalyzerService : IWorkspaceService
 {
+    void Clear();
+
     /// <summary>
     /// Runs all the applicable analyzers on the given project or entire solution if <paramref name="projectId"/> is null.
     /// </summary>

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -177,6 +177,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     }
                     else
                     {
+                        // A real build just finished.  Clear out any results from the last "run code analysis" command.
+                        this.Services.GetRequiredService<ICodeAnalysisDiagnosticAnalyzerService>().Clear();
                         ExternalErrorDiagnosticUpdateSource.OnSolutionBuildCompleted();
                     }
                 };


### PR DESCRIPTION
This ensures that stale RCA results don't stay around, potentially conflicting with the more recent build results.