### PR TITLE
Investigating hot path with semantic tokens taking multiple ranges

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
+++ b/src/EditorFeatures/Core/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
@@ -109,8 +109,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 {
                     // We don't present additive-spans (like static/reassigned-variable) any differently, so strip them
                     // out of the classifications we get back.
+                    // Question - could we directly pass in quickInfoItem.RelatedSpans and take this out of above for loop?
                     var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(
-                        document, span, context.ClassificationOptions, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
+                        document, new[] { span }, context.ClassificationOptions, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
 
                     var tabSize = context.LineFormattingOptions.TabSize;
 

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -93,9 +93,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
                 Dim text = Await document.GetTextAsync()
+                Dim spanArray As TextSpan() = {New TextSpan(0, text.Length)}
 
                 Dim spans = Await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
+                    document, spanArray, ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
 
                 Assert.Equal(
 "(text, '<spaces>', [0..26))
@@ -154,9 +155,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
                 Dim text = Await document.GetTextAsync()
+                Dim spanArray As TextSpan() = {New TextSpan(0, text.Length)}
 
                 Dim spans = Await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
+                    document, spanArray, ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
 
                 Assert.Equal(
 "(text, '<spaces>', [0..26))

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Classification
             // We don't present things like static/assigned variables differently.  So pass `includeAdditiveSpans:
             // false` as we don't need that data.
             var result = await ClassifierHelper.GetClassifiedSpansAsync(
-                document, widenedSpan, options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
+                document, new[] { widenedSpan }, options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
             if (!result.IsDefault)
                 return result;
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -82,13 +82,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // can pass in a range from the full document if they wish.
             ranges ??= new[] { ProtocolConversions.TextSpanToRange(root.FullSpan, text) };
 
-            foreach (var range in ranges)
+            var textSpans = new TextSpan[ranges.Length];
+            for (var i = 0; i < ranges.Length; i++)
             {
-                var textSpan = ProtocolConversions.RangeToTextSpan(range, text);
-
-                await GetClassifiedSpansForDocumentAsync(
-                    classifiedSpans, document, textSpan, options, cancellationToken).ConfigureAwait(false);
+                textSpans[i] = ProtocolConversions.RangeToTextSpan(ranges[i], text);
             }
+
+            await GetClassifiedSpansForDocumentAsync(
+                classifiedSpans, document, textSpans, options, cancellationToken).ConfigureAwait(false);
 
             // Classified spans are not guaranteed to be returned in a certain order so we sort them to be safe.
             classifiedSpans.Sort(ClassifiedSpanComparer.Instance);
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
         private static async Task GetClassifiedSpansForDocumentAsync(
             SegmentedList<ClassifiedSpan> classifiedSpans,
             Document document,
-            TextSpan textSpan,
+            TextSpan[] textSpans,
             ClassificationOptions options,
             CancellationToken cancellationToken)
         {
@@ -116,7 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // `includeAdditiveSpans` will add token modifiers such as 'static', which we want to include in LSP.
             var spans = await ClassifierHelper.GetClassifiedSpansAsync(
-                document, textSpan, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
+                document, textSpans, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
 
             // The spans returned to us may include some empty spans, which we don't care about. We also don't care
             // about the 'text' classification.  It's added for everything between real classifications (including

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
@@ -196,9 +196,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
                         // we don't have guarantee that primary snapshot is from same snapshot as roslyn snapshot. make
                         // sure we map it to right snapshot
+                        // Question roslynSpan is also part of a for loop, could we bulk pass TextSpan here? 
                         var fixedUpSpan = roslynSpan.TranslateTo(roslynSnapshot, SpanTrackingMode.EdgeExclusive);
                         var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(
-                            document, fixedUpSpan.Span.ToTextSpan(), options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
+                            document, new[] { fixedUpSpan.Span.ToTextSpan() }, options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
                         if (classifiedSpans.IsDefault)
                         {
                             continue;


### PR DESCRIPTION
When calling `SemanticTokensHelpers.HandleRequestHelperAsync` during request for semantic tokens with multiple ranges in a document, we end up with `AddSemanticClassificationAsync` as a hot path for this request.
 
I noticed the reference below:
https://github.com/dotnet/roslyn/blob/main/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs#L109-L149

and it made me think maybe we could just update `ClassifierHelper.GetClassifiedSpansAsync`
and call `AddSemanticClassificationAsync` in there using a full text span of the document rather than effectively looping through each item in the text span one at a time.

Would be good to run through some ideas before going further with this draft.
Note: This PR is not complete and is only meant for running through some ideas.

@ToddGrun @CyrusNajmabadi 