### PR TITLE
Fix classification layering

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
@@ -18,13 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal sealed class ClassificationTypeFormatDefinitions
     {
-        // Note:
-        //
-        // Classification of syntax and semantics happens on different cadences.  For that reason, prioritize the
-        // classification of everything 'semantic' to come 'after' 'comment' classification.  That way, if a user
-        // comments something out, they'll see things snap to the commented state immediately, instead of having to wait
-        // for semantic-classification to finish and return no items for that region.
-
         #region Preprocessor Text
         [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.PreprocessorText)]
@@ -123,7 +116,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.OperatorOverloaded)]
         [Name(ClassificationTypeNames.OperatorOverloaded)]
         [Order(After = PredefinedClassificationTypeNames.Operator)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class OperatorOverloadedFormatDefinition : ClassificationFormatDefinition
@@ -140,7 +132,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.ReassignedVariable)]
         [Name(ClassificationTypeNames.ReassignedVariable)]
         [Order(After = Priority.High)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(false)]
         [ExcludeFromCodeCoverage]
         private class ReassignedVariableFormatDefinition : ClassificationFormatDefinition
@@ -160,7 +151,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ClassificationType(ClassificationTypeNames = ClassificationTypeNames.StaticSymbol)]
         [Name(ClassificationTypeNames.StaticSymbol)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class SymbolStaticFormatDefinition : ClassificationFormatDefinition
@@ -201,7 +191,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeClassesFormatDefinition : ClassificationFormatDefinition
@@ -222,7 +211,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeRecordsFormatDefinition : ClassificationFormatDefinition
@@ -242,7 +230,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeRecordStructsFormatDefinition : ClassificationFormatDefinition
@@ -262,7 +249,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeDelegatesFormatDefinition : ClassificationFormatDefinition
@@ -283,7 +269,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeEnumsFormatDefinition : ClassificationFormatDefinition
@@ -304,7 +289,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeInterfacesFormatDefinition : ClassificationFormatDefinition
@@ -325,7 +309,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         private class UserTypeModulesFormatDefinition : ClassificationFormatDefinition
         {
@@ -345,7 +328,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeStructuresFormatDefinition : ClassificationFormatDefinition
@@ -366,7 +348,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserTypeTypeParametersFormatDefinition : ClassificationFormatDefinition
@@ -388,7 +369,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersFieldNameFormatDefinition : ClassificationFormatDefinition
@@ -406,7 +386,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersEnumMemberNameFormatDefinition : ClassificationFormatDefinition
@@ -424,7 +403,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersConstantNameFormatDefinition : ClassificationFormatDefinition
@@ -442,7 +420,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersLocalNameFormatDefinition : ClassificationFormatDefinition
@@ -460,7 +437,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersParameterNameFormatDefinition : ClassificationFormatDefinition
@@ -478,7 +454,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersMethodNameFormatDefinition : ClassificationFormatDefinition
@@ -496,7 +471,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersExtensionMethodNameFormatDefinition : ClassificationFormatDefinition
@@ -514,7 +488,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersPropertyNameFormatDefinition : ClassificationFormatDefinition
@@ -531,7 +504,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.EventName)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersEventNameFormatDefinition : ClassificationFormatDefinition
@@ -548,7 +520,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.NamespaceName)]
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersNamespaceNameFormatDefinition : ClassificationFormatDefinition
@@ -566,7 +537,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Order(After = PredefinedClassificationTypeNames.Identifier)]
         [Order(After = PredefinedClassificationTypeNames.Keyword)]
         [Order(Before = ClassificationTypeNames.StaticSymbol)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class UserMembersLabelNameFormatDefinition : ClassificationFormatDefinition
@@ -766,7 +736,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.TestCode)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class TestCodeFormatDefinition : ClassificationFormatDefinition
@@ -785,7 +754,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.TestCodeMarkdown)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class TestCodeMarkdownFormatDefinition : ClassificationFormatDefinition
@@ -806,7 +774,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexComment)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexCommentFormatDefinition : ClassificationFormatDefinition
@@ -825,7 +792,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexCharacterClass)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexCharacterClassFormatDefinition : ClassificationFormatDefinition
@@ -844,7 +810,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexAnchor)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexAnchorFormatDefinition : ClassificationFormatDefinition
@@ -863,7 +828,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexQuantifier)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexQuantifierFormatDefinition : ClassificationFormatDefinition
@@ -882,7 +846,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexGrouping)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexGroupingFormatDefinition : ClassificationFormatDefinition
@@ -901,7 +864,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexAlternation)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexAlternationFormatDefinition : ClassificationFormatDefinition
@@ -920,7 +882,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexText)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexTextFormatDefinition : ClassificationFormatDefinition
@@ -939,7 +900,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexSelfEscapedCharacter)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexSelfEscapedCharacterFormatDefinition : ClassificationFormatDefinition
@@ -962,7 +922,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.RegexOtherEscape)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class RegexOtherEscapeFormatDefinition : ClassificationFormatDefinition
@@ -984,7 +943,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonComment)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonCommentFormatDefinition : ClassificationFormatDefinition
@@ -999,7 +957,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonNumber)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonNumberFormatDefinition : ClassificationFormatDefinition
@@ -1014,7 +971,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonString)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonStringFormatDefinition : ClassificationFormatDefinition
@@ -1029,7 +985,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonKeyword)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonKeywordFormatDefinition : ClassificationFormatDefinition
@@ -1044,7 +999,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonText)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonTextFormatDefinition : ClassificationFormatDefinition
@@ -1059,7 +1013,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonOperator)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonOperatorFormatDefinition : ClassificationFormatDefinition
@@ -1074,7 +1027,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonPunctuation)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonPunctuationFormatDefinition : ClassificationFormatDefinition
@@ -1089,7 +1041,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonObject)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonObjectFormatDefinition : ClassificationFormatDefinition
@@ -1104,7 +1055,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonArray)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonArrayFormatDefinition : ClassificationFormatDefinition
@@ -1119,7 +1069,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonPropertyName)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonPropertyNameFormatDefinition : ClassificationFormatDefinition
@@ -1134,7 +1083,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [Name(ClassificationTypeNames.JsonConstructorName)]
         [Order(After = ClassificationTypeNames.StringLiteral)]
         [Order(After = ClassificationTypeNames.VerbatimStringLiteral)]
