### PR TITLE
EnC: Fix emit for anonymous indexed delegates

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7284,9 +7284,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PatternSpanCharCannotBeStringNull" xml:space="preserve">
     <value>A string 'null' constant is not supported as a pattern for '{0}'. Use an empty string instead.</value>
   </data>
-  <data name="ERR_EncUpdateFailedDelegateTypeChanged" xml:space="preserve">
-    <value>Cannot update because an inferred delegate type has changed.</value>
-  </data>
   <data name="WRN_CompileTimeCheckedOverflow" xml:space="preserve">
     <value>The operation may overflow '{0}' at runtime (use 'unchecked' syntax to override)</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
@@ -54,8 +54,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         protected override LambdaSyntaxFacts GetLambdaSyntaxFacts()
             => CSharpLambdaSyntaxFacts.Instance;
 
-        internal bool TryGetAnonymousTypeName(AnonymousTypeManager.AnonymousTypeTemplateSymbol template, [NotNullWhen(true)] out string? name, out int index)
-            => _mapToPrevious.TryGetAnonymousTypeName(template, out name, out index);
+        internal bool TryGetAnonymousTypeValue(AnonymousTypeManager.AnonymousTypeOrDelegateTemplateSymbol template, out AnonymousTypeValue typeValue)
+            => _mapToPrevious.TryGetAnonymousTypeValue(template, out typeValue);
 
         protected override void GetStateMachineFieldMapFromMetadata(
             ITypeSymbolInternal stateMachineType,

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -113,36 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 changedTypes: changedTypes.ToImmutableAndFree());
         }
 
-        private static bool ContainsPreviousAnonymousDelegates(
-            CSharpDefinitionMap definitionMap,
-            ImmutableSegmentedDictionary<string, AnonymousTypeValue> previousDictionary,
-            IEnumerable<Cci.ITypeDefinition> currentTypes)
-        {
-            if (previousDictionary.Count == 0)
-            {
-                return true;
-            }
-
-            var currentTypesByName = currentTypes.ToImmutableDictionary(getName);
-            if (previousDictionary.Count > currentTypesByName.Count)
-            {
-                return false;
-            }
-
-            foreach (var previousType in previousDictionary)
-            {
-                if (!currentTypesByName.TryGetValue(getName(previousType.Value.Type), out var currentType) ||
-                    definitionMap.MapDefinition(currentType) is null)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-
-            static string getName(Cci.ITypeDefinition type) => ((Cci.INamedEntity)type).Name!;
-        }
-
         /// <summary>
         /// Return a version of the baseline with all definitions mapped to this compilation.
         /// Definitions from the initial generation, from metadata, are not mapped since

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -84,32 +84,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 filterOpt: s => changes.RequiresCompilation(s.GetISymbol()),
                 cancellationToken: cancellationToken))
             {
-                if (!ContainsPreviousAnonymousDelegates(definitionMap, baseline.SynthesizedTypes.AnonymousDelegatesWithIndexedNames, compilation.AnonymousTypeManager.GetCreatedAnonymousDelegateTypesWithIndexedNames()))
-                {
-                    diagnostics.Add(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged, Location.None);
-                }
-                else
-                {
-                    // Map the definitions from the previous compilation to the current compilation.
-                    // This must be done after compiling above since synthesized definitions
-                    // (generated when compiling method bodies) may be required.
-                    var mappedBaseline = MapToCompilation(compilation, moduleBeingBuilt);
+                // Map the definitions from the previous compilation to the current compilation.
+                // This must be done after compiling above since synthesized definitions
+                // (generated when compiling method bodies) may be required.
+                var mappedBaseline = MapToCompilation(compilation, moduleBeingBuilt);
 
-                    newBaseline = compilation.SerializeToDeltaStreams(
-                        moduleBeingBuilt,
-                        mappedBaseline,
-                        definitionMap,
-                        changes,
-                        metadataStream,
-                        ilStream,
-                        pdbStream,
-                        updatedMethods,
-                        changedTypes,
-                        diagnostics,
-                        testData?.SymWriterFactory,
-                        emitOptions.PdbFilePath,
-                        cancellationToken);
-                }
+                newBaseline = compilation.SerializeToDeltaStreams(
+                    moduleBeingBuilt,
+                    mappedBaseline,
+                    definitionMap,
+                    changes,
+                    metadataStream,
+                    ilStream,
+                    pdbStream,
+                    updatedMethods,
+                    changedTypes,
+                    diagnostics,
+                    testData?.SymWriterFactory,
+                    emitOptions.PdbFilePath,
+                    cancellationToken);
             }
 
             return new EmitDifferenceResult(

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -513,12 +513,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return 0;
         }
 
