### PR TITLE
Refactor how Extract Method returns results.

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             }
             else
             {
-                Assert.True(!result.Succeeded || result.Reasons.Length > 0);
+                Assert.True(result.Succeeded || result.Reasons.Length > 0);
             }
 
             var (doc, _) = await result.GetFormattedDocumentAsync(CodeCleanupOptions.GetDefault(document.Project.Services), CancellationToken.None);
@@ -184,7 +184,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var validator = new CSharpSelectionValidator(semanticDocument, textSpanOverride ?? namedSpans["b"].Single(), ExtractMethodOptions.Default, localFunction: false);
             var result = await validator.GetValidSelectionAsync(CancellationToken.None);
 
-            Assert.True(expectedFail ? result.Status.Failed() : result.Status.Succeeded());
+            if (expectedFail)
+            {
+                Assert.True(result.Status.Failed() || result.Status.Reasons.Length > 0);
+            }
+            else
+            {
+                Assert.True(result.Status.Succeeded());
+            }
 
             if (result.Status.Succeeded() && result.SelectionChanged)
                 Assert.Equal(namedSpans["r"].Single(), result.FinalSpan);

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -151,15 +151,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var result = await extractor.ExtractMethodAsync(CancellationToken.None);
             Assert.NotNull(result);
 
-            // If the test expects us to succeed, validate that we did.  If it expects us to have 
+            // If the test expects us to succeed, validate that we did.  If it expects us to fail, ensure we either
+            // failed or produced a message the user will have to confirm to continue. 
             if (succeed)
             {
                 Assert.Equal(succeed, result.Succeeded);
 
                 if (allowBestEffort)
                     Assert.NotEmpty(result.Reasons);
-                else
-                    Assert.Empty(result.Reasons);
             }
             else
             {

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
 
             Assert.True(expectedFail ? result.Status.Failed() : result.Status.Succeeded());
 
-            if (result.Status.Succeeded() && result.Status.Reasons.Length == 0)
+            if (result.Status.Succeeded() && result.SelectionChanged)
                 Assert.Equal(namedSpans["r"].Single(), result.FinalSpan);
         }
 

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -84,7 +84,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             string expected,
             bool temporaryFailing = false,
             bool dontPutOutOrRefOnStruct = true,
