### PR TITLE
Classify suffixes of numerical literals as keywords

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -6608,5 +6608,52 @@ static T I1.operator checked >>>(T a, T b)
                 Punctuation.CloseCurly,
                 Punctuation.Semicolon);
         }
+
+        [Theory, CombinatorialData]
+        public async Task NumericalLiterals(TestHost testHost)
+        {
+            await TestInMethodAsync("""
+                _ = 1d + 2f + 3.14F + 5.6E10D;
+                _ = 3U + 4L + 5ul + 6Lu;
+                _ = 1m + 1M;
+                """,
+                testHost,
+                Identifier("_"),
+                Operators.Equals,
+                Number("1"),
+                Keyword("d"),
+                Operators.Plus,
+                Number("2"),
+                Keyword("f"),
+                Operators.Plus,
+                Number("3.14"),
+                Keyword("F"),
+                Operators.Plus,
+                Number("5.6E10"),
+                Keyword("D"),
+                Punctuation.Semicolon,
+                Identifier("_"),
+                Operators.Equals,
+                Number("3"),
+                Keyword("U"),
+                Operators.Plus,
+                Number("4"),
+                Keyword("L"),
+                Operators.Plus,
+                Number("5"),
+                Keyword("ul"),
+                Operators.Plus,
+                Number("6"),
+                Keyword("Lu"),
+                Punctuation.Semicolon,
+                Identifier("_"),
+                Operators.Equals,
+                Number("1"),
+                Keyword("m"),
+                Operators.Plus,
+                Number("1"),
+                Keyword("M"),
+                Punctuation.Semicolon);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -102,8 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                             SyntaxKind.Utf8MultiLineRawStringLiteralToken &&
                         token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
                     {
-                        AddClassification(TextSpan.FromBounds(token.Span.Start, token.Span.End - "u8".Length), type);
-                        AddClassification(TextSpan.FromBounds(token.Span.End - "u8".Length, token.Span.End), ClassificationTypeNames.Keyword);
+                        ClassifyLiteralAndSuffix(token.Span, "u8", type);
                     }
                     else
                     {
@@ -261,6 +260,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             {
                 AddClassification(trivia, ClassificationTypeNames.ExcludedCode);
             }
+        }
+
+        private void ClassifyLiteralAndSuffix(TextSpan tokenSpan, string suffix, string literalClassification)
+        {
+            var split = tokenSpan.End - suffix.Length;
+            AddClassification(TextSpan.FromBounds(tokenSpan.Start, split), literalClassification);
+            AddClassification(TextSpan.FromBounds(split, tokenSpan.End), ClassificationTypeNames.Keyword);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                             SyntaxKind.Utf8MultiLineRawStringLiteralToken &&
                         token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
                     {
-                        ClassifyLiteralAndSuffix(token.Span, "u8", type);
+                        ClassifyLiteralAndSuffix(token.Span, type, "u8".Length);
                     }
                     else
                     {
@@ -262,9 +262,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             }
         }
 
-        private void ClassifyLiteralAndSuffix(TextSpan tokenSpan, string suffix, string literalClassification)
+        private void ClassifyLiteralAndSuffix(TextSpan tokenSpan, string literalClassification, int suffixLength)
         {
-            var split = tokenSpan.End - suffix.Length;
+            var split = tokenSpan.End - suffixLength;
             AddClassification(TextSpan.FromBounds(tokenSpan.Start, split), literalClassification);
             AddClassification(TextSpan.FromBounds(split, tokenSpan.End), ClassificationTypeNames.Keyword);
         }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         private static bool TryGetNumericalLiteralSuffix(string tokenText, out int suffixLength)
         {
             // Walk left until the first digit and count the number of characters on the way.
-            // The lexer already did the heavy lifting of determining valid suffixes.
+            // The lexer ensures that the token only ends in valid suffixes; invalid suffix characters are part of a different token.
             suffixLength = 0;
             for (var i = tokenText.Length - 1; i >= 0 && !IsDigit(tokenText[i]); i--)
             {


### PR DESCRIPTION
Unifies the syntactic classification of all suffixes on literals, bringing numerical literal suffixes in line with the `u8` suffix for string literals.

Relates to #70439.