-        internal virtual bool TryGetAnonymousTypeName(AnonymousTypeManager.AnonymousTypeTemplateSymbol template, out string name, out int index)
+        internal virtual int GetNextAnonymousDelegateIndex()
+        {
+            return 0;
+        }
+
+        internal virtual bool TryGetPreviousAnonymousTypeValue(AnonymousTypeManager.AnonymousTypeOrDelegateTemplateSymbol template, out AnonymousTypeValue typeValue)
         {
             Debug.Assert(Compilation == template.DeclaringCompilation);
 
-            name = null;
-            index = -1;
+            typeValue = default;
+            return false;
+        }
+
+        internal virtual bool TryGetAnonymousDelegateValue(AnonymousTypeManager.AnonymousDelegateTemplateSymbol template, out SynthesizedDelegateValue delegateValue)
+        {
+            Debug.Assert(Compilation == template.DeclaringCompilation);
+
+            delegateValue = default;
             return false;
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2021,7 +2021,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_LowerCaseTypeName = 8981,
         ERR_RecordStructConstructorCallsDefaultConstructor = 8982,
         ERR_StructHasInitializersAndNoDeclaredConstructor = 8983,
-        ERR_EncUpdateFailedDelegateTypeChanged = 8984,
+        // ERR_EncUpdateFailedDelegateTypeChanged = 8984,
 
         ERR_ListPatternRequiresLength = 8985,
         ERR_ScopedMismatchInParameterOfTarget = 8986,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -599,7 +599,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_RefReturningCallAndAwait:
                 case ErrorCode.ERR_SpecialByRefInLambda:
                 case ErrorCode.ERR_DynamicRequiredTypesMissing:
-                case ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged:
                 case ErrorCode.ERR_CannotBeConvertedToUtf8:
                 case ErrorCode.ERR_FileTypeNonUniquePath:
                 case ErrorCode.ERR_InterceptorSignatureMismatch:

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -521,28 +521,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 int submissionSlotIndex = this.Compilation.GetSubmissionSlotIndex();
 
-                int typeIndex = moduleBeingBuilt.GetNextAnonymousTypeIndex();
-                foreach (var template in anonymousTypes)
-                {
-                    string name;
-                    int index;
-                    if (!moduleBeingBuilt.TryGetAnonymousTypeName(template, out name, out index))
-                    {
-                        index = typeIndex++;
-                        name = GeneratedNames.MakeAnonymousTypeOrDelegateTemplateName(index, submissionSlotIndex, moduleId, isDelegate: false);
-                    }
-                    // normally it should only happen once, but in case there is a race
-                    // NameAndIndex.set has an assert which guarantees that the
-                    // template name provided is the same as the one already assigned
-                    template.NameAndIndex = new NameAndIndex(name, index);
-                }
+                assignNames(anonymousTypes, moduleBeingBuilt.GetNextAnonymousTypeIndex(), isDelegate: false);
+                assignNames(anonymousDelegatesWithIndexedNames, moduleBeingBuilt.GetNextAnonymousDelegateIndex(), isDelegate: true);
 
-                int delegateIndex = 0;
-                foreach (var template in anonymousDelegatesWithIndexedNames)
+                void assignNames(IReadOnlyList<AnonymousTypeOrDelegateTemplateSymbol> templates, int nextIndex, bool isDelegate)
                 {
-                    int index = delegateIndex++;
-                    string name = GeneratedNames.MakeAnonymousTypeOrDelegateTemplateName(index, submissionSlotIndex, moduleId, isDelegate: true);
-                    template.NameAndIndex = new NameAndIndex(name, index);
+                    foreach (var template in templates)
+                    {
+                        int index;
+                        string name;
+                        if (moduleBeingBuilt.TryGetPreviousAnonymousTypeValue(template, out var typeValue))
+                        {
+                            index = typeValue.UniqueIndex;
+                            name = typeValue.Name;
+                        }
+                        else
+                        {
+                            index = nextIndex++;
+                            name = GeneratedNames.MakeAnonymousTypeOrDelegateTemplateName(index, submissionSlotIndex, moduleId, isDelegate);
+                        }
+
+                        template.NameAndIndex = new NameAndIndex(name, index);
+                    }
                 }
 
                 this.SealTemplates();
@@ -704,16 +704,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal ImmutableSegmentedDictionary<string, AnonymousTypeValue> GetAnonymousDelegatesWithIndexedNames()
+        internal ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> GetAnonymousDelegatesWithIndexedNames()
         {
             // Get anonymous delegates with indexed names (distinct from
             // anonymous delegates from GetAnonymousDelegates() above).
             var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
             GetCreatedAnonymousDelegatesWithIndexedNames(templates);
 
-            var result = templates.ToImmutableSegmentedDictionary(
-                keySelector: template => template.NameAndIndex.Name,
-                elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()));
+            var result = templates.GroupBy(
+                keySelector: template => new AnonymousDelegateWithIndexedNamePartialKey(template.Arity, template.DelegateInvokeMethod.ParameterCount),
+                elementSelector: template => new AnonymousTypeValue(template.NameAndIndex.Name, template.NameAndIndex.Index, template.GetCciAdapter()))
+                .ToImmutableSegmentedDictionary(
+                    keySelector: grouping => grouping.Key,
+                    elementSelector: grouping => grouping.ToImmutableArray());
 
             templates.Free();
             return result;

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -633,19 +633,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal IEnumerable<Cci.INamedTypeDefinition> GetCreatedAnonymousDelegateTypesWithIndexedNames()
-        {
-            var templates = ArrayBuilder<AnonymousDelegateTemplateSymbol>.GetInstance();
-            GetCreatedAnonymousDelegatesWithIndexedNames(templates);
-
-            foreach (var template in templates)
-            {
-                yield return template.GetCciAdapter();
-            }
-
-            templates.Free();
-        }
-
         /// <summary>
         /// The set of synthesized delegates created by
         /// this AnonymousTypeManager.

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constructor = new SynthesizedDelegateConstructor(this, objectType, intPtrType);
                 // https://github.com/dotnet/roslyn/issues/56808: Synthesized delegates should include BeginInvoke() and EndInvoke().
                 var invokeMethod = createInvokeMethod(this, refKinds, voidReturnTypeOpt);
-                _members = ImmutableArray.Create<Symbol>(constructor, invokeMethod);
+                _members = CreateMembers(constructor, invokeMethod);
 
                 static SynthesizedDelegateInvokeMethod createInvokeMethod(AnonymousDelegateTemplateSymbol containingType, RefKindVector refKinds, TypeSymbol? voidReturnTypeOpt)
                 {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constructor = new SynthesizedDelegateConstructor(this, manager.System_Object, manager.System_IntPtr);
                 // https://github.com/dotnet/roslyn/issues/56808: Synthesized delegates should include BeginInvoke() and EndInvoke().
                 var invokeMethod = createInvokeMethod(this, typeDescr.Fields);
-                _members = ImmutableArray.Create<Symbol>(constructor, invokeMethod);
+                _members = CreateMembers(constructor, invokeMethod);
 
                 static SynthesizedDelegateInvokeMethod createInvokeMethod(
                     AnonymousDelegateTemplateSymbol containingType,
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constructor = new SynthesizedDelegateConstructor(this, manager.System_Object, manager.System_IntPtr);
                 // https://github.com/dotnet/roslyn/issues/56808: Synthesized delegates should include BeginInvoke() and EndInvoke().
                 var invokeMethod = createInvokeMethod(this, typeDescr.Fields, typeMap);
-                _members = ImmutableArray.Create<Symbol>(constructor, invokeMethod);
+                _members = CreateMembers(constructor, invokeMethod);
 
                 static SynthesizedDelegateInvokeMethod createInvokeMethod(
                     AnonymousDelegateTemplateSymbol containingType,
@@ -204,6 +204,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return method;
                 }
             }
+
+            private static ImmutableArray<Symbol> CreateMembers(MethodSymbol constructor, MethodSymbol invokeMethod)
+                => ImmutableArray.Create<Symbol>(constructor, invokeMethod);
+
+            public new MethodSymbol DelegateInvokeMethod
+                => (MethodSymbol)_members[1];
 
             // AnonymousTypeOrDelegateComparer should not be calling this property for delegate
             // types since AnonymousTypeOrDelegateComparer is only used during emit and we

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -562,11 +562,6 @@
         <target state="translated">Příkaz nemůže začínat na else.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Nelze aktualizovat, protože se změnil odvozený typ delegáta.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Vstupní body aplikací nemůžou mít atribut UnmanagedCallersOnly.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -562,11 +562,6 @@
         <target state="translated">Eine Anweisung kann nicht mit "else" beginnen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Die Aktualisierung kann nicht durchgeführt werden, da sich ein abgeleiteter Delegattyp geändert hat.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Anwendungseinstiegspunkte können nicht mit dem Attribut "UnmanagedCallersOnly" versehen werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -562,11 +562,6 @@
         <target state="translated">“else” no puede iniciar una instrucción.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">No se puede actualizar porque ha cambiado un tipo delegado inferido.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Los puntos de entrada de la aplicación no se pueden atribuir con "UnmanagedCallersOnly".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else' ne peut pas démarrer d'instruction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Mise à jour impossible, car un type délégué déduit a changé.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Les points d'entrée d'application ne peuvent pas être attribués avec 'UnmanagedCallersOnly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -562,11 +562,6 @@
         <target state="translated">Un'istruzione non può iniziare con 'else'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Non è possibile eseguire l'aggiornamento perché è stato modificato un tipo delegato dedotto.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Non è possibile aggiungere ai punti di ingresso dell'applicazione l'attributo 'UnmanagedCallersOnly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else' でステートメントを開始することはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">推定デリゲート型が変更されたため、更新できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">アプリケーションのエントリ ポイントに 'UnmanagedCallersOnly' 属性を設定することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else'로 문을 시작할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">유추된 대리자 형식이 변경되었으므로 업데이트할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">애플리케이션 진입점에는 'UnmanagedCallersOnly' 특성을 지정할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -562,11 +562,6 @@
         <target state="translated">Instrukcja nie może rozpoczynać się od elementu „else”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Nie można zaktualizować, ponieważ zmienił się wywnioskowany typ delegata.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Punkty wejścia aplikacji nie mogą mieć atrybutu „UnmanagedCallersOnly”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else' não pode iniciar uma instrução.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Não foi possível atualizar porque um tipo de delegado inferido foi alterado.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Os pontos de entrada do aplicativo não podem ser atribuídos com 'UnmanagedCallersOnly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -562,11 +562,6 @@
         <target state="translated">"else" не может запускать оператор.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Не удается выполнить обновление, так как изменен выводимый тип делегата.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Точки входа приложения не могут иметь атрибут "UnmanagedCallersOnly".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else' bir deyim başlatamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">Çıkarsanan bir temsilci türü değiştiğinden güncelleştirilemiyor.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">Uygulama giriş noktaları 'UnmanagedCallersOnly' ile ilişkilendirilemez.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -562,11 +562,6 @@
         <target state="translated">"else" 不能用在语句的开头。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">无法更新，因为推断的委托类型已更改。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">无法使用 "UnmanagedCallersOnly" 对应用程序入口点进行特性化。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -562,11 +562,6 @@
         <target state="translated">'else' 無法開始陳述式。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_EncUpdateFailedDelegateTypeChanged">
-        <source>Cannot update because an inferred delegate type has changed.</source>
-        <target state="translated">無法更新，因為推斷的委派型別已變更。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_EntryPointCannotBeUnmanagedCallersOnly">
         <source>Application entry points cannot be attributed with 'UnmanagedCallersOnly'.</source>
         <target state="translated">無法使用 'UnmanagedCallersOnly' 將應用程式進入點屬性化。</target>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -19,7 +19,7 @@ internal sealed class EditAndContinueTest(
     Verification? verification = null)
     : EditAndContinueTest<EditAndContinueTest>(verification)
 {
-    private readonly CSharpCompilationOptions _compilationOptions = options ?? EditAndContinueTestBase.ComSafeDebugDll;
+    private readonly CSharpCompilationOptions _compilationOptions = (options ?? TestOptions.DebugDll).WithConcurrentBuild(false);
     private readonly CSharpParseOptions _parseOptions = parseOptions ?? TestOptions.Regular.WithNoRefSafetyRulesAttribute();
 
     protected override Compilation CreateCompilation(SyntaxTree tree)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -1957,21 +1957,10 @@ class C
         var z = <N:2>(int* a) => a</N:2>;
     }
 }");
-            var source3 = MarkedSource(
-@"class C
-{
-    static unsafe void F()
-    {
-        var x = <N:0>(int* a, int b) => b</N:0>;
-        var y = <N:1>(int a, int* b) => b</N:1>;
-        var z = <N:2>(int* a) => a</N:2>;
-    }
-}");
 
             var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All));
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source2.Tree);
-            var compilation3 = compilation2.WithSource(source3.Tree);
 
             var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
