### PR TITLE
Ensure the VSCode server process runs on non-preview runtime

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -38,11 +38,6 @@
     <SelfContained>false</SelfContained>
     <PublishDir Condition="'$(RuntimeIdentifier)' != ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
-    <!--
-        Set the minimum runtime to a .NET 7 prerelease so that prerelease SDKs will be considered during rollForward.
-        RollForward values for roslyn are set in eng/config/runtimeconfig.template.json
-    -->
-    <RuntimeFrameworkVersion>7.0.0-preview.7.22362.8</RuntimeFrameworkVersion>
 
     <!-- List of runtime identifiers that we want to publish an executable for -->
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-x64;linux-arm64;alpine-x64;alpine-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -74,6 +74,8 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         }
     }
 
+    logger.LogTrace($"Dotnet Runtime: {RuntimeInformation.FrameworkDescription}");
+
     using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(serverConfiguration.ExtensionAssemblyPaths, serverConfiguration.SharedDependenciesPath, loggerFactory);
 
     // The log file directory passed to us by VSCode might not exist yet, though its parent directory is guaranteed to exist.

--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -74,7 +74,7 @@ static async Task RunAsync(ServerConfiguration serverConfiguration, Cancellation
         }
     }
 
-    logger.LogTrace($"Dotnet Runtime: {RuntimeInformation.FrameworkDescription}");
+    logger.LogTrace($".NET Runtime Version: {RuntimeInformation.FrameworkDescription}");
 
     using var exportProvider = await ExportProviderBuilder.CreateExportProviderAsync(serverConfiguration.ExtensionAssemblyPaths, serverConfiguration.SharedDependenciesPath, loggerFactory);
 

--- a/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
@@ -58,7 +58,7 @@ internal static class Program
 
         logger.LogInformation("RPC channel started.");
 
-        logger.LogInformation($"Dotnet Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+        logger.LogInformation($"BuildHost Runtime Version: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
 
         await jsonRpc.Completion.ConfigureAwait(false);
 

--- a/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
+++ b/src/Workspaces/Core/MSBuild.BuildHost/Program.cs
@@ -58,6 +58,8 @@ internal static class Program
 
         logger.LogInformation("RPC channel started.");
 
+        logger.LogInformation($"Dotnet Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+
         await jsonRpc.Completion.ConfigureAwait(false);
 
         logger.LogInformation("RPC channel closed; process exiting.");


### PR DESCRIPTION
## The change
Removes the `RuntimeFrameworkVersion` specified in the VSCode language server process (and adds logging as to which dotnet runtime the server and build host process are running on)

## Why we specified `RuntimeFrameworkVersion` in the past
Specifying the `RuntimeFrameworkVersion` was an old hack that allowed the main server process to roll forward to run on preview runtimes.  This was required to be able to load some projects using preview SDKs.

## Why we don't need `RuntimeFrameworkVersion` now
We now launch a separate build host process with roll forward `LatestMajor` and `DOTNET_ROLL_FORWARD_TO_PRERELEASE` to `1`.  This will allow the build host to run and load the project on preview runtimes.  It is not necessary for our main server process to run on preview runtimes.

## Why this is changing now
Setting `RuntimeFrameworkVersion` to a preview version causes the language server to prefer to run on a preview version of .NET 7, even when a non-preview version of .NET 7 is installed.  

This causes the exceptions noted in https://github.com/dotnet/vscode-csharp/issues/6479 because the version of `System.Text.Json` in the .NET 7 Preview 7 SDK is missing the `JsonRequiredAttribute`.  But the copy of `Newtonsoft.Json` in the server is expecting it to be present (and it *is* available in non-preview versions of .NET 7).

Note: if only a preview version of .NET 7 is installed it won't match our runtime version requirement and we will download a non-preview .NET 7 runtime (via the runtime installer extension).

Resolves https://github.com/dotnet/vscode-csharp/issues/6479

