### PR TITLE
Fix issue where primary constructors were not being grouped across TFMs in the results window

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -259,7 +259,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             foreach (var location in symbol.DeclaringSyntaxReferences)
             {
                 var originalDocument = solution.GetDocument(location.SyntaxTree);
-                var originalRoot = await location.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
                 // GetDocument will return null for locations in #load'ed trees. TODO:  Remove this check and add logic
                 // to fetch the #load'ed tree's Document once https://github.com/dotnet/roslyn/issues/5260 is fixed.
@@ -269,6 +268,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     continue;
                 }
 
+                var originalRoot = await location.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
                 foreach (var linkedDocumentId in originalDocument.GetLinkedDocumentIds())
                 {
                     var linkedDocument = solution.GetRequiredDocument(linkedDocumentId);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -290,12 +290,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                     if (linkedSymbol.Kind != symbol.Kind)
                     {
+                        // With primary constructors, the declaring node of the primary constructor is the type
+                        // declaration node itself.  So, see if we're in that situation, and try to find the
+                        // corresponding primary constructor in the linked file.
                         if (linkedSymbol is INamedTypeSymbol linkedNamedType &&
                             symbol.IsConstructor())
                         {
-                            // With primary constructors, the declaring node of the primary constructor is the type
-                            // declaration node itself.  So, see if we're in that situation, and try to find the
-                            // corresponding primary constructor in the linked file.
                             linkedSymbol = linkedNamedType.Constructors.FirstOrDefault(
                                 c => c.DeclaringSyntaxReferences.Any(r => linkedNode.Equals(r.GetSyntax(cancellationToken))));
                             if (linkedSymbol is null)


### PR DESCRIPTION
Before:

![image](https://github.com/dotnet/roslyn/assets/4564579/87e02619-d001-437d-901c-629d0600a908)


After:

![image](https://github.com/dotnet/roslyn/assets/4564579/82c1383a-3d88-434c-8844-510c47a44bad)

This was because our logic to unify types cross tfms requires the node+symbolkind to match up in each tfm.  however, primary constructor parameters are special in that their node is the same as their containing type's declaration node, leading to the unification not working for that case.   


Working on test for this now.