### PR TITLE
Publish `EA.EditorConfigGenerator`

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -65,6 +65,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.CodeLens": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSDK": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Debugger": "vs-impl",
+      "Microsoft.CodeAnalysis.ExternalAccess.EditorConfigGenerator": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.FSharp": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.IntelliTrace": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.ProjectSystem": "vs-impl",


### PR DESCRIPTION
Fixes [signed builds](https://dev.azure.com/dnceng/internal/_build?definitionId=327&_a=summary) broken since https://github.com/dotnet/roslyn/pull/70415.

Run for this PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2298520&view=results