@@ -1980,7 +1969,6 @@ class C
             var method0 = compilation0.GetMember<MethodSymbol>("C.F");
             var method1 = compilation1.GetMember<MethodSymbol>("C.F");
             var method2 = compilation2.GetMember<MethodSymbol>("C.F");
-            var method3 = compilation3.GetMember<MethodSymbol>("C.F");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
@@ -2021,64 +2009,6 @@ class C
             diff2.VerifySynthesizedMembers(
                 "C: {<>c}",
                 "C.<>c: {<>9__0_0, <>9__0_1#1, <>9__0_2#1, <F>b__0_0, <F>b__0_1#1, <F>b__0_2#1}");
-
-            var diff3 = compilation3.EmitDifference(
-                diff2.NextGeneration,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method2, method3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables: true)));
-
-            Assert.False(diff3.EmitResult.Success);
-            diff3.EmitResult.Diagnostics.Verify(
-                // error CS8984: Cannot update because an inferred delegate type has changed.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged).WithLocation(1, 1));
-        }
-
-        [Fact]
-        public void Lambda_SynthesizedDelegate_03()
-        {
-            var source0 = MarkedSource(
-@"class A { }
-struct B<T> { }
-class C
-{
-    static unsafe void F()
-    {
-        var x = <N:0>(B<A>* a, int b) => a</N:0>;
-    }
-}");
-            var source1 = MarkedSource(
-@"class A { }
-struct B<T> { }
-class C
-{
-    static unsafe void F()
-    {
-        var x = <N:0>(B<A>* a, int b) => b</N:0>;
-    }
-}");
-
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All));
-            var compilation1 = compilation0.WithSource(source1.Tree);
-
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
-            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
-            var reader0 = md0.MetadataReader;
-
-            var method0 = compilation0.GetMember<MethodSymbol>("C.F");
-            var method1 = compilation1.GetMember<MethodSymbol>("C.F");
-
-            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
-
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "<>f__AnonymousDelegate0", "A", "B`1", "C", "<>c");
-            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "Invoke", ".ctor", "F", ".ctor", ".cctor", ".ctor", "<F>b__0_0");
-
-            var diff1 = compilation1.EmitDifference(
-                generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method0, method1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
-
-            Assert.False(diff1.EmitResult.Success);
-            diff1.EmitResult.Diagnostics.Verify(
-                // error CS8984: Cannot update because an inferred delegate type has changed.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged).WithLocation(1, 1));
         }
 
         [Fact]
@@ -2103,20 +2033,9 @@ class C
         var x = <N:0>(B<A>* a, int b) => a</N:0>;
     }
 }");
