### PR TITLE
Reduce dependency on ImmutableDictionary in CompletionItem's properties storage.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OperatorCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OperatorCompletionProviderTests.cs
@@ -302,7 +302,7 @@ public class Program
 ", SourceCodeKind.Regular);
             Assert.Equal(
                 numberOfSuggestions,
-                completionItems.Count(c => c.Properties[UnnamedSymbolCompletionProvider.KindName] == UnnamedSymbolCompletionProvider.OperatorKindName));
+                completionItems.Count(c => c.GetProperty(UnnamedSymbolCompletionProvider.KindName) == UnnamedSymbolCompletionProvider.OperatorKindName));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/47511")]

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var suggestionItemOptions = new AsyncCompletionData.SuggestionItemOptions(
                 completionList.SuggestionModeItem.DisplayText,
-                completionList.SuggestionModeItem.Properties.TryGetValue(CommonCompletionItem.DescriptionProperty, out var description) ? description : string.Empty);
+                completionList.SuggestionModeItem.TryGetProperty(CommonCompletionItem.DescriptionProperty, out var description) ? description : string.Empty);
 
             return (new(completionItemList, suggestionItemOptions, selectionHint: AsyncCompletionData.InitialSelectionHint.SoftSelection, filters, isIncomplete: false, null), completionList);
         }

--- a/src/EditorFeatures/Test/Completion/FileSystemCompletionHelperTests.cs
+++ b/src/EditorFeatures/Test/Completion/FileSystemCompletionHelperTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             AssertEx.Equal(
                 expected,
-                actual.Select(c => $"'{c.DisplayText}', {string.Join(", ", c.Tags)}, '{c.Properties[CommonCompletionItem.DescriptionProperty]}'"),
+                actual.Select(c => $"'{c.DisplayText}', {string.Join(", ", c.Tags)}, '{c.GetProperty(CommonCompletionItem.DescriptionProperty)}'"),
                 itemInspector: c => $"@\"{c}\"");
 
             Assert.True(actual.All(i => i.Rules == TestFileSystemCompletionHelper.CompletionRules));

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
                 var span = GetCompletionItemSpan(text, position);
-                var serializedOptions = ImmutableDictionary<string, string>.Empty.Add(HideAdvancedMembers, options.HideAdvancedMembers.ToString());
+                var serializedOptions = ImmutableArray.Create(new KeyValuePair<string, string>(HideAdvancedMembers, options.HideAdvancedMembers.ToString()));
 
                 var items = CreateCompletionItems(semanticModel, symbols, token, position, serializedOptions);
 
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private static IEnumerable<CompletionItem> CreateCompletionItems(
-            SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, int position, ImmutableDictionary<string, string> options)
+            SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, int position, ImmutableArray<KeyValuePair<string, string>> options)
         {
             var builder = SharedPools.Default<StringBuilder>().Allocate();
             try
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private static bool TryCreateSpecialTypeItem(
             SemanticModel semanticModel, ISymbol symbol, SyntaxToken token, int position, StringBuilder builder,
-            ImmutableDictionary<string, string> options, [NotNullWhen(true)] out CompletionItem? item)
+            ImmutableArray<KeyValuePair<string, string>> options, [NotNullWhen(true)] out CompletionItem? item)
         {
             // If the type is a SpecialType, create an additional item using 
             // its actual name (as opposed to intrinsic type keyword)
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             SyntaxToken token,
             int position,
             StringBuilder builder,
-            ImmutableDictionary<string, string> options,
+            ImmutableArray<KeyValuePair<string, string>> options,
             SymbolDisplayFormat unqualifiedCrefFormat)
         {
             builder.Clear();
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return CreateItemFromBuilder(symbol, position, builder, options);
         }
 