-            bool allowBestEffort = false,
             CSharpParseOptions parseOptions = null)
         {
             using var workspace = TestWorkspace.CreateCSharp(codeWithMarker, parseOptions: parseOptions);
@@ -93,8 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
 
             var tree = await ExtractMethodAsync(
                 workspace, testDocument,
-                dontPutOutOrRefOnStruct: dontPutOutOrRefOnStruct,
-                allowBestEffort: allowBestEffort);
+                dontPutOutOrRefOnStruct: dontPutOutOrRefOnStruct);
 
             using (var edit = subjectBuffer.CreateEdit())
             {
@@ -125,8 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             TestWorkspace workspace,
             TestHostDocument testDocument,
             bool succeed = true,
-            bool dontPutOutOrRefOnStruct = true,
-            bool allowBestEffort = false)
+            bool dontPutOutOrRefOnStruct = true)
         {
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
             Assert.NotNull(document);
@@ -156,13 +153,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             if (succeed)
             {
                 Assert.Equal(succeed, result.Succeeded);
-
-                if (allowBestEffort)
-                    Assert.NotEmpty(result.Reasons);
             }
             else
             {
-                Assert.True(result.Succeeded || result.Reasons.Length > 0);
+                Assert.True(!result.Succeeded || result.Reasons.Length > 0);
             }
 
             var (doc, _) = await result.GetFormattedDocumentAsync(CodeCleanupOptions.GetDefault(document.Project.Services), CancellationToken.None);

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -11992,7 +11992,7 @@ $@"namespace ClassLibrary9
                     }
                 }
                 """;
-            await TestExtractMethodAsync(code, expected, allowBestEffort: true);
+            await TestExtractMethodAsync(code, expected);
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/30750")]

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -3,15 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using EnvDTE;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.BackgroundWorkIndicator;
@@ -24,8 +20,6 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Commanding;
-using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -34,270 +28,256 @@ using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.ExtractMethod
+namespace Microsoft.CodeAnalysis.ExtractMethod;
+
+[Export(typeof(ICommandHandler))]
+[ContentType(ContentTypeNames.CSharpContentType)]
+[ContentType(ContentTypeNames.VisualBasicContentType)]
+[Name(PredefinedCommandHandlerNames.ExtractMethod)]
+[Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
+internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMethodCommandArgs>
 {
-    [Export(typeof(ICommandHandler))]
-    [ContentType(ContentTypeNames.CSharpContentType)]
-    [ContentType(ContentTypeNames.VisualBasicContentType)]
-    [Name(PredefinedCommandHandlerNames.ExtractMethod)]
-    [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
-    internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMethodCommandArgs>
+    private readonly IThreadingContext _threadingContext;
+    private readonly ITextBufferUndoManagerProvider _undoManager;
+    private readonly IInlineRenameService _renameService;
+    private readonly IGlobalOptionService _globalOptions;
+    private readonly IAsynchronousOperationListener _asyncListener;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public ExtractMethodCommandHandler(
+        IThreadingContext threadingContext,
+        ITextBufferUndoManagerProvider undoManager,
+        IInlineRenameService renameService,
+        IGlobalOptionService globalOptions,
+        IAsynchronousOperationListenerProvider asyncListenerProvider)
     {
-        private readonly IThreadingContext _threadingContext;
-        private readonly ITextBufferUndoManagerProvider _undoManager;
-        private readonly IInlineRenameService _renameService;
-        private readonly IGlobalOptionService _globalOptions;
-        private readonly IAsynchronousOperationListener _asyncListener;
+        Contract.ThrowIfNull(threadingContext);
+        Contract.ThrowIfNull(undoManager);
+        Contract.ThrowIfNull(renameService);
 
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public ExtractMethodCommandHandler(
-            IThreadingContext threadingContext,
-            ITextBufferUndoManagerProvider undoManager,
-            IInlineRenameService renameService,
-            IGlobalOptionService globalOptions,
-            IAsynchronousOperationListenerProvider asyncListenerProvider)
+        _threadingContext = threadingContext;
+        _undoManager = undoManager;
+        _renameService = renameService;
+        _globalOptions = globalOptions;
+        _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.ExtractMethod);
+    }
+
+    public string DisplayName => EditorFeaturesResources.Extract_Method;
+
+    public CommandState GetCommandState(ExtractMethodCommandArgs args)
+    {
+        var spans = args.TextView.Selection.GetSnapshotSpansOnBuffer(args.SubjectBuffer);
+        if (spans.Count(s => s.Length > 0) != 1)
         {
-            Contract.ThrowIfNull(threadingContext);
-            Contract.ThrowIfNull(undoManager);
-            Contract.ThrowIfNull(renameService);
-
-            _threadingContext = threadingContext;
-            _undoManager = undoManager;
-            _renameService = renameService;
-            _globalOptions = globalOptions;
-            _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.ExtractMethod);
+            return CommandState.Unspecified;
         }
 
-        public string DisplayName => EditorFeaturesResources.Extract_Method;
-
-        public CommandState GetCommandState(ExtractMethodCommandArgs args)
+        if (!args.SubjectBuffer.TryGetWorkspace(out var workspace) ||
+            !workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) ||
+            !args.SubjectBuffer.SupportsRefactorings())
         {
-            var spans = args.TextView.Selection.GetSnapshotSpansOnBuffer(args.SubjectBuffer);
-            if (spans.Count(s => s.Length > 0) != 1)
-            {
-                return CommandState.Unspecified;
-            }
-
-            if (!args.SubjectBuffer.TryGetWorkspace(out var workspace) ||
-                !workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) ||
-                !args.SubjectBuffer.SupportsRefactorings())
-            {
-                return CommandState.Unspecified;
-            }
-
-            return CommandState.Available;
+            return CommandState.Unspecified;
         }
 
-        public bool ExecuteCommand(ExtractMethodCommandArgs args, CommandExecutionContext context)
+        return CommandState.Available;
+    }
+
+    public bool ExecuteCommand(ExtractMethodCommandArgs args, CommandExecutionContext context)
+    {
+        // Finish any rename that had been started. We'll do this here before we enter the
+        // wait indicator for Extract Method
+        if (_renameService.ActiveSession != null)
         {
-            // Finish any rename that had been started. We'll do this here before we enter the
-            // wait indicator for Extract Method
-            if (_renameService.ActiveSession != null)
-            {
-                _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, CancellationToken.None));
-            }
-
-            if (!args.SubjectBuffer.SupportsRefactorings())
-                return false;
-
-            var view = args.TextView;
-            var textBuffer = args.SubjectBuffer;
-            var spans = view.Selection.GetSnapshotSpansOnBuffer(textBuffer).Where(s => s.Length > 0).ToList();
-            if (spans.Count != 1)
-                return false;
-
-            var span = spans[0];
-
-            var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-            if (document is null)
-                return false;
-
-            _ = ExecuteAsync(view, textBuffer, document, span);
-            return true;
+            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, CancellationToken.None));
         }
 
-        private async Task ExecuteAsync(
-            ITextView view,
-            ITextBuffer textBuffer,
-            Document document,
-            SnapshotSpan span)
-        {
-            _threadingContext.ThrowIfNotOnUIThread();
-            var indicatorFactory = document.Project.Solution.Services.GetRequiredService<IBackgroundWorkIndicatorFactory>();
-            using var indicatorContext = indicatorFactory.Create(
-                view, span, EditorFeaturesResources.Applying_Extract_Method_refactoring, cancelOnEdit: true, cancelOnFocusLost: true);
+        if (!args.SubjectBuffer.SupportsRefactorings())
+            return false;
 
-            using var asyncToken = _asyncListener.BeginAsyncOperation(nameof(ExecuteCommand));
-            await ExecuteWorkerAsync(view, textBuffer, span.Span.ToTextSpan(), indicatorContext).ConfigureAwait(false);
-        }
+        var view = args.TextView;
+        var textBuffer = args.SubjectBuffer;
+        var spans = view.Selection.GetSnapshotSpansOnBuffer(textBuffer).Where(s => s.Length > 0).ToList();
+        if (spans.Count != 1)
+            return false;
 
-        private async Task ExecuteWorkerAsync(
-            ITextView view,
-            ITextBuffer textBuffer,
-            TextSpan span,
-            IBackgroundWorkIndicatorContext waitContext)
-        {
-            _threadingContext.ThrowIfNotOnUIThread();
+        var span = spans[0];
 
-            var cancellationToken = waitContext.UserCancellationToken;
+        var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+        if (document is null)
+            return false;
 
-            var document = await textBuffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(waitContext).ConfigureAwait(false);
-            if (document is null)
-                return;
+        _ = ExecuteAsync(view, textBuffer, document, span);
+        return true;
+    }
 
-            var options = await document.GetExtractMethodGenerationOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
-            var result = await ExtractMethodService.ExtractMethodAsync(
-                document, span, localFunction: false, options, cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(result);
+    private async Task ExecuteAsync(
+        ITextView view,
+        ITextBuffer textBuffer,
+        Document document,
+        SnapshotSpan span)
+    {
+        _threadingContext.ThrowIfNotOnUIThread();
+        var indicatorFactory = document.Project.Solution.Services.GetRequiredService<IBackgroundWorkIndicatorFactory>();
+        using var indicatorContext = indicatorFactory.Create(
+            view, span, EditorFeaturesResources.Applying_Extract_Method_refactoring, cancelOnEdit: true, cancelOnFocusLost: true);
 
-            if (!result.Succeeded)
-            {
-                // if it failed due to out/ref parameter in async method, try it with different option
-                var newResult = await TryWithoutMakingValueTypesRefAsync(
-                    document, span, result, options, cancellationToken).ConfigureAwait(false);
-                if (newResult != null)
-                {
-                    var notificationService = document.Project.Solution.Services.GetService<INotificationService>();
-                    if (notificationService != null)
-                    {
-                        // We are about to show a modal UI dialog so we should take over the command execution
-                        // wait context. That means the command system won't attempt to show its own wait dialog 
-                        // and also will take it into consideration when measuring command handling duration.
-                        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        using var asyncToken = _asyncListener.BeginAsyncOperation(nameof(ExecuteCommand));
+        await ExecuteWorkerAsync(view, textBuffer, span.Span.ToTextSpan(), indicatorContext).ConfigureAwait(false);
+    }
 
-                        if (!notificationService.ConfirmMessageBox(
-                                EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine + Environment.NewLine +
-                                string.Join(Environment.NewLine, result.Reasons) + Environment.NewLine + Environment.NewLine +
-                                EditorFeaturesResources.We_can_fix_the_error_by_not_making_struct_out_ref_parameter_s_Do_you_want_to_proceed,
-                                title: EditorFeaturesResources.Extract_Method,
-                                severity: NotificationSeverity.Error))
-                        {
-                            // We handled the command, displayed a notification and did not produce code.
-                            return;
-                        }
+    private async Task ExecuteWorkerAsync(
+        ITextView view,
+        ITextBuffer textBuffer,
+        TextSpan span,
+        IBackgroundWorkIndicatorContext waitContext)
+    {
+        _threadingContext.ThrowIfNotOnUIThread();
 
-                        await TaskScheduler.Default;
-                    }
+        var cancellationToken = waitContext.UserCancellationToken;
 
-                    // reset result
-                    result = newResult;
-                }
-                else if (await TryNotifyFailureToUserAsync(document, result, cancellationToken).ConfigureAwait(false))
-                {
-                    // We handled the command, displayed a notification and did not produce code.
-                    return;
-                }
-            }
+        var document = await textBuffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(waitContext).ConfigureAwait(false);
+        if (document is null)
+            return;
 
-            var cleanupOptions = await document.GetCodeCleanupOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
-            var (formattedDocument, methodNameAtInvocation) = await result.GetFormattedDocumentAsync(cleanupOptions, cancellationToken).ConfigureAwait(false);
-            var changes = await formattedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false);
+        var options = await document.GetExtractMethodGenerationOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+        var result = await ExtractMethodService.ExtractMethodAsync(
+            document, span, localFunction: false, options, cancellationToken).ConfigureAwait(false);
+        Contract.ThrowIfNull(result);
 
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        result = await NotifyUserIfNecessaryAsync(
+            document, span, options, result, cancellationToken).ConfigureAwait(false);
+        if (result is null)
+            return;
 
-            ApplyChange_OnUIThread(textBuffer, changes, waitContext);
+        var cleanupOptions = await document.GetCodeCleanupOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+        var (formattedDocument, methodNameAtInvocation) = await result.GetFormattedDocumentAsync(cleanupOptions, cancellationToken).ConfigureAwait(false);
+        var changes = await formattedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false);
 
-            // start inline rename to allow the user to change the name if they want.
-            var textSnapshot = textBuffer.CurrentSnapshot;
-            document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-            if (document != null)
-                _renameService.StartInlineSession(document, methodNameAtInvocation.Span, cancellationToken);
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            // select invocation span
-            view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(textSnapshot, methodNameAtInvocation.Span.End));
-            view.SetSelection(methodNameAtInvocation.Span.ToSnapshotSpan(textSnapshot));
-        }
+        ApplyChange_OnUIThread(textBuffer, changes, waitContext);
 
-        private void ApplyChange_OnUIThread(
-            ITextBuffer textBuffer, IEnumerable<TextChange> changes, IBackgroundWorkIndicatorContext waitContext)
-        {
-            _threadingContext.ThrowIfNotOnUIThread();
+        // start inline rename to allow the user to change the name if they want.
+        var textSnapshot = textBuffer.CurrentSnapshot;
+        document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+        if (document != null)
+            _renameService.StartInlineSession(document, methodNameAtInvocation.Span, cancellationToken);
 
-            using var undoTransaction = _undoManager.GetTextBufferUndoManager(textBuffer).TextBufferUndoHistory.CreateTransaction("Extract Method");
+        // select invocation span
+        view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(textSnapshot, methodNameAtInvocation.Span.End));
+        view.SetSelection(methodNameAtInvocation.Span.ToSnapshotSpan(textSnapshot));
+    }
 
-            // We're about to make an edit ourselves.  so disable the cancellation that happens on editing.
-            waitContext.CancelOnEdit = false;
-            textBuffer.ApplyChanges(changes);
+    private async Task<ExtractMethodResult?> NotifyUserIfNecessaryAsync(
+        Document document, TextSpan span, ExtractMethodGenerationOptions options, ExtractMethodResult result, CancellationToken cancellationToken)
+    {
+        // If we succeeded without any problems, just proceed without notifying the user.
+        if (result is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
+            return result;
 
-            // apply changes
-            undoTransaction.Complete();
-        }
+        // We have some sort of issue.  See what the user wants to do.  If we have no way to inform the user bail
+        // out rather than doing something wrong.
+        var notificationService = document.Project.Solution.Services.GetService<INotificationService>();
+        if (notificationService is null)
+            return null;
 
-        /// <returns>
-        /// True: if a failure notification was displayed or the user did not want to proceed in a best effort scenario. 
-        ///       Extract Method does not proceed further and is done.
-        /// False: the user proceeded to a best effort scenario.
-        /// </returns>
-        private async Task<bool> TryNotifyFailureToUserAsync(
-            Document document, ExtractMethodResult result, CancellationToken cancellationToken)
+        // The initial extract method failed, or it succeeded with warning reasons.  Attempt again with
+        // different options to see if we get better results.
+        var alternativeResult = await TryWithoutMakingValueTypesRefAsync(
+            document, span, result, options, cancellationToken).ConfigureAwait(false);
+        if (alternativeResult is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
         {
             // We are about to show a modal UI dialog so we should take over the command execution
             // wait context. That means the command system won't attempt to show its own wait dialog 
             // and also will take it into consideration when measuring command handling duration.
-            var project = document.Project;
-            var solution = project.Solution;
-            var notificationService = solution.Services.GetService<INotificationService>();
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            // see whether we will allow best effort extraction and if it is possible.
-            if (!_globalOptions.GetOption(ExtractMethodPresentationOptionsStorage.AllowBestEffort, document.Project.Language) ||
-                !result.Status.HasBestEffort() ||
-                result.DocumentWithoutFinalFormatting == null)
+            if (!notificationService.ConfirmMessageBox(
+                    EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine + Environment.NewLine +
+                    string.Join(Environment.NewLine, result.Reasons) + Environment.NewLine + Environment.NewLine +
+                    EditorFeaturesResources.We_can_fix_the_error_by_not_making_struct_out_ref_parameter_s_Do_you_want_to_proceed,
+                    title: EditorFeaturesResources.Extract_Method,
+                    severity: NotificationSeverity.Error))
             {
-                if (notificationService != null)
-                {
-                    await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                    notificationService.SendNotification(
-                        EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
-                        string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)),
-                        title: EditorFeaturesResources.Extract_Method,
-                        severity: NotificationSeverity.Error);
-                }
-
-                return true;
+                // We handled the command, displayed a notification and did not produce code.
+                return null;
             }
 
-            // okay, best effort is turned on, let user know it is an best effort
-            if (notificationService != null)
-            {
-                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                if (!notificationService.ConfirmMessageBox(
-                        EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
-                        string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)) + Environment.NewLine + Environment.NewLine +
-                        EditorFeaturesResources.Do_you_still_want_to_proceed_This_may_produce_broken_code,
-                        title: EditorFeaturesResources.Extract_Method,
-                        severity: NotificationSeverity.Warning))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            // Otherwise, prefer the new approach that has less problems.
+            return alternativeResult;
         }
 
-        private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
-            Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
+        // The alternative approach wasn't better.  If we failed, just let the user know and bail out.  Otherwise,
+        // if we succeeded with messages, tell the user and let them decide if they want to proceed or not.
+        if (!result.Succeeded || result.DocumentWithoutFinalFormatting is null)
         {
-            if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
-                return null;
-
-            var reason = result.Reasons.FirstOrDefault();
-            var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
-            if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
-            {
-                var newResult = await ExtractMethodService.ExtractMethodAsync(
-                    document,
-                    span,
-                    localFunction: false,
-                    options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
-                    cancellationToken).ConfigureAwait(false);
-
-                // retry succeeded, return new result
-                if (newResult.Succeeded)
-                    return newResult;
-            }
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            notificationService.SendNotification(
+                EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
+                string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)),
+                title: EditorFeaturesResources.Extract_Method,
+                severity: NotificationSeverity.Error);
 
             return null;
         }
+
+        // We succeed and have a not null document.  We must them have some issues to report to the user (otherwise
+        // we would have fast returned at the top of this method).  Tell the user about them and let them decide
+        // what they want to do.
+        Contract.ThrowIfTrue(result.Reasons.Length == 0);
+
+        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        if (!notificationService.ConfirmMessageBox(
+                EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
+                string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)) + Environment.NewLine + Environment.NewLine +
+                EditorFeaturesResources.Do_you_still_want_to_proceed_This_may_produce_broken_code,
+                title: EditorFeaturesResources.Extract_Method,
+                severity: NotificationSeverity.Warning))
+        {
+            return null;
+        }
+
+        return result;
+    }
+
+    private void ApplyChange_OnUIThread(
+        ITextBuffer textBuffer, IEnumerable<TextChange> changes, IBackgroundWorkIndicatorContext waitContext)
+    {
+        _threadingContext.ThrowIfNotOnUIThread();
+
+        using var undoTransaction = _undoManager.GetTextBufferUndoManager(textBuffer).TextBufferUndoHistory.CreateTransaction("Extract Method");
+
+        // We're about to make an edit ourselves.  so disable the cancellation that happens on editing.
+        waitContext.CancelOnEdit = false;
+        textBuffer.ApplyChanges(changes);
+
+        // apply changes
+        undoTransaction.Complete();
+    }
+
+    private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
+        Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
+    {
+        if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
+            return null;
+
+        var reason = result.Reasons.FirstOrDefault();
+        var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
+        if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
+        {
+            var newResult = await ExtractMethodService.ExtractMethodAsync(
+                document,
+                span,
+                localFunction: false,
+                options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
+                cancellationToken).ConfigureAwait(false);
+
+            // retry succeeded, return new result
+            if (newResult.Succeeded)
+                return newResult;
+        }
+
+        return null;
     }
 }

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -184,31 +184,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             undoTransaction.Complete();
         }
 
-        private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
-            Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
-        {
-            if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
-                return null;
-
-            var reason = result.Reasons.FirstOrDefault();
-            var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
-            if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
-            {
-                var newResult = await ExtractMethodService.ExtractMethodAsync(
-                    document,
-                    span,
-                    localFunction: false,
-                    options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
-                    cancellationToken).ConfigureAwait(false);
-
-                // retry succeeded, return new result
-                if (newResult.Succeeded)
-                    return newResult;
-            }
-
-            return null;
-        }
-
         private async Task<ExtractMethodResult?> NotifyUserIfNecessaryAsync(
             Document document, TextSpan span, ExtractMethodGenerationOptions options, ExtractMethodResult result, CancellationToken cancellationToken)
         {
@@ -279,6 +254,31 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             return result;
+        }
+
+        private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
+            Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
+        {
+            if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
+                return null;
+
+            var reason = result.Reasons.FirstOrDefault();
+            var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
+            if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
+            {
+                var newResult = await ExtractMethodService.ExtractMethodAsync(
+                    document,
+                    span,
+                    localFunction: false,
+                    options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
+                    cancellationToken).ConfigureAwait(false);
+
+                // retry succeeded, return new result
+                if (newResult.Succeeded)
+                    return newResult;
+            }
+
+            return null;
         }
     }
 }

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -28,256 +28,257 @@ using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.ExtractMethod;
-
-[Export(typeof(ICommandHandler))]
-[ContentType(ContentTypeNames.CSharpContentType)]
-[ContentType(ContentTypeNames.VisualBasicContentType)]
-[Name(PredefinedCommandHandlerNames.ExtractMethod)]
-[Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
-internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMethodCommandArgs>
+namespace Microsoft.CodeAnalysis.ExtractMethod
 {
-    private readonly IThreadingContext _threadingContext;
-    private readonly ITextBufferUndoManagerProvider _undoManager;
-    private readonly IInlineRenameService _renameService;
-    private readonly IGlobalOptionService _globalOptions;
-    private readonly IAsynchronousOperationListener _asyncListener;
-
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-    public ExtractMethodCommandHandler(
-        IThreadingContext threadingContext,
-        ITextBufferUndoManagerProvider undoManager,
-        IInlineRenameService renameService,
-        IGlobalOptionService globalOptions,
-        IAsynchronousOperationListenerProvider asyncListenerProvider)
+    [Export(typeof(ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [Name(PredefinedCommandHandlerNames.ExtractMethod)]
+    [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
+    internal sealed class ExtractMethodCommandHandler : ICommandHandler<ExtractMethodCommandArgs>
     {
-        Contract.ThrowIfNull(threadingContext);
-        Contract.ThrowIfNull(undoManager);
-        Contract.ThrowIfNull(renameService);
+        private readonly IThreadingContext _threadingContext;
+        private readonly ITextBufferUndoManagerProvider _undoManager;
+        private readonly IInlineRenameService _renameService;
+        private readonly IGlobalOptionService _globalOptions;
+        private readonly IAsynchronousOperationListener _asyncListener;
 
-        _threadingContext = threadingContext;
-        _undoManager = undoManager;
-        _renameService = renameService;
-        _globalOptions = globalOptions;
-        _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.ExtractMethod);
-    }
-
-    public string DisplayName => EditorFeaturesResources.Extract_Method;
-
-    public CommandState GetCommandState(ExtractMethodCommandArgs args)
-    {
-        var spans = args.TextView.Selection.GetSnapshotSpansOnBuffer(args.SubjectBuffer);
-        if (spans.Count(s => s.Length > 0) != 1)
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public ExtractMethodCommandHandler(
+            IThreadingContext threadingContext,
+            ITextBufferUndoManagerProvider undoManager,
+            IInlineRenameService renameService,
+            IGlobalOptionService globalOptions,
+            IAsynchronousOperationListenerProvider asyncListenerProvider)
         {
-            return CommandState.Unspecified;
+            Contract.ThrowIfNull(threadingContext);
+            Contract.ThrowIfNull(undoManager);
+            Contract.ThrowIfNull(renameService);
+
+            _threadingContext = threadingContext;
+            _undoManager = undoManager;
+            _renameService = renameService;
+            _globalOptions = globalOptions;
+            _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.ExtractMethod);
         }
 
-        if (!args.SubjectBuffer.TryGetWorkspace(out var workspace) ||
-            !workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) ||
-            !args.SubjectBuffer.SupportsRefactorings())
+        public string DisplayName => EditorFeaturesResources.Extract_Method;
+
+        public CommandState GetCommandState(ExtractMethodCommandArgs args)
         {
-            return CommandState.Unspecified;
+            var spans = args.TextView.Selection.GetSnapshotSpansOnBuffer(args.SubjectBuffer);
+            if (spans.Count(s => s.Length > 0) != 1)
+            {
+                return CommandState.Unspecified;
+            }
+
+            if (!args.SubjectBuffer.TryGetWorkspace(out var workspace) ||
+                !workspace.CanApplyChange(ApplyChangesKind.ChangeDocument) ||
+                !args.SubjectBuffer.SupportsRefactorings())
+            {
+                return CommandState.Unspecified;
+            }
+
+            return CommandState.Available;
         }
 
-        return CommandState.Available;
-    }
-
-    public bool ExecuteCommand(ExtractMethodCommandArgs args, CommandExecutionContext context)
-    {
-        // Finish any rename that had been started. We'll do this here before we enter the
-        // wait indicator for Extract Method
-        if (_renameService.ActiveSession != null)
+        public bool ExecuteCommand(ExtractMethodCommandArgs args, CommandExecutionContext context)
         {
-            _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, CancellationToken.None));
+            // Finish any rename that had been started. We'll do this here before we enter the
+            // wait indicator for Extract Method
+            if (_renameService.ActiveSession != null)
+            {
+                _threadingContext.JoinableTaskFactory.Run(() => _renameService.ActiveSession.CommitAsync(previewChanges: false, CancellationToken.None));
+            }
+
+            if (!args.SubjectBuffer.SupportsRefactorings())
+                return false;
+
+            var view = args.TextView;
+            var textBuffer = args.SubjectBuffer;
+            var spans = view.Selection.GetSnapshotSpansOnBuffer(textBuffer).Where(s => s.Length > 0).ToList();
+            if (spans.Count != 1)
+                return false;
+
+            var span = spans[0];
+
+            var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            if (document is null)
+                return false;
+
+            _ = ExecuteAsync(view, textBuffer, document, span);
+            return true;
         }
 
-        if (!args.SubjectBuffer.SupportsRefactorings())
-            return false;
-
-        var view = args.TextView;
-        var textBuffer = args.SubjectBuffer;
-        var spans = view.Selection.GetSnapshotSpansOnBuffer(textBuffer).Where(s => s.Length > 0).ToList();
-        if (spans.Count != 1)
-            return false;
-
-        var span = spans[0];
-
-        var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-        if (document is null)
-            return false;
-
-        _ = ExecuteAsync(view, textBuffer, document, span);
-        return true;
-    }
-
-    private async Task ExecuteAsync(
-        ITextView view,
-        ITextBuffer textBuffer,
-        Document document,
-        SnapshotSpan span)
-    {
-        _threadingContext.ThrowIfNotOnUIThread();
-        var indicatorFactory = document.Project.Solution.Services.GetRequiredService<IBackgroundWorkIndicatorFactory>();
-        using var indicatorContext = indicatorFactory.Create(
-            view, span, EditorFeaturesResources.Applying_Extract_Method_refactoring, cancelOnEdit: true, cancelOnFocusLost: true);
-
-        using var asyncToken = _asyncListener.BeginAsyncOperation(nameof(ExecuteCommand));
-        await ExecuteWorkerAsync(view, textBuffer, span.Span.ToTextSpan(), indicatorContext).ConfigureAwait(false);
-    }
-
-    private async Task ExecuteWorkerAsync(
-        ITextView view,
-        ITextBuffer textBuffer,
-        TextSpan span,
-        IBackgroundWorkIndicatorContext waitContext)
-    {
-        _threadingContext.ThrowIfNotOnUIThread();
-
-        var cancellationToken = waitContext.UserCancellationToken;
-
-        var document = await textBuffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(waitContext).ConfigureAwait(false);
-        if (document is null)
-            return;
-
-        var options = await document.GetExtractMethodGenerationOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
-        var result = await ExtractMethodService.ExtractMethodAsync(
-            document, span, localFunction: false, options, cancellationToken).ConfigureAwait(false);
-        Contract.ThrowIfNull(result);
-
-        result = await NotifyUserIfNecessaryAsync(
-            document, span, options, result, cancellationToken).ConfigureAwait(false);
-        if (result is null)
-            return;
-
-        var cleanupOptions = await document.GetCodeCleanupOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
-        var (formattedDocument, methodNameAtInvocation) = await result.GetFormattedDocumentAsync(cleanupOptions, cancellationToken).ConfigureAwait(false);
-        var changes = await formattedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false);
-
-        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-        ApplyChange_OnUIThread(textBuffer, changes, waitContext);
-
-        // start inline rename to allow the user to change the name if they want.
-        var textSnapshot = textBuffer.CurrentSnapshot;
-        document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-        if (document != null)
-            _renameService.StartInlineSession(document, methodNameAtInvocation.Span, cancellationToken);
-
-        // select invocation span
-        view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(textSnapshot, methodNameAtInvocation.Span.End));
-        view.SetSelection(methodNameAtInvocation.Span.ToSnapshotSpan(textSnapshot));
-    }
-
-    private void ApplyChange_OnUIThread(
-        ITextBuffer textBuffer, IEnumerable<TextChange> changes, IBackgroundWorkIndicatorContext waitContext)
-    {
-        _threadingContext.ThrowIfNotOnUIThread();
-
-        using var undoTransaction = _undoManager.GetTextBufferUndoManager(textBuffer).TextBufferUndoHistory.CreateTransaction("Extract Method");
-
-        // We're about to make an edit ourselves.  so disable the cancellation that happens on editing.
-        waitContext.CancelOnEdit = false;
-        textBuffer.ApplyChanges(changes);
-
-        // apply changes
-        undoTransaction.Complete();
-    }
-
-    private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
-        Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
-    {
-        if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
-            return null;
-
-        var reason = result.Reasons.FirstOrDefault();
-        var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
-        if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
+        private async Task ExecuteAsync(
+            ITextView view,
+            ITextBuffer textBuffer,
+            Document document,
+            SnapshotSpan span)
         {
-            var newResult = await ExtractMethodService.ExtractMethodAsync(
-                document,
-                span,
-                localFunction: false,
-                options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
-                cancellationToken).ConfigureAwait(false);
+            _threadingContext.ThrowIfNotOnUIThread();
+            var indicatorFactory = document.Project.Solution.Services.GetRequiredService<IBackgroundWorkIndicatorFactory>();
+            using var indicatorContext = indicatorFactory.Create(
+                view, span, EditorFeaturesResources.Applying_Extract_Method_refactoring, cancelOnEdit: true, cancelOnFocusLost: true);
 
-            // retry succeeded, return new result
-            if (newResult.Succeeded)
-                return newResult;
+            using var asyncToken = _asyncListener.BeginAsyncOperation(nameof(ExecuteCommand));
+            await ExecuteWorkerAsync(view, textBuffer, span.Span.ToTextSpan(), indicatorContext).ConfigureAwait(false);
         }
 
-        return null;
-    }
-
-    private async Task<ExtractMethodResult?> NotifyUserIfNecessaryAsync(
-        Document document, TextSpan span, ExtractMethodGenerationOptions options, ExtractMethodResult result, CancellationToken cancellationToken)
-    {
-        // If we succeeded without any problems, just proceed without notifying the user.
-        if (result is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
-            return result;
-
-        // We have some sort of issue.  See what the user wants to do.  If we have no way to inform the user bail
-        // out rather than doing something wrong.
-        var notificationService = document.Project.Solution.Services.GetService<INotificationService>();
-        if (notificationService is null)
-            return null;
-
-        // The initial extract method failed, or it succeeded with warning reasons.  Attempt again with
-        // different options to see if we get better results.
-        var alternativeResult = await TryWithoutMakingValueTypesRefAsync(
-            document, span, result, options, cancellationToken).ConfigureAwait(false);
-        if (alternativeResult is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
+        private async Task ExecuteWorkerAsync(
+            ITextView view,
+            ITextBuffer textBuffer,
+            TextSpan span,
+            IBackgroundWorkIndicatorContext waitContext)
         {
-            // We are about to show a modal UI dialog so we should take over the command execution
-            // wait context. That means the command system won't attempt to show its own wait dialog 
-            // and also will take it into consideration when measuring command handling duration.
+            _threadingContext.ThrowIfNotOnUIThread();
+
+            var cancellationToken = waitContext.UserCancellationToken;
+
+            var document = await textBuffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(waitContext).ConfigureAwait(false);
+            if (document is null)
+                return;
+
+            var options = await document.GetExtractMethodGenerationOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+            var result = await ExtractMethodService.ExtractMethodAsync(
+                document, span, localFunction: false, options, cancellationToken).ConfigureAwait(false);
+            Contract.ThrowIfNull(result);
+
+            result = await NotifyUserIfNecessaryAsync(
+                document, span, options, result, cancellationToken).ConfigureAwait(false);
+            if (result is null)
+                return;
+
+            var cleanupOptions = await document.GetCodeCleanupOptionsAsync(_globalOptions, cancellationToken).ConfigureAwait(false);
+            var (formattedDocument, methodNameAtInvocation) = await result.GetFormattedDocumentAsync(cleanupOptions, cancellationToken).ConfigureAwait(false);
+            var changes = await formattedDocument.GetTextChangesAsync(document, cancellationToken).ConfigureAwait(false);
+
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            if (!notificationService.ConfirmMessageBox(
-                    EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine + Environment.NewLine +
-                    string.Join(Environment.NewLine, result.Reasons) + Environment.NewLine + Environment.NewLine +
-                    EditorFeaturesResources.We_can_fix_the_error_by_not_making_struct_out_ref_parameter_s_Do_you_want_to_proceed,
-                    title: EditorFeaturesResources.Extract_Method,
-                    severity: NotificationSeverity.Error))
+            ApplyChange_OnUIThread(textBuffer, changes, waitContext);
+
+            // start inline rename to allow the user to change the name if they want.
+            var textSnapshot = textBuffer.CurrentSnapshot;
+            document = textSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            if (document != null)
+                _renameService.StartInlineSession(document, methodNameAtInvocation.Span, cancellationToken);
+
+            // select invocation span
+            view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(textSnapshot, methodNameAtInvocation.Span.End));
+            view.SetSelection(methodNameAtInvocation.Span.ToSnapshotSpan(textSnapshot));
+        }
+
+        private void ApplyChange_OnUIThread(
+            ITextBuffer textBuffer, IEnumerable<TextChange> changes, IBackgroundWorkIndicatorContext waitContext)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+
+            using var undoTransaction = _undoManager.GetTextBufferUndoManager(textBuffer).TextBufferUndoHistory.CreateTransaction("Extract Method");
+
+            // We're about to make an edit ourselves.  so disable the cancellation that happens on editing.
+            waitContext.CancelOnEdit = false;
+            textBuffer.ApplyChanges(changes);
+
+            // apply changes
+            undoTransaction.Complete();
+        }
+
+        private static async Task<ExtractMethodResult?> TryWithoutMakingValueTypesRefAsync(
+            Document document, TextSpan span, ExtractMethodResult result, ExtractMethodGenerationOptions options, CancellationToken cancellationToken)
+        {
+            if (options.ExtractOptions.DoNotPutOutOrRefOnStruct || !result.Reasons.IsSingle())
+                return null;
+
+            var reason = result.Reasons.FirstOrDefault();
+            var length = FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket.IndexOf(':');
+            if (reason != null && length > 0 && reason.IndexOf(FeaturesResources.Asynchronous_method_cannot_have_ref_out_parameters_colon_bracket_0_bracket[..length], 0, length, StringComparison.Ordinal) >= 0)
             {
-                // We handled the command, displayed a notification and did not produce code.
+                var newResult = await ExtractMethodService.ExtractMethodAsync(
+                    document,
+                    span,
+                    localFunction: false,
+                    options with { ExtractOptions = options.ExtractOptions with { DoNotPutOutOrRefOnStruct = true } },
+                    cancellationToken).ConfigureAwait(false);
+
+                // retry succeeded, return new result
+                if (newResult.Succeeded)
+                    return newResult;
+            }
+
+            return null;
+        }
+
+        private async Task<ExtractMethodResult?> NotifyUserIfNecessaryAsync(
+            Document document, TextSpan span, ExtractMethodGenerationOptions options, ExtractMethodResult result, CancellationToken cancellationToken)
+        {
+            // If we succeeded without any problems, just proceed without notifying the user.
+            if (result is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
+                return result;
+
+            // We have some sort of issue.  See what the user wants to do.  If we have no way to inform the user bail
+            // out rather than doing something wrong.
+            var notificationService = document.Project.Solution.Services.GetService<INotificationService>();
+            if (notificationService is null)
+                return null;
+
+            // The initial extract method failed, or it succeeded with warning reasons.  Attempt again with
+            // different options to see if we get better results.
+            var alternativeResult = await TryWithoutMakingValueTypesRefAsync(
+                document, span, result, options, cancellationToken).ConfigureAwait(false);
+            if (alternativeResult is { Succeeded: true, Reasons.Length: 0, DocumentWithoutFinalFormatting: not null })
+            {
+                // We are about to show a modal UI dialog so we should take over the command execution
+                // wait context. That means the command system won't attempt to show its own wait dialog 
+                // and also will take it into consideration when measuring command handling duration.
+                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                if (!notificationService.ConfirmMessageBox(
+                        EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine + Environment.NewLine +
+                        string.Join(Environment.NewLine, result.Reasons) + Environment.NewLine + Environment.NewLine +
+                        EditorFeaturesResources.We_can_fix_the_error_by_not_making_struct_out_ref_parameter_s_Do_you_want_to_proceed,
+                        title: EditorFeaturesResources.Extract_Method,
+                        severity: NotificationSeverity.Error))
+                {
+                    // We handled the command, displayed a notification and did not produce code.
+                    return null;
+                }
+
+                // Otherwise, prefer the new approach that has less problems.
+                return alternativeResult;
+            }
+
+            // The alternative approach wasn't better.  If we failed, just let the user know and bail out.  Otherwise,
+            // if we succeeded with messages, tell the user and let them decide if they want to proceed or not.
+            if (!result.Succeeded || result.DocumentWithoutFinalFormatting is null)
+            {
+                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                notificationService.SendNotification(
+                    EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
+                    string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)),
+                    title: EditorFeaturesResources.Extract_Method,
+                    severity: NotificationSeverity.Error);
+
                 return null;
             }
 
-            // Otherwise, prefer the new approach that has less problems.
-            return alternativeResult;
-        }
+            // We succeed and have a not null document.  We must them have some issues to report to the user (otherwise
+            // we would have fast returned at the top of this method).  Tell the user about them and let them decide
+            // what they want to do.
+            Contract.ThrowIfTrue(result.Reasons.Length == 0);
 
-        // The alternative approach wasn't better.  If we failed, just let the user know and bail out.  Otherwise,
-        // if we succeeded with messages, tell the user and let them decide if they want to proceed or not.
-        if (!result.Succeeded || result.DocumentWithoutFinalFormatting is null)
-        {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            notificationService.SendNotification(
-                EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
-                string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)),
-                title: EditorFeaturesResources.Extract_Method,
-                severity: NotificationSeverity.Error);
+            if (!notificationService.ConfirmMessageBox(
+                    EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
+                    string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)) + Environment.NewLine + Environment.NewLine +
+                    EditorFeaturesResources.Do_you_still_want_to_proceed_This_may_produce_broken_code,
+                    title: EditorFeaturesResources.Extract_Method,
+                    severity: NotificationSeverity.Warning))
+            {
+                return null;
+            }
 
-            return null;
+            return result;
         }
-
-        // We succeed and have a not null document.  We must them have some issues to report to the user (otherwise
-        // we would have fast returned at the top of this method).  Tell the user about them and let them decide
-        // what they want to do.
-        Contract.ThrowIfTrue(result.Reasons.Length == 0);
-
-        await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-        if (!notificationService.ConfirmMessageBox(
-                EditorFeaturesResources.Extract_method_encountered_the_following_issues + Environment.NewLine +
-                string.Join("", result.Reasons.Select(r => Environment.NewLine + "  " + r)) + Environment.NewLine + Environment.NewLine +
-                EditorFeaturesResources.Do_you_still_want_to_proceed_This_may_produce_broken_code,
-                title: EditorFeaturesResources.Extract_Method,
-                severity: NotificationSeverity.Warning))
-        {
-            return null;
-        }
-
-        return result;
     }
 }

--- a/src/EditorFeatures/Core/ExtractMethod/ExtractMethodPresentationOptionsStorage.cs
+++ b/src/EditorFeatures/Core/ExtractMethod/ExtractMethodPresentationOptionsStorage.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 {
     internal static class ExtractMethodPresentationOptionsStorage
     {
+        // Deprecated.  Never exposed in the UI to users in any way.  Kep around to still support automation
+        // getting/setting our storage values from the user's profile.
         public static readonly PerLanguageOption2<bool> AllowBestEffort = new("dotnet_allow_best_effort_when_extracting_method", defaultValue: true);
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -150,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                     Assert.True(Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status), "Selection wasn't expected to fail")
                 End If
 
-                If Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status) Then
+                If Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status) AndAlso result.SelectionChanged Then
                     Assert.Equal(namedSpans("r").Single(), result.FinalSpan)
                 End If
             End Using

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                 Dim result = Await validator.GetValidSelectionAsync(CancellationToken.None)
 
                 If expectedFail Then
-                    Assert.True(result.Status.Failed(), "Selection didn't fail as expected")
+                    Assert.True(result.Status.Failed() OrElse result.Status.Reasons.Length > 0, "Selection didn't fail as expected")
                 Else
                     Assert.True(Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status), "Selection wasn't expected to fail")
                 End If

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -5,14 +5,11 @@
 Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.AddImport
 Imports Microsoft.CodeAnalysis.CodeCleanup
 Imports Microsoft.CodeAnalysis.CodeGeneration
-Imports Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.ExtractMethod
-Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.CodeAnalysis.UnitTests
@@ -148,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                     Assert.True(Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status), "Selection wasn't expected to fail")
                 End If
 
-                If (Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status) OrElse result.Status.Flag.HasBestEffort()) AndAlso result.Status.Flag.HasSuggestion() Then
+                If Microsoft.CodeAnalysis.ExtractMethod.Extensions.Succeeded(result.Status) Then
                     Assert.Equal(namedSpans("r").Single(), result.FinalSpan)
                 End If
             End Using
@@ -178,7 +175,7 @@ End Class</text>
 
                         ' check the obvious case
                         If Not (TypeOf node Is ExpressionSyntax) AndAlso (Not node.UnderValidContext()) Then
-                            Assert.True(result.Status.Flag.Failed())
+                            Assert.True(Microsoft.CodeAnalysis.ExtractMethod.Extensions.Failed(result.Status.Flag))
                         End If
                     Catch e1 As ArgumentException
                         ' catch and ignore unknown issue. currently control flow analysis engine doesn't support field initializer.

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -120,7 +120,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim extractor = New VisualBasicMethodExtractor(CType(selectedCode, VisualBasicSelectionResult), extractGenerationOptions)
             Dim result = Await extractor.ExtractMethodAsync(CancellationToken.None)
             Assert.NotNull(result)
-            Assert.Equal(succeeded, result.Succeeded)
+
+            If succeeded Then
+                Assert.Equal(succeeded, result.Succeeded)
+            Else
+                Assert.True(Not result.Succeeded OrElse result.Reasons.Length > 0)
+            End If
 
             Return Await (Await result.GetFormattedDocumentAsync(cleanupOptions, CancellationToken.None)).document.GetSyntaxRootAsync()
         End Function

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var currentType = semanticModel.GetSpeculativeTypeInfo(contextNode.SpanStart, typeName, SpeculativeBindingOption.BindAsTypeOrNamespace).Type;
                 if (currentType == null || !SymbolEqualityComparer.Default.Equals(currentType, semanticModel.ResolveType(typeParameter)))
                 {
-                    return new OperationStatus(OperationStatusFlag.BestEffort,
+                    return new OperationStatus(OperationStatusFlag.Succeeded,
                         string.Format(FeaturesResources.Type_parameter_0_is_hidden_by_another_type_parameter_1,
                             typeParameter.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                             currentType == null ? string.Empty : currentType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -10,21 +10,19 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExtractMethod;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 {
-    internal partial class CSharpMethodExtractor(CSharpSelectionResult result, ExtractMethodGenerationOptions options, bool localFunction) : MethodExtractor(result, options, localFunction)
+    internal partial class CSharpMethodExtractor(CSharpSelectionResult result, ExtractMethodGenerationOptions options, bool localFunction)
+        : MethodExtractor(result, options, localFunction)
     {
         protected override Task<AnalyzerResult> AnalyzeAsync(SelectionResult selectionResult, bool localFunction, CancellationToken cancellationToken)
             => CSharpAnalyzer.AnalyzeAsync(selectionResult, localFunction, cancellationToken);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -26,7 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             bool selectionInExpression,
             SemanticDocument document,
             SyntaxAnnotation firstTokenAnnotation,
-            SyntaxAnnotation lastTokenAnnotation) : CSharpSelectionResult(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
+            SyntaxAnnotation lastTokenAnnotation,
+            bool selectionChanged) : CSharpSelectionResult(
+                status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation, selectionChanged)
         {
             public override bool ContainingScopeHasAsyncKeyword()
                 => false;

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
@@ -7,7 +7,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExtractMethod;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -24,7 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             bool selectionInExpression,
             SemanticDocument document,
             SyntaxAnnotation firstTokenAnnotation,
-            SyntaxAnnotation lastTokenAnnotation) : CSharpSelectionResult(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
+            SyntaxAnnotation lastTokenAnnotation,
+            bool selectionChanged) : CSharpSelectionResult(
+                status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation, selectionChanged)
         {
             public override bool ContainingScopeHasAsyncKeyword()
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             SemanticDocument document,
             SyntaxToken firstToken,
             SyntaxToken lastToken,
+            bool selectionChanged,
             CancellationToken cancellationToken)
         {
             Contract.ThrowIfNull(status);
@@ -50,13 +51,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 return new ExpressionResult(
                     status, originalSpan, finalSpan, options, selectionInExpression,
-                    newDocument, firstTokenAnnotation, lastTokenAnnotation);
+                    newDocument, firstTokenAnnotation, lastTokenAnnotation, selectionChanged);
             }
             else
             {
                 return new StatementResult(
                     status, originalSpan, finalSpan, options, selectionInExpression,
-                    newDocument, firstTokenAnnotation, lastTokenAnnotation);
+                    newDocument, firstTokenAnnotation, lastTokenAnnotation, selectionChanged);
             }
         }
 
@@ -68,9 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             bool selectionInExpression,
             SemanticDocument document,
             SyntaxAnnotation firstTokenAnnotation,
-            SyntaxAnnotation lastTokenAnnotation)
+            SyntaxAnnotation lastTokenAnnotation,
+            bool selectionChanged)
             : base(status, originalSpan, finalSpan, options, selectionInExpression,
-                   document, firstTokenAnnotation, lastTokenAnnotation)
+                   document, firstTokenAnnotation, lastTokenAnnotation, selectionChanged)
         {
         }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -72,6 +72,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
             }
 
+            var selectionChanged = selectionInfo.FirstTokenInOriginalSpan != selectionInfo.FirstTokenInFinalSpan || selectionInfo.LastTokenInOriginalSpan != selectionInfo.LastTokenInFinalSpan;
+
             return await CSharpSelectionResult.CreateAsync(
                 selectionInfo.Status,
                 selectionInfo.OriginalSpan,
@@ -81,6 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 doc,
                 selectionInfo.FirstTokenInFinalSpan,
                 selectionInfo.LastTokenInFinalSpan,
+                selectionChanged,
                 cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -49,10 +49,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             selectionInfo = CheckErrorCasesAndAppendDescriptions(selectionInfo, root);
 
             // there was a fatal error that we couldn't even do negative preview, return error result
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return new ErrorSelectionResult(selectionInfo.Status);
-            }
 
             var controlFlowSpan = GetControlFlowSpan(selectionInfo);
             if (!selectionInfo.SelectionInExpression)
@@ -60,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var statementRange = GetStatementRangeContainedInSpan<StatementSyntax>(root, controlFlowSpan, cancellationToken);
                 if (statementRange == null)
                 {
-                    selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Can_t_determine_valid_range_of_statements_to_extract));
+                    selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Can_t_determine_valid_range_of_statements_to_extract));
                     return new ErrorSelectionResult(selectionInfo.Status);
                 }
 
@@ -70,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     // check control flow only if we are extracting statement level, not expression
                     // level. you can not have goto that moves control out of scope in expression level
                     // (even in lambda)
-                    selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.BestEffort, CSharpFeaturesResources.Not_all_code_paths_return));
+                    selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Succeeded, CSharpFeaturesResources.Not_all_code_paths_return));
                 }
             }
 
@@ -88,10 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
         private SelectionInfo ApplySpecialCases(SelectionInfo selectionInfo, SourceText text, ParseOptions options, bool localFunction)
         {
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return selectionInfo;
-            }
 
             if (selectionInfo.CommonRootFromOriginalSpan.IsKind(SyntaxKind.CompilationUnit)
                 || selectionInfo.CommonRootFromOriginalSpan.IsParentKind(SyntaxKind.GlobalStatement))
@@ -99,13 +95,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 // Cannot extract a local function from a global statement in script code
                 if (localFunction && options is { Kind: SourceCodeKind.Script })
                 {
-                    return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Selection_cannot_include_global_statements));
+                    return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_cannot_include_global_statements));
                 }
 
                 // Cannot extract a method from a top-level statement in normal code
                 if (!localFunction && options is { Kind: SourceCodeKind.Regular })
                 {
-                    return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Selection_cannot_include_top_level_statements));
+                    return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_cannot_include_top_level_statements));
                 }
             }
 
@@ -115,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 {
                     if (ancestor.Kind() is SyntaxKind.BaseConstructorInitializer or SyntaxKind.ThisConstructorInitializer)
                     {
-                        return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Selection_cannot_be_in_constructor_initializer));
+                        return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_cannot_be_in_constructor_initializer));
                     }
 
                     if (ancestor is AnonymousFunctionExpressionSyntax)
@@ -157,10 +153,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             SemanticModel semanticModel,
             CancellationToken cancellationToken)
         {
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return selectionInfo;
-            }
 
             // don't need to adjust anything if it is multi-statements case
             if (!selectionInfo.SelectionInExpression && !selectionInfo.SelectionInSingleStatement)
@@ -181,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             if (firstValidNode == null)
             {
                 // couldn't find any valid node
-                return selectionInfo.WithStatus(s => new OperationStatus(OperationStatusFlag.None, CSharpFeaturesResources.Selection_does_not_contain_a_valid_node))
+                return selectionInfo.WithStatus(s => new OperationStatus(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_does_not_contain_a_valid_node))
                                     .With(s => s.FirstTokenInFinalSpan = default)
                                     .With(s => s.LastTokenInFinalSpan = default);
             }
@@ -203,14 +197,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
             if (firstTokenInSelection.Kind() == SyntaxKind.None || lastTokenInSelection.Kind() == SyntaxKind.None)
             {
-                return new SelectionInfo { Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.Invalid_selection), OriginalSpan = adjustedSpan };
+                return new SelectionInfo { Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Invalid_selection), OriginalSpan = adjustedSpan };
             }
 
             if (!adjustedSpan.Contains(firstTokenInSelection.Span) && !adjustedSpan.Contains(lastTokenInSelection.Span))
             {
                 return new SelectionInfo
                 {
-                    Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.Selection_does_not_contain_a_valid_token),
+                    Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Selection_does_not_contain_a_valid_token),
                     OriginalSpan = adjustedSpan,
                     FirstTokenInOriginalSpan = firstTokenInSelection,
                     LastTokenInOriginalSpan = lastTokenInSelection
@@ -221,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 return new SelectionInfo
                 {
-                    Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.No_valid_selection_to_perform_extraction),
+                    Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_valid_selection_to_perform_extraction),
                     OriginalSpan = adjustedSpan,
                     FirstTokenInOriginalSpan = firstTokenInSelection,
                     LastTokenInOriginalSpan = lastTokenInSelection
@@ -234,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 return new SelectionInfo
                 {
-                    Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.No_common_root_node_for_extraction),
+                    Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_common_root_node_for_extraction),
                     OriginalSpan = adjustedSpan,
                     FirstTokenInOriginalSpan = firstTokenInSelection,
                     LastTokenInOriginalSpan = lastTokenInSelection
@@ -245,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 return new SelectionInfo
                 {
-                    Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.Selection_not_contained_inside_a_type),
+                    Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Selection_not_contained_inside_a_type),
                     OriginalSpan = adjustedSpan,
                     FirstTokenInOriginalSpan = firstTokenInSelection,
                     LastTokenInOriginalSpan = lastTokenInSelection
@@ -257,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 return new SelectionInfo
                 {
-                    Status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.No_valid_selection_to_perform_extraction),
+                    Status = new OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_valid_selection_to_perform_extraction),
                     OriginalSpan = adjustedSpan,
                     FirstTokenInOriginalSpan = firstTokenInSelection,
                     LastTokenInOriginalSpan = lastTokenInSelection
@@ -279,14 +273,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             SelectionInfo selectionInfo,
             SyntaxNode root)
         {
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return selectionInfo;
-            }
 
             if (selectionInfo.FirstTokenInFinalSpan.IsMissing || selectionInfo.LastTokenInFinalSpan.IsMissing)
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Contains_invalid_selection));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Contains_invalid_selection));
             }
 
             // get the node that covers the selection
@@ -294,30 +286,30 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
             if ((selectionInfo.SelectionInExpression || selectionInfo.SelectionInSingleStatement) && commonNode.HasDiagnostics())
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.The_selection_contains_syntactic_errors));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.The_selection_contains_syntactic_errors));
             }
 
             var tokens = root.DescendantTokens(selectionInfo.FinalSpan);
             if (tokens.ContainPreprocessorCrossOver(selectionInfo.FinalSpan))
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.BestEffort, CSharpFeaturesResources.Selection_can_not_cross_over_preprocessor_directives));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Succeeded, CSharpFeaturesResources.Selection_can_not_cross_over_preprocessor_directives));
             }
 
             // TODO : check whether this can be handled by control flow analysis engine
             if (tokens.Any(t => t.Kind() == SyntaxKind.YieldKeyword))
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.BestEffort, CSharpFeaturesResources.Selection_can_not_contain_a_yield_statement));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Succeeded, CSharpFeaturesResources.Selection_can_not_contain_a_yield_statement));
             }
 
             // TODO : check behavior of control flow analysis engine around exception and exception handling.
             if (tokens.ContainArgumentlessThrowWithoutEnclosingCatch(selectionInfo.FinalSpan))
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.BestEffort, CSharpFeaturesResources.Selection_can_not_contain_throw_statement));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Succeeded, CSharpFeaturesResources.Selection_can_not_contain_throw_statement));
             }
 
             if (selectionInfo.SelectionInExpression && commonNode.PartOfConstantInitializerExpression())
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Selection_can_not_be_part_of_constant_initializer_expression));
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_can_not_be_part_of_constant_initializer_expression));
             }
 
             if (commonNode.IsUnsafeContext())
@@ -330,13 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             // https://github.com/dotnet/roslyn/issues/9244
             if (commonNode.Kind() == SyntaxKind.IsPatternExpression)
             {
-                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.Selection_can_not_contain_a_pattern_expression));
-            }
-
-            var selectionChanged = selectionInfo.FirstTokenInOriginalSpan != selectionInfo.FirstTokenInFinalSpan || selectionInfo.LastTokenInOriginalSpan != selectionInfo.LastTokenInFinalSpan;
-            if (selectionChanged)
-            {
-                selectionInfo = selectionInfo.WithStatus(s => s.MarkSuggestion());
+                selectionInfo = selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.Selection_can_not_contain_a_pattern_expression));
             }
 
             return selectionInfo;
@@ -344,10 +330,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
         private static SelectionInfo AssignInitialFinalTokens(SelectionInfo selectionInfo, SyntaxNode root, CancellationToken cancellationToken)
         {
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return selectionInfo;
-            }
 
             if (selectionInfo.SelectionInExpression)
             {
@@ -363,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
             if (range == null)
             {
-                return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.None, CSharpFeaturesResources.No_valid_statement_range_to_extract));
+                return selectionInfo.WithStatus(s => s.With(OperationStatusFlag.Failed, CSharpFeaturesResources.No_valid_statement_range_to_extract));
             }
 
             var statement1 = (StatementSyntax)range.Item1;
@@ -393,10 +377,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
         private static SelectionInfo AssignFinalSpan(SelectionInfo selectionInfo, SourceText text)
         {
-            if (selectionInfo.Status.FailedWithNoBestEffortSuggestion())
-            {
+            if (selectionInfo.Status.Failed())
                 return selectionInfo;
-            }
 
             // set final span
             var start = (selectionInfo.FirstTokenInOriginalSpan == selectionInfo.FirstTokenInFinalSpan)

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4823,7 +4823,7 @@ class Program
         [WorkItem("https://github.com/dotnet/roslyn/issues/40654")]
         public async Task TestMissingOnUsingStatement()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestMissingAsync(
                 """
                 class C
                 {
@@ -4872,9 +4872,9 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
-        public async Task TestMissingInGoto()
+        public async Task TestOnGoto()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
                 """
                 delegate int del(int i);
 
@@ -4890,7 +4890,29 @@ class Program
                         return;
                     }
                 }
-                """, new TestParameters(index: CodeActionIndex));
+                """,
+                """
+                delegate int del(int i);
+
+                class C
+                {
+                    static void Main(string[] args)
+                    {
+                        del q = x =>
+                        {
+                            return {|Rename:NewMethod|}(x);
+                
+                            static int NewMethod(int x)
+                            {
+                                goto label2;
+                                return x * x;
+                            }
+                        };
+                    label2:
+                        return;
+                    }
+                }
+                """, index: CodeActionIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]

--- a/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4823,7 +4823,7 @@ class Program
         [WorkItem("https://github.com/dotnet/roslyn/issues/40654")]
         public async Task TestMissingOnUsingStatement()
         {
-            await TestMissingAsync(
+            await TestMissingInRegularAndScriptAsync(
                 """
                 class C
                 {

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -596,9 +596,9 @@ new TestParameters(options: Option(CSharpCodeStyleOptions.PreferExpressionBodied
         }
 
         [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
-        public async Task TestMissingOnGoto()
+        public async Task TestOnGoto()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
                 """
                 delegate int del(int i);
 
@@ -613,6 +613,28 @@ new TestParameters(options: Option(CSharpCodeStyleOptions.PreferExpressionBodied
                     label2:
                         return;
                     }
+                }
+                """,
+                """
+                delegate int del(int i);
+
+                class C
+                {
+                    static void Main(string[] args)
+                    {
+                        del q = x =>
+                        {
+                            return {|Rename:NewMethod|}(x);
+                        };
+                    label2:
+                        return;
+                    }
+
+                    private static int NewMethod(int x)
+                    {
+                        goto label2;
+                        return x * x;
+                     }
                 }
                 """);
         }
@@ -4498,7 +4520,7 @@ class Program
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40654")]
         public async Task TestMissingOnInvalidUsingStatement()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestMissingAsync(
                 """
                 class C
                 {

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -634,7 +634,7 @@ new TestParameters(options: Option(CSharpCodeStyleOptions.PreferExpressionBodied
                     {
                         goto label2;
                         return x * x;
-                     }
+                    }
                 }
                 """);
         }

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -4520,7 +4520,7 @@ class Program
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/40654")]
         public async Task TestMissingOnInvalidUsingStatement()
         {
-            await TestMissingAsync(
+            await TestMissingInRegularAndScriptAsync(
                 """
                 class C
                 {

--- a/src/Features/Core/Portable/ExtractMethod/Enums.cs
+++ b/src/Features/Core/Portable/ExtractMethod/Enums.cs
@@ -2,58 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
-namespace Microsoft.CodeAnalysis.ExtractMethod
+namespace Microsoft.CodeAnalysis.ExtractMethod;
+
+internal enum DeclarationBehavior
 {
-    internal enum DeclarationBehavior
-    {
-        None,
-        Delete,
-        MoveIn,
-        MoveOut,
-        SplitIn,
-        SplitOut
-    }
+    None,
+    Delete,
+    MoveIn,
+    MoveOut,
+    SplitIn,
+    SplitOut
+}
 
-    internal enum ReturnBehavior
-    {
-        None,
-        Initialization,
-        Assignment
-    }
+internal enum ReturnBehavior
+{
+    None,
+    Initialization,
+    Assignment
+}
 
-    internal enum ParameterBehavior
-    {
-        None,
-        Input,
-        Out,
-        Ref
-    }
+internal enum ParameterBehavior
+{
+    None,
+    Input,
+    Out,
+    Ref
+}
+
+/// <summary>
+/// status code for extract method operations
+/// </summary>
+[Flags]
+internal enum OperationStatusFlag
+{
+    Failed = 0x0,
 
     /// <summary>
-    /// status code for extract method operations
+    /// operation has succeeded
     /// </summary>
-    [Flags]
-    internal enum OperationStatusFlag
-    {
-        None = 0x0,
-
-        /// <summary>
-        /// operation has succeeded
-        /// </summary>
-        Succeeded = 0x1,
-
-        /// <summary>
-        /// operation has succeeded with a span that is different than original span
-        /// </summary>
-        Suggestion = 0x2,
-
-        /// <summary>
-        /// operation has failed but can provide some best effort result
-        /// </summary>
-        BestEffort = 0x4,
-    }
+    Succeeded = 0x1,
 }

--- a/src/Features/Core/Portable/ExtractMethod/Extensions.cs
+++ b/src/Features/Core/Portable/ExtractMethod/Extensions.cs
@@ -4,98 +4,86 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.ExtractMethod
+namespace Microsoft.CodeAnalysis.ExtractMethod;
+
+internal static class Extensions
 {
-    internal static class Extensions
+    public static bool Succeeded(this OperationStatus status)
+        => status.Flag.Succeeded();
+
+    public static bool Failed(this OperationStatus status)
+        => status.Flag.Failed();
+
+    public static bool Succeeded(this OperationStatusFlag flag)
+        => (flag & OperationStatusFlag.Succeeded) != 0;
+
+    public static bool Failed(this OperationStatusFlag flag)
+        => !flag.Succeeded();
+
+    public static bool HasMask(this OperationStatusFlag flag, OperationStatusFlag mask)
+        => (flag & mask) != 0x0;
+
+    public static OperationStatusFlag RemoveFlag(this OperationStatusFlag baseFlag, OperationStatusFlag flagToRemove)
+        => baseFlag & ~flagToRemove;
+
+    public static ITypeSymbol? GetLambdaOrAnonymousMethodReturnType(this SemanticModel binding, SyntaxNode node)
     {
-        public static bool Succeeded(this OperationStatus status)
-            => status.Flag.Succeeded();
-
-        public static bool FailedWithNoBestEffortSuggestion(this OperationStatus status)
-            => status.Flag.Failed() && !status.Flag.HasBestEffort();
-
-        public static bool Failed(this OperationStatus status)
-            => status.Flag.Failed();
-
-        public static bool Succeeded(this OperationStatusFlag flag)
-            => (flag & OperationStatusFlag.Succeeded) != 0;
-
-        public static bool Failed(this OperationStatusFlag flag)
-            => !flag.Succeeded();
-
-        public static bool HasBestEffort(this OperationStatusFlag flag)
-            => (flag & OperationStatusFlag.BestEffort) != 0;
-
-        public static bool HasSuggestion(this OperationStatusFlag flag)
-            => (flag & OperationStatusFlag.Suggestion) != 0;
-
-        public static bool HasMask(this OperationStatusFlag flag, OperationStatusFlag mask)
-            => (flag & mask) != 0x0;
-
-        public static OperationStatusFlag RemoveFlag(this OperationStatusFlag baseFlag, OperationStatusFlag flagToRemove)
-            => baseFlag & ~flagToRemove;
-
-        public static ITypeSymbol? GetLambdaOrAnonymousMethodReturnType(this SemanticModel binding, SyntaxNode node)
+        var info = binding.GetSymbolInfo(node);
+        if (info.Symbol == null)
         {
-            var info = binding.GetSymbolInfo(node);
-            if (info.Symbol == null)
-            {
-                return null;
-            }
-
-            var methodSymbol = info.Symbol as IMethodSymbol;
-            if (methodSymbol?.MethodKind != MethodKind.AnonymousFunction)
-            {
-                return null;
-            }
-
-            return methodSymbol.ReturnType;
+            return null;
         }
 
-        /// <summary>
-        /// get tokens with given annotation in current document
-        /// </summary>
-        public static SyntaxToken GetTokenWithAnnotation(this SemanticDocument document, SyntaxAnnotation annotation)
-            => document.Root.GetAnnotatedNodesAndTokens(annotation).Single().AsToken();
-
-        /// <summary>
-        /// resolve the given symbol against compilation this snapshot has
-        /// </summary>
-        public static T ResolveType<T>(this SemanticModel semanticModel, T symbol) where T : class, ITypeSymbol
+        var methodSymbol = info.Symbol as IMethodSymbol;
+        if (methodSymbol?.MethodKind != MethodKind.AnonymousFunction)
         {
-            // Can be cleaned up when https://github.com/dotnet/roslyn/issues/38061 is resolved
-            var typeSymbol = (T?)symbol.GetSymbolKey().Resolve(semanticModel.Compilation).GetAnySymbol();
-            Contract.ThrowIfNull(typeSymbol);
-            return (T)typeSymbol.WithNullableAnnotation(symbol.NullableAnnotation);
+            return null;
         }
 
-        /// <summary>
-        /// check whether node contains error for itself but not from its child node
-        /// </summary>
-        public static bool HasDiagnostics(this SyntaxNode node)
+        return methodSymbol.ReturnType;
+    }
+
+    /// <summary>
+    /// get tokens with given annotation in current document
+    /// </summary>
+    public static SyntaxToken GetTokenWithAnnotation(this SemanticDocument document, SyntaxAnnotation annotation)
+        => document.Root.GetAnnotatedNodesAndTokens(annotation).Single().AsToken();
+
+    /// <summary>
+    /// resolve the given symbol against compilation this snapshot has
+    /// </summary>
+    public static T ResolveType<T>(this SemanticModel semanticModel, T symbol) where T : class, ITypeSymbol
+    {
+        // Can be cleaned up when https://github.com/dotnet/roslyn/issues/38061 is resolved
+        var typeSymbol = (T?)symbol.GetSymbolKey().Resolve(semanticModel.Compilation).GetAnySymbol();
+        Contract.ThrowIfNull(typeSymbol);
+        return (T)typeSymbol.WithNullableAnnotation(symbol.NullableAnnotation);
+    }
+
+    /// <summary>
+    /// check whether node contains error for itself but not from its child node
+    /// </summary>
+    public static bool HasDiagnostics(this SyntaxNode node)
+    {
+        var set = new HashSet<Diagnostic>(node.GetDiagnostics());
+
+        foreach (var child in node.ChildNodes())
         {
-            var set = new HashSet<Diagnostic>(node.GetDiagnostics());
-
-            foreach (var child in node.ChildNodes())
-            {
-                set.ExceptWith(child.GetDiagnostics());
-            }
-
-            return set.Count > 0;
+            set.ExceptWith(child.GetDiagnostics());
         }
 
-        public static bool FromScript(this SyntaxNode node)
-        {
-            if (node.SyntaxTree == null)
-            {
-                return false;
-            }
+        return set.Count > 0;
+    }
 
-            return node.SyntaxTree.Options.Kind != SourceCodeKind.Regular;
+    public static bool FromScript(this SyntaxNode node)
+    {
+        if (node.SyntaxTree == null)
+        {
+            return false;
         }
+
+        return node.SyntaxTree.Options.Kind != SourceCodeKind.Regular;
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodResult.cs
@@ -24,6 +24,11 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public bool Succeeded { get; }
 
         /// <summary>
+        /// The reasons why the extract method operation did not succeed.
+        /// </summary>
+        public ImmutableArray<string> Reasons { get; }
+
+        /// <summary>
         /// The transformed document that was produced as a result of the extract method operation.
         /// </summary>
         public Document? DocumentWithoutFinalFormatting { get; }
@@ -33,11 +38,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         /// document.
         /// </summary>
         public ImmutableArray<AbstractFormattingRule> FormattingRules { get; }
-
-        /// <summary>
-        /// The reasons why the extract method operation did not succeed.
-        /// </summary>
-        public ImmutableArray<string> Reasons { get; }
 
         /// <summary>
         /// the generated method node that contains the extracted code.

--- a/src/Features/Core/Portable/ExtractMethod/InsertionPoint.cs
+++ b/src/Features/Core/Portable/ExtractMethod/InsertionPoint.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         {
             var root = document.Root;
             var annotation = new SyntaxAnnotation();
-            var newRoot = root.AddAnnotations(SpecializedCollections.SingletonEnumerable(Tuple.Create(node, annotation)));
+            var newRoot = root.ReplaceNode(node, node.WithAdditionalAnnotations(annotation));
             return new InsertionPoint(await document.WithSyntaxRootAsync(newRoot, cancellationToken).ConfigureAwait(false), annotation);
         }
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TriviaResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.TriviaResult.cs
@@ -40,16 +40,12 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
                 var annotationResolver = GetAnnotationResolver(callsite, method);
                 var triviaResolver = GetTriviaResolver(method);
-                if (annotationResolver == null || triviaResolver == null)
-                {
-                    // bug # 6644
-                    // this could happen in malformed code. return as it was.
-                    var status = new OperationStatus(OperationStatusFlag.None, FeaturesResources.can_t_not_construct_final_tree);
-                    return status.With(document);
-                }
 
-                return OperationStatus.Succeeded.With(
-                    await document.WithSyntaxRootAsync(_result.RestoreTrivia(root, annotationResolver, triviaResolver), cancellationToken).ConfigureAwait(false));
+                // Failed to restore the trivia.  Just return whatever best effort result is that we have so far.
+                return annotationResolver == null || triviaResolver == null
+                    ? OperationStatus.Succeeded.With(document)
+                    : OperationStatus.Succeeded.With(
+                        await document.WithSyntaxRootAsync(_result.RestoreTrivia(root, annotationResolver, triviaResolver), cancellationToken).ConfigureAwait(false));
             }
 
             protected IEnumerable<SyntaxTrivia> FilterTriviaList(IEnumerable<SyntaxTrivia> list)

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
@@ -57,10 +57,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             cancellationToken.ThrowIfCancellationRequested();
 
             operationStatus = await CheckVariableTypesAsync(analyzeResult.Status.With(operationStatus), analyzeResult, cancellationToken).ConfigureAwait(false);
-            if (operationStatus.FailedWithNoBestEffortSuggestion())
-            {
+            if (operationStatus.Failed())
                 return new FailedExtractMethodResult(operationStatus);
-            }
 
             var insertionPoint = await GetInsertionPointAsync(analyzeResult.SemanticDocument, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
@@ -158,10 +156,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             SemanticDocument document, SyntaxNode contextNode, IEnumerable<VariableInfo> variables,
             OperationStatus status, CancellationToken cancellationToken)
         {
-            if (status.FailedWithNoBestEffortSuggestion())
-            {
+            if (status.Failed())
                 return Tuple.Create(false, status);
-            }
 
             var location = contextNode.GetLocation();
 
@@ -169,7 +165,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             {
                 var originalType = variable.GetVariableType();
                 var result = await CheckTypeAsync(document.Document, contextNode, location, originalType, cancellationToken).ConfigureAwait(false);
-                if (result.FailedWithNoBestEffortSuggestion())
+                if (result.Failed())
                 {
                     status = status.With(result);
                     return Tuple.Create(false, status);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.cs
@@ -81,12 +81,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             var afterTriviaRestored = applied.With(operationStatus);
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (afterTriviaRestored.Status.FailedWithNoBestEffortSuggestion())
-            {
-                return await CreateExtractMethodResultAsync(
-                    operationStatus, generatedCode.SemanticDocument, ImmutableArray<AbstractFormattingRule>.Empty, generatedCode.MethodNameAnnotation, generatedCode.MethodDefinitionAnnotation, cancellationToken).ConfigureAwait(false);
-            }
-
             var documentWithoutFinalFormatting = afterTriviaRestored.Data.Document;
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
@@ -9,14 +9,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     internal partial class OperationStatus
     {
         public static readonly OperationStatus Succeeded = new(OperationStatusFlag.Succeeded, reason: null);
-        public static readonly OperationStatus FailedWithUnknownReason = new(OperationStatusFlag.None, reason: FeaturesResources.Unknown_error_occurred);
-        public static readonly OperationStatus OverlapsHiddenPosition = new(OperationStatusFlag.None, FeaturesResources.generated_code_is_overlapping_with_hidden_portion_of_the_code);
-        public static readonly OperationStatus NoValidLocationToInsertMethodCall = new(OperationStatusFlag.None, FeaturesResources.No_valid_location_to_insert_method_call);
+        public static readonly OperationStatus FailedWithUnknownReason = new(OperationStatusFlag.Failed, reason: FeaturesResources.Unknown_error_occurred);
+        public static readonly OperationStatus OverlapsHiddenPosition = new(OperationStatusFlag.Failed, FeaturesResources.generated_code_is_overlapping_with_hidden_portion_of_the_code);
+        public static readonly OperationStatus NoValidLocationToInsertMethodCall = new(OperationStatusFlag.Failed, FeaturesResources.No_valid_location_to_insert_method_call);
 
-        public static readonly OperationStatus NoActiveStatement = new(OperationStatusFlag.BestEffort, FeaturesResources.The_selection_contains_no_active_statement);
-        public static readonly OperationStatus ErrorOrUnknownType = new(OperationStatusFlag.BestEffort, FeaturesResources.The_selection_contains_an_error_or_unknown_type);
-        public static readonly OperationStatus UnsafeAddressTaken = new(OperationStatusFlag.BestEffort, FeaturesResources.The_address_of_a_variable_is_used_inside_the_selected_code);
-        public static readonly OperationStatus LocalFunctionCallWithoutDeclaration = new(OperationStatusFlag.BestEffort, FeaturesResources.The_selection_contains_a_local_function_call_without_its_declaration);
+        public static readonly OperationStatus NoActiveStatement = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_no_active_statement);
+        public static readonly OperationStatus ErrorOrUnknownType = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_an_error_or_unknown_type);
+        public static readonly OperationStatus UnsafeAddressTaken = new(OperationStatusFlag.Succeeded, FeaturesResources.The_address_of_a_variable_is_used_inside_the_selected_code);
+        public static readonly OperationStatus LocalFunctionCallWithoutDeclaration = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_a_local_function_call_without_its_declaration);
 
         /// <summary>
         /// create operation status with the given data

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public static readonly OperationStatus NoActiveStatement = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_no_active_statement);
         public static readonly OperationStatus ErrorOrUnknownType = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_an_error_or_unknown_type);
         public static readonly OperationStatus UnsafeAddressTaken = new(OperationStatusFlag.Succeeded, FeaturesResources.The_address_of_a_variable_is_used_inside_the_selected_code);
-        public static readonly OperationStatus LocalFunctionCallWithoutDeclaration = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_a_local_function_call_without_its_declaration);
+        public static readonly OperationStatus LocalFunctionCallWithoutDeclaration = new(OperationStatusFlag.Failed, FeaturesResources.The_selection_contains_a_local_function_call_without_its_declaration);
 
         /// <summary>
         /// create operation status with the given data

--- a/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
+++ b/src/Features/Core/Portable/ExtractMethod/OperationStatus_Statics.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public static readonly OperationStatus OverlapsHiddenPosition = new(OperationStatusFlag.Failed, FeaturesResources.generated_code_is_overlapping_with_hidden_portion_of_the_code);
         public static readonly OperationStatus NoValidLocationToInsertMethodCall = new(OperationStatusFlag.Failed, FeaturesResources.No_valid_location_to_insert_method_call);
 
-        public static readonly OperationStatus NoActiveStatement = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_no_active_statement);
+        public static readonly OperationStatus NoActiveStatement = new(OperationStatusFlag.Failed, FeaturesResources.The_selection_contains_no_active_statement);
         public static readonly OperationStatus ErrorOrUnknownType = new(OperationStatusFlag.Succeeded, FeaturesResources.The_selection_contains_an_error_or_unknown_type);
         public static readonly OperationStatus UnsafeAddressTaken = new(OperationStatusFlag.Succeeded, FeaturesResources.The_address_of_a_variable_is_used_inside_the_selected_code);
         public static readonly OperationStatus LocalFunctionCallWithoutDeclaration = new(OperationStatusFlag.Failed, FeaturesResources.The_selection_contains_a_local_function_call_without_its_declaration);

--- a/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionResult.cs
@@ -6,7 +6,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -33,7 +32,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             bool selectionInExpression,
             SemanticDocument document,
             SyntaxAnnotation firstTokenAnnotation,
-            SyntaxAnnotation lastTokenAnnotation)
+            SyntaxAnnotation lastTokenAnnotation,
+            bool selectionChanged)
         {
             Status = status;
 
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             LastTokenAnnotation = lastTokenAnnotation;
 
             SemanticDocument = document;
+            SelectionChanged = selectionChanged;
         }
 
         protected abstract bool UnderAnonymousOrLocalMethod(SyntaxToken token, SyntaxToken firstToken, SyntaxToken lastToken);
@@ -64,6 +65,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         public SemanticDocument SemanticDocument { get; private set; }
         public SyntaxAnnotation FirstTokenAnnotation { get; }
         public SyntaxAnnotation LastTokenAnnotation { get; }
+        public bool SelectionChanged { get; }
 
         public SelectionResult With(SemanticDocument document)
         {

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
@@ -106,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim currentType = TryCast(symbolInfo.Symbol, ITypeSymbol)
 
                 If Not SymbolEqualityComparer.Default.Equals(currentType, binding.ResolveType(typeParameter)) Then
-                    Return New OperationStatus(OperationStatusFlag.BestEffort,
+                    Return New OperationStatus(OperationStatusFlag.Succeeded,
                         String.Format(FeaturesResources.Type_parameter_0_is_hidden_by_another_type_parameter_1,
                             typeParameter.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                             If(currentType Is Nothing, String.Empty, currentType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))))

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionResult.vb
@@ -26,6 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             document As SemanticDocument,
             firstToken As SyntaxToken,
             lastToken As SyntaxToken,
+            selectionChanged As Boolean,
             cancellationToken As CancellationToken) As Task(Of VisualBasicSelectionResult)
 
             Contract.ThrowIfNull(document)
@@ -46,7 +47,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 selectionInExpression,
                 newDocument,
                 firstAnnotation,
-                lastAnnotation)
+                lastAnnotation,
+                selectionChanged)
         End Function
 
         Private Sub New(
@@ -57,7 +59,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             selectionInExpression As Boolean,
             document As SemanticDocument,
             firstTokenAnnotation As SyntaxAnnotation,
-            lastTokenAnnotation As SyntaxAnnotation)
+            lastTokenAnnotation As SyntaxAnnotation,
+            selectionChanged As Boolean)
 
             MyBase.New(
                 status,
@@ -67,7 +70,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 selectionInExpression,
                 document,
                 firstTokenAnnotation,
-                lastTokenAnnotation)
+                lastTokenAnnotation,
+                selectionChanged)
         End Sub
 
         Protected Overrides Function UnderAnonymousOrLocalMethod(token As SyntaxToken, firstToken As SyntaxToken, lastToken As SyntaxToken) As Boolean

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim statementRange = GetStatementRangeContainedInSpan(Of StatementSyntax)(root, controlFlowSpan, cancellationToken)
                 If statementRange Is Nothing Then
                     With selectionInfo
-                        .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.can_t_determine_valid_range_of_statements_to_extract_out)
+                        .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.can_t_determine_valid_range_of_statements_to_extract_out)
                     End With
 
                     Return New ErrorSelectionResult(selectionInfo.Status)
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     ' check control flow only if we are extracting statement level, not expression level.
                     ' you can't have goto that moves control out of scope in expression level (even in lambda)
                     With selectionInfo
-                        .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.Not_all_code_paths_return)
+                        .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.Not_all_code_paths_return)
                     End With
                 End If
             End If
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 
             If selectionInfo.FirstTokenInFinalSpan.IsMissing OrElse selectionInfo.LastTokenInFinalSpan.IsMissing Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.contains_invalid_selection)
+                    .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.contains_invalid_selection)
                 End With
             End If
 
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 
             If (selectionInfo.SelectionInExpression OrElse selectionInfo.SelectionInSingleStatement) AndAlso commonNode.HasDiagnostics() Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.the_selection_contains_syntactic_errors)
+                    .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.the_selection_contains_syntactic_errors)
                 End With
             End If
 
@@ -103,33 +103,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             Dim tokens = root.DescendantTokens(selectionInfo.FinalSpan)
             If tokens.ContainPreprocessorCrossOver(selectionInfo.FinalSpan) Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.Selection_can_t_be_crossed_over_preprocessors)
+                    .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.Selection_can_t_be_crossed_over_preprocessors)
                 End With
             End If
 
             ' TODO : check behavior of control flow analysis engine around exception and exception handling.
             If tokens.ContainArgumentlessThrowWithoutEnclosingCatch(selectionInfo.FinalSpan) Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.Selection_can_t_contain_throw_without_enclosing_catch_block)
+                    .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.Selection_can_t_contain_throw_without_enclosing_catch_block)
                 End With
             End If
 
             If selectionInfo.SelectionInExpression AndAlso commonNode.PartOfConstantInitializerExpression() Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.Selection_can_t_be_parts_of_constant_initializer_expression)
+                    .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.Selection_can_t_be_parts_of_constant_initializer_expression)
                 End With
             End If
 
             If selectionInfo.SelectionInExpression AndAlso commonNode.IsArgumentForByRefParameter(semanticModel, cancellationToken) Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.Argument_used_for_ByRef_parameter_can_t_be_extracted_out)
+                    .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.Argument_used_for_ByRef_parameter_can_t_be_extracted_out)
                 End With
             End If
 
             Dim containsAllStaticLocals = ContainsAllStaticLocalUsagesDefinedInSelectionIfExist(selectionInfo, semanticModel, cancellationToken)
             If Not containsAllStaticLocals Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.all_static_local_usages_defined_in_the_selection_must_be_included_in_the_selection)
+                    .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.all_static_local_usages_defined_in_the_selection_must_be_included_in_the_selection)
                 End With
             End If
 
@@ -138,7 +138,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 If commonNode.GetAncestorOrThis(Of WithBlockSyntax)() IsNot Nothing Then
                     If commonNode.GetImplicitMemberAccessExpressions(selectionInfo.FinalSpan).Any() Then
                         With clone
-                            .Status = .Status.With(OperationStatusFlag.BestEffort, VBFeaturesResources.Implicit_member_access_can_t_be_included_in_the_selection_without_containing_statement)
+                            .Status = .Status.With(OperationStatusFlag.Succeeded, VBFeaturesResources.Implicit_member_access_can_t_be_included_in_the_selection_without_containing_statement)
                         End With
                     End If
                 End If
@@ -148,15 +148,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 If selectionInfo.FirstTokenInFinalSpan.GetAncestor(Of ExecutableStatementSyntax)() Is Nothing OrElse
                     selectionInfo.LastTokenInFinalSpan.GetAncestor(Of ExecutableStatementSyntax)() Is Nothing Then
                     With clone
-                        .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.Selection_must_be_part_of_executable_statements)
+                        .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.Selection_must_be_part_of_executable_statements)
                     End With
                 End If
-            End If
-
-            If SelectionChanged(selectionInfo) Then
-                With clone
-                    .Status = .Status.MarkSuggestion()
-                End With
             End If
 
             Return clone
@@ -285,7 +279,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
                Not symbol.Locations.First().IsInSource OrElse
                symbol.Locations.First().SourceTree IsNot semanticModel.SyntaxTree Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.next_statement_control_variable_doesn_t_have_matching_declaration_statement)
+                    .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.next_statement_control_variable_doesn_t_have_matching_declaration_statement)
                 End With
 
                 Return clone
@@ -296,7 +290,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             Dim forBlock = root.FindToken(startPosition).GetAncestor(Of ForOrForEachBlockSyntax)()
             If forBlock Is Nothing Then
                 With clone
-                    .Status = .Status.With(OperationStatusFlag.None, VBFeaturesResources.next_statement_control_variable_doesn_t_have_matching_declaration_statement)
+                    .Status = .Status.With(OperationStatusFlag.Failed, VBFeaturesResources.next_statement_control_variable_doesn_t_have_matching_declaration_statement)
                 End With
 
                 Return clone
@@ -341,7 +335,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If firstValidNode Is Nothing Then
                 ' couldn't find any valid node
                 With clone
-                    .Status = New OperationStatus(OperationStatusFlag.None, VBFeaturesResources.Selection_doesn_t_contain_any_valid_node)
+                    .Status = New OperationStatus(OperationStatusFlag.Failed, VBFeaturesResources.Selection_doesn_t_contain_any_valid_node)
                     .FirstTokenInFinalSpan = Nothing
                     .LastTokenInFinalSpan = Nothing
                 End With
@@ -388,7 +382,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
 
             If range Is Nothing Then
                 With clone
-                    .Status = clone.Status.With(OperationStatusFlag.None, VBFeaturesResources.no_valid_statement_range_to_extract_out)
+                    .Status = clone.Status.With(OperationStatusFlag.Failed, VBFeaturesResources.no_valid_statement_range_to_extract_out)
                 End With
 
                 Return clone
@@ -417,7 +411,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
 
                 If singleStatement Is Nothing Then
                     With clone
-                        .Status = clone.Status.With(OperationStatusFlag.None, VBFeaturesResources.no_valid_statement_range_to_extract_out)
+                        .Status = clone.Status.With(OperationStatusFlag.Failed, VBFeaturesResources.no_valid_statement_range_to_extract_out)
                     End With
 
                     Return clone
@@ -471,18 +465,18 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             Dim lastTokenInSelection = root.FindTokenOnLeftOfPosition(adjustedSpan.End, includeSkipped:=False)
 
             If firstTokenInSelection.Kind = SyntaxKind.None OrElse lastTokenInSelection.Kind = SyntaxKind.None Then
-                Return New SelectionInfo With {.Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.Invalid_selection), .OriginalSpan = adjustedSpan}
+                Return New SelectionInfo With {.Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Invalid_selection), .OriginalSpan = adjustedSpan}
             End If
 
             If firstTokenInSelection <> lastTokenInSelection AndAlso
                firstTokenInSelection.Span.End > lastTokenInSelection.SpanStart Then
-                Return New SelectionInfo With {.Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.Invalid_selection), .OriginalSpan = adjustedSpan}
+                Return New SelectionInfo With {.Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Invalid_selection), .OriginalSpan = adjustedSpan}
             End If
 
             If (Not adjustedSpan.Contains(firstTokenInSelection.Span)) AndAlso (Not adjustedSpan.Contains(lastTokenInSelection.Span)) Then
                 Return New SelectionInfo With
                        {
-                           .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.Selection_does_not_contain_a_valid_token),
+                           .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Selection_does_not_contain_a_valid_token),
                            .OriginalSpan = adjustedSpan,
                            .FirstTokenInOriginalSpan = firstTokenInSelection,
                            .LastTokenInOriginalSpan = lastTokenInSelection
@@ -492,7 +486,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If (Not firstTokenInSelection.UnderValidContext()) OrElse (Not lastTokenInSelection.UnderValidContext()) Then
                 Return New SelectionInfo With
                        {
-                           .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.No_valid_selection_to_perform_extraction),
+                           .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_valid_selection_to_perform_extraction),
                            .OriginalSpan = adjustedSpan,
                            .FirstTokenInOriginalSpan = firstTokenInSelection,
                            .LastTokenInOriginalSpan = lastTokenInSelection
@@ -503,7 +497,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If commonRoot Is Nothing Then
                 Return New SelectionInfo With
                        {
-                           .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.No_common_root_node_for_extraction),
+                           .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_common_root_node_for_extraction),
                            .OriginalSpan = adjustedSpan,
                            .FirstTokenInOriginalSpan = firstTokenInSelection,
                            .LastTokenInOriginalSpan = lastTokenInSelection
@@ -513,7 +507,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If Not commonRoot.ContainedInValidType() Then
                 Return New SelectionInfo With
                     {
-                        .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.Selection_not_contained_inside_a_type),
+                        .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.Selection_not_contained_inside_a_type),
                         .OriginalSpan = adjustedSpan,
                         .FirstTokenInOriginalSpan = firstTokenInSelection,
                         .LastTokenInOriginalSpan = lastTokenInSelection
@@ -527,7 +521,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If (Not selectionInExpression) AndAlso (Not commonRoot.UnderValidContext()) Then
                 Return New SelectionInfo With
                        {
-                           .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.No_valid_selection_to_perform_extraction),
+                           .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_valid_selection_to_perform_extraction),
                            .OriginalSpan = adjustedSpan,
                            .FirstTokenInOriginalSpan = firstTokenInSelection,
                            .LastTokenInOriginalSpan = lastTokenInSelection
@@ -538,7 +532,7 @@ result.ReadOutside().Any(Function(s) Equals(s, local)) Then
             If commonRoot.GetAncestor(Of TypeBlockSyntax)() Is Nothing Then
                 Return New SelectionInfo With
                        {
-                           .Status = New OperationStatus(OperationStatusFlag.None, FeaturesResources.No_valid_selection_to_perform_extraction),
+                           .Status = New OperationStatus(OperationStatusFlag.Failed, FeaturesResources.No_valid_selection_to_perform_extraction),
                            .OriginalSpan = adjustedSpan,
                            .FirstTokenInOriginalSpan = firstTokenInSelection,
                            .LastTokenInOriginalSpan = lastTokenInSelection

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
@@ -62,15 +62,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 End If
             End If
 
-            Return Await VisualBasicSelectionResult.CreateResultAsync(selectionInfo.Status,
-                                                           selectionInfo.OriginalSpan,
-                                                           selectionInfo.FinalSpan,
-                                                           Me.Options,
-                                                           selectionInfo.SelectionInExpression,
-                                                           Me.SemanticDocument,
-                                                           selectionInfo.FirstTokenInFinalSpan,
-                                                           selectionInfo.LastTokenInFinalSpan,
-                                                           cancellationToken).ConfigureAwait(False)
+            Return Await VisualBasicSelectionResult.CreateResultAsync(
+                selectionInfo.Status,
+                selectionInfo.OriginalSpan,
+                selectionInfo.FinalSpan,
+                Me.Options,
+                selectionInfo.SelectionInExpression,
+                Me.SemanticDocument,
+                selectionInfo.FirstTokenInFinalSpan,
+                selectionInfo.LastTokenInFinalSpan,
+                SelectionChanged(selectionInfo),
+                cancellationToken).ConfigureAwait(False)
         End Function
 
         Private Shared Function GetControlFlowSpan(selectionInfo As SelectionInfo) As TextSpan


### PR DESCRIPTION
Lowering the amount of concepts and combinations of flags that extract method uses.  There is now simply:

1. Failed - Couldn't extract method at all.  Will tell the user why.
2. Succeeded - No messages.  Can extract method, and can do so without user involvement.
3. Succeeded - With messages.  There was an issue with trying to extract the method.  User can be prompted to decide if they want to proceed or not.

This will also help with some work in the next PR to pull a few failure cases up closer to the start of the work to avoid unnecessary checks later after we've already done computationally expensive work. 

End goal here is to change extract method logic to do as little as it can up front (just determining if it should be offered or not), and then defer everything expensive to the actual invocation of the feature.  Thsi will help a *lot* as just selecting anything in teh editor causes us to try running it just to populate the lightbulb gutter icon.