-            var source2 = MarkedSource(
-@"class A { }
-struct B<T> { }
-class C
-{
-    static unsafe void F()
-    {
-        var x = <N:0>(B<A>* a, int b) => b</N:0>;
-    }
-}");
 
             var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All));
             var compilation1 = compilation0.WithSource(source1.Tree);
-            var compilation2 = compilation1.WithSource(source2.Tree);
 
             var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
@@ -2124,7 +2043,6 @@ class C
 
             var method0 = compilation0.GetMember<MethodSymbol>("C.F");
             var method1 = compilation1.GetMember<MethodSymbol>("C.F");
-            var method2 = compilation2.GetMember<MethodSymbol>("C.F");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
@@ -2148,15 +2066,6 @@ class C
             diff1.VerifySynthesizedMembers(
                "C.<>c: {<>9__0#1, <F>b__0#1}",
                "C: {<>c}");
-
-            var diff2 = compilation2.EmitDifference(
-                diff1.NextGeneration,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method1, method2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
-
-            Assert.False(diff2.EmitResult.Success);
-            diff2.EmitResult.Diagnostics.Verify(
-                // error CS8984: Cannot update because an inferred delegate type has changed.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged).WithLocation(1, 1));
         }
 
         [Fact]
@@ -2188,20 +2097,10 @@ class C
         var y = <N:1>(U u, T* t) => *t</N:1>;
     }
 }");
-            var source3 = MarkedSource(
-@"class C<T> where T : unmanaged
-{
-    static unsafe void F<U>() where U : unmanaged
-    {
-        var x = <N:0>(T t, U* u) => *u</N:0>;
-        var y = <N:1>(U u, T* t) => t</N:1>;
-    }
-}");
 
             var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll.WithAllowUnsafe(true).WithMetadataImportOptions(MetadataImportOptions.All));
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source2.Tree);
-            var compilation3 = compilation2.WithSource(source3.Tree);
 
             var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
@@ -2210,7 +2109,6 @@ class C
             var method0 = compilation0.GetMember<MethodSymbol>("C.F");
             var method1 = compilation1.GetMember<MethodSymbol>("C.F");
             var method2 = compilation2.GetMember<MethodSymbol>("C.F");
-            var method3 = compilation3.GetMember<MethodSymbol>("C.F");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
 
@@ -2263,15 +2161,6 @@ class C
                 "System.Runtime: {CompilerServices}",
                 "Microsoft: {CodeAnalysis}",
                 "C<T>.<>c__0<U>: {<>9__0_0, <>9__0_1#1, <F>b__0_0, <F>b__0_1#1}");
-
-            var diff3 = compilation3.EmitDifference(
-                diff2.NextGeneration,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method2, method3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables: true)));
-
-            Assert.False(diff3.EmitResult.Success);
-            diff3.EmitResult.Diagnostics.Verify(
-                // error CS8984: Cannot update because an inferred delegate type has changed.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged).WithLocation(1, 1));
         }
 
         [Fact]
@@ -2329,69 +2218,69 @@ class C
                 "C: {<>c}");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/67243")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/67243")]
