### PR TITLE
[Performance] Reduce the work done by remove unreachable analyzer when calculating diagnostics

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode
             // binding diagnostics directly on the SourceMethodSymbol containing this block, and
             // so it can retrieve the diagnostics at practically no cost.
             var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
-            var diagnostics = semanticModel.GetDiagnostics(context.FilterSpan, cancellationToken);
+            var diagnostics = semanticModel.GetMethodBodyDiagnostics(context.FilterSpan, cancellationToken);
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
This change will skip the following code:

https://github.com/dotnet/roslyn/blob/b2ea3475c8b2b9bf23bab6e2ea3ef2471875cccf/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs#L3191-L3208 which seems unnecessary since we are looking specifically for CS0162