-        [Order(Before = PredefinedClassificationTypeNames.Comment)]
         [UserVisible(true)]
         [ExcludeFromCodeCoverage]
         private class JsonConstructorNameFormatDefinition : ClassificationFormatDefinition

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -22,6 +22,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
 
@@ -43,7 +44,6 @@ namespace Microsoft.CodeAnalysis.Classification
             private readonly ITextBuffer2 _subjectBuffer;
             private readonly IAsynchronousOperationListener _listener;
             private readonly IClassificationTypeMap _typeMap;
-
             private readonly WorkspaceRegistration _workspaceRegistration;
 
             private readonly CancellationTokenSource _disposalCancellationSource = new();

--- a/src/EditorFeatures/Core/Shared/Utilities/AbstractClassificationTypeMap.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/AbstractClassificationTypeMap.cs
@@ -4,58 +4,87 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Text.Classification;
 using Roslyn.Utilities;
 using ReferenceEqualityComparer = Roslyn.Utilities.ReferenceEqualityComparer;
 
-namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+
+/// <summary>
+/// Note: we very intentionally layer things in the following fashion (from lowest to highest priority):
+/// <list type="number">
+/// <item>
+/// Roslyn Syntactic Classifications.  These go into the "Editor Lexical" bucket, lower than everything else.
+/// </item>
+/// <item>
+/// Roslyn Semantic Classifications.  These go into the "Editor Syntactic" bucket.  Effectively *almost* always beating
+/// out the classifications produced by Roslyn's syntactic classifier.
+/// </item>
+/// <item>
+/// Comments.  These go into the highest bucket "Editor Semantic".  This ensures that comments override *everything*,
+/// causing classification to instantly 'snap' to the commented-out classification when the user comments code.  Without
+/// this, our stale semantic classifications could show up *above* the commented code *up until* the point that semantic
+/// classification ran again.
+/// </item>
+/// </list>
+/// </summary>
+internal abstract class AbstractClassificationTypeMap : IClassificationTypeMap
 {
-    internal abstract class AbstractClassificationTypeMap : IClassificationTypeMap
+    private readonly Dictionary<string, IClassificationType> _identityMap;
+    private readonly IClassificationTypeRegistryService _registryService;
+    private readonly ClassificationLayer _classificationLayer;
+
+    public AbstractClassificationTypeMap(
+        IClassificationTypeRegistryService registryService,
+        ClassificationLayer classificationLayer)
     {
-        private readonly Dictionary<string, IClassificationType> _identityMap;
-        private readonly IClassificationTypeRegistryService _registryService;
+        _registryService = registryService;
+        _classificationLayer = classificationLayer;
 
-        public AbstractClassificationTypeMap(
-            IClassificationTypeRegistryService registryService,
-            ClassificationLayer classificationLayer)
+        // Prepopulate the identity map with the constant string values from ClassificationTypeNames
+        var fields = typeof(ClassificationTypeNames).GetFields();
+        _identityMap = new Dictionary<string, IClassificationType>(fields.Length, ReferenceEqualityComparer.Instance);
+
+        foreach (var field in fields)
         {
-            _registryService = registryService;
+            // The strings returned from reflection do not have reference-identity with the string constants used by
+            // the compiler. Fortunately, a call to string.Intern fixes them.
+            var rawValue = (string?)field.GetValue(null);
+            Contract.ThrowIfNull(rawValue);
+            var value = string.Intern(rawValue);
 
-            // Prepopulate the identity map with the constant string values from ClassificationTypeNames
-            var fields = typeof(ClassificationTypeNames).GetFields();
-            _identityMap = new Dictionary<string, IClassificationType>(fields.Length, ReferenceEqualityComparer.Instance);
+            // Note:
+            //
+            // Classification of syntax and semantics happens on different cadences.  For that reason, prioritize the
+            // classification 'comments' to be higher than everything else (place it on the editors highest 'semantic'
+            // layer). That way, if a user comments something out, they'll see things snap to the commented state
+            // immediately, instead of having to wait for semantic-classification to finish and return no items for that
+            // region.
+            var layer = value == ClassificationTypeNames.Comment
+                ? ClassificationLayer.Semantic
+                : classificationLayer;
 
-            foreach (var field in fields)
-            {
-                // The strings returned from reflection do not have reference-identity
-                // with the string constants used by the compiler. Fortunately, a call
-                // to string.Intern fixes them.
-                var rawValue = (string?)field.GetValue(null);
-                Contract.ThrowIfNull(rawValue);
-                var value = string.Intern(rawValue);
-                _identityMap.Add(value, registryService.GetClassificationType(classificationLayer, value));
-            }
+            _identityMap.Add(value, registryService.GetClassificationType(layer, value));
+        }
+    }
+
+    public IClassificationType GetClassificationType(string name)
+    {
+        var type = GetClassificationTypeWorker(name);
+        if (type == null)
+        {
+            FatalError.ReportAndCatch(new Exception($"classification type doesn't exist for {name}"));
         }
 
-        public IClassificationType GetClassificationType(string name)
-        {
-            var type = GetClassificationTypeWorker(name);
-            if (type == null)
-            {
-                FatalError.ReportAndCatch(new Exception($"classification type doesn't exist for {name}"));
-            }
+        return type ?? GetClassificationTypeWorker(ClassificationTypeNames.Text);
+    }
 
-            return type ?? GetClassificationTypeWorker(ClassificationTypeNames.Text);
-        }
-
-        private IClassificationType GetClassificationTypeWorker(string name)
-        {
-            return _identityMap.TryGetValue(name, out var result)
-                ? result
-                : _registryService.GetClassificationType(name);
-        }
+    private IClassificationType GetClassificationTypeWorker(string name)
+    {
+        return _identityMap.TryGetValue(name, out var result)
+            ? result
+            : _registryService.GetClassificationType(_classificationLayer, name);
     }
 }