-        public void SynthesizedDelegate_MethodGroup()
+        public void SynthesizedDelegates_Ordering()
         {
             using var _ = new EditAndContinueTest(options: TestOptions.DebugExe)
                 .AddBaseline(
-                    source: @"
-using System;
-
-Console.WriteLine(1);
-var <N:0>y = C.G</N:0>;
-Console.WriteLine(2);
-
-class C
-{
-   public static void G(bool a = true) { }
-}
-",
+                    source: """
+                    var <N:0>g1 = C.G1</N:0>;
+                    var <N:1>g2 = C.G2</N:1>;
+                    
+                    class C
+                    {
+                       public static void G1(bool a = true) { }
+                       public static void G2(bool a = false) { }
+                    }
+                    """,
                     validator: g =>
                     {
-                        g.VerifyTypeDefNames("<Module>", "<>f__AnonymousDelegate0`1", "Program", "C", "<>O");
+                        g.VerifyTypeDefNames("<Module>", "<>f__AnonymousDelegate0`1", "<>f__AnonymousDelegate1`1", "Program", "C", "<>O");
 
-                        g.VerifyMethodBody("<top-level-statements-entry-point>", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals init (<>f__AnonymousDelegate0<bool> V_0) //y
-  // sequence point: Console.WriteLine(1);
-  IL_0000:  ldc.i4.1
-  IL_0001:  call       ""void System.Console.WriteLine(int)""
-  IL_0006:  nop
-  // sequence point: var      y = C.G      ;
-  IL_0007:  ldsfld     ""<anonymous delegate> Program.<>O.<0>__G""
-  IL_000c:  dup
-  IL_000d:  brtrue.s   IL_0022
-  IL_000f:  pop
-  IL_0010:  ldnull
-  IL_0011:  ldftn      ""void C.G(bool)""
-  IL_0017:  newobj     ""<>f__AnonymousDelegate0<bool>..ctor(object, System.IntPtr)""
-  IL_001c:  dup
-  IL_001d:  stsfld     ""<anonymous delegate> Program.<>O.<0>__G""
-  IL_0022:  stloc.0
-  // sequence point: Console.WriteLine(2);
-  IL_0023:  ldc.i4.2
-  IL_0024:  call       ""void System.Console.WriteLine(int)""
-  IL_0029:  nop
-  IL_002a:  ret
-}
-");
+                        g.VerifyMethodBody("<top-level-statements-entry-point>", """
+                        {
+                          // Code size       57 (0x39)
+                          .maxstack  2
+                          .locals init (<>f__AnonymousDelegate0<bool> V_0, //g1
+                                        <>f__AnonymousDelegate1<bool> V_1) //g2
+                          // sequence point: var      g1 = C.G1      ;
+                          IL_0000:  ldsfld     "<anonymous delegate> Program.<>O.<0>__G1"
+                          IL_0005:  dup
+                          IL_0006:  brtrue.s   IL_001b
+                          IL_0008:  pop
+                          IL_0009:  ldnull
+                          IL_000a:  ldftn      "void C.G1(bool)"
+                          IL_0010:  newobj     "<>f__AnonymousDelegate0<bool>..ctor(object, System.IntPtr)"
+                          IL_0015:  dup
+                          IL_0016:  stsfld     "<anonymous delegate> Program.<>O.<0>__G1"
+                          IL_001b:  stloc.0
+                          // sequence point: var      g2 = C.G2      ;
+                          IL_001c:  ldsfld     "<anonymous delegate> Program.<>O.<1>__G2"
+                          IL_0021:  dup
+                          IL_0022:  brtrue.s   IL_0037
+                          IL_0024:  pop
+                          IL_0025:  ldnull
+                          IL_0026:  ldftn      "void C.G2(bool)"
+                          IL_002c:  newobj     "<>f__AnonymousDelegate1<bool>..ctor(object, System.IntPtr)"
+                          IL_0031:  dup
+                          IL_0032:  stsfld     "<anonymous delegate> Program.<>O.<1>__G2"
+                          IL_0037:  stloc.1
+                          IL_0038:  ret
+                        }
+                        """);
                     })
                 .AddGeneration(
-                    source: @"
-using System;
+                    source: """
+                    var <N:1>g2 = C.G2</N:1>;
+                    var <N:0>g1 = C.G1</N:0>;
 
-Console.WriteLine(1);
-var <N:0>y = C.G</N:0>;
-Console.WriteLine(3);
-
-class C
-{
-   public static void G(bool a = true) { }
-}
-",
+                    class C
+                    {
+                       public static void G1(bool a = true) { }
+                       public static void G2(bool a = false) { }
+                    }
+                    """,
                     edits: new[]
                     {
                         Edit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true),
@@ -2400,31 +2289,127 @@ class C
                     {
                         g.VerifyTypeDefNames("<>O#1");
 
-                        g.VerifyIL("<top-level-statements-entry-point>", @"
-{
-  // Code size       43 (0x2b)
-  .maxstack  2
-  .locals init ([unchanged] V_0,
-                <>f__AnonymousDelegate0<bool> V_1) //y
-  IL_0000:  ldc.i4.1
-  IL_0001:  call       ""void System.Console.WriteLine(int)""
-  IL_0006:  nop
-  IL_0007:  ldsfld     ""<anonymous delegate> Program.<>O#1.<0>__G""
-  IL_000c:  dup
-  IL_000d:  brtrue.s   IL_0022
-  IL_000f:  pop
-  IL_0010:  ldnull
-  IL_0011:  ldftn      ""void C.G(bool)""
-  IL_0017:  newobj     ""<>f__AnonymousDelegate0<bool>..ctor(object, System.IntPtr)""
-  IL_001c:  dup
-  IL_001d:  stsfld     ""<anonymous delegate> Program.<>O#1.<0>__G""
-  IL_0022:  stloc.1
-  IL_0023:  ldc.i4.3
-  IL_0024:  call       ""void System.Console.WriteLine(int)""
-  IL_0029:  nop
-  IL_002a:  ret
-}
-");
+                        g.VerifyIL("<top-level-statements-entry-point>", """
+                        {
+                          // Code size       57 (0x39)
+                          .maxstack  2
+                          .locals init (<>f__AnonymousDelegate0<bool> V_0, //g1
+                                        <>f__AnonymousDelegate1<bool> V_1) //g2
+                          IL_0000:  ldsfld     "<anonymous delegate> Program.<>O#1.<0>__G2"
+                          IL_0005:  dup
+                          IL_0006:  brtrue.s   IL_001b
+                          IL_0008:  pop
+                          IL_0009:  ldnull
+                          IL_000a:  ldftn      "void C.G2(bool)"
+                          IL_0010:  newobj     "<>f__AnonymousDelegate1<bool>..ctor(object, System.IntPtr)"
+                          IL_0015:  dup
+                          IL_0016:  stsfld     "<anonymous delegate> Program.<>O#1.<0>__G2"
+                          IL_001b:  stloc.1
+                          IL_001c:  ldsfld     "<anonymous delegate> Program.<>O#1.<1>__G1"
+                          IL_0021:  dup
+                          IL_0022:  brtrue.s   IL_0037
+                          IL_0024:  pop
+                          IL_0025:  ldnull
+                          IL_0026:  ldftn      "void C.G1(bool)"
+                          IL_002c:  newobj     "<>f__AnonymousDelegate0<bool>..ctor(object, System.IntPtr)"
+                          IL_0031:  dup
+                          IL_0032:  stsfld     "<anonymous delegate> Program.<>O#1.<1>__G1"
+                          IL_0037:  stloc.0
+                          IL_0038:  ret
+                        }
+                        """);
+                    })
+                .Verify();
+        }
+
+        [Fact]
+        public void SynthesizedDelegates_Delete()
+        {
+            using var _ = new EditAndContinueTest(options: TestOptions.DebugExe)
+                .AddBaseline(
+                    source: """
+                    var <N:0>g1 = C.G1</N:0>;
+                    var <N:1>g2 = C.G2</N:1>;
+                    
+                    class C
+                    {
+                       public static void G1(bool a = true) { }
+                       public static void G2(bool a = false) { }
+                    }
+                    """,
+                    validator: g =>
+                    {
+                        g.VerifyTypeDefNames("<Module>", "<>f__AnonymousDelegate0`1", "<>f__AnonymousDelegate1`1", "Program", "C", "<>O");
+
+                        g.VerifyMethodBody("<top-level-statements-entry-point>", """
+                        {
+                          // Code size       57 (0x39)
+                          .maxstack  2
+                          .locals init (<>f__AnonymousDelegate0<bool> V_0, //g1
+                                        <>f__AnonymousDelegate1<bool> V_1) //g2
+                          // sequence point: var      g1 = C.G1      ;
+                          IL_0000:  ldsfld     "<anonymous delegate> Program.<>O.<0>__G1"
+                          IL_0005:  dup
+                          IL_0006:  brtrue.s   IL_001b
+                          IL_0008:  pop
+                          IL_0009:  ldnull
+                          IL_000a:  ldftn      "void C.G1(bool)"
+                          IL_0010:  newobj     "<>f__AnonymousDelegate0<bool>..ctor(object, System.IntPtr)"
+                          IL_0015:  dup
+                          IL_0016:  stsfld     "<anonymous delegate> Program.<>O.<0>__G1"
+                          IL_001b:  stloc.0
+                          // sequence point: var      g2 = C.G2      ;
+                          IL_001c:  ldsfld     "<anonymous delegate> Program.<>O.<1>__G2"
+                          IL_0021:  dup
+                          IL_0022:  brtrue.s   IL_0037
+                          IL_0024:  pop
+                          IL_0025:  ldnull
+                          IL_0026:  ldftn      "void C.G2(bool)"
+                          IL_002c:  newobj     "<>f__AnonymousDelegate1<bool>..ctor(object, System.IntPtr)"
+                          IL_0031:  dup
+                          IL_0032:  stsfld     "<anonymous delegate> Program.<>O.<1>__G2"
+                          IL_0037:  stloc.1
+                          IL_0038:  ret
+                        }
+                        """);
+                    })
+                .AddGeneration(
+                    source: """
+                    var <N:1>g2 = C.G2</N:1>;
+
+                    class C
+                    {
+                       public static void G1(bool a = true) { }
+                       public static void G2(bool a = false) { }
+                    }
+                    """,
+                    edits: new[]
+                    {
+                        Edit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true),
+                    },
+                    validator: g =>
+                    {
+                        g.VerifyTypeDefNames("<>O#1");
+
+                        g.VerifyIL("<top-level-statements-entry-point>", """
+                        {
+                          // Code size       29 (0x1d)
+                          .maxstack  2
+                          .locals init ([unchanged] V_0,
+                                        <>f__AnonymousDelegate1<bool> V_1) //g2
+                          IL_0000:  ldsfld     "<anonymous delegate> Program.<>O#1.<0>__G2"
+                          IL_0005:  dup
+                          IL_0006:  brtrue.s   IL_001b
+                          IL_0008:  pop
+                          IL_0009:  ldnull
+                          IL_000a:  ldftn      "void C.G2(bool)"
+                          IL_0010:  newobj     "<>f__AnonymousDelegate1<bool>..ctor(object, System.IntPtr)"
+                          IL_0015:  dup
+                          IL_0016:  stsfld     "<anonymous delegate> Program.<>O#1.<0>__G2"
+                          IL_001b:  stloc.1
+                          IL_001c:  ret
+                        }
+                        """);
                     })
                 .Verify();
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -44,6 +45,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 SynthesizedTypeMaps.Empty,
                 fromCompilation.SourceAssembly,
                 peAssemblySymbol);
