### PR TITLE
Shorten the namedpipe used to connect with C# extension

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
+++ b/src/Features/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Program.cs
@@ -233,7 +233,10 @@ static (string clientPipe, string serverPipe) CreateNewPipeNames()
     const string WINDOWS_NODJS_PREFIX = @"\\.\pipe\";
     const string WINDOWS_DOTNET_PREFIX = @"\\.\";
 
-    var pipeName = Guid.NewGuid().ToString();
+    // The pipe name constructed by some systems is very long (due to temp path).
+    // Shorten the unique id for the pipe. 
+    var newGuid = Guid.NewGuid().ToString();
+    var pipeName = newGuid.Split('-')[0];
 
     return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         ? (WINDOWS_NODJS_PREFIX + pipeName, WINDOWS_DOTNET_PREFIX + pipeName)


### PR DESCRIPTION
The path created by mac can be too long and causes an error. I've shorted the pipe name to be just the first segment of a guid. We are only creating one pipe, so there shouldn't be concern with collisions. 

`[stderr] Unhandled exception: System.ArgumentOutOfRangeException: The path '/var/folders/rh/p2xvyg710y15pmy1bf75ds340000gn/T/com.apple.shortcuts.mac-helper/f2622daa-af31-4dce-bb8e-787f1d869eba.sock' is of an invalid length for use with domain sockets on this platform. The length must be between 1 and 104 characters, inclusive. (Parameter 'path')`

Issue: https://github.com/dotnet/vscode-csharp/issues/6485