### PR TITLE
Handle missing ISimplificationService implementation for non-C#/VB languages

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Simplification
     {
 #if !CODE_STYLE
         public static SimplifierOptions GetSimplifierOptions(this IOptionsReader options, LanguageServices languageServices, SimplifierOptions? fallbackOptions)
-            => languageServices.GetRequiredService<ISimplificationService>().GetSimplifierOptions(options, fallbackOptions);
+            => languageServices.GetService<ISimplificationService>()?.GetSimplifierOptions(options, fallbackOptions) ?? fallbackOptions ?? SimplifierOptions.CommonDefaults;
 
         public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, SimplifierOptions? fallbackOptions, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Fixes [AB#1901118](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1901118)

Verified that the added unit test fails with the same exception as in the above bug prior to the product change.