+
+        private static IEnumerable<string> Inspect(ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> anonymousDelegatesWithIndexedNames)
+            => from entry in anonymousDelegatesWithIndexedNames
+               from value in entry.Value
+               select $"({entry.Key.GenericArity},{entry.Key.ParameterCount}): {value.Type}";
 
         [Fact]
         public void ConcurrentAccess()
@@ -1523,7 +1529,7 @@ class C
 
             var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
             var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
-            Assert.Equal("<>f__AnonymousDelegate0", anonymousDelegates0["<>f__AnonymousDelegate0"].Name);
+            Assert.Equal("<>f__AnonymousDelegate0", anonymousDelegates0.Single().Value.Single().Name);
             Assert.Equal(1, anonymousDelegates0.Count);
 
             var testData = new CompilationTestData();
@@ -1582,11 +1588,13 @@ class C
             var decoder0 = new MetadataDecoder(peModule0);
 
             var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
-            var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
-            Assert.Equal(3, anonymousDelegates0.Count);
-            Assert.Equal("<>f__AnonymousDelegate0<T1, T2, TResult>", anonymousDelegates0["<>f__AnonymousDelegate0"].Type.ToString());
-            Assert.Equal("<>f__AnonymousDelegate1", anonymousDelegates0["<>f__AnonymousDelegate1"].Type.ToString());
-            Assert.Equal("<>f__AnonymousDelegate2", anonymousDelegates0["<>f__AnonymousDelegate2"].Type.ToString());
+
+            AssertEx.SetEqual(new[]
+            {
+                "(3, 3): <>f__AnonymousDelegate0<T1, T2, TResult>",
+                "(0, 2): <>f__AnonymousDelegate1",
+                "(0, 2): <>f__AnonymousDelegate2"
+            }, Inspect(synthesizedTypes0.AnonymousDelegatesWithIndexedNames));
 
             var testData = new CompilationTestData();
             compilation1.EmitToArray(testData: testData);
