### PR TITLE
Add IVT to a future unified razor test project

### DIFF
--- a/src/Tools/ExternalAccess/RazorCompiler/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj
+++ b/src/Tools/ExternalAccess/RazorCompiler/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.csproj
@@ -29,6 +29,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Compiler.SourceGenerators" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Compiler" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Test" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Compiler.Tests" Key="$(RazorKey)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/8400. Follow up on https://github.com/dotnet/roslyn/pull/69655. Forgot to update tests IVT which is a prerequisite for merging razor test projects into one in the future.