-        private static CompletionItem CreateItemFromBuilder(ISymbol symbol, int position, StringBuilder builder, ImmutableDictionary<string, string> options)
+        private static CompletionItem CreateItemFromBuilder(ISymbol symbol, int position, StringBuilder builder, ImmutableArray<KeyValuePair<string, string>> options)
         {
             var symbolText = builder.ToString();
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             char? commitKey,
             CancellationToken cancellationToken)
         {
-            var kind = item.Properties[KindName];
+            var kind = item.GetProperty(KindName);
             return kind switch
             {
                 IndexerKindName => GetIndexerChangeAsync(document, item, cancellationToken),
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             SymbolDescriptionOptions displayOptions,
             CancellationToken cancellationToken)
         {
-            var kind = item.Properties[KindName];
+            var kind = item.GetProperty(KindName);
             return kind switch
             {
                 IndexerKindName => await GetIndexerDescriptionAsync(document, item, displayOptions, cancellationToken).ConfigureAwait(false),

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Indexers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     internal partial class UnnamedSymbolCompletionProvider
     {
-        private readonly ImmutableDictionary<string, string> IndexerProperties =
-            ImmutableDictionary<string, string>.Empty.Add(KindName, IndexerKindName);
+        private readonly ImmutableArray<KeyValuePair<string, string>> IndexerProperties =
+            ImmutableArray.Create(new KeyValuePair<string, string>(KindName, IndexerKindName));
 
         private void AddIndexers(CompletionContext context, ImmutableArray<ISymbol> indexers)
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Operators.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider_Operators.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private readonly int OperatorSortingGroupIndex = 2;
 
         private readonly string OperatorName = nameof(OperatorName);
-        private readonly ImmutableDictionary<string, string> OperatorProperties =
-            ImmutableDictionary<string, string>.Empty.Add(KindName, OperatorKindName);
+        private readonly ImmutableArray<KeyValuePair<string, string>> OperatorProperties =
+            ImmutableArray.Create(new KeyValuePair<string, string>(KindName, OperatorKindName));
 
         /// <summary>
         /// Ordered in the order we want to display operators in the completion list.
@@ -104,6 +104,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
             var displayText = GetOperatorText(opName);
 
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+
+            builder.Add(new KeyValuePair<string, string>(OperatorName, opName));
+
             context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
                 displayText: displayText,
                 displayTextSuffix: null,
@@ -113,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 symbols: operators.ToImmutableArray(),
                 rules: s_operatorRules,
                 contextPosition: context.Position,
-                properties: OperatorProperties.Add(OperatorName, opName),
+                properties: builder.ToImmutable(),
                 isComplexTextEdit: true));
         }
 
@@ -123,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private async Task<CompletionChange> GetOperatorChangeAsync(
             Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            var opName = item.Properties[OperatorName];
+            var opName = item.GetProperty(OperatorName);
             var opPosition = GetOperatorPosition(opName);
 
             if (opPosition.HasFlag(OperatorPosition.Infix))

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -75,15 +75,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private static bool IsPartialTypeDeclaration(SyntaxNode syntax)
             => syntax is BaseTypeDeclarationSyntax declarationSyntax && declarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword);
 
-        protected override ImmutableDictionary<string, string> GetProperties(INamedTypeSymbol symbol, CSharpSyntaxContext context)
-            => ImmutableDictionary<string, string>.Empty.Add(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier());
+        protected override ImmutableArray<KeyValuePair<string, string>> GetProperties(INamedTypeSymbol symbol, CSharpSyntaxContext context)
+            => ImmutableArray.Create(new KeyValuePair<string, string>(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier()));
 
         public override async Task<TextChange?> GetTextChangeAsync(
             Document document, CompletionItem selectedItem, char? ch, CancellationToken cancellationToken)
         {
             if (ch == '<')
             {
-                if (selectedItem.Properties.TryGetValue(InsertionTextOnLessThan, out var insertionText))
+                if (selectedItem.TryGetProperty(InsertionTextOnLessThan, out var insertionText))
                 {
                     return new TextChange(selectedItem.Span, insertionText);
                 }

--- a/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Tags;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion
             string? sortText = null,
             string? filterText = null,
             bool showsWarningIcon = false,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             string? inlineDescription = null,
             string? displayTextPrefix = null,
@@ -41,13 +42,12 @@ namespace Microsoft.CodeAnalysis.Completion
                 tags = tags.Add(WellKnownTags.Warning);
             }
 
-            properties ??= ImmutableDictionary<string, string>.Empty;
             if (!description.IsDefault && description.Length > 0)
             {
-                properties = properties.Add(DescriptionProperty, EncodeDescription(description.ToTaggedText()));
+                properties = properties.NullToEmpty().Add(new KeyValuePair<string, string>(DescriptionProperty, EncodeDescription(description.ToTaggedText())));
             }
 
-            return CompletionItem.Create(
+            return CompletionItem.CreateInternal(
                 displayText: displayText,
                 displayTextSuffix: displayTextSuffix,
                 displayTextPrefix: displayTextPrefix,
@@ -61,11 +61,11 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         public static bool HasDescription(CompletionItem item)
-            => item.Properties.ContainsKey(DescriptionProperty);
+            => item.TryGetProperty(DescriptionProperty, out var _);
 
         public static CompletionDescription GetDescription(CompletionItem item)
         {
-            if (item.Properties.TryGetValue(DescriptionProperty, out var encodedDescription))
+            if (item.TryGetProperty(DescriptionProperty, out var encodedDescription))
             {
                 return DecodeDescription(encodedDescription);
             }

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -20,6 +21,8 @@ namespace Microsoft.CodeAnalysis.Completion
     {
         private readonly string? _filterText;
         private string? _lazyEntireDisplayText;
+        private ImmutableDictionary<string, string>? _propertiesAsImmutableDictionary;
+        private readonly ImmutableArray<KeyValuePair<string, string>> _properties;
 
         /// <summary>
         /// The text that is displayed to the user.
@@ -89,7 +92,50 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <summary>
         /// Additional information attached to a completion item by it creator.
         /// </summary>
-        public ImmutableDictionary<string, string> Properties { get; }
+        public ImmutableDictionary<string, string> Properties
+        {
+            get
+            {
+                if (_propertiesAsImmutableDictionary is null)
+                    _propertiesAsImmutableDictionary = _properties.ToImmutableDictionary();
+
+                return _propertiesAsImmutableDictionary;
+            }
+        }
+
+        internal IEnumerable<KeyValuePair<string, string>> GetProperties()
+        {
+            if (_propertiesAsImmutableDictionary is not null)
+                return _propertiesAsImmutableDictionary;
+
+            return _properties;
+        }
+
+        internal bool TryGetProperty(string name, [NotNullWhen(true)] out string? value)
+        {
+            if (_propertiesAsImmutableDictionary is not null)
+                return _propertiesAsImmutableDictionary.TryGetValue(name, out value);
+
+            foreach ((var propName, var propValue) in _properties)
+            {
+                if (name == propName)
+                {
+                    value = propValue;
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        internal string GetProperty(string name)
+        {
+            if (TryGetProperty(name, out var value))
+                return value;
+
+            throw new KeyNotFoundException($"Property {name} not found");
+        }
 
         /// <summary>
         /// Descriptive tags from <see cref="Tags.WellKnownTags"/>.
@@ -132,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Completion
             string? filterText,
             string? sortText,
             TextSpan span,
-            ImmutableDictionary<string, string>? properties,
+            ImmutableArray<KeyValuePair<string, string>> properties,
             ImmutableArray<string> tags,
             CompletionItemRules? rules,
             string? displayTextPrefix,
@@ -146,10 +192,17 @@ namespace Microsoft.CodeAnalysis.Completion
             SortText = sortText ?? DisplayText;
             InlineDescription = inlineDescription ?? "";
             Span = span;
-            Properties = properties ?? ImmutableDictionary<string, string>.Empty;
             Tags = tags.NullToEmpty();
             Rules = rules ?? CompletionItemRules.Default;
             IsComplexTextEdit = isComplexTextEdit;
+
+            _properties = properties.NullToEmpty();
+            if (_properties.Length > 10)
+            {
+                // Prefer to just keep an ImmutableArray, but performance on large property collections
+                //  (quite uncommon) dictate falling back to a non-linear lookup data structure.
+                _propertiesAsImmutableDictionary = _properties.ToImmutableDictionary();
+            }
 
             if (!DisplayText.Equals(filterText ?? "", StringComparison.Ordinal))
             {
@@ -212,6 +265,23 @@ namespace Microsoft.CodeAnalysis.Completion
             string? inlineDescription = null,
             bool isComplexTextEdit = false)
         {
+            return CreateInternal(
+                displayText, filterText, sortText, properties != null ? properties.ToImmutableArray() : default, tags, rules, displayTextPrefix,
+                displayTextSuffix, inlineDescription, isComplexTextEdit);
+        }
+
+        internal static CompletionItem CreateInternal(
+            string? displayText,
+            string? filterText = null,
+            string? sortText = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
+            ImmutableArray<string> tags = default,
+            CompletionItemRules? rules = null,
+            string? displayTextPrefix = null,
+            string? displayTextSuffix = null,
+            string? inlineDescription = null,
+            bool isComplexTextEdit = false)
+        {
             return new CompletionItem(
                 span: default,
                 displayText: displayText,
@@ -253,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 displayText: displayText,
                 filterText: filterText,
                 sortText: sortText,
-                properties: properties,
+                properties: properties != null ? properties.ToImmutableArray() : default,
                 tags: tags,
                 rules: rules,
                 displayTextPrefix: null,
@@ -267,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Completion
             Optional<string> displayText = default,
             Optional<string> filterText = default,
             Optional<string> sortText = default,
-            Optional<ImmutableDictionary<string, string>?> properties = default,
+            Optional<ImmutableArray<KeyValuePair<string, string>>> properties = default,
             Optional<ImmutableArray<string>> tags = default,
             Optional<CompletionItemRules> rules = default,
             Optional<string> displayTextPrefix = default,
@@ -281,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var newFilterText = filterText.HasValue ? filterText.Value : FilterText;
             var newSortText = sortText.HasValue ? sortText.Value : SortText;
             var newInlineDescription = inlineDescription.HasValue ? inlineDescription.Value : InlineDescription;
-            var newProperties = properties.HasValue ? properties.Value : Properties;
+            var newProperties = properties.HasValue ? properties.Value : _properties;
             var newTags = tags.HasValue ? tags.Value : Tags;
             var newRules = rules.HasValue ? rules.Value : Rules;
             var newDisplayTextPrefix = displayTextPrefix.HasValue ? displayTextPrefix.Value : DisplayTextPrefix;
@@ -293,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 newDisplayText == DisplayText &&
                 newFilterText == FilterText &&
                 newSortText == SortText &&
-                newProperties == Properties &&
+                newProperties == _properties &&
                 newTags == Tags &&
                 newRules == Rules &&
                 newDisplayTextPrefix == DisplayTextPrefix &&
@@ -367,13 +437,16 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Properties"/> property changed.
         /// </summary>
         public CompletionItem WithProperties(ImmutableDictionary<string, string> properties)
+            => With(properties: properties != null ? properties.ToImmutableArray() : default);
+
+        internal CompletionItem WithProperties(ImmutableArray<KeyValuePair<string, string>> properties)
             => With(properties: properties);
 
         /// <summary>
-        /// Creates a copy of this <see cref="CompletionItem"/> with a property added to the <see cref="Properties"/> collection.
+        /// Creates a copy of this <see cref="CompletionItem"/> with the specified property.
         /// </summary>
         public CompletionItem AddProperty(string name, string value)
-            => With(properties: Properties.Add(name, value));
+            => With(properties: ImmutableArray.Create(new KeyValuePair<string, string>(name, value)));
 
         /// <summary>
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Tags"/> property changed.

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             if (_languageProviders.IsDefault)
                 throw ExceptionUtilities.Unreachable();
 
-            return _languageProviders.Single(lang => lang.CompletionProvider?.Name == item.Properties[EmbeddedProviderName]);
+            return _languageProviders.Single(lang => lang.CompletionProvider?.Name == item.GetProperty(EmbeddedProviderName));
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var position = SymbolCompletionItem.GetContextPosition(item);
 
             // What EditorBrowsable settings were we previously passed in (if it mattered)?
-            if (item.Properties.TryGetValue(HideAdvancedMembers, out var hideAdvancedMembersString) &&
+            if (item.TryGetProperty(HideAdvancedMembers, out var hideAdvancedMembersString) &&
                 bool.TryParse(hideAdvancedMembersString, out var hideAdvancedMembers))
             {
                 options = options with { HideAdvancedMembers = hideAdvancedMembers };

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     displayTextSuffix: "",
                     rules: CompletionItemRules.Default,
                     glyph: project.GetGlyph(),
-                    properties: ImmutableDictionary.Create<string, string>().Add(ProjectGuidKey, projectGuid));
+                    properties: ImmutableArray.Create(new KeyValuePair<string, string>(ProjectGuidKey, projectGuid)));
                 context.AddItem(completionItem);
             }
 
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
         {
-            var projectIdGuid = item.Properties[ProjectGuidKey];
+            var projectIdGuid = item.GetProperty(ProjectGuidKey);
             var projectId = ProjectId.CreateFromSerialized(new Guid(projectIdGuid));
             var project = document.Project.Solution.GetRequiredProject(projectId);
             var assemblyName = item.DisplayText;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 rules: CompletionItemRules.Default);
         }
 
-        protected abstract ImmutableDictionary<string, string> GetProperties(INamedTypeSymbol symbol, TSyntaxContext context);
+        protected abstract ImmutableArray<KeyValuePair<string, string>> GetProperties(INamedTypeSymbol symbol, TSyntaxContext context);
 
         protected abstract SyntaxNode? GetPartialTypeSyntaxNode(SyntaxTree tree, int position, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ImportCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -37,30 +38,30 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             (string methodSymbolKey, string receiverTypeSymbolKey, int overloadCount)? extensionMethodData,
             bool includedInTargetTypeCompletion = false)
         {
-            ImmutableDictionary<string, string>? properties = null;
+            ImmutableArray<KeyValuePair<string, string>> properties = default;
 
             if (extensionMethodData != null || arity > 0)
             {
-                var builder = PooledDictionary<string, string>.GetInstance();
+                using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
 
                 if (extensionMethodData.HasValue)
                 {
-                    builder.Add(MethodKey, extensionMethodData.Value.methodSymbolKey);
-                    builder.Add(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey);
+                    builder.Add(new KeyValuePair<string, string>(MethodKey, extensionMethodData.Value.methodSymbolKey));
+                    builder.Add(new KeyValuePair<string, string>(ReceiverKey, extensionMethodData.Value.receiverTypeSymbolKey));
 
                     if (extensionMethodData.Value.overloadCount > 0)
                     {
-                        builder.Add(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString());
+                        builder.Add(new KeyValuePair<string, string>(OverloadCountKey, extensionMethodData.Value.overloadCount.ToString()));
                     }
                 }
                 else
                 {
                     // We don't need arity to recover symbol if we already have SymbolKeyData or it's 0.
                     // (but it still needed below to decide whether to show generic suffix)
-                    builder.Add(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity));
+                    builder.Add(new KeyValuePair<string, string>(TypeAritySuffixName, ArityUtilities.GetMetadataAritySuffix(arity)));
                 }
 
-                properties = builder.ToImmutableDictionaryAndFree();
+                properties = builder.ToImmutable();
             }
 
             // Use "<display name> <namespace>" as sort text. The space before namespace makes items with identical display name
@@ -69,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var sortTextBuilder = PooledStringBuilder.GetInstance();
             sortTextBuilder.Builder.AppendFormat(GetSortTextFormatString(containingNamespace), name, containingNamespace);
 
-            var item = CompletionItem.Create(
+            var item = CompletionItem.CreateInternal(
                  displayText: name,
                  sortText: sortTextBuilder.ToStringAndFree(),
                  properties: properties,
@@ -91,18 +92,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static CompletionItem CreateAttributeItemWithoutSuffix(CompletionItem attributeItem, string attributeNameWithoutSuffix, CompletionItemFlags flags)
         {
-            Debug.Assert(!attributeItem.Properties.ContainsKey(AttributeFullName));
+            Debug.Assert(!attributeItem.TryGetProperty(AttributeFullName, out var _));
 
             // Remember the full type name so we can get the symbol when description is displayed.
-            var newProperties = attributeItem.Properties.Add(AttributeFullName, attributeItem.DisplayText);
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+            builder.AddRange(attributeItem.GetProperties());
+            builder.Add(new KeyValuePair<string, string>(AttributeFullName, attributeItem.DisplayText));
 
             var sortTextBuilder = PooledStringBuilder.GetInstance();
             sortTextBuilder.Builder.AppendFormat(GetSortTextFormatString(attributeItem.InlineDescription), attributeNameWithoutSuffix, attributeItem.InlineDescription);
 
-            var item = CompletionItem.Create(
+            var item = CompletionItem.CreateInternal(
                  displayText: attributeNameWithoutSuffix,
                  sortText: sortTextBuilder.ToStringAndFree(),
-                 properties: newProperties,
+                 properties: builder.ToImmutable(),
                  tags: attributeItem.Tags,
                  rules: attributeItem.Rules,
                  displayTextPrefix: attributeItem.DisplayTextPrefix,
@@ -153,11 +156,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static string GetTypeName(CompletionItem item)
         {
-            var typeName = item.Properties.TryGetValue(AttributeFullName, out var attributeFullName)
+            var typeName = item.TryGetProperty(AttributeFullName, out var attributeFullName)
                 ? attributeFullName
                 : item.DisplayText;
 
-            if (item.Properties.TryGetValue(TypeAritySuffixName, out var aritySuffix))
+            if (item.TryGetProperty(TypeAritySuffixName, out var aritySuffix))
             {
                 return typeName + aritySuffix;
             }
@@ -171,16 +174,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private static (ISymbol? symbol, int overloadCount) GetSymbolAndOverloadCount(CompletionItem item, Compilation compilation)
         {
             // If we have SymbolKey data (i.e. this is an extension method item), use it to recover symbol
-            if (item.Properties.TryGetValue(MethodKey, out var methodSymbolKey))
+            if (item.TryGetProperty(MethodKey, out var methodSymbolKey))
             {
                 var methodSymbol = SymbolKey.ResolveString(methodSymbolKey, compilation).GetAnySymbol() as IMethodSymbol;
 
                 if (methodSymbol != null)
                 {
-                    var overloadCount = item.Properties.TryGetValue(OverloadCountKey, out var overloadCountString) && int.TryParse(overloadCountString, out var count) ? count : 0;
+                    var overloadCount = item.TryGetProperty(OverloadCountKey, out var overloadCountString) && int.TryParse(overloadCountString, out var count) ? count : 0;
 
                     // Get reduced extension method symbol for the given receiver type.
-                    if (item.Properties.TryGetValue(ReceiverKey, out var receiverTypeKey))
+                    if (item.TryGetProperty(ReceiverKey, out var receiverTypeKey))
                     {
                         if (SymbolKey.ResolveString(receiverTypeKey, compilation).GetAnySymbol() is ITypeSymbol receiverTypeSymbol)
                         {
@@ -197,13 +200,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             // Otherwise, this is a type item, so we don't have SymbolKey data. But we should still have all 
             // the data to construct its full metadata name
             var containingNamespace = GetContainingNamespace(item);
-            var typeName = item.Properties.TryGetValue(AttributeFullName, out var attributeFullName) ? attributeFullName : item.DisplayText;
+            var typeName = item.TryGetProperty(AttributeFullName, out var attributeFullName) ? attributeFullName : item.DisplayText;
             var fullyQualifiedName = GetFullyQualifiedName(containingNamespace, typeName);
 
             // We choose not to display the number of "type overloads" for simplicity.
             // Otherwise, we need additional logic to track internal and public visible
             // types separately, and cache both completion items.
-            if (item.Properties.TryGetValue(TypeAritySuffixName, out var aritySuffix))
+            if (item.TryGetProperty(TypeAritySuffixName, out var aritySuffix))
             {
                 return (compilation.GetTypeByMetadataName(fullyQualifiedName + aritySuffix), 0);
             }
@@ -211,8 +214,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return (compilation.GetTypeByMetadataName(fullyQualifiedName), 0);
         }
 
-        public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item) => item.WithProperties(item.Properties.Add(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey));
+        public static CompletionItem MarkItemToAlwaysFullyQualify(CompletionItem item)
+        {
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+            builder.AddRange(item.GetProperties());
+            builder.Add(new KeyValuePair<string, string>(AlwaysFullyQualifyKey, AlwaysFullyQualifyKey));
 
-        public static bool ShouldAlwaysFullyQualify(CompletionItem item) => item.Properties.ContainsKey(AlwaysFullyQualifyKey);
+            return item.WithProperties(builder.ToImmutable());
+        }
+
+        public static bool ShouldAlwaysFullyQualify(CompletionItem item) => item.TryGetProperty(AlwaysFullyQualifyKey, out var _);
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/MemberInsertingCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,10 +23,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             int descriptionPosition,
             CompletionItemRules rules)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add("Line", line.ToString())
-                .Add("Modifiers", modifiers.ToString())
-                .Add("TokenSpanEnd", token.Span.End.ToString());
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>("Line", line.ToString()),
+                new KeyValuePair<string, string>("Modifiers", modifiers.ToString()),
+                new KeyValuePair<string, string>("TokenSpanEnd", token.Span.End.ToString()));
 
             return SymbolCompletionItem.CreateWithSymbolId(
                 displayText: displayText,
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static DeclarationModifiers GetModifiers(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("Modifiers", out var text) &&
+            if (item.TryGetProperty("Modifiers", out var text) &&
                 DeclarationModifiers.TryParse(text, out var modifiers))
             {
                 return modifiers;
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetLine(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("Line", out var text)
+            if (item.TryGetProperty("Line", out var text)
                 && int.TryParse(text, out var number))
             {
                 return number;
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetTokenSpanEnd(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("TokenSpanEnd", out var text)
+            if (item.TryGetProperty("TokenSpanEnd", out var text)
                 && int.TryParse(text, out var number))
             {
                 return number;

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             string inlineDescription,
             ImmutableArray<string> additionalFilterTexts)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add("Position", position.ToString())
-                .Add(SnippetIdentifierKey, snippetIdentifier);
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>("Position", position.ToString()),
+                new KeyValuePair<string, string>(SnippetIdentifierKey, snippetIdentifier));
 
             return CommonCompletionItem.Create(
                 displayText: displayText,
@@ -44,20 +44,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public static string GetSnippetIdentifier(CompletionItem item)
         {
-            Contract.ThrowIfFalse(item.Properties.TryGetValue(SnippetIdentifierKey, out var text));
+            Contract.ThrowIfFalse(item.TryGetProperty(SnippetIdentifierKey, out var text));
             return text;
         }
 
         public static int GetInvocationPosition(CompletionItem item)
         {
-            Contract.ThrowIfFalse(item.Properties.TryGetValue("Position", out var text));
+            Contract.ThrowIfFalse(item.TryGetProperty("Position", out var text));
             Contract.ThrowIfFalse(int.TryParse(text, out var num));
             return num;
         }
 
         public static bool IsSnippet(CompletionItem item)
         {
-            return item.Properties.TryGetValue(SnippetIdentifierKey, out var _);
+            return item.TryGetProperty(SnippetIdentifierKey, out var _);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     {
         private const string InsertionTextProperty = "InsertionText";
 
-        private static readonly Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> s_addSymbolEncoding = AddSymbolEncoding;
-        private static readonly Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> s_addSymbolInfo = AddSymbolInfo;
+        private static readonly Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolEncoding = AddSymbolEncoding;
+        private static readonly Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> s_addSymbolInfo = AddSymbolInfo;
         private static readonly char[] s_projectSeperators = new[] { ';' };
 
         private static CompletionItem CreateWorker(
@@ -30,26 +30,29 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             IReadOnlyList<ISymbol> symbols,
             CompletionItemRules rules,
             int contextPosition,
-            Action<IReadOnlyList<ISymbol>, ImmutableDictionary<string, string>.Builder> symbolEncoder,
+            Action<IReadOnlyList<ISymbol>, ArrayBuilder<KeyValuePair<string, string>>> symbolEncoder,
             string? sortText = null,
             string? insertionText = null,
             string? filterText = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             string? displayTextPrefix = null,
             string? inlineDescription = null,
             Glyph? glyph = null,
             bool isComplexTextEdit = false)
         {
-            var builder = properties != null ? properties.ToBuilder() : ImmutableDictionary<string, string>.Empty.ToBuilder();
+            using var _ = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var builder);
+
+            if (!properties.IsDefault)
+                builder.AddRange(properties);
 
             if (insertionText != null)
             {
-                builder.Add(InsertionTextProperty, insertionText);
+                builder.Add(new KeyValuePair<string, string>(InsertionTextProperty, insertionText));
             }
 
-            builder.Add("ContextPosition", contextPosition.ToString());
+            builder.Add(new KeyValuePair<string, string>("ContextPosition", contextPosition.ToString()));
             AddSupportedPlatforms(builder, supportedPlatforms);
             symbolEncoder(symbols, builder);
 
@@ -71,18 +74,18 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return item;
         }
 
-        private static void AddSymbolEncoding(IReadOnlyList<ISymbol> symbols, ImmutableDictionary<string, string>.Builder properties)
-            => properties.Add("Symbols", EncodeSymbols(symbols));
+        private static void AddSymbolEncoding(IReadOnlyList<ISymbol> symbols, ArrayBuilder<KeyValuePair<string, string>> properties)
+            => properties.Add(new KeyValuePair<string, string>("Symbols", EncodeSymbols(symbols)));
 
-        private static void AddSymbolInfo(IReadOnlyList<ISymbol> symbols, ImmutableDictionary<string, string>.Builder properties)
+        private static void AddSymbolInfo(IReadOnlyList<ISymbol> symbols, ArrayBuilder<KeyValuePair<string, string>> properties)
         {
             var symbol = symbols[0];
             var isGeneric = symbol.GetArity() > 0;
-            properties.Add("SymbolKind", ((int)symbol.Kind).ToString());
-            properties.Add("SymbolName", symbol.Name);
+            properties.Add(new KeyValuePair<string, string>("SymbolKind", ((int)symbol.Kind).ToString()));
+            properties.Add(new KeyValuePair<string, string>("SymbolName", symbol.Name));
 
             if (isGeneric)
-                properties.Add("IsGeneric", isGeneric.ToString());
+                properties.Add(new KeyValuePair<string, string>("IsGeneric", isGeneric.ToString()));
         }
 
         public static CompletionItem AddShouldProvideParenthesisCompletion(CompletionItem item)
@@ -90,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static bool GetShouldProvideParenthesisCompletion(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("ShouldProvideParenthesisCompletion", out _))
+            if (item.TryGetProperty("ShouldProvideParenthesisCompletion", out _))
             {
                 return true;
             }
@@ -118,13 +121,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             => SymbolKey.CreateString(symbol);
 
         public static bool HasSymbols(CompletionItem item)
-            => item.Properties.ContainsKey("Symbols");
+            => item.TryGetProperty("Symbols", out var _);
 
         private static readonly char[] s_symbolSplitters = new[] { '|' };
 
         public static async Task<ImmutableArray<ISymbol>> GetSymbolsAsync(CompletionItem item, Document document, CancellationToken cancellationToken)
         {
-            if (item.Properties.TryGetValue("Symbols", out var symbolIds))
+            if (item.TryGetProperty("Symbols", out var symbolIds))
             {
                 var idList = symbolIds.Split(s_symbolSplitters, StringSplitOptions.RemoveEmptyEntries).ToList();
                 using var _ = ArrayBuilder<ISymbol>.GetInstance(out var symbols);
@@ -213,19 +216,19 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return document;
         }
 
-        private static void AddSupportedPlatforms(ImmutableDictionary<string, string>.Builder properties, SupportedPlatformData? supportedPlatforms)
+        private static void AddSupportedPlatforms(ArrayBuilder<KeyValuePair<string, string>> properties, SupportedPlatformData? supportedPlatforms)
         {
             if (supportedPlatforms != null)
             {
-                properties.Add("InvalidProjects", string.Join(";", supportedPlatforms.InvalidProjects.Select(id => id.Id)));
-                properties.Add("CandidateProjects", string.Join(";", supportedPlatforms.CandidateProjects.Select(id => id.Id)));
+                properties.Add(new KeyValuePair<string, string>("InvalidProjects", string.Join(";", supportedPlatforms.InvalidProjects.Select(id => id.Id))));
+                properties.Add(new KeyValuePair<string, string>("CandidateProjects", string.Join(";", supportedPlatforms.CandidateProjects.Select(id => id.Id))));
             }
         }
 
         public static SupportedPlatformData? GetSupportedPlatforms(CompletionItem item, Solution solution)
         {
-            if (item.Properties.TryGetValue("InvalidProjects", out var invalidProjects)
-                && item.Properties.TryGetValue("CandidateProjects", out var candidateProjects))
+            if (item.TryGetProperty("InvalidProjects", out var invalidProjects)
+                && item.TryGetProperty("CandidateProjects", out var candidateProjects))
             {
                 return new SupportedPlatformData(
                     solution,
@@ -238,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static int GetContextPosition(CompletionItem item)
         {
-            if (item.Properties.TryGetValue("ContextPosition", out var text) &&
+            if (item.TryGetProperty("ContextPosition", out var text) &&
                 int.TryParse(text, out var number))
             {
                 return number;
@@ -253,10 +256,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             => GetContextPosition(item);
 
         public static string GetInsertionText(CompletionItem item)
-            => item.Properties[InsertionTextProperty];
+            => item.GetProperty(InsertionTextProperty);
 
         public static bool TryGetInsertionText(CompletionItem item, [NotNullWhen(true)] out string? insertionText)
-            => item.Properties.TryGetValue(InsertionTextProperty, out insertionText);
+            => item.TryGetProperty(InsertionTextProperty, out insertionText);
 
         // COMPAT OVERLOAD: This is used by IntelliCode.
         public static CompletionItem CreateWithSymbolId(
@@ -285,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 inlineDescription: null,
                 glyph: null,
                 supportedPlatforms,
-                properties,
+                properties != null ? properties.ToImmutableArray() : default,
                 tags,
                 isComplexTextEdit);
         }
@@ -303,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             string? inlineDescription = null,
             Glyph? glyph = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             bool isComplexTextEdit = false)
         {
@@ -327,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             string? inlineDescription = null,
             Glyph? glyph = null,
             SupportedPlatformData? supportedPlatforms = null,
-            ImmutableDictionary<string, string>? properties = null,
+            ImmutableArray<KeyValuePair<string, string>> properties = default,
             ImmutableArray<string> tags = default,
             bool isComplexTextEdit = false)
         {
@@ -339,13 +342,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         internal static string? GetSymbolName(CompletionItem item)
-            => item.Properties.TryGetValue("SymbolName", out var name) ? name : null;
+            => item.TryGetProperty("SymbolName", out var name) ? name : null;
 
         internal static SymbolKind? GetKind(CompletionItem item)
-            => item.Properties.TryGetValue("SymbolKind", out var kind) ? (SymbolKind?)int.Parse(kind) : null;
+            => item.TryGetProperty("SymbolKind", out var kind) ? (SymbolKind?)int.Parse(kind) : null;
 
         internal static bool GetSymbolIsGeneric(CompletionItem item)
-            => item.Properties.TryGetValue("IsGeneric", out var v) && bool.TryParse(v, out var isGeneric) && isGeneric;
+            => item.TryGetProperty("IsGeneric", out var v) && bool.TryParse(v, out var isGeneric) && isGeneric;
 
         public static async Task<CompletionDescription> GetDescriptionAsync(
             CompletionItem item, IReadOnlyList<ISymbol> symbols, Document document, SemanticModel semanticModel, SymbolDescriptionOptions options, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/XmlDocCommentCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
@@ -13,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public static CompletionItem Create(string displayText, string beforeCaretText, string afterCaretText, CompletionItemRules rules)
         {
-            var props = ImmutableDictionary<string, string>.Empty
-                .Add(BeforeCaretText, beforeCaretText)
-                .Add(AfterCaretText, afterCaretText);
+            var props = ImmutableArray.Create(
+                new KeyValuePair<string, string>(BeforeCaretText, beforeCaretText),
+                new KeyValuePair<string, string>(AfterCaretText, afterCaretText));
 
             // Set isComplexTextEdit to be always true for simplicity, even
             // though we don't always need to make change outside the default
@@ -32,9 +33,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         public static string GetBeforeCaretText(CompletionItem item)
-            => item.Properties[BeforeCaretText];
+            => item.GetProperty(BeforeCaretText);
 
         public static string? GetAfterCaretText(CompletionItem item)
-            => item.Properties[AfterCaretText];
+            => item.GetProperty(AfterCaretText);
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeEmbeddedCompletionProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 
             var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
 
-            using var _ = ArrayBuilder<DateAndTimeItem>.GetInstance(out var items);
+            using var _1 = ArrayBuilder<DateAndTimeItem>.GetInstance(out var items);
 
             var embeddedContext = new EmbeddedCompletionContext(text, context, virtualChars, items);
 
@@ -102,20 +103,22 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
             if (items.Count == 0)
                 return;
 
+            using var _2 = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(out var properties);
             foreach (var embeddedItem in items)
             {
+                properties.Clear();
+
                 var textChange = embeddedItem.Change.TextChange;
 
-                var properties = ImmutableDictionary.CreateBuilder<string, string>();
-                properties.Add(StartKey, textChange.Span.Start.ToString());
-                properties.Add(LengthKey, textChange.Span.Length.ToString());
-                properties.Add(NewTextKey, textChange.NewText!);
-                properties.Add(DescriptionKey, embeddedItem.FullDescription);
-                properties.Add(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name);
+                properties.Add(new KeyValuePair<string, string>(StartKey, textChange.Span.Start.ToString()));
+                properties.Add(new KeyValuePair<string, string>(LengthKey, textChange.Span.Length.ToString()));
+                properties.Add(new KeyValuePair<string, string>(NewTextKey, textChange.NewText!));
+                properties.Add(new KeyValuePair<string, string>(DescriptionKey, embeddedItem.FullDescription));
+                properties.Add(new KeyValuePair<string, string>(AbstractAggregateEmbeddedLanguageCompletionProvider.EmbeddedProviderName, Name));
 
                 // Keep everything sorted in the order we just produced the items in.
                 var sortText = context.Items.Count.ToString("0000");
-                context.AddItem(CompletionItem.Create(
+                context.AddItem(CompletionItem.CreateInternal(
                     displayText: embeddedItem.DisplayText,
                     inlineDescription: embeddedItem.InlineDescription,
                     sortText: sortText,
@@ -212,9 +215,9 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
         public override Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey, CancellationToken cancellationToken)
         {
             // These values have always been added by us.
-            var startString = item.Properties[StartKey];
-            var lengthString = item.Properties[LengthKey];
-            var newText = item.Properties[NewTextKey];
+            var startString = item.GetProperty(StartKey);
+            var lengthString = item.GetProperty(LengthKey);
+            var newText = item.GetProperty(NewTextKey);
 
             Contract.ThrowIfNull(startString);
             Contract.ThrowIfNull(lengthString);
@@ -226,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime
 
         public override Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            if (!item.Properties.TryGetValue(DescriptionKey, out var description))
+            if (!item.TryGetProperty(DescriptionKey, out var description))
                 return SpecializedTasks.Null<CompletionDescription>();
 
             return Task.FromResult((CompletionDescription?)CompletionDescription.Create(

--- a/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
             ImmutableDictionary<string, string>? properties = null,
             ImmutableArray<string> tags = default,
             string? inlineDescription = null)
-            => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, properties, tags, inlineDescription);
+            => CommonCompletionItem.Create(displayText, displayTextSuffix, rules, (Glyph?)glyph, description, sortText, filterText, showsWarningIcon, properties != null ? properties.AsImmutable() : ImmutableArray<KeyValuePair<string, string>>.Empty, tags, inlineDescription);
 
         public static CompletionItem CreateSymbolCompletionItem(
             string displayText,
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
             ImmutableDictionary<string, string>? properties = null,
             ImmutableArray<string> tags = default)
             => SymbolCompletionItem.CreateWithSymbolId(displayText, displayTextSuffix: null, symbols, rules, contextPosition, sortText, insertionText,
-                filterText, displayTextPrefix: null, inlineDescription: null, glyph: null, supportedPlatforms, properties, tags);
+                filterText, displayTextPrefix: null, inlineDescription: null, glyph: null, supportedPlatforms, properties != null ? properties.AsImmutable() : ImmutableArray<KeyValuePair<string, string>>.Empty, tags);
 
         public static ImmutableArray<SymbolDisplayPart> CreateRecommendedKeywordDisplayParts(string keyword, string toolTip)
             => RecommendedKeyword.CreateDisplayParts(keyword, toolTip);

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
@@ -319,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         Protected Overrides Function GetInsertionText(item As CompletionItem, ch As Char) As String
             If ch = "("c Then
                 Dim insertionText As String = Nothing
-                If item.Properties.TryGetValue(InsertionTextOnOpenParen, insertionText) Then
+                If item.TryGetProperty(InsertionTextOnOpenParen, insertionText) Then
                     Return insertionText
                 End If
             End If

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
@@ -65,15 +65,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return (displayText, "", insertionText)
         End Function
 
-        Protected Overrides Function GetProperties(symbol As INamedTypeSymbol, context As VisualBasicSyntaxContext) As ImmutableDictionary(Of String, String)
-            Return ImmutableDictionary(Of String, String).Empty.Add(
-                InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier())
+        Protected Overrides Function GetProperties(symbol As INamedTypeSymbol, context As VisualBasicSyntaxContext) As ImmutableArray(Of KeyValuePair(Of String, String))
+            Return ImmutableArray.Create(
+                New KeyValuePair(Of String, String)(InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier()))
         End Function
 
         Public Overrides Async Function GetTextChangeAsync(document As Document, selectedItem As CompletionItem, ch As Char?, cancellationToken As CancellationToken) As Task(Of TextChange?)
             If ch = "("c Then
                 Dim insertionText As String = Nothing
-                If selectedItem.Properties.TryGetValue(InsertionTextOnOpenParen, insertionText) Then
+                If selectedItem.TryGetProperty(InsertionTextOnOpenParen, insertionText) Then
                     Return New TextChange(selectedItem.Span, insertionText)
                 End If
             End If

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
         {
             var roslynGlyph = glyph.HasValue ? FSharpGlyphHelpers.ConvertTo(glyph.Value) : (Glyph?)null;
             return CommonCompletionItem.Create(
-                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, properties, tags, inlineDescription);
+                displayText, displayTextSuffix, rules, roslynGlyph, description, sortText, filterText, showsWarningIcon, properties != null ? properties.ToImmutableArray() : default, tags, inlineDescription);
         }
     }
 }


### PR DESCRIPTION
I don't believe ImmutableDictionary is the right data structure for CompletionItem properties for several reasons.

1) I've seen the property immutable dictionary creation/modification show up in profiles 
2) From the testing I've done, the properties collection hasn't yet exceeded 5 items

Because these property collections are so small, just using an ImmutableArray for them would be significantly faster for creation, modification, and querying (I've verified using some simple benchmarks that ImmutableArray is faster than ImmutableDictionary for those sizes). The biggest problem I see with changing this is that the property collection is exposed as a public property on CompletionItem. As that can't be changed, I instead had that property be delay populated, with no Roslyn codepaths accessing that dictionary.

I tested with and without this change by bringing up completion 10 times within a single file with no edits between. For this scenario, I saw the following changes under CompletionService.GetCompletionsAsync

CPU: 1658 ms -> 1424 ms
Allocations: 158 MB -> 137 MB

Created as a draft PR as I know this is obtrusive, but I think the perf benefits are potentially quite nice.