@@ -1650,11 +1658,13 @@ class C
             var decoder0 = new MetadataDecoder(peModule0);
 
             var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
-            var anonymousDelegates0 = synthesizedTypes0.AnonymousDelegatesWithIndexedNames;
-            Assert.Equal(3, anonymousDelegates0.Count);
-            Assert.Equal("<>f__AnonymousDelegate0<T1, T2, TResult>", anonymousDelegates0["<>f__AnonymousDelegate0"].Type.ToString());
-            Assert.Equal("<>f__AnonymousDelegate1", anonymousDelegates0["<>f__AnonymousDelegate1"].Type.ToString());
-            Assert.Equal("<>f__AnonymousDelegate2", anonymousDelegates0["<>f__AnonymousDelegate2"].Type.ToString());
+
+            AssertEx.SetEqual(new[]
+           {
+                "(3, 3): <>f__AnonymousDelegate0<T1, T2, TResult>",
+                "(0, 2): <>f__AnonymousDelegate1",
+                "(0, 2): <>f__AnonymousDelegate2"
+            }, Inspect(synthesizedTypes0.AnonymousDelegatesWithIndexedNames));
 
             var testData = new CompilationTestData();
             compilation1.EmitToArray(testData: testData);

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -1591,9 +1591,9 @@ class C
 
             AssertEx.SetEqual(new[]
             {
-                "(3, 3): <>f__AnonymousDelegate0<T1, T2, TResult>",
-                "(0, 2): <>f__AnonymousDelegate1",
-                "(0, 2): <>f__AnonymousDelegate2"
+                "(3,2): <>f__AnonymousDelegate0<T1, T2, TResult>",
+                "(0,2): <>f__AnonymousDelegate1",
+                "(0,2): <>f__AnonymousDelegate2"
             }, Inspect(synthesizedTypes0.AnonymousDelegatesWithIndexedNames));
 
             var testData = new CompilationTestData();
