### PR TITLE
Restrict EnableGenerateDocumentationFile to .NET 8 warning wave

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -20,6 +20,7 @@ The compiler shipped with .NET 8 (the C# 12 compiler) contains the following war
 | Warning ID | Description |
 |------------|-------------|
 | CS9123 | [Taking address of local or parameter in async method can create a GC hole](https://github.com/dotnet/roslyn/issues/63100) |
+| EnableGenerateDocumentationFile | [Helper diagnostic for enforcing IDE0005 on build](https://github.com/dotnet/roslyn/issues/70460) |
 
 ## Warning level 7
 

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -114,6 +114,9 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             // in their project file to enable IDE0005 on build.
 
             var compilation = context.Compilation;
+            if (compilation.Options.WarningLevel < 8)
+                return;
+
             var tree = compilation.SyntaxTrees.FirstOrDefault(tree => !GeneratedCodeUtilities.IsGeneratedCode(tree, IsRegularCommentOrDocComment, context.CancellationToken));
             if (tree is null || tree.Options.DocumentationMode != DocumentationMode.None)
                 return;


### PR DESCRIPTION
Fixes #70460