### PR TITLE
Collection expressions: spread elements are not expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -985,7 +985,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateTypedConstant(collection, typedConstantKind, diagnostics, ref attrHasErrors, curArgumentHasErrors, arrayValue: builder.ToImmutableAndFree());
             }
 
-            private TypedConstant VisitCollectionExpressionElement(BoundExpression node, BindingDiagnosticBag diagnostics, ref bool attrHasErrors, bool curArgumentHasErrors)
+            private TypedConstant VisitCollectionExpressionElement(BoundNode node, BindingDiagnosticBag diagnostics, ref bool attrHasErrors, bool curArgumentHasErrors)
             {
                 if (node is BoundCollectionExpressionSpreadElement spread)
                 {
@@ -993,7 +993,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     attrHasErrors = true;
                     return new TypedConstant(spread.Expression.Type, TypedConstantKind.Error, value: null);
                 }
-                return VisitExpression(node, diagnostics, ref attrHasErrors, curArgumentHasErrors);
+                return VisitExpression((BoundExpression)node, diagnostics, ref attrHasErrors, curArgumentHasErrors);
             }
 
             private TypedConstant VisitConversion(BoundConversion node, BindingDiagnosticBag diagnostics, ref bool attrHasErrors, bool curArgumentHasErrors)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var elements = node.Elements;
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(elements.Length);
+            var builder = ArrayBuilder<BoundNode>.GetInstance(elements.Length);
             BoundExpression? collectionCreation = null;
             BoundObjectOrCollectionValuePlaceholder? implicitReceiver = null;
 
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var collectionInitializerAddMethodBinder = this.WithAdditionalFlags(BinderFlags.CollectionInitializerAddMethod);
                 foreach (var element in elements)
                 {
-                    BoundExpression convertedElement = BindCollectionExpressionElementAddMethod(
+                    BoundNode convertedElement = BindCollectionExpressionElementAddMethod(
                         element,
                         collectionInitializerAddMethodBinder,
                         implicitReceiver,
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             diagnostics) :
                         CreateConversion(
                             element.Syntax,
-                            element,
+                            (BoundExpression)element,
                             elementConversion,
                             isCast: false,
                             conversionGroupOpt: null,
@@ -729,7 +729,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.ToImmutableAndFree(),
                 targetType);
 
-            BoundExpression bindSpreadElement(BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion, BindingDiagnosticBag diagnostics)
+            BoundNode bindSpreadElement(BoundCollectionExpressionSpreadElement element, TypeSymbol elementType, Conversion elementConversion, BindingDiagnosticBag diagnostics)
             {
                 var enumeratorInfo = element.EnumeratorInfoOpt;
                 Debug.Assert(enumeratorInfo is { });
@@ -775,10 +775,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             var syntax = node.Syntax;
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(node.Elements.Length);
+            var builder = ArrayBuilder<BoundNode>.GetInstance(node.Elements.Length);
             foreach (var element in node.Elements)
             {
-                builder.Add(BindToNaturalType(element, diagnostics, reportNoTargetType: !targetType.IsErrorType()));
+                var result = element is BoundExpression expression ?
+                    BindToNaturalType(expression, diagnostics, reportNoTargetType: !targetType.IsErrorType()) :
+                    element;
+                builder.Add(result);
             }
             return new BoundCollectionExpression(
                 syntax,
@@ -847,10 +850,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        Conversion elementConversion = Conversions.ClassifyImplicitConversionFromExpression(element, elementType, ref useSiteInfo);
+                        Conversion elementConversion = Conversions.ClassifyImplicitConversionFromExpression((BoundExpression)element, elementType, ref useSiteInfo);
                         if (!elementConversion.Exists)
                         {
-                            GenerateImplicitConversionError(diagnostics, element.Syntax, elementConversion, element, elementType);
+                            GenerateImplicitConversionError(diagnostics, element.Syntax, elementConversion, (BoundExpression)element, elementType);
                             reportedErrors = true;
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4737,14 +4737,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MessageID.IDS_FeatureCollectionExpressions.CheckFeatureAvailability(diagnostics, syntax, syntax.OpenBracketToken.GetLocation());
 
-            var builder = ArrayBuilder<BoundExpression>.GetInstance(syntax.Elements.Count);
+            var builder = ArrayBuilder<BoundNode>.GetInstance(syntax.Elements.Count);
             foreach (var element in syntax.Elements)
             {
                 builder.Add(bindElement(element, diagnostics));
             }
             return new BoundUnconvertedCollectionExpression(syntax, builder.ToImmutableAndFree());
 
-            BoundExpression bindElement(CollectionElementSyntax syntax, BindingDiagnosticBag diagnostics)
+            BoundNode bindElement(CollectionElementSyntax syntax, BindingDiagnosticBag diagnostics)
             {
                 return syntax switch
                 {
@@ -4754,7 +4754,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
             }
 
-            BoundExpression bindSpreadElement(SpreadElementSyntax syntax, BindingDiagnosticBag diagnostics)
+            BoundNode bindSpreadElement(SpreadElementSyntax syntax, BindingDiagnosticBag diagnostics)
             {
                 var expression = BindRValueWithoutTargetType(syntax.Expression, diagnostics);
                 ForEachEnumeratorInfo.Builder builder;
@@ -5922,15 +5922,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        internal BoundExpression BindCollectionExpressionElementAddMethod(
-            BoundExpression element,
+        internal BoundNode BindCollectionExpressionElementAddMethod(
+            BoundNode element,
             Binder collectionInitializerAddMethodBinder,
             BoundObjectOrCollectionValuePlaceholder implicitReceiver,
             BindingDiagnosticBag diagnostics,
             out bool hasErrors)
         {
             var result = element is BoundCollectionExpressionSpreadElement spreadElement ?
-                BindCollectionExpressionSpreadElementAddMethod(
+                (BoundNode)BindCollectionExpressionSpreadElementAddMethod(
                     (SpreadElementSyntax)spreadElement.Syntax,
                     spreadElement,
                     collectionInitializerAddMethodBinder,
@@ -5938,7 +5938,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics) :
                 BindCollectionInitializerElementAddMethod(
                     (ExpressionSyntax)element.Syntax,
-                    ImmutableArray.Create(element),
+                    ImmutableArray.Create((BoundExpression)element),
                     hasEnumerableInitializerType: true,
                     collectionInitializerAddMethodBinder,
                     diagnostics,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.CreateCollectionExpressionConversion(collectionTypeKind, elementType, builder.ToImmutableAndFree());
 
             bool isCompatibleIEnumerableT(NamedTypeSymbol targetInterface, NamedTypeSymbol ienumerableType,
-                ImmutableArray<BoundExpression> elements, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+                ImmutableArray<BoundNode> elements, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
                 Debug.Assert(ienumerableType.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T);
                 if (!ReferenceEquals(targetInterface.OriginalDefinition, ienumerableType))
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return elementsCanAllConvert(elements, targetElementType.Type, ref useSiteInfo);
             }
 
-            bool elementsCanAllConvert(ImmutableArray<BoundExpression> elements, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+            bool elementsCanAllConvert(ImmutableArray<BoundNode> elements, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
                 foreach (var element in elements)
                 {
@@ -240,12 +240,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            Conversion convertElement(BoundExpression element, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+            Conversion convertElement(BoundNode element, TypeSymbol elementType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
                 return element switch
                 {
                     BoundCollectionExpressionSpreadElement spreadElement => GetCollectionExpressionSpreadElementConversion(spreadElement, elementType, ref useSiteInfo),
-                    _ => ClassifyImplicitConversionFromExpression(element, elementType, ref useSiteInfo),
+                    _ => ClassifyImplicitConversionFromExpression((BoundExpression)element, elementType, ref useSiteInfo),
                 };
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -615,10 +615,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 MakeCollectionExpressionTypeInferences(binder, (BoundUnconvertedCollectionExpression)argument, target, kind, ref useSiteInfo);
             }
-            else if (argument.Kind == BoundKind.CollectionExpressionSpreadElement)
-            {
-                MakeSpreadElementTypeInferences((BoundCollectionExpressionSpreadElement)argument, target, ref useSiteInfo);
-            }
             else if (argument.Kind != BoundKind.TupleLiteral ||
                 !MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, kind, ref useSiteInfo))
             {
@@ -662,7 +658,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                MakeExplicitParameterTypeInferences(binder, element, targetElementType, kind, ref useSiteInfo);
+                if (element is BoundCollectionExpressionSpreadElement spread)
+                {
+                    MakeSpreadElementTypeInferences(spread, targetElementType, ref useSiteInfo);
+                }
+                else
+                {
+                    MakeExplicitParameterTypeInferences(binder, (BoundExpression)element, targetElementType, kind, ref useSiteInfo);
+                }
             }
         }
 
@@ -880,7 +883,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var element in argument.Elements)
             {
-                MakeOutputTypeInferences(binder, element, targetElementType, ref useSiteInfo);
+                if (element is BoundExpression expression)
+                {
+                    MakeOutputTypeInferences(binder, expression, targetElementType, ref useSiteInfo);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1874,7 +1874,7 @@
 
   <AbstractNode Name="BoundCollectionExpressionBase" Base="BoundExpression">
     <!-- Collection expression elements. -->
-    <Field Name="Elements" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <Field Name="Elements" Type="ImmutableArray&lt;BoundNode&gt;"/>
   </AbstractNode>
 
   <!--
@@ -1904,9 +1904,7 @@
 
   <Node Name="BoundCollectionExpressionSpreadExpressionPlaceholder" Base="BoundValuePlaceholderBase"/>
 
-  <Node Name="BoundCollectionExpressionSpreadElement" Base="BoundExpression">
-    <!-- Type is not significant for this node type; always null -->
-    <Field Name="Type" Type="TypeSymbol?" Override="true" Null="always"/>
+  <Node Name="BoundCollectionExpressionSpreadElement" Base="BoundNode">
     <!-- Collection being spread. -->
     <Field Name="Expression" Type="BoundExpression"/>
     <!-- Collection placeholder, used in Conversion and LengthOrCount fields. -->

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1981,11 +1981,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private void VisitCollectionExpression(ImmutableArray<BoundExpression> elements)
+        private void VisitCollectionExpression(ImmutableArray<BoundNode> elements)
         {
             foreach (var element in elements)
             {
-                VisitRvalue(element);
+                if (element is BoundExpression expression)
+                {
+                    VisitRvalue(expression);
+                }
+                else
+                {
+                    Visit(element);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3508,7 +3508,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Visit(spread);
                         break;
                     default:
-                        _ = VisitOptionalImplicitConversion(element, targetElementType, useLegacyWarnings: false, trackMembers: false, AssignmentKind.Assignment);
+                        _ = VisitOptionalImplicitConversion((BoundExpression)element, targetElementType, useLegacyWarnings: false, trackMembers: false, AssignmentKind.Assignment);
 
                         break;
                 }
@@ -3522,17 +3522,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var element in node.Elements)
             {
-                VisitRvalue(element);
+                if (element is BoundExpression expression)
+                {
+                    VisitRvalue(expression);
+                }
+                else
+                {
+                    Visit(element);
+                }
             }
 
             SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.NotNull));
-            return null;
-        }
-
-        public override BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node)
-        {
-            base.VisitCollectionExpressionSpreadElement(node);
-            SetResultType(node, default);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6288,7 +6288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal abstract partial class BoundCollectionExpressionBase : BoundExpression
     {
-        protected BoundCollectionExpressionBase(BoundKind kind, SyntaxNode syntax, ImmutableArray<BoundExpression> elements, TypeSymbol? type, bool hasErrors = false)
+        protected BoundCollectionExpressionBase(BoundKind kind, SyntaxNode syntax, ImmutableArray<BoundNode> elements, TypeSymbol? type, bool hasErrors = false)
             : base(kind, syntax, type, hasErrors)
         {
 
@@ -6297,12 +6297,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Elements = elements;
         }
 
-        public ImmutableArray<BoundExpression> Elements { get; }
+        public ImmutableArray<BoundNode> Elements { get; }
     }
 
     internal sealed partial class BoundUnconvertedCollectionExpression : BoundCollectionExpressionBase
     {
-        public BoundUnconvertedCollectionExpression(SyntaxNode syntax, ImmutableArray<BoundExpression> elements, bool hasErrors = false)
+        public BoundUnconvertedCollectionExpression(SyntaxNode syntax, ImmutableArray<BoundNode> elements, bool hasErrors = false)
             : base(BoundKind.UnconvertedCollectionExpression, syntax, elements, null, hasErrors || elements.HasErrors())
         {
 
@@ -6315,7 +6315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUnconvertedCollectionExpression(this);
 
-        public BoundUnconvertedCollectionExpression Update(ImmutableArray<BoundExpression> elements)
+        public BoundUnconvertedCollectionExpression Update(ImmutableArray<BoundNode> elements)
         {
             if (elements != this.Elements)
             {
@@ -6329,7 +6329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundCollectionExpression : BoundCollectionExpressionBase
     {
-        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundValuePlaceholder? collectionBuilderInvocationPlaceholder, BoundExpression? collectionBuilderInvocationConversion, ImmutableArray<BoundExpression> elements, TypeSymbol type, bool hasErrors = false)
+        public BoundCollectionExpression(SyntaxNode syntax, CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundValuePlaceholder? collectionBuilderInvocationPlaceholder, BoundExpression? collectionBuilderInvocationConversion, ImmutableArray<BoundNode> elements, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.CollectionExpression, syntax, elements, type, hasErrors || placeholder.HasErrors() || collectionCreation.HasErrors() || collectionBuilderInvocationPlaceholder.HasErrors() || collectionBuilderInvocationConversion.HasErrors() || elements.HasErrors())
         {
 
@@ -6355,7 +6355,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitCollectionExpression(this);
 
-        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundValuePlaceholder? collectionBuilderInvocationPlaceholder, BoundExpression? collectionBuilderInvocationConversion, ImmutableArray<BoundExpression> elements, TypeSymbol type)
+        public BoundCollectionExpression Update(CollectionExpressionTypeKind collectionTypeKind, BoundObjectOrCollectionValuePlaceholder? placeholder, BoundExpression? collectionCreation, MethodSymbol? collectionBuilderMethod, BoundValuePlaceholder? collectionBuilderInvocationPlaceholder, BoundExpression? collectionBuilderInvocationConversion, ImmutableArray<BoundNode> elements, TypeSymbol type)
         {
             if (collectionTypeKind != this.CollectionTypeKind || placeholder != this.Placeholder || collectionCreation != this.CollectionCreation || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(collectionBuilderMethod, this.CollectionBuilderMethod) || collectionBuilderInvocationPlaceholder != this.CollectionBuilderInvocationPlaceholder || collectionBuilderInvocationConversion != this.CollectionBuilderInvocationConversion || elements != this.Elements || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
@@ -6395,10 +6395,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundCollectionExpressionSpreadElement : BoundExpression
+    internal sealed partial class BoundCollectionExpressionSpreadElement : BoundNode
     {
         public BoundCollectionExpressionSpreadElement(SyntaxNode syntax, BoundExpression expression, BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder, BoundExpression? conversion, ForEachEnumeratorInfo? enumeratorInfoOpt, BoundExpression? lengthOrCount, BoundValuePlaceholder? elementPlaceholder, BoundStatement? iteratorBody, bool hasErrors = false)
-            : base(BoundKind.CollectionExpressionSpreadElement, syntax, null, hasErrors || expression.HasErrors() || expressionPlaceholder.HasErrors() || conversion.HasErrors() || lengthOrCount.HasErrors() || elementPlaceholder.HasErrors() || iteratorBody.HasErrors())
+            : base(BoundKind.CollectionExpressionSpreadElement, syntax, hasErrors || expression.HasErrors() || expressionPlaceholder.HasErrors() || conversion.HasErrors() || lengthOrCount.HasErrors() || elementPlaceholder.HasErrors() || iteratorBody.HasErrors())
         {
 
             RoslynDebug.Assert(expression is object, "Field 'expression' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
@@ -6412,7 +6412,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.IteratorBody = iteratorBody;
         }
 
-        public new TypeSymbol? Type => base.Type;
         public BoundExpression Expression { get; }
         public BoundCollectionExpressionSpreadExpressionPlaceholder? ExpressionPlaceholder { get; }
         public BoundExpression? Conversion { get; }
@@ -11624,7 +11623,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
         {
-            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(elements);
         }
@@ -11634,7 +11633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? collectionCreation = node.CollectionCreation;
             BoundValuePlaceholder? collectionBuilderInvocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
             BoundExpression? collectionBuilderInvocationConversion = node.CollectionBuilderInvocationConversion;
-            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(node.CollectionTypeKind, placeholder, collectionCreation, node.CollectionBuilderMethod, collectionBuilderInvocationPlaceholder, collectionBuilderInvocationConversion, elements, type);
         }
@@ -11651,7 +11650,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? lengthOrCount = node.LengthOrCount;
             BoundValuePlaceholder? elementPlaceholder = node.ElementPlaceholder;
             BoundStatement? iteratorBody = node.IteratorBody;
-            TypeSymbol? type = this.VisitType(node.Type);
             return node.Update(expression, expressionPlaceholder, conversion, node.EnumeratorInfoOpt, lengthOrCount, elementPlaceholder, iteratorBody);
         }
         public override BoundNode? VisitTupleLiteral(BoundTupleLiteral node)
@@ -13843,7 +13841,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitUnconvertedCollectionExpression(BoundUnconvertedCollectionExpression node)
         {
-            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             BoundUnconvertedCollectionExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
@@ -13865,7 +13863,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression? collectionCreation = node.CollectionCreation;
             BoundValuePlaceholder? collectionBuilderInvocationPlaceholder = node.CollectionBuilderInvocationPlaceholder;
             BoundExpression? collectionBuilderInvocationConversion = node.CollectionBuilderInvocationConversion;
-            ImmutableArray<BoundExpression> elements = this.VisitList(node.Elements);
+            ImmutableArray<BoundNode> elements = this.VisitList(node.Elements);
             BoundCollectionExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
@@ -13889,28 +13887,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundCollectionExpressionSpreadExpressionPlaceholder updatedNode = node.Update(infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
-            return updatedNode;
-        }
-
-        public override BoundNode? VisitCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement node)
-        {
-            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            BoundCollectionExpressionSpreadExpressionPlaceholder? expressionPlaceholder = node.ExpressionPlaceholder;
-            BoundExpression? conversion = node.Conversion;
-            BoundExpression? lengthOrCount = node.LengthOrCount;
-            BoundValuePlaceholder? elementPlaceholder = node.ElementPlaceholder;
-            BoundStatement? iteratorBody = node.IteratorBody;
-            BoundCollectionExpressionSpreadElement updatedNode;
-
-            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
-            {
-                updatedNode = node.Update(expression, expressionPlaceholder, conversion, node.EnumeratorInfoOpt, lengthOrCount, elementPlaceholder, iteratorBody);
-                updatedNode.TopLevelNullability = infoAndType.Info;
-            }
-            else
-            {
-                updatedNode = node.Update(expression, expressionPlaceholder, conversion, node.EnumeratorInfoOpt, lengthOrCount, elementPlaceholder, iteratorBody);
-            }
             return updatedNode;
         }
 
@@ -16315,8 +16291,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("lengthOrCount", null, new TreeDumperNode[] { Visit(node.LengthOrCount, null) }),
             new TreeDumperNode("elementPlaceholder", null, new TreeDumperNode[] { Visit(node.ElementPlaceholder, null) }),
             new TreeDumperNode("iteratorBody", null, new TreeDumperNode[] { Visit(node.IteratorBody, null) }),
-            new TreeDumperNode("type", node.Type, null),
-            new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = boundCollectionExpression.WasCompilerGenerated;
             return new NoneOperation(elements, _semanticModel, syntax, type: type, constantValue: null, isImplicit);
 
-            ImmutableArray<IOperation> createChildren(ImmutableArray<BoundExpression> elements)
+            ImmutableArray<IOperation> createChildren(ImmutableArray<BoundNode> elements)
             {
                 var builder = ArrayBuilder<IOperation>.GetInstance(elements.Length);
                 foreach (var element in elements)
@@ -1243,24 +1243,23 @@ namespace Microsoft.CodeAnalysis.Operations
                 return builder.ToImmutableAndFree();
             }
 
-            IOperation? createChild(BoundExpression expression)
+            IOperation? createChild(BoundNode element)
             {
-                var element = expression switch
+                var result = element switch
                 {
                     BoundCollectionElementInitializer initializer => initializer.Arguments.First(),
-                    _ => expression,
+                    _ => element,
                 };
-                return Create(element);
+                return Create(result);
             }
         }
 
         private IOperation CreateBoundCollectionExpressionSpreadElement(BoundCollectionExpressionSpreadElement boundSpreadExpression)
         {
             SyntaxNode syntax = boundSpreadExpression.Syntax;
-            ITypeSymbol? type = boundSpreadExpression.GetPublicTypeSymbol();
             bool isImplicit = boundSpreadExpression.WasCompilerGenerated;
             var children = ImmutableArray.Create<IOperation>(Create(boundSpreadExpression.Expression));
-            return new NoneOperation(children, _semanticModel, syntax, type, constantValue: null, isImplicit);
+            return new NoneOperation(children, _semanticModel, syntax, type: null, constantValue: null, isImplicit);
         }
 
         private IDefaultValueOperation CreateBoundDefaultLiteralOperation(BoundDefaultLiteral boundDefaultLiteral)


### PR DESCRIPTION
Adjust bound tree implementation to reflect that spread elements are not expressions.

See also https://github.com/dotnet/csharplang/pull/7604.