@@ -1661,9 +1661,9 @@ class C
 
             AssertEx.SetEqual(new[]
            {
-                "(3, 3): <>f__AnonymousDelegate0<T1, T2, TResult>",
-                "(0, 2): <>f__AnonymousDelegate1",
-                "(0, 2): <>f__AnonymousDelegate2"
+                "(3,2): <>f__AnonymousDelegate0<T1, T2, TResult>",
+                "(0,2): <>f__AnonymousDelegate1",
+                "(0,2): <>f__AnonymousDelegate2"
             }, Inspect(synthesizedTypes0.AnonymousDelegatesWithIndexedNames));
 
             var testData = new CompilationTestData();

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -1660,7 +1660,7 @@ class C
             var synthesizedTypes0 = PEDeltaAssemblyBuilder.GetSynthesizedTypesFromMetadata(reader0, decoder0);
 
             AssertEx.SetEqual(new[]
-           {
+            {
                 "(3,2): <>f__AnonymousDelegate0<T1, T2, TResult>",
                 "(0,2): <>f__AnonymousDelegate1",
                 "(0,2): <>f__AnonymousDelegate2"

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2956,7 +2956,6 @@ class Program
                     case ErrorCode.ERR_RefReturningCallAndAwait:
                     case ErrorCode.ERR_SpecialByRefInLambda:
                     case ErrorCode.ERR_DynamicRequiredTypesMissing:
-                    case ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged:
                     case ErrorCode.ERR_CannotBeConvertedToUtf8:
                     case ErrorCode.ERR_FileTypeNonUniquePath:
                     case ErrorCode.ERR_InterceptorSignatureMismatch:

--- a/src/Compilers/Core/Portable/Emit/AnonymousDelegateWithIndexedNamePartialKey.cs
+++ b/src/Compilers/Core/Portable/Emit/AnonymousDelegateWithIndexedNamePartialKey.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Emit;
+
+/// <summary>
+/// Key used to group anonymous delegate templates by properties that are easy to infer from both source symbols and metadata.
+/// </summary>
+internal readonly record struct AnonymousDelegateWithIndexedNamePartialKey(int GenericArity, int ParameterCount);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -597,5 +597,23 @@ namespace Microsoft.CodeAnalysis.Emit
 
             return nextIndex;
         }
+
+        internal int GetNextAnonymousDelegateIndex()
+        {
+            int nextIndex = 0;
+            foreach (var (typeKey, typeValues) in SynthesizedTypes.AnonymousDelegatesWithIndexedNames)
+            {
+                foreach (var typeValue in typeValues)
+                {
+                    int index = typeValue.UniqueIndex;
+                    if (index >= nextIndex)
+                    {
+                        nextIndex = index + 1;
+                    }
+                }
+            }
+
+            return nextIndex;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -133,15 +133,15 @@ namespace Microsoft.CodeAnalysis.Emit
             return builder.ToImmutable();
         }
 
-        private ImmutableSegmentedDictionary<string, AnonymousTypeValue> MapAnonymousDelegatesWithIndexedNames(IReadOnlyDictionary<string, AnonymousTypeValue> anonymousDelegates)
+        private ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> MapAnonymousDelegatesWithIndexedNames(
+            IReadOnlyDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> anonymousDelegates)
         {
-            var builder = ImmutableSegmentedDictionary.CreateBuilder<string, AnonymousTypeValue>();
+            var builder = ImmutableSegmentedDictionary.CreateBuilder<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>();
 
-            foreach (var (key, value) in anonymousDelegates)
+            foreach (var (key, values) in anonymousDelegates)
             {
-                var type = (Cci.ITypeDefinition?)MapDefinition(value.Type);
-                Debug.Assert(type != null);
-                builder.Add(key, new AnonymousTypeValue(value.Name, value.UniqueIndex, type));
+                builder.Add(key, values.SelectAsArray(value => new AnonymousTypeValue(
+                    value.Name, value.UniqueIndex, (Cci.ITypeDefinition?)MapDefinition(value.Type) ?? throw ExceptionUtilities.UnexpectedValue(value.Type))));
             }
 
             return builder.ToImmutable();

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SynthesizedTypeMaps.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.Emit;
@@ -11,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Emit;
 internal readonly struct SynthesizedTypeMaps(
     ImmutableSegmentedDictionary<AnonymousTypeKey, AnonymousTypeValue>? anonymousTypeMap,
     ImmutableSegmentedDictionary<SynthesizedDelegateKey, SynthesizedDelegateValue>? anonymousDelegates,
-    ImmutableSegmentedDictionary<string, AnonymousTypeValue>? anonymousDelegatesWithIndexedNames)
+    ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>? anonymousDelegatesWithIndexedNames)
 {
     public static readonly SynthesizedTypeMaps Empty = new SynthesizedTypeMaps(null, null, null);
 
@@ -35,8 +34,8 @@ internal readonly struct SynthesizedTypeMaps(
     /// A map of the assembly identities of the baseline compilation to the identities of the original metadata AssemblyRefs.
     /// Only includes identities that differ between these two.
     /// </summary>
-    public ImmutableSegmentedDictionary<string, AnonymousTypeValue> AnonymousDelegatesWithIndexedNames { get; }
-        = anonymousDelegatesWithIndexedNames ?? ImmutableSegmentedDictionary<string, AnonymousTypeValue>.Empty;
+    public ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>> AnonymousDelegatesWithIndexedNames { get; }
+        = anonymousDelegatesWithIndexedNames ?? ImmutableSegmentedDictionary<AnonymousDelegateWithIndexedNamePartialKey, ImmutableArray<AnonymousTypeValue>>.Empty;
 
     public bool IsSubsetOf(SynthesizedTypeMaps other)
         => AnonymousTypes.Keys.All(static (key, other) => other.AnonymousTypes.ContainsKey(key), other) &&

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -1250,6 +1250,9 @@ tryAgain:
             return paramInfo;
         }
 
+        internal void DecodeMethodSignatureParameterCountsOrThrow(MethodDefinitionHandle methodDef, out int parameterCount, out int typeParameterCount)
+            => GetSignatureCountsOrThrow(Module, methodDef, out parameterCount, out typeParameterCount);
+
         /// <exception cref="BadImageFormatException">An exception from metadata reader.</exception>
         internal static void GetSignatureCountsOrThrow(PEModule module, MethodDefinitionHandle methodDef, out int parameterCount, out int typeParameterCount)
         {

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
 
             MyBase.New(verification)
 
-            _options = If(options, EditAndContinueTestBase.ComSafeDebugDll)
+            _options = If(options, TestOptions.DebugDll).WithConcurrentBuild(False)
             _parseOptions = If(parseOptions, TestOptions.Regular)
             _targetFramework = targetFramework
         End Sub

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -3405,6 +3405,37 @@ class C
         }
 
         [Fact]
+        public void Lambdas_Update_Signature_ReturnType_Anonymous()
+        {
+            var src1 = @"
+using System;
+
+class C
+{
+    void F()
+    {
+        var x = (int* a, int b) => a;
+    }
+}
+";
+            var src2 = @"
+using System;
+
+class C
+{
+    void F()
+    {
+        var x = (int* a, int b) => b;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.ChangingLambdaReturnType, "(int* a, int b)", GetResource("lambda")));
+        }
+
+        [Fact]
         public void Lambdas_Update_Signature_BodySyntaxOnly()
         {
             var src1 = @"

--- a/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/LanguageServer/CSharpLspBuildOnlyDiagnostics.cs
@@ -42,7 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServer
         "CS8178", // ErrorCode.ERR_RefReturningCallAndAwait:
         "CS4013", // ErrorCode.ERR_SpecialByRefInLambda:
         "CS1969", // ErrorCode.ERR_DynamicRequiredTypesMissing:
-        "CS8984", // ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged:
         "CS9026", // ErrorCode.ERR_CannotBeConvertedToUtf8:
         "CS9068", // ErrorCode.ERR_FileTypeNonUniquePath:
         "CS9144", // ErrorCode.ERR_InterceptorSignatureMismatch


### PR DESCRIPTION
Removes emit error ERR_EncUpdateFailedDelegateTypeChanged and implements the same approach to indexed synthesized delegate templates as we have had for anonymous type templates.

The IDE reports rude edit when a lambda signature changes, so the compiler doesn't need to report ERR_EncUpdateFailedDelegateTypeChanged for that case. 

Fixes https://github.com/dotnet/roslyn/issues/67243 


