### PR TITLE
Remove unnecessary casts.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3818,7 +3818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override SemanticModel CommonGetSemanticModel(SyntaxTree syntaxTree, bool ignoreAccessibility)
         {
-            return this.GetSemanticModel((SyntaxTree)syntaxTree, ignoreAccessibility);
+            return this.GetSemanticModel(syntaxTree, ignoreAccessibility);
         }
 
         protected internal override ImmutableArray<SyntaxTree> CommonSyntaxTrees

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </remarks>
             private void RecordSyntaxDiagnostics(CSharpSyntaxNode treelessSyntax, Location sourceLocation)
             {
-                if (treelessSyntax.ContainsDiagnostics && ((SyntaxTree)sourceLocation.SourceTree).ReportDocumentationCommentDiagnostics())
+                if (treelessSyntax.ContainsDiagnostics && sourceLocation.SourceTree.ReportDocumentationCommentDiagnostics())
                 {
                     // NOTE: treelessSyntax doesn't have its own SyntaxTree, so we have to access the diagnostics
                     // via the Dummy tree.
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </remarks>
             private void RecordBindingDiagnostics(BindingDiagnosticBag bindingDiagnostics, Location sourceLocation)
             {
-                if (((SyntaxTree)sourceLocation.SourceTree).ReportDocumentationCommentDiagnostics())
+                if (sourceLocation.SourceTree.ReportDocumentationCommentDiagnostics())
                 {
                     if (bindingDiagnostics.DiagnosticBag?.IsEmptyWithoutResolution == false)
                     {

--- a/src/Compilers/CSharp/Portable/DocumentationComments/SourceDocumentationCommentUtils.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/SourceDocumentationCommentUtils.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // In most cases, unprocessed doc comments are reported by UnprocessedDocumentationCommentFinder.
                                 // However, in places where doc comments *are* allowed, it's easier to determine which will
                                 // be unprocessed here.
-                                var tree = (SyntaxTree)trivia.SyntaxTree;
+                                var tree = trivia.SyntaxTree;
                                 if (tree.ReportDocumentationCommentDiagnostics())
                                 {
                                     int start = trivia.Position; // FullSpan start to include /** or ///

--- a/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LexicalSortKey.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // WARNING: Only use this if the location is obtainable without allocating it (even if cached later). E.g., only
         // if the location object is stored in the constructor of the symbol.
         public LexicalSortKey(Location location, CSharpCompilation compilation)
-            : this((SyntaxTree)location.SourceTree, location.SourceSpan.Start, compilation)
+            : this(location.SourceTree, location.SourceSpan.Start, compilation)
         {
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // if the node is stored in the constructor of the symbol. In particular, do not call this on the result of a GetSyntax()
         // call on a SyntaxReference.
         public LexicalSortKey(SyntaxToken token, CSharpCompilation compilation)
-            : this((SyntaxTree)token.SyntaxTree, token.SpanStart, compilation)
+            : this(token.SyntaxTree, token.SpanStart, compilation)
         {
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4741,9 +4741,7 @@ public class C
             var enumDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<EnumDeclarationSyntax>().Single();
             var eventDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<EventDeclarationSyntax>().Single();
 
-            // To repro DevDiv #563572, we need to go through the interface (which, at the time, followed
-            // a different code path).
-            var model = (SemanticModel)compilation.GetSemanticModel(tree);
+            var model = compilation.GetSemanticModel(tree);
 
             var enumSymbol = model.GetDeclaredSymbol(enumDecl); //Used to assert.
             Assert.Equal(SymbolKind.NamedType, enumSymbol.Kind);
@@ -4769,7 +4767,7 @@ public class S
             var structDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<StructDeclarationSyntax>().First();
             var interfaceDecl = tree.GetCompilationUnitRoot().DescendantNodes().OfType<InterfaceDeclarationSyntax>().Last();
 
-            var model = (SemanticModel)compilation.GetSemanticModel(tree);
+            var model = compilation.GetSemanticModel(tree);
 
             var structSymbol = model.GetDeclaredSymbol(structDecl);
             var interfaceSymbol = model.GetDeclaredSymbol(interfaceDecl);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -1252,7 +1252,7 @@ using goo.bar;
             List<SyntaxToken> tokens = syntaxTree.GetRoot().DescendantTokens().ToList();
 
             List<SyntaxToken> list = new List<SyntaxToken>();
-            SyntaxToken token = ((SyntaxToken)((SyntaxTree)syntaxTree).GetCompilationUnitRoot().EndOfFileToken).GetPreviousToken(includeZeroWidth: true);
+            SyntaxToken token = syntaxTree.GetCompilationUnitRoot().EndOfFileToken.GetPreviousToken(includeZeroWidth: true);
             while (token.RawKind != 0)
             {
                 list.Add(token);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
@@ -541,7 +541,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var rewriter = new BadRewriter();
             var rewrittenRoot = rewriter.Visit(tree.GetCompilationUnitRoot());
             Assert.NotNull(rewrittenRoot.SyntaxTree);
-            Assert.True(((SyntaxTree)rewrittenRoot.SyntaxTree).HasCompilationUnitRoot, "how did we get a non-CompilationUnit root?");
+            Assert.True(rewrittenRoot.SyntaxTree.HasCompilationUnitRoot, "how did we get a non-CompilationUnit root?");
             Assert.Same(rewrittenRoot, rewrittenRoot.SyntaxTree.GetRoot());
         }
 

--- a/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
@@ -98,7 +98,7 @@ Public MustInherit Class SemanticModelTestBase : Inherits BasicTestBase
         Return DirectCast(semanticModel.GetAliasInfo(node), AliasSymbol)
     End Function
 
-    Protected Function GetBlockOrStatementInfoForTest(Of StmtSyntax As SyntaxNode, ISM As SemanticModel)(compilation As Compilation, fileName As String, Optional which As Integer = 0, Optional useParent As Boolean = False) As Object
+    Protected Function GetBlockOrStatementInfoForTest(Of StmtSyntax As SyntaxNode)(compilation As Compilation, fileName As String, Optional which As Integer = 0, Optional useParent As Boolean = False) As Object
         Dim node As SyntaxNode = CompilationUtils.FindBindingText(Of StmtSyntax)(compilation, fileName, which)
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
         Dim semanticModel = CType(compilation.GetSemanticModel(tree), VBSemanticModel)

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim compilation = semanticModelOpt.Compilation
 
             Dim sourceModule = DirectCast(compilation.SourceModule, SourceModuleSymbol)
-            Dim sourceFile = sourceModule.TryGetSourceFile(DirectCast(GetSyntaxTree(DirectCast(semanticModelOpt, SemanticModel)), VisualBasicSyntaxTree))
+            Dim sourceFile = sourceModule.TryGetSourceFile(DirectCast(GetSyntaxTree(semanticModelOpt), VisualBasicSyntaxTree))
             Debug.Assert(sourceFile IsNot Nothing)
 
             If Not sourceFile.AliasImportsOpt Is Nothing Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -6221,25 +6221,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                     useParent:=useBlock),
+                                            ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6273,25 +6263,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6321,25 +6301,15 @@ End Class
             Dim current = DirectCast(getEnumerator.ReturnType.GetMember("get_Current"), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(DirectCast(current.AssociatedSymbol, PropertySymbol), semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(DirectCast(current.AssociatedSymbol, PropertySymbol), semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6387,25 +6357,15 @@ End Class
             Dim moveNext = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("MoveNext"), MethodSymbol)
             Dim current = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("Current"), PropertySymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6459,25 +6419,15 @@ End Class
             Dim current = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetTypeMember("CustomEnumerator").GetMember("Current"), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6536,25 +6486,15 @@ BC30149: Class 'CustomEnumerator' must implement 'Sub Dispose()' for interface '
             ' the type claimed to implement IDisposable and we believed it ...
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6601,25 +6541,15 @@ End Class
 
             Dim getEnumerator = DirectCast(compilation.GlobalNamespace.GetTypeMember("Custom").GetMember("GetEnumerator"), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod) ' methods are partly present up to the point where the pattern was violated.
-                    Assert.Null(semanticInfoEx.MoveNextMethod)
-                    Assert.Null(semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod) ' methods are partly present up to the point where the pattern was violated.
+                Assert.Null(semanticInfoEx.MoveNextMethod)
+                Assert.Null(semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6655,25 +6585,15 @@ End Class
             Dim current = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__Current), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6713,25 +6633,15 @@ End Class
             Dim current = DirectCast(ienumerator.GetMember("Current"), PropertySymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    Assert.Equal(current, semanticInfoEx.CurrentProperty)
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal(getEnumerator, semanticInfoEx.GetEnumeratorMethod)
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                Assert.Equal(current, semanticInfoEx.CurrentProperty)
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6756,28 +6666,18 @@ End Class
             Dim moveNext = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__MoveNext), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Equal("Function System.Collections.Generic.IEnumerable(Of System.Int32).GetEnumerator() As System.Collections.Generic.IEnumerator(Of System.Int32)",
-                                 semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-                    ' the first matching symbol on IEnumerable(Of T)
-                    Assert.Equal("ReadOnly Property System.Collections.Generic.IEnumerator(Of System.Int32).Current As System.Int32",
-                                 semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal("Function System.Collections.Generic.IEnumerable(Of System.Int32).GetEnumerator() As System.Collections.Generic.IEnumerator(Of System.Int32)",
+                             semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
+                ' the first matching symbol on IEnumerable(Of T)
+                Assert.Equal("ReadOnly Property System.Collections.Generic.IEnumerator(Of System.Int32).Current As System.Int32",
+                             semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6800,25 +6700,15 @@ End Class
 ]]></file>
 </compilation>)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
-
-                    Assert.Null(semanticInfoEx.GetEnumeratorMethod)
-                    Assert.Null(semanticInfoEx.MoveNextMethod)
-                    Assert.Null(semanticInfoEx.CurrentProperty)
-                    Assert.Null(semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Null(semanticInfoEx.GetEnumeratorMethod)
+                Assert.Null(semanticInfoEx.MoveNextMethod)
+                Assert.Null(semanticInfoEx.CurrentProperty)
+                Assert.Null(semanticInfoEx.DisposeMethod)
             Next
         End Sub
 
@@ -6843,28 +6733,18 @@ End Class
             Dim moveNext = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__MoveNext), MethodSymbol)
             Dim dispose = DirectCast(compilation.GetSpecialType(System_Object).ContainingAssembly.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose), MethodSymbol)
 
-            For Each useInterface In {True, False}
-                For Each useBlock In {True, False}
+            For Each useBlock In {True, False}
+                Dim semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax)(compilation, "a.vb",
+                                                                                                                          useParent:=useBlock),
+                                                ForEachStatementInfo)
 
-                    Dim semanticInfoEx As ForEachStatementInfo
-                    If useInterface Then
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, SemanticModel)(compilation, "a.vb",
-                                                                                                                              useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    Else
-                        semanticInfoEx = DirectCast(GetBlockOrStatementInfoForTest(Of ForEachStatementSyntax, VBSemanticModel)(compilation, "a.vb",
-                                                                                                                             useParent:=useBlock),
-                                                    ForEachStatementInfo)
-                    End If
+                Assert.Equal("Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator",
+                             semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
 
-                    Assert.Equal("Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator",
-                                 semanticInfoEx.GetEnumeratorMethod.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(moveNext, semanticInfoEx.MoveNextMethod)
-
-                    Assert.Equal("ReadOnly Property System.Collections.IEnumerator.Current As System.Object",
-                                 semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
-                    Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
-                Next
+                Assert.Equal("ReadOnly Property System.Collections.IEnumerator.Current As System.Object",
+                             semanticInfoEx.CurrentProperty.ToDisplayString(SymbolDisplayFormat.TestFormat))
+                Assert.Equal(dispose, semanticInfoEx.DisposeMethod)
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_SemanticModel.vb
@@ -1177,7 +1177,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(DirectCast(node11, SyntaxNode))
+            commonSymbolInfo = semanticModel.GetSymbolInfo(DirectCast(node11, SyntaxNode))
 
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
@@ -1429,7 +1429,7 @@ End Module
                 Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
                 Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-                Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(ordering)
+                Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(ordering)
                 Assert.Null(commonSymbolInfo.Symbol)
                 Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
                 Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1480,7 +1480,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node1)
+            Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(node1)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1492,7 +1492,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node2)
+            commonSymbolInfo = semanticModel.GetSymbolInfo(node2)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1707,7 +1707,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo As SymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node6)
+            Dim commonSymbolInfo As SymbolInfo = semanticModel.GetSymbolInfo(node6)
             Assert.Null(commonSymbolInfo.Symbol)
             Assert.Equal(CandidateReason.None, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -1726,7 +1726,7 @@ End Module
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason)
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length)
 
-            commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(node8)
+            commonSymbolInfo = semanticModel.GetSymbolInfo(node8)
             Assert.Same(symbolInfo.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(symbolInfo.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -3385,7 +3385,7 @@ End Module
             Assert.Same(symbolInfo1.Symbol, symbolInfo2.Symbol)
             Assert.Equal(0, symbolInfo2.CandidateSymbols.Length)
 
-            Dim commonSymbolInfo = DirectCast(semanticModel, SemanticModel).GetSymbolInfo(DirectCast(node9, SyntaxNode))
+            Dim commonSymbolInfo = semanticModel.GetSymbolInfo(DirectCast(node9, SyntaxNode))
             Assert.Equal(symbolInfo1.CandidateReason, commonSymbolInfo.CandidateReason)
             Assert.Same(symbolInfo1.Symbol, commonSymbolInfo.Symbol)
             Assert.Equal(0, commonSymbolInfo.CandidateSymbols.Length)
@@ -3917,7 +3917,7 @@ End Module
             Dim semanticModel = compilation.GetSemanticModel(tree)
             Dim node = tree.GetCompilationUnitRoot().FindToken(tree.GetCompilationUnitRoot().ToString().IndexOf("By", StringComparison.Ordinal)).Parent.Parent.DescendantNodes().OfType(Of IdentifierNameSyntax)().First()
 
-            Dim containingSymbol = DirectCast(semanticModel, SemanticModel).GetEnclosingSymbol(node.SpanStart)
+            Dim containingSymbol = semanticModel.GetEnclosingSymbol(node.SpanStart)
 
             Assert.Equal("Function (z As System.Int32) As <anonymous type: Key z As System.Int32, Key Group As ?>", DirectCast(containingSymbol, Symbol).ToTestDisplayString())
         End Sub

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -223,7 +223,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
         End Function
 
         Protected Overrides Function GetQueryClauseInfo(
-                model As SemanticModel,
+                semanticModel As SemanticModel,
                 node As SyntaxNode,
                 cancellationToken As CancellationToken) As ITypeSymbol
 
@@ -232,8 +232,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             If query Is Nothing Then
                 query = node.GetAncestor(Of QueryExpressionSyntax)()
             End If
-
-            Dim semanticModel = DirectCast(model, SemanticModel)
 
             For Each clause In query.Clauses
                 If TypeOf clause Is AggregateClauseSyntax Then

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
@@ -90,7 +90,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateVariable
                 simpleNameOrMemberAccessExpression = identifierName
             End If
 
-            Dim semanticModel = DirectCast(document.SemanticModel, SemanticModel)
+            Dim semanticModel = document.SemanticModel
             If Not IsLegal(semanticModel, simpleNameOrMemberAccessExpression, cancellationToken) AndAlso
                Not simpleNameOrMemberAccessExpression.Parent.IsKind(SyntaxKind.NameOfExpression, SyntaxKind.NamedFieldInitializer) Then
                 identifierToken = Nothing

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SemanticFacts/VisualBasicSemanticFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SemanticFacts/VisualBasicSemanticFacts.vb
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function GetAliasNameSet(model As SemanticModel, cancellationToken As CancellationToken) As ImmutableHashSet(Of String) Implements ISemanticFacts.GetAliasNameSet
-            Dim original = DirectCast(model.GetOriginalSemanticModel(), SemanticModel)
+            Dim original = model.GetOriginalSemanticModel()
 
             If Not original.SyntaxTree.HasCompilationUnitRoot Then
                 Return ImmutableHashSet.Create(Of String)()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/INamespaceOrTypeSymbolExtensions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/INamespaceOrTypeSymbolExtensions.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return Nothing
             End If
 
-            Dim originalSemanticModel = DirectCast(semanticModel.GetOriginalSemanticModel(), SemanticModel)
+            Dim originalSemanticModel = semanticModel.GetOriginalSemanticModel()
             If Not originalSemanticModel.SyntaxTree.HasCompilationUnitRoot Then
                 Return Nothing
             End If

--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
 
             Private ReadOnly _createAliasSet As Func(Of ImmutableHashSet(Of String)) =
                 Function()
-                    Dim model = DirectCast(Me._semanticModel.GetOriginalSemanticModel(), SemanticModel)
+                    Dim model = Me._semanticModel.GetOriginalSemanticModel()
 
                     ' root should be already available
                     If Not model.SyntaxTree.HasCompilationUnitRoot Then

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -1036,7 +1036,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
 
             Dim isInNamespaceOrTypeContext = SyntaxFacts.IsInNamespaceOrTypeContext(TryCast(syntax, ExpressionSyntax))
             Dim position = nodeToSpeculate.SpanStart
-            Return SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(nodeToSpeculate, DirectCast(originalSemanticModel, SemanticModel), position, isInNamespaceOrTypeContext)
+            Return SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(nodeToSpeculate, originalSemanticModel, position, isInNamespaceOrTypeContext)
         End Function
 
 #End Region

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             End Function
 
             Public Function VisitNodeOrToken(nodeOrToken As SyntaxNodeOrToken, semanticModel As SemanticModel, simplifyAllDescendants As Boolean) As SyntaxNodeOrToken Implements IReductionRewriter.VisitNodeOrToken
-                _semanticModel = DirectCast(semanticModel, SemanticModel)
+                _semanticModel = semanticModel
                 _alwaysSimplify = simplifyAllDescendants
                 _hasMoreWork = False
                 _processedParentNodes.Clear()


### PR DESCRIPTION
These casts existed due to the *ancient* initial design of roslyn, where there was no common subclasses between VB and C# types.  Instead, we had interfaces (For things like ISemanticModel and ICompilation), and code would often cast those types back down to the concrete 'SemanticModel' for each langauge.

When these interfaces went away, we tried to fixup most places to not have redundant casts, but we clearly missed several cases.