### PR TITLE
Prevent a bit of dictionary resizing in NullableWalker.Variables.Populate

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.Variables.cs
@@ -166,6 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(_variableBySlot.Count == 1);
 
                 _variableBySlot.AddMany(default, snapshot.VariableSlot.Length);
+#if NETCOREAPP
+                _variableSlot.EnsureCapacity(snapshot.VariableSlot.Length);
+                _variableTypes.EnsureCapacity(snapshot.VariableTypes.Count);
+#endif
                 foreach (var pair in snapshot.VariableSlot)
                 {
                     var identifier = pair.Key;


### PR DESCRIPTION
We know the number of items that will be individually added to _variableSlot and _variableTypes, so we can just ensure that multiple resizes don't occur when doing so.

Allocation data from profile I'm looking at (it was a very heavy source generator compilation codepath, so this isn't reflective of a normal experience in the editor.

![image](https://github.com/dotnet/roslyn/assets/6785178/6583237a-d788-46ac-ab9a-3fcb52d12bd0)