--- a/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ClassificationTypeMap.cs
@@ -7,13 +7,16 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text.Classification;
 
-namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+
+/// <summary>
+/// Note: we very intentionally place ourselves in the editors 'syntactic' bucket (and not 'semantic' bucket).  See
+/// comments on <see cref="AbstractClassificationTypeMap"/> for more details.
+/// </summary>
+[Export]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class ClassificationTypeMap(IClassificationTypeRegistryService registryService)
+    : AbstractClassificationTypeMap(registryService, ClassificationLayer.Syntactic)
 {
-    [Export]
-    [method: ImportingConstructor]
-    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal class ClassificationTypeMap(
-        IClassificationTypeRegistryService registryService) : AbstractClassificationTypeMap(registryService, ClassificationLayer.Default)
-    {
-    }
 }

--- a/src/EditorFeatures/Core/Shared/Utilities/SyntacticClassificationTypeMap.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/SyntacticClassificationTypeMap.cs
@@ -7,12 +7,16 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text.Classification;
 
-namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+
+/// <summary>
+/// Note: we very intentionally place ourselves in the editors 'lexical' bucket (and not 'syntactic' bucket).  See
+/// comments on <see cref="AbstractClassificationTypeMap"/> for more details.
+/// </summary>
+[Export]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal class SyntacticClassificationTypeMap(IClassificationTypeRegistryService registryService)
+    : AbstractClassificationTypeMap(registryService, ClassificationLayer.Lexical)
 {
-    [Export]
-    [method: ImportingConstructor]
-    [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    internal class SyntacticClassificationTypeMap(IClassificationTypeRegistryService registryService) : AbstractClassificationTypeMap(registryService, ClassificationLayer.Syntactic)
-    {
-    }
 }


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1901034

Editor explicitly hardcodes that identifiers have higher priority than comments.  Which means all our classifications that derive from identifier (like all our symbol classification types) are placed on top of comments.

A prior changed fixed this on our end by reordering classifications.  But this ended up causing cycle-asserts within the editor (and user visible problems).  

The fix is to undo the ordering attributes, and actually use the editor's classification layering system to enforce a particular overriding behavior for comments versus all other classification types.