### PR TITLE
Update config file after 17.9 branch is created

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -170,7 +170,7 @@
       ],
       "vsBranch": "rel/d17.7",
       "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.7P3]"
+      "insertionTitlePrefix": "[d17.7]"
     },
     "release/dev17.8": {
       "nugetKind": [
@@ -179,7 +179,17 @@
       ],
       "vsBranch": "rel/d17.8",
       "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[d17.8P3]"
+      "insertionTitlePrefix": "[d17.8]"
+    },
+    "release/dev17.9": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "main",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[d17.9P1]"
     },
     "main": {
       "nugetKind": [
@@ -189,7 +199,7 @@
       "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[d17.9P1]"
+      "insertionTitlePrefix": "[main]"
     },
     "dev/jorobich/fix-pr-val": {
       "nugetKind": [


### PR DESCRIPTION
As offline discussion , create `release/dev17.9` branch to consume internal 17.9 APIs (specifically, this PR https://github.com/dotnet/roslyn/pull/70420) (It acts as the `vs-deps` branch we used to have)

I have created [it](https://github.com/dotnet/roslyn/tree/release/dev17.9) based on main.

Our branch model later would be:
1. Let the bot always flow change from `main` -> `release/dev17.9`
2. Daily Insertion should triggered from `release/dev17.9` -> VS main